### PR TITLE
Migrate from original user when ldap auth succeeds

### DIFF
--- a/lib/form/admin/securityGeneral.js
+++ b/lib/form/admin/securityGeneral.js
@@ -11,6 +11,7 @@ module.exports = form(
   field('settingForm[security:basicSecret]'),
   field('settingForm[security:restrictGuestMode]').required(),
   field('settingForm[security:registrationMode]').required(),
-  field('settingForm[security:registrationWhiteList]').custom(normalizeCRLF).custom(stringToArray)
+  field('settingForm[security:registrationWhiteList]').custom(normalizeCRLF).custom(stringToArray),
+  field('settingForm[security:externalAsLocal]'),
 );
 

--- a/lib/form/admin/securityGeneral.js
+++ b/lib/form/admin/securityGeneral.js
@@ -12,6 +12,6 @@ module.exports = form(
   field('settingForm[security:restrictGuestMode]').required(),
   field('settingForm[security:registrationMode]').required(),
   field('settingForm[security:registrationWhiteList]').custom(normalizeCRLF).custom(stringToArray),
-  field('settingForm[security:externalAsLocal]'),
+  field('settingForm[security:externalAsLocal]').trim().toBooleanStrict(),
 );
 

--- a/lib/locales/en-US/translation.json
+++ b/lib/locales/en-US/translation.json
@@ -275,7 +275,9 @@
     "for_instance":" For instance, if you use growi within a company, you can write ",
     "only_those":" Only those whose e-mail address including the company address can register.",
     "insert_single":"Please insert single e-mail address per line.",
