### PR TITLE
Feat/thread comments frontend

### DIFF
--- a/src/client/js/app.js
+++ b/src/client/js/app.js
@@ -311,13 +311,11 @@ const componentMappings = {
 };
 // additional definitions if data exists
 if (pageId) {
-  const pagePostCompleteHandler = (comment) => {
-    if (componentMappings['page-comments-list'] != null) {
-      componentMappings['page-comments-list'].retrieveData();
-    }
+  const pagePostCompleteHandler = () => {
+    // TODO
   };
   const temp = (
-    <I18nextProvider i18n={i18n}><PageComments
+    <PageComments
       pageId={pageId}
       pagePath={pagePath}
       revisionId={pageRevisionId}
@@ -328,9 +326,9 @@ if (pageId) {
       editorOptions={pageEditorOptions}
       slackChannels={slackChannels}
     />
-    </I18nextProvider>
   );
-  componentMappings['page-comments-list'] = temp;
+  componentMappings['page-comments-form'] = temp;
+  componentMappings['page-comments-list'] = <I18nextProvider i18n={i18n}>{temp}</I18nextProvider>;
   componentMappings['page-attachment'] = <PageAttachment pageId={pageId} markdown={markdown} crowi={crowi} />;
 }
 if (pagePath) {
@@ -505,10 +503,10 @@ if (pageEditorElem) {
 // render comment form
 const writeCommentElem = document.getElementById('page-comment-write');
 if (writeCommentElem) {
-  const pageCommentsElem = componentInstances['page-comments-list'];
+  const pageCommentsElem = componentInstances['page-comments-form'];
   const postCompleteHandler = (comment) => {
     if (pageCommentsElem != null) {
-      pageCommentsElem.retrieveData();
+      pageCommentsElem.retrieveData(); // this needs to be configured
     }
   };
   ReactDOM.render(

--- a/src/client/js/app.js
+++ b/src/client/js/app.js
@@ -286,6 +286,8 @@ if (!pageRevisionId && draft != null) {
   markdown = draft;
 }
 
+const pageEditorOptions = new EditorOptions(crowi.editorOptions);
+
 /**
  * define components
  *  key: id of element
@@ -309,7 +311,26 @@ const componentMappings = {
 };
 // additional definitions if data exists
 if (pageId) {
-  componentMappings['page-comments-list'] = <PageComments pageId={pageId} revisionId={pageRevisionId} revisionCreatedAt={pageRevisionCreatedAt} crowi={crowi} crowiOriginRenderer={crowiRenderer} />;
+  const pagePostCompleteHandler = (comment) => {
+    if (componentMappings['page-comments-list'] != null) {
+      componentMappings['page-comments-list'].retrieveData();
+    }
+  };
+  const temp = (
+    <I18nextProvider i18n={i18n}><PageComments
+      pageId={pageId}
+      pagePath={pagePath}
+      revisionId={pageRevisionId}
+      revisionCreatedAt={pageRevisionCreatedAt}
+      onPostComplete={pagePostCompleteHandler}
+      crowi={crowi}
+      crowiOriginRenderer={crowiRenderer}
+      editorOptions={pageEditorOptions}
+      slackChannels={slackChannels}
+    />
+    </I18nextProvider>
+  );
+  componentMappings['page-comments-list'] = temp;
   componentMappings['page-attachment'] = <PageAttachment pageId={pageId} markdown={markdown} crowi={crowi} />;
 }
 if (pagePath) {

--- a/src/client/js/components/PageComment/Comment.jsx
+++ b/src/client/js/components/PageComment/Comment.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import Button from 'react-bootstrap/es/Button';
 import dateFnsFormat from 'date-fns/format';
-// import CommentForm from './CommentForm';
+import CommentForm from './CommentForm';
 
 import RevisionBody from '../Page/RevisionBody';
 
@@ -35,6 +35,13 @@ export default class Comment extends React.Component {
     this.getRevisionLabelClassName = this.getRevisionLabelClassName.bind(this);
     this.deleteBtnClickedHandler = this.deleteBtnClickedHandler.bind(this);
     this.renderHtml = this.renderHtml.bind(this);
+    this.showForm = this.showForm.bind(this);
+  }
+
+  showForm() {
+    this.setState({
+      showCommentForm: true,
+    });
   }
 
   componentWillMount() {
@@ -128,40 +135,56 @@ export default class Comment extends React.Component {
     const revHref = `?revision=${comment.revision}`;
     const revFirst8Letters = comment.revision.substr(-8);
     const revisionLavelClassName = this.getRevisionLabelClassName();
-    const commentId = comment._id;
     const replyButton = (
       <Button
         type="button"
-        name="replyTo"
-        value={commentId}
         className="fcbtn btn btn-primary btn-sm btn-success btn-rounded btn-1b"
-        onClick={this.state.showCommentForm = true}
+        onClick={this.showForm}
       >
               Reply
       </Button>
     );
 
     return (
-      <div className={rootClassName}>
-        <UserPicture user={creator} />
-        <div className="page-comment-main">
-          <div className="page-comment-creator">
-            <Username user={creator} />
-          </div>
-          <div className="page-comment-body">{commentBody}</div>
-          <div className="page-comment-reply">
-            {replyButton}
-          </div>
-          <div className="page-comment-meta">
-            {commentDate}&nbsp;
-            <a className={revisionLavelClassName} href={revHref}>{revFirst8Letters}</a>
-          </div>
-          <div className="page-comment-control">
-            <button type="button" className="btn btn-link" onClick={this.deleteBtnClickedHandler}>
-              <i className="ti-close"></i>
-            </button>
+      <div>
+        <div className={rootClassName}>
+          <UserPicture user={creator} />
+          <div className="page-comment-main">
+            <div className="page-comment-creator">
+              <Username user={creator} />
+            </div>
+            <div className="page-comment-body">{commentBody}</div>
+            {comment._id} {this.props.replyTo}
+            <div className="page-comment-reply">
+              {replyButton}
+            </div>
+            <div className="page-comment-meta">
+              {commentDate}&nbsp;
+              <a className={revisionLavelClassName} href={revHref}>{revFirst8Letters}</a>
+            </div>
+            <div className="page-comment-control">
+              <button type="button" className="btn btn-link" onClick={this.deleteBtnClickedHandler}>
+                <i className="ti-close"></i>
+              </button>
+            </div>
           </div>
         </div>
+        {
+          this.state.showCommentForm
+          && (
+          <CommentForm
+            crowi={this.props.crowi}
+            crowiOriginRenderer={this.props.crowiRenderer}
+            pageId={this.props.pageId}
+            pagePath={this.props.pagePath}
+            revisionId={this.props.revisionId}
+            onPostComplete={this.props.onPostComplete}
+            editorOptions={this.props.editorOptions}
+            slackChannels={this.props.slackChannels}
+            replyTo={comment._id.toString()}
+          />
+        )
+        }
       </div>
     );
   }
@@ -170,10 +193,17 @@ export default class Comment extends React.Component {
 
 Comment.propTypes = {
   comment: PropTypes.object.isRequired,
+  crowi: PropTypes.object.isRequired,
+  crowiOriginRenderer: PropTypes.object.isRequired,
+  crowiRenderer: PropTypes.object.isRequired,
+  pageId: PropTypes.string,
+  pagePath: PropTypes.string,
+  revisionId: PropTypes.string,
+  onPostComplete: PropTypes.func,
+  editorOptions: PropTypes.object,
+  slackChannels: PropTypes.string,
   currentRevisionId: PropTypes.string.isRequired,
   currentUserId: PropTypes.string.isRequired,
   deleteBtnClicked: PropTypes.func.isRequired,
-  crowi: PropTypes.object.isRequired,
-  crowiRenderer: PropTypes.object.isRequired,
   replyTo: PropTypes.string,
 };

--- a/src/client/js/components/PageComment/Comment.jsx
+++ b/src/client/js/components/PageComment/Comment.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import Button from 'react-bootstrap/es/Button';
 import dateFnsFormat from 'date-fns/format';
+// import CommentForm from './CommentForm';
 
 import RevisionBody from '../Page/RevisionBody';
 
@@ -24,6 +26,7 @@ export default class Comment extends React.Component {
 
     this.state = {
       html: '',
+      showCommentForm: false,
     };
 
     this.isCurrentUserIsAuthor = this.isCurrentUserEqualsToAuthor.bind(this);
@@ -117,6 +120,7 @@ export default class Comment extends React.Component {
     const comment = this.props.comment;
     const creator = comment.creator;
     const isMarkdown = comment.isMarkdown;
+    // const indentPixels = typeof (this.props.replyTo) !== 'undefined' ? '50px' : '0px';
 
     const rootClassName = this.getRootClassName();
     const commentDate = dateFnsFormat(comment.createdAt, 'YYYY/MM/DD HH:mm');
@@ -124,6 +128,18 @@ export default class Comment extends React.Component {
     const revHref = `?revision=${comment.revision}`;
     const revFirst8Letters = comment.revision.substr(-8);
     const revisionLavelClassName = this.getRevisionLabelClassName();
+    const commentId = comment._id;
+    const replyButton = (
+      <Button
+        type="button"
+        name="replyTo"
+        value={commentId}
+        className="fcbtn btn btn-primary btn-sm btn-success btn-rounded btn-1b"
+        onClick={this.state.showCommentForm = true}
+      >
+              Reply
+      </Button>
+    );
 
     return (
       <div className={rootClassName}>
@@ -133,6 +149,9 @@ export default class Comment extends React.Component {
             <Username user={creator} />
           </div>
           <div className="page-comment-body">{commentBody}</div>
+          <div className="page-comment-reply">
+            {replyButton}
+          </div>
           <div className="page-comment-meta">
             {commentDate}&nbsp;
             <a className={revisionLavelClassName} href={revHref}>{revFirst8Letters}</a>
@@ -156,4 +175,5 @@ Comment.propTypes = {
   deleteBtnClicked: PropTypes.func.isRequired,
   crowi: PropTypes.object.isRequired,
   crowiRenderer: PropTypes.object.isRequired,
+  replyTo: PropTypes.string,
 };

--- a/src/client/js/components/PageComment/Comment.jsx
+++ b/src/client/js/components/PageComment/Comment.jsx
@@ -154,7 +154,6 @@ export default class Comment extends React.Component {
               <Username user={creator} />
             </div>
             <div className="page-comment-body">{commentBody}</div>
-            {comment._id} {this.props.replyTo}
             <div className="page-comment-reply">
               {replyButton}
             </div>

--- a/src/client/js/components/PageComments.js
+++ b/src/client/js/components/PageComments.js
@@ -128,10 +128,17 @@ export default class PageComments extends React.Component {
         <Comment
           key={comment._id}
           comment={comment}
+          crowi={this.props.crowi}
+          crowiOriginRenderer={this.props.crowiOriginRenderer}
+          pageId={this.props.pageId}
+          pagePath={this.props.pagePath}
+          revisionId={this.props.revisionId}
+          onPostComplete={this.props.onPostComplete}
+          editorOptions={this.props.editorOptions}
+          slackChannels={this.props.slackChannels}
           currentUserId={this.props.crowi.me}
           currentRevisionId={this.props.revisionId}
           deleteBtnClicked={this.confirmToDeleteComment}
-          crowi={this.props.crowi}
           crowiRenderer={this.growiRenderer}
           replyTo={comment.replyTo}
         />
@@ -250,6 +257,10 @@ export default class PageComments extends React.Component {
 
 PageComments.propTypes = {
   pageId: PropTypes.string,
+  pagePath: PropTypes.string,
+  onPostComplete: PropTypes.func,
+  editorOptions: PropTypes.object,
+  slackChannels: PropTypes.string,
   revisionId: PropTypes.string,
   revisionCreatedAt: PropTypes.number,
   crowi: PropTypes.object.isRequired,

--- a/src/client/js/components/PageComments.js
+++ b/src/client/js/components/PageComments.js
@@ -133,6 +133,7 @@ export default class PageComments extends React.Component {
           deleteBtnClicked={this.confirmToDeleteComment}
           crowi={this.props.crowi}
           crowiRenderer={this.growiRenderer}
+          replyTo={comment.replyTo}
         />
       );
     });

--- a/src/client/styles/scss/_comment_growi.scss
+++ b/src/client/styles/scss/_comment_growi.scss
@@ -85,6 +85,10 @@
         vertical-align: 25%;
       }
     }
+
+    .page-comment-reply {
+      text-align: right;
+    }
   }
 
   // show when hover

--- a/src/server/models/comment.js
+++ b/src/server/models/comment.js
@@ -29,7 +29,6 @@ module.exports = function(crowi) {
       newComment.comment = comment;
       newComment.commentPosition = position;
       newComment.isMarkdown = isMarkdown || false;
-      newComment.replyTo = ObjectId(replyTo);
 
       newComment.save((err, data) => {
         if (err) {

--- a/src/server/models/comment.js
+++ b/src/server/models/comment.js
@@ -29,6 +29,7 @@ module.exports = function(crowi) {
       newComment.comment = comment;
       newComment.commentPosition = position;
       newComment.isMarkdown = isMarkdown || false;
+      newComment.replyTo = replyTo;
 
       newComment.save((err, data) => {
         if (err) {

--- a/src/server/routes/comment.js
+++ b/src/server/routes/comment.js
@@ -74,7 +74,7 @@ module.exports = function(crowi, app) {
     const comment = commentForm.comment;
     const position = commentForm.comment_position || -1;
     const isMarkdown = commentForm.is_markdown;
-    const replyTo = commentForm.replyTo;
+    const replyTo = commentForm.replyTo === '' ? undefined : commentForm.replyTo;
 
     // check whether accessible
     const isAccessible = await Page.isAccessiblePageByViewer(pageId, req.user);


### PR DESCRIPTION
フロントサイドとバックサイドをつなげて、対象のコメントから'Reply'ボタンを押すとそのコメントに対してのリプライ形式のコメントができる。
コメントをデータベースからリストとして並べるときにそのコメントがリプライなのかどうか把握できる。