### PR TITLE
filter out svg

### DIFF
--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -5,7 +5,16 @@ autoReap.options.reapOnError = true; // continue reaping the file even if an err
 
 module.exports = function(crowi, app) {
   const middleware = require('../util/middlewares');
-  const uploads = multer({ dest: `${crowi.tmpDir}uploads` });
+  const uploads = multer({
+    dest: `${crowi.tmpDir}uploads`,
+    fileFilter: (req, file, cb) => {
+      if (file.mimetype === 'image/svg+xml') {
+        return cb(new Error('svg files are not allowed'));
+      }
+
+      return cb(null, true);
+    },
+  });
   const form = require('../form');
   const page = require('./page')(crowi, app);
   const login = require('./login')(crowi, app);


### PR DESCRIPTION
JVNより
> 厳密なContent-Typeの検証が必要です。

とのことだったので、とりあえず楽な方法で、svg はアップロードできない仕様に変更しました。

もしsvgも使いたいとなったら...
とりあえず、multerでsvgの中身にはアクセス出来なそうなので...
ブラウザでD&D時にAPIでアップロードする前に、ブラウザに保持してもらって、blobだかバイナリをxml型に戻して、XSSとか出来るのか!?