### PR TITLE
fix #815: null check for 'user' when searching

### DIFF
--- a/src/server/util/search.js
+++ b/src/server/util/search.js
@@ -541,13 +541,19 @@ SearchClient.prototype.filterPagesByViewer = async function(query, user, userGro
 
   const grantConditions = [
     { term: { grant: GRANT_PUBLIC } },
-    { bool: {
-      must: [
-        { term: { grant: GRANT_RESTRICTED } },
-        { term: { granted_users: user._id.toString() } }
-      ]
-    } },
   ];
+
+  // ensure to hit to GRANT_RESTRICTED pages that the user specified at own
+  if (user != null) {
+    grantConditions.push(
+      { bool: {
+        must: [
+          { term: { grant: GRANT_RESTRICTED } },
+          { term: { granted_users: user._id.toString() } }
+        ]
+      } }
+    );
+  }
 
   if (showPagesRestrictedByOwner) {
     grantConditions.push(


### PR DESCRIPTION
fix #815 