### PR TITLE
Fix broken path

### DIFF
--- a/lib/routes/page.js
+++ b/lib/routes/page.js
@@ -11,6 +11,7 @@ module.exports = function(crowi, app) {
     , UserGroupRelation = crowi.model('UserGroupRelation')
     , ApiResponse = require('../util/apiResponse')
     , interceptorManager = crowi.getInterceptorManager()
+    , pagePathUtil = require('../util/pagePathUtil')
 
     , actions = {};
 
@@ -62,24 +63,6 @@ module.exports = function(crowi, app) {
       next: next,
       offset: offset,
     };
-  }
-
-  function encodePagesPath(pages) {
-    pages.forEach(function(page) {
-      if (!page.path) {
-        return;
-      }
-      page.path = encodePagePath(page.path);
-    });
-    return pages;
-  }
-
-  function encodePagePath(path) {
-    var paths = path.split('/');
-    paths.forEach(function(item, index) {
-      paths[index] = encodeURIComponent(item);
-    });
-    return paths.join('/');
   }
 
   /**
@@ -211,7 +194,7 @@ module.exports = function(crowi, app) {
         seener_threshold: SEENER_THRESHOLD,
       };
       renderVars.pager = generatePager(pagerOptions);
-      renderVars.pages = encodePagesPath(pageList);
+      renderVars.pages = pagePathUtil.encodePagesPath(pageList);
       res.render('customlayout-selector/page_list', renderVars);
     }).catch(function(err) {
       debug('Error on rendering pageListShow', err);
@@ -266,7 +249,7 @@ module.exports = function(crowi, app) {
       if (page.redirectTo) {
         debug(`Redirect to '${page.redirectTo}'`);
         isRedirect = true;
-        return res.redirect(encodeURI(page.redirectTo + '?redirectFrom=' + encodePagePath(page.path)));
+        return res.redirect(encodeURI(page.redirectTo + '?redirectFrom=' + pagePathUtil.encodePagePath(page.path)));
       }
 
       renderVars.page = page;
@@ -338,7 +321,7 @@ module.exports = function(crowi, app) {
             seener_threshold: SEENER_THRESHOLD,
           };
           renderVars.pager = generatePager(pagerOptions);
-          renderVars.pages = encodePagesPath(pageList);
+          renderVars.pages = pagePathUtil.encodePagesPath(pageList);
 
           return Promise.resolve();
         })
@@ -397,7 +380,7 @@ module.exports = function(crowi, app) {
       pagerOptions.length = pageList.length;
 
       renderVars.pager = generatePager(pagerOptions);
-      renderVars.pages = encodePagesPath(pageList);
+      renderVars.pages = pagePathUtil.encodePagesPath(pageList);
       res.render('customlayout-selector/page_list', renderVars);
     }).catch(function(err) {
       debug('Error on rendering deletedPageListShow', err);
@@ -426,7 +409,7 @@ module.exports = function(crowi, app) {
 
       res.render('customlayout-selector/page_list', {
         path: '/',
-        pages: encodePagesPath(pages),
+        pages: pagePathUtil.encodePagesPath(pages),
         pager: generatePager({offset: 0, limit: 50})
       });
     }).catch(function(err) {
@@ -444,7 +427,7 @@ module.exports = function(crowi, app) {
     }
 
     if (pageData.redirectTo) {
-      return res.redirect(encodeURI(pageData.redirectTo + '?redirectFrom=' + encodePagePath(pageData.path)));
+      return res.redirect(encodeURI(pageData.redirectTo + '?redirectFrom=' + pagePathUtil.encodePagePath(pageData.path)));
     }
 
     var renderVars = {
@@ -537,7 +520,7 @@ module.exports = function(crowi, app) {
         return ;
       }
       if (req.query.revision) {
-        return res.redirect(encodePagePath(path));
+        return res.redirect(pagePathUtil.encodePagePath(path));
       }
 
       if (isMarkdown) {
@@ -547,13 +530,13 @@ module.exports = function(crowi, app) {
       Page.hasPortalPage(path + '/', req.user)
       .then(function(page) {
         if (page) {
-          return res.redirect(encodePagePath(path) + '/');
+          return res.redirect(pagePathUtil.encodePagePath(path) + '/');
         } else {
 
           var fixed = Page.fixToCreatableName(path)
           if (fixed !== path) {
             debug('fixed page name', fixed)
-            res.redirect(encodePagePath(fixed));
+            res.redirect(pagePathUtil.encodePagePath(fixed));
             return ;
           }
 
@@ -586,7 +569,7 @@ module.exports = function(crowi, app) {
 
     debug('notify: ', notify);
 
-    var redirectPath = encodePagePath(path);
+    var redirectPath = pagePathUtil.encodePagePath(path);
     var pageData = {};
     var updateOrCreate;
     var previousRevision = false;
@@ -675,7 +658,7 @@ module.exports = function(crowi, app) {
       return Promise.resolve(pageData);
     }).then(function(page) {
 
-      return res.redirect(encodePagePath(page.path));
+      return res.redirect(pagePathUtil.encodePagePath(page.path));
     }).catch(function(err) {
       return res.redirect('/');
     });
@@ -727,7 +710,7 @@ module.exports = function(crowi, app) {
       pagerOptions.length = pages.length;
 
       var result = {};
-      result.pages = encodePagesPath(pages);
+      result.pages = pagePathUtil.encodePagesPath(pages);
       return res.json(ApiResponse.success(result));
     }).catch(function(err) {
       return res.json(ApiResponse.error(err));

--- a/lib/routes/page.js
+++ b/lib/routes/page.js
@@ -64,6 +64,24 @@ module.exports = function(crowi, app) {
     };
   }
 
+  function encodePagesPath(pages) {
+    pages.forEach(function(page) {
+      if (!page.path) {
+        return;
+      }
+      page.path = encodePagePath(page.path);
+    });
+    return pages;
+  }
+
+  function encodePagePath(path) {
+    var paths = path.split('/');
+    paths.forEach(function(item, index) {
+      paths[index] = encodeURIComponent(item);
+    });
+    return paths.join('/');
+  }
+
   /**
    * switch action by behaviorType
    */
