### PR TITLE
fix #359: Cannot input "c" and "e" in page-editor

### DIFF
--- a/resource/js/legacy/crowi.js
+++ b/resource/js/legacy/crowi.js
@@ -902,7 +902,7 @@ window.addEventListener('keydown', (event) => {
 
   // ignore when target dom is input
   const inputPattern = /^input|textinput|textarea$/i;
-  if (target.tagName.match(inputPattern)) {
+  if (target.tagName.match(inputPattern) || target.isContentEditable) {
     return;
   }
 


### PR DESCRIPTION
- When you edit page from iOS, CodeMirror editor target.tagName is not matches the inputPattern.(This is the bugs root cause)
- But the same time, that the target has a contentEditable property and it will be true.