### PR TITLE
differentiate markdown/plain comments in backend

### DIFF
--- a/lib/form/comment.js
+++ b/lib/form/comment.js
@@ -7,5 +7,6 @@ module.exports = form(
   field('commentForm.page_id').trim().required(),
   field('commentForm.revision_id').trim().required(),
   field('commentForm.comment').trim().required(),
-  field('commentForm.comment_position').trim().toInt()
+  field('commentForm.comment_position').trim().toInt(),
+  field('commentForm.is_markdown')
 );

--- a/lib/form/comment.js
+++ b/lib/form/comment.js
@@ -8,5 +8,5 @@ module.exports = form(
   field('commentForm.revision_id').trim().required(),
   field('commentForm.comment').trim().required(),
   field('commentForm.comment_position').trim().toInt(),
-  field('commentForm.is_markdown')
+  field('commentForm.is_markdown').trim().toBoolean()
 );

--- a/lib/form/comment.js
+++ b/lib/form/comment.js
@@ -8,5 +8,5 @@ module.exports = form(
   field('commentForm.revision_id').trim().required(),
   field('commentForm.comment').trim().required(),
   field('commentForm.comment_position').trim().toInt(),
-  field('commentForm.is_markdown').trim().toBoolean()
+  field('commentForm.is_markdown').trim().toBooleanStrict()
 );

