### PR TITLE
refs Bug #410 公開範囲「特定グループのみ」でグループ指定できない

### DIFF
--- a/lib/models/page.js
+++ b/lib/models/page.js
@@ -344,7 +344,7 @@ module.exports = function(crowi) {
     grantLabels[GRANT_PUBLIC]     = 'Public'; // 公開
     grantLabels[GRANT_RESTRICTED] = 'Anyone with the link'; // リンクを知っている人のみ
     //grantLabels[GRANT_SPECIFIED]  = 'Specified users only'; // 特定ユーザーのみ
-    // grantLabels[GRANT_USER_GROUP] = 'Only inside the group'; // 特定グループのみ
+    grantLabels[GRANT_USER_GROUP] = 'Only inside the group'; // 特定グループのみ
     grantLabels[GRANT_OWNER]      = 'Just me'; // 自分のみ
 
     return grantLabels;


### PR DESCRIPTION
* Fix the bug that caused by "grant user group"-grantLabel has been commented out...
  * Page view is not looks to be published "only inside the group", but actually it grant data is published only inside the group.
* なぜかどこかのタイミングでグループの公開範囲ラベルをコメントアウトしてしまっていたため、コメントアウトから復帰させました。