### PR TITLE
feat: Show line numbers of highlight.js (#457)

### DIFF
--- a/resource/cdn-manifests.js
+++ b/resource/cdn-manifests.js
@@ -26,7 +26,8 @@ module.exports = {
 'gh/highlightjs/cdn-release@9.12.0/build/languages/less.min.js,' +
 'gh/highlightjs/cdn-release@9.12.0/build/languages/scss.min.js,' +
 'gh/highlightjs/cdn-release@9.12.0/build/languages/typescript.min.js,' +
-'gh/highlightjs/cdn-release@9.12.0/build/languages/yaml.min.js',
+'gh/highlightjs/cdn-release@9.12.0/build/languages/yaml.min.js,' +
+'npm/highlightjs-line-numbers.js@2.6.0/dist/highlightjs-line-numbers.min.js',
       args: {
         async: true,
         integrity: '',

--- a/src/client/js/util/GrowiRenderer.js
+++ b/src/client/js/util/GrowiRenderer.js
@@ -174,7 +174,7 @@ export default class GrowiRenderer {
       const citeTag = (langFn) ? `<cite>${langFn}</cite>` : '';
       if (hljs.getLanguage(lang)) {
         try {
-          return `<pre class="hljs ${noborder}">${citeTag}<code class="language-${lang}">${hljs.highlight(lang, code, true).value}</code></pre>`;
+          return `<pre class="hljs ${noborder}">${citeTag}<code class="language-${lang}">${hljs.lineNumbersValue(hljs.highlight(lang, code, true).value)}</code></pre>`;
         }
         catch (__) {
           return `<pre class="hljs ${noborder}">${citeTag}<code class="language-${lang}">${code}}</code></pre>`;

--- a/src/server/views/admin/customize.html
+++ b/src/server/views/admin/customize.html
@@ -592,6 +592,7 @@ window.addEventListener('load', (event) => {
      * highlight.js style switcher
      */
     hljs.initHighlightingOnLoad()
+    hljs.initLineNumbersOnLoad()
 
     function selectHighlightJsStyle(event) {
       var highlightJsCssDOM = $("#highlightJsCssContainer link")[0]


### PR DESCRIPTION
I pushed https://github.com/wcoder/highlightjs-line-numbers.js/pull/55 to `highlightjs-line-numbers.js` to have this module to process `innerHTML` instead of modifying DOM.

Now it's ready to integrate it here