### PR TITLE
bugfix: mongodb migration failed in heroku

### DIFF
--- a/config/migrate.js
+++ b/config/migrate.js
@@ -18,7 +18,7 @@ const match = mongoUri.match(/^(.+)\/([^/]+)$/);
 module.exports = {
   mongoUri,
   mongodb: {
-    url: match[1],
+    url: match[0],
     databaseName: match[2],
     options: {
       useNewUrlParser: true, // removes a deprecation warning when connecting


### PR DESCRIPTION
herokuでgrowiのバージョンを更新しようとすると、preserver:prodで実行されるmigrate upが`ERROR: Authentication failed.`になります
### 再現方法
前提: すでにherokuにmy-growiというapp名でdeployされている
```
heroku git:clone -a my-growi
cd my-growi
git remote add origin https://github.com/weseek/growi
// v3.3.3をリリース
git pull origin refs/tags/v3.3.3:master
git push heroku master
```

### 原因
`config/migrate.js`にて設定される`mongodb.url`はDB名を含まないconnection urlになっています
`migrate-mongo/lib/env/database.js`はこのDB名を含まないconnection urlを利用して`MongoClient.connect()`します
herokuで通常使われるmLabのmongodbは、DBごとに権限が付与されるのでDB名なしconnection urlだと`ERROR: Authentication failed.`になります

### 備考
heroku以外の環境は動作確認していません