### PR TITLE
imprv/count-multibyte-in-md-table

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,6 +145,7 @@
     "slack-node": "^0.1.8",
     "socket.io": "^2.0.3",
     "socket.io-client": "^2.0.3",
+    "string-width": "^2.1.1",
     "style-loader": "^0.21.0",
     "swig-templates": "^2.0.2",
     "throttle-debounce": "^1.0.1",

--- a/resource/js/components/PageEditor/MarkdownTableUtil.js
+++ b/resource/js/components/PageEditor/MarkdownTableUtil.js
@@ -1,4 +1,5 @@
-import markdown_table from 'markdown-table';
+import markdownTable from 'markdown-table';
+import stringWidth from 'string-width';
 
 /**
  * Utility for markdown table
@@ -127,7 +128,7 @@ class MarkdownTableUtil {
         contents.push(row);
       }
     }
-    return (new MarkdownTable(contents, { align: aligns }));
+    return (new MarkdownTable(contents, { align: aligns, stringLength: stringWidth }));
   }
 
   /**
@@ -199,7 +200,7 @@ class MarkdownTable {
   }
 
   toString() {
-    return markdown_table(this.table, this.options);
+    return markdownTable(this.table, this.options);
   }
 }
 


### PR DESCRIPTION
# Improved

* `markdown-table` supports multi-byte characters width when auto-formatting.

# Result of this PR

* capture image<br>
![image](https://user-images.githubusercontent.com/32702772/40002854-d7ae24d8-57cc-11e8-89b2-6019a1701841.png)

* texts after formatted
```
| タイトル | 備考   |
| -------- | ------ |
| テスト   | test   |
| ﾃｽﾄ      | test   |
| sample   | sample |
| サンプル | sample |
| ｻﾝﾌﾟﾙ    | sample |
```