@@ -193,7 +211,7 @@ module.exports = function(crowi, app) {
         seener_threshold: SEENER_THRESHOLD,
       };
       renderVars.pager = generatePager(pagerOptions);
-      renderVars.pages = pageList;
+      renderVars.pages = encodePagesPath(pageList);
       res.render('customlayout-selector/page_list', renderVars);
     }).catch(function(err) {
       debug('Error on rendering pageListShow', err);
@@ -248,7 +266,7 @@ module.exports = function(crowi, app) {
       if (page.redirectTo) {
         debug(`Redirect to '${page.redirectTo}'`);
         isRedirect = true;
-        return res.redirect(encodeURI(page.redirectTo + '?redirectFrom=' + page.path));
+        return res.redirect(encodeURI(page.redirectTo + '?redirectFrom=' + encodePagePath(page.path)));
       }
 
       renderVars.page = page;
@@ -320,7 +338,7 @@ module.exports = function(crowi, app) {
             seener_threshold: SEENER_THRESHOLD,
           };
           renderVars.pager = generatePager(pagerOptions);
-          renderVars.pages = pageList;
+          renderVars.pages = encodePagesPath(pageList);
 
           return Promise.resolve();
         })
@@ -379,7 +397,7 @@ module.exports = function(crowi, app) {
       pagerOptions.length = pageList.length;
 
       renderVars.pager = generatePager(pagerOptions);
-      renderVars.pages = pageList;
+      renderVars.pages = encodePagesPath(pageList);
       res.render('customlayout-selector/page_list', renderVars);
     }).catch(function(err) {
       debug('Error on rendering deletedPageListShow', err);
@@ -408,7 +426,7 @@ module.exports = function(crowi, app) {
 
       res.render('customlayout-selector/page_list', {
         path: '/',
-        pages: pages,
+        pages: encodePagesPath(pages),
         pager: generatePager({offset: 0, limit: 50})
       });
     }).catch(function(err) {
@@ -426,7 +444,7 @@ module.exports = function(crowi, app) {
     }
 
     if (pageData.redirectTo) {
-      return res.redirect(encodeURI(pageData.redirectTo + '?redirectFrom=' + pageData.path));
+      return res.redirect(encodeURI(pageData.redirectTo + '?redirectFrom=' + encodePagePath(pageData.path)));
     }
 
     var renderVars = {
@@ -519,7 +537,7 @@ module.exports = function(crowi, app) {
         return ;
       }
       if (req.query.revision) {
-        return res.redirect(encodeURI(path));
+        return res.redirect(encodePagePath(path));
       }
 
       if (isMarkdown) {
@@ -529,13 +547,13 @@ module.exports = function(crowi, app) {
       Page.hasPortalPage(path + '/', req.user)
       .then(function(page) {
         if (page) {
-          return res.redirect(encodeURI(path) + '/');
+          return res.redirect(encodePagePath(path) + '/');
         } else {
 
           var fixed = Page.fixToCreatableName(path)
           if (fixed !== path) {
             debug('fixed page name', fixed)
-            res.redirect(encodeURI(fixed));
+            res.redirect(encodePagePath(fixed));
             return ;
           }
 
@@ -568,7 +586,7 @@ module.exports = function(crowi, app) {
 
     debug('notify: ', notify);
 
-    var redirectPath = encodeURI(path);
+    var redirectPath = encodePagePath(path);
     var pageData = {};
     var updateOrCreate;
     var previousRevision = false;
@@ -657,7 +675,7 @@ module.exports = function(crowi, app) {
       return Promise.resolve(pageData);
     }).then(function(page) {
 
-      return res.redirect(encodeURI(page.path));
+      return res.redirect(encodePagePath(page.path));
     }).catch(function(err) {
       return res.redirect('/');
     });
@@ -709,7 +727,7 @@ module.exports = function(crowi, app) {
       pagerOptions.length = pages.length;
 
       var result = {};
-      result.pages = pages;
+      result.pages = encodePagesPath(pages);
       return res.json(ApiResponse.success(result));
     }).catch(function(err) {
       return res.json(ApiResponse.error(err));

--- a/lib/util/pagePathUtil.js
+++ b/lib/util/pagePathUtil.js
@@ -1,0 +1,24 @@
+'use strict';
+
+function encodePagesPath(pages) {
+  pages.forEach(function(page) {
+    if (!page.path) {
+      return;
+    }
+    page.path = encodePagePath(page.path);
+  });
+  return pages;
+}
+
+function encodePagePath(path) {
+  var paths = path.split('/');
+  paths.forEach(function(item, index) {
+    paths[index] = encodeURIComponent(item);
+  });
+  return paths.join('/');
+}
+
+module.exports = {
+  encodePagePath: encodePagePath,
+  encodePagesPath: encodePagesPath
+};

--- a/lib/views/widget/page_list.html
+++ b/lib/views/widget/page_list.html
@@ -12,7 +12,7 @@
   <a href="{{ page.path }}"
     class="page-list-link"
     data-path="{{ page.path }}"
-    data-short-path="{{ page.path|path2name }}">{{ page.path }}
+    data-short-path="{{ page.path|path2name }}">{{ decodeURIComponent(page.path) }}
   </a>
   <span class="page-list-meta">
     {% if page.isPortal() %}

--- a/resource/js/components/Page/RevisionPath.js
+++ b/resource/js/components/Page/RevisionPath.js
@@ -36,7 +36,7 @@ export default class RevisionPath extends React.Component {
     let parentPath = '/';
     splitted.forEach((pageName) => {
       pages.push({
-        pagePath: parentPath + pageName,
+        pagePath: parentPath + encodeURIComponent(pageName),
         pageName: pageName,
       });
       parentPath += pageName + '/';

--- a/resource/js/legacy/crowi.js
+++ b/resource/js/legacy/crowi.js
@@ -15,6 +15,7 @@ require('bootstrap-sass');
 require('jquery.cookie');
 
 require('./thirdparty-js/agile-admin');
+const pagePathUtil = require('../../../lib/util/pagePathUtil');
 
 var Crowi = {};
 
@@ -233,11 +234,7 @@ $(function() {
     if (name.match(/.+\/$/)) {
       name = name.substr(0, name.length - 1);
     }
-    var names = name.split('/');
-    names.forEach(function(item, index) {
-      names[index] = encodeURIComponent(item);
-    });
-    top.location.href = names.join('/') + '#edit-form';
+    top.location.href = pagePathUtil.encodePagePath(name) + '#edit-form';
     return false;
   });
 

--- a/resource/js/legacy/crowi.js
+++ b/resource/js/legacy/crowi.js
@@ -233,7 +233,11 @@ $(function() {
     if (name.match(/.+\/$/)) {
       name = name.substr(0, name.length - 1);
     }
-    top.location.href = name + '#edit-form';
+    var names = name.split('/');
+    names.forEach(function(item, index) {
+      names[index] = encodeURIComponent(item);
+    });
+    top.location.href = names.join('/') + '#edit-form';
     return false;
   });
 

--- a/resource/js/legacy/crowi.js
+++ b/resource/js/legacy/crowi.js
@@ -389,8 +389,8 @@ $(function() {
   $('.page-list-link').each(function() {
     var $link = $(this);
     var text = $link.text();
-    var path = $link.data('path');
-    var shortPath = String($link.data('short-path')); // convert to string
+    var path = decodeURIComponent($link.data('path'));
+    var shortPath = decodeURIComponent($link.data('short-path')); // convert to string
 
     if (path == null || shortPath == null) {
       // continue


### PR DESCRIPTION
Fix to generate link correctly when creating a new page containing `?` in the path.

`?` をパスに含む新規に作成したページのリンクを正しく生成するよう修正しました。

e.g.: `/Sandbox/foo?bar`