-    "Authentication mechanism settings":"Authentication mechanism settings"
+    "Authentication mechanism settings":"Authentication mechanism settings",
+    "external_as_local": "Bind the external account with the same username as the local one to the local one automatically",
+    "external_as_local_help": "Enabling this option may be helpful if you want to authenticate users with external accounts, that are originally created as local accounts."
   },
 
   "markdown_setting": {

--- a/lib/locales/ja/translation.json
+++ b/lib/locales/ja/translation.json
@@ -295,7 +295,9 @@
     "for_instance":"例えば、会社で使う場合 などと記載すると、",
     "only_those":"その会社のメールアドレスを持っている人のみ登録可能になります。",
     "insert_single":"1行に1メールアドレス入力してください。",
-    "Authentication mechanism settings":"認証機構設定"
+    "Authentication mechanism settings":"認証機構設定",
+    "external_as_local": "外部アカウントをそれと同じユーザー名を持ったローカルアカウントに自動的にリンクする",
+    "external_as_local_help": "ローカルアカウントとして作成されたユーザーを外部アカウントで認証したい場合に役に立つかもしれません。"
   },
   "markdown_setting": {
     "markdown_rendering": "Markdownレンダリングの設定を変更できます。",

--- a/lib/models/config.js
+++ b/lib/models/config.js
@@ -53,6 +53,7 @@ module.exports = function(crowi) {
       'security:registrationWhiteList' : [],
 
       'security:isEnabledPassport' : false,
+      'security:externalAsLocal': false,
       'security:passport-ldap:isEnabled' : false,
       'security:passport-ldap:serverUrl' : undefined,
       'security:passport-ldap:isUserBind' : undefined,
@@ -274,6 +275,12 @@ module.exports = function(crowi) {
   configSchema.statics.isEnabledPassportLdap = function(config)
   {
     const key = 'security:passport-ldap:isEnabled';
+    return getValueForCrowiNS(config, key);
+  };
+
+  configSchema.statics.shouldTreatExternalAccountAsLocal = function(config)
+  {
+    const key = 'security:externalAsLocal';
     return getValueForCrowiNS(config, key);
   };
 

--- a/lib/models/external-account.js
+++ b/lib/models/external-account.js
@@ -79,19 +79,24 @@ class ExternalAccount {
         }
         // not found
         else {
-          debug(`ExternalAccount '${accountId}' is not found, it is going to be registered.`);
-
           const User = ExternalAccount.crowi.model('User');
 
-          return User.count({username: usernameToBeRegistered})
-            .then((count) => {
+          return User.find({username: usernameToBeRegistered})
+            .then(users => {
               // throw Exception when count is not zero
-              if (count > 0) {
+              if (users.length > 1) {
                 throw new DuplicatedUsernameException(`username '${usernameToBeRegistered}' has already been existed`);
               }
+              else if (users.length === 0) {
+                debug(`ExternalAccount '${accountId}' is not found, it is going to be registered.`);
+                // create user with STATUS_ACTIVE
+                return User.createUser('', usernameToBeRegistered, undefined, undefined, undefined, User.STATUS_ACTIVE);
+              }
+              else {
+                debug(`ExternalAccount '${accountId}' will be linked to an exisiting account`);
+                return users[0];
+              }
 
-              // create user with STATUS_ACTIVE
-              return User.createUser('', usernameToBeRegistered, undefined, undefined, undefined, User.STATUS_ACTIVE);
             })
             .then((user) => {
               return this.create({ providerType: 'ldap', accountId, user: user._id });

--- a/lib/models/external-account.js
+++ b/lib/models/external-account.js
@@ -78,7 +78,9 @@ class ExternalAccount {
     }
 
     const User = ExternalAccount.crowi.model('User');
-    const treatExternalUserAsLocalUser = false; // TODO: fetch from config model
+    const Config = ExternalAccount.crowi.model('Config');
+
+    const treatExternalUserAsLocalUser = Config.shouldTreatExternalAccountAsLocal(ExternalAccount.crowi.getConfig());
 
     const users = await User.find({username: usernameToBeRegistered})
 

--- a/lib/models/external-account.js
+++ b/lib/models/external-account.js
@@ -68,40 +68,41 @@ class ExternalAccount {
    * @returns {Promise<ExternalAccount>}
    * @memberof ExternalAccount
    */
-  static async findOrRegister(providerType, accountId, usernameToBeRegistered) {
+  static findOrRegister(providerType, accountId, usernameToBeRegistered) {
 
-    const account = await this.findOne({ providerType, accountId })
-    // found
-    if (account != null) {
-      debug(`ExternalAccount '${accountId}' is found `, account);
-      return account;
-    }
+    return this.findOne({ providerType, accountId }).then( account => {
+      // found
+      if (account != null) {
+        debug(`ExternalAccount '${accountId}' is found `, account);
+        return account;
+      }
 
-    const User = ExternalAccount.crowi.model('User');
-    const Config = ExternalAccount.crowi.model('Config');
+      const User = ExternalAccount.crowi.model('User');
+      const Config = ExternalAccount.crowi.model('Config');
 
-    const treatExternalUserAsLocalUser = Config.shouldTreatExternalAccountAsLocal(ExternalAccount.crowi.getConfig());
+      const treatExternalUserAsLocalUser = Config.shouldTreatExternalAccountAsLocal(ExternalAccount.crowi.getConfig());
 
-    const users = await User.find({username: usernameToBeRegistered})
+      return User.find({username: usernameToBeRegistered}).then( users => {
+        // throw Exception when count is not zero
+        const maxDuplicateUserCount = treatExternalUserAsLocalUser ? 1 : 0;
+        if (users.length > maxDuplicateUserCount) {
+          throw new DuplicatedUsernameException(`username '${usernameToBeRegistered}' has already been existed`);
+        }
 
-    // throw Exception when count is not zero
-    const maxDuplicateUserCount = treatExternalUserAsLocalUser ? 1 : 0;
-    if (users.length > maxDuplicateUserCount) {
-      throw new DuplicatedUsernameException(`username '${usernameToBeRegistered}' has already been existed`);
-    }
+        if (users.length === 0) {
+          debug(`ExternalAccount '${accountId}' is not found, it is going to be registered.`);
+          // create user with STATUS_ACTIVE
+          return User.createUser('', usernameToBeRegistered, undefined, undefined, undefined, User.STATUS_ACTIVE);
+        }
 
-    let newUser;
-    if (users.length === 0) {
-      debug(`ExternalAccount '${accountId}' is not found, it is going to be registered.`);
-      // create user with STATUS_ACTIVE
-      newUser = await User.createUser('', usernameToBeRegistered, undefined, undefined, undefined, User.STATUS_ACTIVE);
-    }
-    else {
-      debug(`ExternalAccount '${accountId}' will be linked to an exisiting account`);
-      newUser = users[0];
-    }
+        debug(`ExternalAccount '${accountId}' will be linked to an exisiting account`);
+        return users[0];
 
-    return this.create({ providerType: 'ldap', accountId, user: newUser._id });
+      }).then( newUser => {
+        return this.create({ providerType: 'ldap', accountId, user: newUser._id });
+      })
+
+    });
   }
 
   /**

--- a/lib/models/external-account.js
+++ b/lib/models/external-account.js
@@ -68,42 +68,38 @@ class ExternalAccount {
    * @returns {Promise<ExternalAccount>}
    * @memberof ExternalAccount
    */
-  static findOrRegister(providerType, accountId, usernameToBeRegistered) {
+  static async findOrRegister(providerType, accountId, usernameToBeRegistered) {
 
-    return this.findOne({ providerType, accountId })
-      .then((account) => {
-        // found
-        if (account != null) {
-          debug(`ExternalAccount '${accountId}' is found `, account);
-          return account;
-        }
-        // not found
-        else {
-          const User = ExternalAccount.crowi.model('User');
+    const account = await this.findOne({ providerType, accountId })
+    // found
+    if (account != null) {
+      debug(`ExternalAccount '${accountId}' is found `, account);
+      return account;
+    }
 
-          return User.find({username: usernameToBeRegistered})
-            .then(users => {
-              // throw Exception when count is not zero
-              if (users.length > 1) {
-                throw new DuplicatedUsernameException(`username '${usernameToBeRegistered}' has already been existed`);
-              }
-              else if (users.length === 0) {
-                debug(`ExternalAccount '${accountId}' is not found, it is going to be registered.`);
-                // create user with STATUS_ACTIVE
-                return User.createUser('', usernameToBeRegistered, undefined, undefined, undefined, User.STATUS_ACTIVE);
-              }
-              else {
-                debug(`ExternalAccount '${accountId}' will be linked to an exisiting account`);
-                return users[0];
-              }
+    const User = ExternalAccount.crowi.model('User');
+    const treatExternalUserAsLocalUser = false; // TODO: fetch from config model
 
-            })
-            .then((user) => {
-              return this.create({ providerType: 'ldap', accountId, user: user._id });
-            });
-        }
-      });
+    const users = await User.find({username: usernameToBeRegistered})
 
+    // throw Exception when count is not zero
+    const maxDuplicateUserCount = treatExternalUserAsLocalUser ? 1 : 0;
+    if (users.length > maxDuplicateUserCount) {
+      throw new DuplicatedUsernameException(`username '${usernameToBeRegistered}' has already been existed`);
+    }
+
+    let newUser;
+    if (users.length === 0) {
+      debug(`ExternalAccount '${accountId}' is not found, it is going to be registered.`);
+      // create user with STATUS_ACTIVE
+      newUser = await User.createUser('', usernameToBeRegistered, undefined, undefined, undefined, User.STATUS_ACTIVE);
+    }
+    else {
+      debug(`ExternalAccount '${accountId}' will be linked to an exisiting account`);
+      newUser = users[0];
+    }
+
+    return this.create({ providerType: 'ldap', accountId, user: newUser._id });
   }
 
   /**

--- a/lib/routes/admin.js
+++ b/lib/routes/admin.js
@@ -95,8 +95,8 @@ module.exports = function(crowi, app) {
   // app.get('/admin/security'                  , admin.security.index);
   actions.security = {};
   actions.security.index = function(req, res) {
-    var settingForm;
-    settingForm = Config.setupCofigFormData('crowi', req.config);
+    const settingForm = Config.setupCofigFormData('crowi', req.config);
+    debug(req.config)
     return res.render('admin/security', { settingForm });
   };
 
@@ -862,7 +862,7 @@ module.exports = function(crowi, app) {
   };
 
   actions.api.securitySetting = function(req, res) {
-    var form = req.form.settingForm;
+    const form = req.form.settingForm;
 
     if (req.form.isValid) {
       debug('form content', form);

--- a/lib/routes/admin.js
+++ b/lib/routes/admin.js
@@ -96,7 +96,6 @@ module.exports = function(crowi, app) {
   actions.security = {};
   actions.security.index = function(req, res) {
     const settingForm = Config.setupCofigFormData('crowi', req.config);
-    debug(req.config)
     return res.render('admin/security', { settingForm });
   };
 

--- a/lib/views/admin/security.html
+++ b/lib/views/admin/security.html
@@ -93,7 +93,7 @@
           <div class="form-group">
             <div class="col-xs-offset-3 col-xs-6">
               <div class="checkbox checkbox-info">
-                <input type="checkbox" id="externalAsLocal" name="settingForm[security:externalAsLocal]"
+                <input type="checkbox" id="externalAsLocal" name="settingForm[security:externalAsLocal]" value="1"
                                                                                                                  {% if settingForm['security:externalAsLocal'] %}
                 checked
                 {% endif %}

--- a/lib/views/admin/security.html
+++ b/lib/views/admin/security.html
@@ -92,6 +92,25 @@
 
           <div class="form-group">
             <div class="col-xs-offset-3 col-xs-6">
+              <div class="checkbox checkbox-info">
+                <input type="checkbox" id="externalAsLocal" name="settingForm[security:externalAsLocal]"
+                                                                                                                 {% if settingForm['security:externalAsLocal'] %}
+                checked
+                {% endif %}
+                />
+                <label for="externalAsLocal">
+                  {{ t("security_setting.external_as_local") }}
+                </label>
+              </div>
+  
+              <p class="help-block">
+                {{ t("security_setting.external_as_local_help") }}
+              </p>
+            </div>
+          </div>
+
+          <div class="form-group">
+            <div class="col-xs-offset-3 col-xs-6">
               <input type="hidden" name="_csrf" value="{{ csrf() }}">
               <button type="submit" class="btn btn-primary">{{ t('Update') }}</button>
             </div>


### PR DESCRIPTION
When an existing user logged in with LDAP for the first time, the user data (including his/her articles) are linked to an external account, instead of creating a new user.