### PR TITLE
check toggle

### DIFF
--- a/resource/js/components/SearchPage/DeletePageListModal.js
+++ b/resource/js/components/SearchPage/DeletePageListModal.js
@@ -43,8 +43,8 @@ export default class DeletePageListModal extends React.Component {
         <Modal.Footer>
           <div className="d-flex justify-content-between">
             <span className="text-danger">{this.props.errorMessage}</span>
-            <span className="d-flex">
-              <Checkbox onClick={this.props.toggleDeleteCompletely}>Delete completely</Checkbox>
+            <span className="d-flex align-items-center">
+              <Checkbox className="text-danger" onChange={this.props.toggleDeleteCompletely} inline={true} checked={this.props.isDeleteCompletely ? true : false}>Delete completely</Checkbox>
               <span className="m-l-10">
                 <Button onClick={this.props.confirmedToDelete}><i className="icon-trash"></i>Delete</Button>
               </span>
@@ -64,4 +64,5 @@ DeletePageListModal.propTypes = {
   cancel: PropTypes.func.isRequired,                 // for cancel evnet handling
   confirmedToDelete: PropTypes.func.isRequired,      // for confirmed event handling
   toggleDeleteCompletely: PropTypes.func.isRequired, // for delete completely check event handling
+  isDeleteCompletely: PropTypes.bool,
 };

--- a/resource/js/components/SearchPage/DeletePageListModal.js
+++ b/resource/js/components/SearchPage/DeletePageListModal.js
@@ -44,7 +44,7 @@ export default class DeletePageListModal extends React.Component {
           <div className="d-flex justify-content-between">
             <span className="text-danger">{this.props.errorMessage}</span>
             <span className="d-flex align-items-center">
-              <Checkbox className="text-danger" onChange={this.props.toggleDeleteCompletely} inline={true} checked={this.props.isDeleteCompletely ? true : false}>Delete completely</Checkbox>
+              <Checkbox className="text-danger" onClick={this.props.toggleDeleteCompletely} inline={true}>Delete completely</Checkbox>
               <span className="m-l-10">
                 <Button onClick={this.props.confirmedToDelete}><i className="icon-trash"></i>Delete</Button>
               </span>
@@ -64,5 +64,4 @@ DeletePageListModal.propTypes = {
   cancel: PropTypes.func.isRequired,                 // for cancel evnet handling
   confirmedToDelete: PropTypes.func.isRequired,      // for confirmed event handling
   toggleDeleteCompletely: PropTypes.func.isRequired, // for delete completely check event handling
-  isDeleteCompletely: PropTypes.bool,
 };

--- a/resource/js/components/SearchPage/SearchResult.js
+++ b/resource/js/components/SearchPage/SearchResult.js
@@ -283,6 +283,7 @@ export default class SearchResult extends React.Component {
           cancel={this.closeDeleteConfirmModal}
           confirmedToDelete={this.deleteSelectedPages}
           toggleDeleteCompletely={this.toggleDeleteCompletely}
+          isDeleteCompletely={this.state.isDeleteCompletely}
         />
 
       </div>//content-main

--- a/resource/js/components/SearchPage/SearchResult.js
+++ b/resource/js/components/SearchPage/SearchResult.js
@@ -283,7 +283,6 @@ export default class SearchResult extends React.Component {
           cancel={this.closeDeleteConfirmModal}
           confirmedToDelete={this.deleteSelectedPages}
           toggleDeleteCompletely={this.toggleDeleteCompletely}
-          isDeleteCompletely={this.state.isDeleteCompletely}
         />
 
       </div>//content-main


### PR DESCRIPTION
https://github.com/weseek/growi/issues/560

原因は不明。`React-Bootstrap`のバグだと思われます。
`<Checkbox>`のpropsの`inline={true}`で解決された。
agile-adminのclass`.checkbox .checkbox-info`をつけようとするとこの`inline`がもたらすsytleか何かが上書きされて、checkがつかなくなるので、素のHTMLのcheckboxを採用