### PR TITLE
add markdown-it-blockdiag (like PlantUML)

### DIFF
--- a/lib/models/config.js
+++ b/lib/models/config.js
@@ -465,6 +465,7 @@ module.exports = function(crowi) {
       isSavedStatesOfTabChanges: Config.isSavedStatesOfTabChanges(config),
       env: {
         PLANTUML_URI: env.PLANTUML_URI || null,
+        BLOCKDIAG_URI: env.BLOCKDIAG_URI || null,
         MATHJAX: env.MATHJAX || null,
       },
     };

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "i18next-express-middleware": "^1.1.1",
     "i18next-node-fs-backend": "^1.0.0",
     "i18next-sprintf-postprocessor": "^0.2.2",
-    "markdown-it-blockdiag": "^0.3.5",
+    "markdown-it-blockdiag": "^1.0.0",
     "md5": "^2.2.1",
     "method-override": "^2.3.10",
     "mkdirp": "~0.5.1",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "i18next-express-middleware": "^1.1.1",
     "i18next-node-fs-backend": "^1.0.0",
     "i18next-sprintf-postprocessor": "^0.2.2",
+    "markdown-it-blockdiag": "^0.3.5",
     "md5": "^2.2.1",
     "method-override": "^2.3.10",
     "mkdirp": "~0.5.1",

--- a/resource/js/util/GrowiRenderer.js
+++ b/resource/js/util/GrowiRenderer.js
@@ -15,6 +15,7 @@ import PlantUMLConfigurer from './markdown-it/plantuml';
 import TableConfigurer from './markdown-it/table';
 import TaskListsConfigurer from './markdown-it/task-lists';
 import TocAndAnchorConfigurer from './markdown-it/toc-and-anchor';
+import BlockdiagConfigurer from './markdown-it/blockdiag';
 
 export default class GrowiRenderer {
 
@@ -75,6 +76,7 @@ export default class GrowiRenderer {
       new EmojiConfigurer(crowi),
       new MathJaxConfigurer(crowi),
       new PlantUMLConfigurer(crowi),
+      new BlockdiagConfigurer(crowi),
     ];
 
     // add configurers according to mode

--- a/resource/js/util/markdown-it/blockdiag.js
+++ b/resource/js/util/markdown-it/blockdiag.js
@@ -10,6 +10,7 @@ export default class BlockdiagConfigurer {
   configure(md) {
     md.use(require('markdown-it-blockdiag'), {
       generateSourceUrl: this.generateSourceUrl,
+      marker: '```',
     });
   }
 }

--- a/resource/js/util/markdown-it/blockdiag.js
+++ b/resource/js/util/markdown-it/blockdiag.js
@@ -1,0 +1,15 @@
+export default class BlockdiagConfigurer {
+
+  constructor(crowi) {
+    this.crowi = crowi;
+    const config = crowi.getConfig();
+
+    this.generateSourceUrl = config.env.BLOCKDIAG_URL || 'https://blockdiag-api.com/';
+  }
+
+  configure(md) {
+    md.use(require('markdown-it-blockdiag'), {
+      generateSourceUrl: this.generateSourceUrl,
+    });
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4370,6 +4370,15 @@ map-values@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-values/-/map-values-1.0.1.tgz#768b8e79c009bf2b64fee806e22a7b1c4190c990"
 
+markdown-it-blockdiag@^0.3.5:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/markdown-it-blockdiag/-/markdown-it-blockdiag-0.3.5.tgz#02d119ef9b5cddb1dcfc6f040c4bda0f78017510"
+  dependencies:
+    pako "^1.0.6"
+    paths "^0.1.1"
+    url-join "^4.0.0"
+    utf8-bytes "0.0.1"
+
 markdown-it-emoji@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/markdown-it-emoji/-/markdown-it-emoji-1.4.0.tgz#9bee0e9a990a963ba96df6980c4fddb05dfb4dcc"
@@ -5218,7 +5227,7 @@ pako@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.3.tgz#5f515b0c6722e1982920ae8005eacb0b7ca73ccf"
 
-pako@~1.0.5:
+pako@^1.0.6, pako@~1.0.5:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.6.tgz#0101211baa70c4bca4a0f63f2206e97b7dfaf258"
 
@@ -5355,6 +5364,10 @@ path-type@^3.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-3.0.0.tgz#cef31dc8e0a1a3bb0d105c0cd97cf3bf47f4e36f"
   dependencies:
     pify "^3.0.0"
+
+paths@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/paths/-/paths-0.1.1.tgz#9ad909d7f769dd8acb3a1c033c5eef43123d3d17"
 
 pathval@^1.0.0:
   version "1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4370,10 +4370,11 @@ map-values@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-values/-/map-values-1.0.1.tgz#768b8e79c009bf2b64fee806e22a7b1c4190c990"
 
-markdown-it-blockdiag@^0.3.5:
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/markdown-it-blockdiag/-/markdown-it-blockdiag-0.3.5.tgz#02d119ef9b5cddb1dcfc6f040c4bda0f78017510"
+markdown-it-blockdiag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/markdown-it-blockdiag/-/markdown-it-blockdiag-1.0.0.tgz#d949ab426e59f948713eb9702ab186a92a572736"
   dependencies:
+    markdown-it-fence "0.0.2"
     pako "^1.0.6"
     paths "^0.1.1"
     url-join "^4.0.0"
@@ -4382,6 +4383,10 @@ markdown-it-blockdiag@^0.3.5:
 markdown-it-emoji@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/markdown-it-emoji/-/markdown-it-emoji-1.4.0.tgz#9bee0e9a990a963ba96df6980c4fddb05dfb4dcc"
+
+markdown-it-fence@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/markdown-it-fence/-/markdown-it-fence-0.0.2.tgz#ce1fe95900891603300d9da519aada144d5de9fc"
 
 markdown-it-footnote@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
I implemented live preview of blockdiag.
If you like this please merge.

## Demo

![markdown-it-blockdiag-demo](https://user-images.githubusercontent.com/1567423/41103737-d05b5d46-6aa4-11e8-944c-7454e9eba663.gif)

## refs

* http://blockdiag.com/en/
* https://www.npmjs.com/package/markdown-it-blockdiag