### PR TITLE
Imprv/Add option to use email for account link when using SAML federation

### DIFF
--- a/resource/locales/en-US/translation.json
+++ b/resource/locales/en-US/translation.json
@@ -352,6 +352,8 @@
     "optional": "Optional",
     "Treat username matching as identical": "Automatically bind external accounts newly logged in to local accounts when <code>%s</code> match",
     "Treat username matching as identical_warn": "WARNING: Be aware of security because the system treats the same user as a match of <code>%s</code>.",
+    "Treat email matching as identical": "Automatically bind external accounts newly logged in to local accounts when <code>%s</code> match",
+    "Treat email matching as identical_warn": "WARNING: Be aware of security because the system treats the same user as a match of <code>%s</code>.",
     "Use env var if empty": "Use env var <code>%s</code> if empty",
     "ldap": {
       "server_url_detail": "The LDAP URL of the directory service in the format <code>ldap://host:port/DN</code> or <code>ldaps://host:port/DN</code>.",

--- a/resource/locales/ja/translation.json
+++ b/resource/locales/ja/translation.json
@@ -368,6 +368,8 @@
     "optional": "オプション",
     "Treat username matching as identical": "新規ログイン時、<code>%s</code> が一致したローカルアカウントが存在した場合は自動的に紐付ける",
     "Treat username matching as identical_warn": "警告: <code>%s</code> の一致を以て同一ユーザーであるとみなすので、セキュリティに注意してください",
+    "Treat email matching as identical": "新規ログイン時、<code>%s</code> が一致したローカルアカウントが存在した場合は自動的に紐付ける",
+    "Treat email matching as identical_warn": "警告: <code>%s</code> の一致を以て同一ユーザーであるとみなすので、セキュリティに注意してください",
     "Use env var if empty": "空の場合、環境変数 <code>%s</code> を利用します",
     "ldap": {
       "server_url_detail": "LDAP URLを <code>ldap://host:port/DN</code> または <code>ldaps://host:port/DN</code> の形式で入力してください。",

--- a/src/server/form/admin/securityPassportSaml.js
+++ b/src/server/form/admin/securityPassportSaml.js
@@ -14,4 +14,5 @@ module.exports = form(
   field('settingForm[security:passport-saml:attrMapLastName]').trim(),
   field('settingForm[security:passport-saml:cert]').trim(),
   field('settingForm[security:passport-saml:isSameUsernameTreatedAsIdenticalUser]').trim().toBooleanStrict(),
+  field('settingForm[security:passport-saml:isSameEmailTreatedAsIdenticalUser]').trim().toBooleanStrict(),
 );

--- a/src/server/models/config.js
+++ b/src/server/models/config.js
@@ -75,6 +75,7 @@ module.exports = function(crowi) {
       'security:passport-ldap:groupDnProperty' : undefined,
       'security:passport-ldap:isSameUsernameTreatedAsIdenticalUser': false,
       'security:passport-saml:isEnabled' : false,
+      'security:passport-saml:isSameEmailTreatedAsIdenticalUser': false,
       'security:passport-google:isEnabled' : false,
       'security:passport-github:isEnabled' : false,
       'security:passport-twitter:isEnabled' : false,
@@ -326,6 +327,11 @@ module.exports = function(crowi) {
 
   configSchema.statics.isSameUsernameTreatedAsIdenticalUser = function(config, providerType) {
     const key = `security:passport-${providerType}:isSameUsernameTreatedAsIdenticalUser`;
+    return getValueForCrowiNS(config, key);
+  };
+
+  configSchema.statics.isSameEmailTreatedAsIdenticalUser = function(config, providerType) {
+    const key = `security:passport-${providerType}:isSameEmailTreatedAsIdenticalUser`;
     return getValueForCrowiNS(config, key);
   };
 

--- a/src/server/models/external-account.js
+++ b/src/server/models/external-account.js
@@ -84,15 +84,16 @@ class ExternalAccount {
 
         const User = ExternalAccount.crowi.model('User');
 
-        let promise = User.findUserByUsername(usernameToBeRegistered);
+        let promise = User.findOne({username: usernameToBeRegistered});
         if (isSameUsernameTreatedAsIdenticalUser && isSameEmailTreatedAsIdenticalUser) {
           promise = promise
             .then(user => {
-              if (user == null) { return User.findUserByEmail(mailToBeRegistered) }
+              if (user == null) { return User.findOne({email: mailToBeRegistered}) }
               return user;
             });
-        } else if (isSameEmailTreatedAsIdenticalUser) {
-          promise = User.findUserByEmail(mailToBeRegistered);
+        }
+        else if (isSameEmailTreatedAsIdenticalUser) {
+          promise = User.findOne({email: mailToBeRegistered});
         }
 
         return promise

--- a/src/server/models/user.js
+++ b/src/server/models/user.js
@@ -471,6 +471,13 @@ module.exports = function(crowi) {
     return this.findOne({username});
   };
 
+  userSchema.statics.findUserByEmail = function(email) {
+    if (email == null) {
+      return Promise.resolve(null);
+    }
+    return this.findOne({email});
+  };
+
   userSchema.statics.findUserByApiToken = function(apiToken) {
     if (apiToken == null) {
       return Promise.resolve(null);

--- a/src/server/models/user.js
+++ b/src/server/models/user.js
@@ -471,13 +471,6 @@ module.exports = function(crowi) {
     return this.findOne({username});
   };
 
-  userSchema.statics.findUserByEmail = function(email) {
-    if (email == null) {
-      return Promise.resolve(null);
-    }
-    return this.findOne({email});
-  };
-
   userSchema.statics.findUserByApiToken = function(apiToken) {
     if (apiToken == null) {
       return Promise.resolve(null);

--- a/src/server/routes/login-passport.js
+++ b/src/server/routes/login-passport.js
@@ -427,6 +427,9 @@ module.exports = function(crowi, app) {
   };
 
   const getOrCreateUser = async(req, res, userInfo, providerId) => {
+    // get option
+    const isSameUsernameTreatedAsIdenticalUser = Config.isSameUsernameTreatedAsIdenticalUser(config, providerId);
+    const isSameEmailTreatedAsIdenticalUser = Config.isSameEmailTreatedAsIdenticalUser(config, providerId);
     try {
       // find or register(create) user
       const externalAccount = await ExternalAccount.findOrRegister(
@@ -435,14 +438,14 @@ module.exports = function(crowi, app) {
         userInfo.username,
         userInfo.name,
         userInfo.email,
+        isSameUsernameTreatedAsIdenticalUser,
+        isSameEmailTreatedAsIdenticalUser,
       );
       return externalAccount;
     }
     catch (err) {
       if (err.name === 'DuplicatedUsernameException') {
-        // get option
-        const isSameUsernameTreatedAsIdenticalUser = Config.isSameUsernameTreatedAsIdenticalUser(config, providerId);
-        if (isSameUsernameTreatedAsIdenticalUser) {
+        if (isSameEmailTreatedAsIdenticalUser || isSameUsernameTreatedAsIdenticalUser) {
           // associate to existing user
           debug(`ExternalAccount '${userInfo.username}' will be created and bound to the exisiting User account`);
           return ExternalAccount.associate(providerId, userInfo.id, err.user);

--- a/src/server/views/admin/widget/passport/saml.html
+++ b/src/server/views/admin/widget/passport/saml.html
@@ -120,7 +120,7 @@
     <div class="form-group">
       <div class="col-xs-6 col-xs-offset-3">
         <div class="checkbox checkbox-info">
-          <input type="checkbox" id="bindByEmailName-SAML" name="settingForm[security:passport-saml:isSameEmailTreatedAsIdenticalUser]" value="1"
+          <input type="checkbox" id="bindByEmail-SAML" name="settingForm[security:passport-saml:isSameEmailTreatedAsIdenticalUser]" value="1"
               {% if settingForm['security:passport-saml:isSameEmailTreatedAsIdenticalUser'] %}checked{% endif %} />
           <label for="bindByEmail-SAML">
             {{ t("security_setting.Treat email matching as identical", "email") }}

--- a/src/server/views/admin/widget/passport/saml.html
+++ b/src/server/views/admin/widget/passport/saml.html
@@ -118,6 +118,23 @@
     </div>
 
     <div class="form-group">
+      <div class="col-xs-6 col-xs-offset-3">
+        <div class="checkbox checkbox-info">
+          <input type="checkbox" id="bindByEmailName-SAML" name="settingForm[security:passport-saml:isSameEmailTreatedAsIdenticalUser]" value="1"
+              {% if settingForm['security:passport-saml:isSameEmailTreatedAsIdenticalUser'] %}checked{% endif %} />
+          <label for="bindByEmail-SAML">
+            {{ t("security_setting.Treat email matching as identical", "email") }}
+          </label>
+          <p class="help-block">
+            <small>
+              {{ t("security_setting.Treat email matching as identical_warn", "email") }}
+            </small>
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <div class="form-group">
       <label for="settingForm[security:passport-saml:attrMapFirstName]" class="col-xs-3 control-label">{{ t("security_setting.SAML.First Name") }}</label>
       <div class="col-xs-6">
         <input class="form-control" type="text" placeholder="Default: firstName"


### PR DESCRIPTION
Currently, growi uses `username` for account linking when SAML federation.
This PR adds option to use `email` for the linking. Using `email` is better approach for security than using `username` to find existing user.

Note: To further improve security, we should perform re-authentication or mail authentication when account linking, but adding the `email` option is the first step for improvement.