--- a/lib/models/comment.js
+++ b/lib/models/comment.js
@@ -29,7 +29,7 @@ module.exports = function(crowi) {
       newComment.revision = revisionId;
       newComment.comment = comment;
       newComment.commentPosition = position;
-      newComment.isMarkdown = isMarkdown;
+      newComment.isMarkdown = isMarkdown || false;
 
       newComment.save(function(err, data) {
         if (err) {

--- a/lib/models/comment.js
+++ b/lib/models/comment.js
@@ -12,10 +12,11 @@ module.exports = function(crowi) {
     revision: { type: ObjectId, ref: 'Revision', index: true },
     comment: { type: String, required: true },
     commentPosition: { type: Number, default: -1 },
-    createdAt: { type: Date, default: Date.now }
+    createdAt: { type: Date, default: Date.now },
+    isMarkdown: { type: Boolean, default: false}
   });
 
-  commentSchema.statics.create = function(pageId, creatorId, revisionId, comment, position) {
+  commentSchema.statics.create = function(pageId, creatorId, revisionId, comment, position, isMarkdown) {
     var Comment = this,
       commentPosition = position || -1;
 
@@ -28,6 +29,7 @@ module.exports = function(crowi) {
       newComment.revision = revisionId;
       newComment.comment = comment;
       newComment.commentPosition = position;
+      newComment.isMarkdown = isMarkdown;
 
       newComment.save(function(err, data) {
         if (err) {

--- a/lib/routes/comment.js
+++ b/lib/routes/comment.js
@@ -62,7 +62,7 @@ module.exports = function(crowi, app) {
     var revisionId = form.revision_id;
     var comment = form.comment;
     var position = form.comment_position || -1;
-    var isMarkdown = form.is_markdown;
+    var isMarkdown = form.is_markdown || false;
 
     return Comment.create(pageId, req.user._id, revisionId, comment, position, isMarkdown)
       .then(function(createdComment) {

--- a/lib/routes/comment.js
+++ b/lib/routes/comment.js
@@ -19,7 +19,7 @@ module.exports = function(crowi, app) {
    * @apiParam {String} page_id Page Id.
    * @apiParam {String} revision_id Revision Id.
    */
-  api.get = function(req, res){
+  api.get = function(req, res) {
     var pageId = req.query.page_id;
     var revisionId = req.query.revision_id;
 
@@ -50,7 +50,7 @@ module.exports = function(crowi, app) {
    * @apiParam {String} comment Comment body
    * @apiParam {Number} comment_position=-1 Line number of the comment
    */
-  api.add = function(req, res){
+  api.add = function(req, res) {
     var form = req.form.commentForm;
 
     if (!req.form.isValid) {
@@ -62,8 +62,13 @@ module.exports = function(crowi, app) {
     var revisionId = form.revision_id;
     var comment = form.comment;
     var position = form.comment_position || -1;
+    var isMarkdown = form.is_markdown || 0;
 
-    return Comment.create(pageId, req.user._id, revisionId, comment, position)
+    console.log('---------------------------------------------');
+    console.log(isMarkdown);
+    console.log('---------------------------------------------');
+
+    return Comment.create(pageId, req.user._id, revisionId, comment, position, isMarkdown)
       .then(function(createdComment) {
         createdComment.creator = req.user;
         return res.json(ApiResponse.success({comment: createdComment}));
@@ -79,7 +84,7 @@ module.exports = function(crowi, app) {
    *
    * @apiParam {String} comment_id Comment Id.
    */
-  api.remove = function(req, res){
+  api.remove = function(req, res) {
     var commentId = req.body.comment_id;
     if (!commentId) {
       return Promise.resolve(res.json(ApiResponse.error(`'comment_id' is undefined`)));
@@ -92,11 +97,11 @@ module.exports = function(crowi, app) {
            return Page.updateCommentCount(comment.page);
         })
         .then(function() {
-           return res.json(ApiResponse.success({})); 
+           return res.json(ApiResponse.success({}));
         });
       })
       .catch(function(err) {
-        return res.json(ApiResponse.error(err)); 
+        return res.json(ApiResponse.error(err));
       });
 
   };

--- a/lib/routes/comment.js
+++ b/lib/routes/comment.js
@@ -64,10 +64,6 @@ module.exports = function(crowi, app) {
     var position = form.comment_position || -1;
     var isMarkdown = form.is_markdown || 0;
 
-    console.log('---------------------------------------------');
-    console.log(isMarkdown);
-    console.log('---------------------------------------------');
-
     return Comment.create(pageId, req.user._id, revisionId, comment, position, isMarkdown)
       .then(function(createdComment) {
         createdComment.creator = req.user;

--- a/lib/routes/comment.js
+++ b/lib/routes/comment.js
@@ -62,7 +62,7 @@ module.exports = function(crowi, app) {
     var revisionId = form.revision_id;
     var comment = form.comment;
     var position = form.comment_position || -1;
-    var isMarkdown = form.is_markdown || false;
+    var isMarkdown = form.is_markdown;
 
     return Comment.create(pageId, req.user._id, revisionId, comment, position, isMarkdown)
       .then(function(createdComment) {

--- a/lib/routes/comment.js
+++ b/lib/routes/comment.js
@@ -62,7 +62,7 @@ module.exports = function(crowi, app) {
     var revisionId = form.revision_id;
     var comment = form.comment;
     var position = form.comment_position || -1;
-    var isMarkdown = form.is_markdown || 0;
+    var isMarkdown = form.is_markdown;
 
     return Comment.create(pageId, req.user._id, revisionId, comment, position, isMarkdown)
       .then(function(createdComment) {

--- a/lib/views/layout-growi/widget/comments.html
+++ b/lib/views/layout-growi/widget/comments.html
@@ -28,6 +28,7 @@
           <div class="comment-write" id="comment-write">
             <textarea class="comment-form-comment form-control" id="comment-form-comment" name="commentForm[comment]"
                 required placeholder="Write comments here..." {% if not user %}disabled{% endif %}></textarea>
+            <input type="checkbox" id="comment-form-is-markdown" name="commentForm[is_markdown]" value="1"> Markdown<br>
           </div>
           <div class="comment-submit">
             <input type="hidden" name="_csrf" value="{{ csrf() }}">

--- a/resource/js/components/PageComment/Comment.js
+++ b/resource/js/components/PageComment/Comment.js
@@ -52,6 +52,11 @@ export default class Comment extends React.Component {
     const comment = this.props.comment;
     const creator = comment.creator;
 
+    // temporary from here
+    const isMarkdown = comment.isMarkdown;
+    let markdownText = isMarkdown ? 'markdown' : 'plain';
+    // to here
+
     const rootClassName = this.getRootClassName();
     const commentDate = dateFnsFormat(comment.createdAt, 'YYYY/MM/DD HH:mm');
     const commentBody = ReactUtils.nl2br(comment.comment);
@@ -68,6 +73,7 @@ export default class Comment extends React.Component {
         <div className="page-comment-main">
           <div className="page-comment-creator">
             <a href={creatorsPage}>{creator.username}</a>
+            <p>{markdownText}!!!</p>
           </div>
           <div className="page-comment-body">{commentBody}</div>
           <div className="page-comment-meta">

--- a/resource/js/components/PageCommentFormBehavior.js
+++ b/resource/js/components/PageCommentFormBehavior.js
@@ -38,6 +38,7 @@ export default class PageCommentFormBehavior extends React.Component {
           pageComments.init();
 
           $('#comment-form-comment').val('');
+          $('#comment-form-is-markdown').prop('checked', false);
           $('#comment-form-message').text('');
         } else {
           $('#comment-form-message').text(data.error);


### PR DESCRIPTION
一時的にチェックボックスを追加して、チェックの有無でmarkdown/plainを差別化
一時的にmarkdown/plainをユーザーネームの下に表示