### PR TITLE
add title tag to theme colorbox

### DIFF
--- a/lib/views/admin/widget/theme-colorbox.html
+++ b/lib/views/admin/widget/theme-colorbox.html
@@ -4,6 +4,7 @@
     data-theme="{{ webpack_asset('style-theme-' + name).css }}">
 
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+    <title>{{name}}</title>
     <g>
       <path d="M -1 -1 L65 -1 L65 65 L-1 65 L-1 -1 Z" fill="{{bg}}"></path>
       <path d="M -1 -1 L65 -1 L65 15 L-1 15 L-1 -1 Z" fill="{{topbar}}"></path>


### PR DESCRIPTION
* like img alt attribute
    * popup title when mouse over.

![growi-svg-theme-hover-title](https://user-images.githubusercontent.com/1567423/40624177-eb18fc04-62e5-11e8-8eb7-cc6f68366202.gif)
