### PR TITLE
Brushup grant selector style for mobile.

### DIFF
--- a/resource/js/components/PageEditor/GrantSelector.js
+++ b/resource/js/components/PageEditor/GrantSelector.js
@@ -150,7 +150,7 @@ export default class GrantSelector extends React.Component {
 
   render() {
     return <span>
-      <span className="m-l-5">{this.renderGrantSelector()}</span>
+      <span>{this.renderGrantSelector()}</span>
     </span>;
   }
 }

--- a/resource/styles/scss/_on-edit.scss
+++ b/resource/styles/scss/_on-edit.scss
@@ -343,6 +343,18 @@ body.on-edit {
     }
   }
 
+  #page-grant-selector {
+    label {
+      margin-right: 0.5em;
+    }
+
+    .form-group {
+      margin-bottom: 0;
+      margin-right: 10px;
+    }
+  }
+
+
 } // }}}
 
 /*


### PR DESCRIPTION
- Fixed the style of grant selector on page editor.
  - When you browsing on a mobile, grant selector select-box style collapses.