### PR TITLE
Add more HTML tags to whiltelist

### DIFF
--- a/src/lib/service/xss/recommended-whitelist.js
+++ b/src/lib/service/xss/recommended-whitelist.js
@@ -1,14 +1,16 @@
 /**
- * reference: https://meta.stackexchange.com/questions/1777/what-html-tags-are-allowed-on-stack-exchange-sites
- * added tags: h4, h5, h6, span, div, iframe, table, thead, tbody, tfoot, th, td, tr, colgroup, col
- * added attributes: class, style
+ * reference: https://meta.stackexchange.com/questions/1777/what-html-tags-are-allowed-on-stack-exchange-sites,
+ *            https://github.com/jch/html-pipeline/blob/70b6903b025c668ff3c02a6fa382031661182147/lib/html/pipeline/sanitization_filter.rb#L41
  */
 
 const tags = [
-  '-', 'a', 'b', 'blockquote', 'blockquote', 'code', 'del', 'dd', 'dl', 'dt', 'em',
-  'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'i', 'img', 'kbd', 'li', 'ol', 'p', 'pre',
-  's', 'sup', 'sub', 'strong', 'strike', 'ul', 'br', 'hr', 'span', 'div', 'iframe',
-  'table', 'thead', 'tbody', 'tfoot', 'th', 'td', 'tr', 'colgroup', 'col',
+  '-', 'a', 'abbr', 'b', 'bdi', 'bdo', 'blockquote', 'br', 'caption', 'cite',
+  'code', 'col', 'colgroup', 'data', 'dd', 'del', 'details', 'dfn', 'div', 'dl',
+  'dt', 'em', 'figcaption', 'figure', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'h7',
+  'h8', 'hr', 'i', 'iframe', 'img', 'ins', 'kbd', 'li', 'mark', 'ol', 'p',
+  'pre', 'q', 'rb', 'rp', 'rt', 'ruby', 's', 'samp', 'small', 'span', 'strike',
+  'strong', 'sub', 'summary', 'sup', 'table', 'tbody', 'td', 'tfoot', 'th',
+  'thead', 'time', 'tr', 'tt', 'u', 'ul', 'var', 'wbr',
 ];
 
 const attrs = ['src', 'href', 'class', 'id', 'width', 'height', 'alt', 'title', 'style'];


### PR DESCRIPTION
Fix #1010 

----
FYI: 
```
diff --git a/a b/b
index f3b0f2c..1728520 100644
--- a/a
+++ b/b
@@ -1,37 +1,59 @@
 -
 a
+abbr
 b
+bdi
+bdo
 blockquote
 br
+caption
+cite
 code
 col
 colgroup
+data
 dd
 del
+details
+dfn
 div
 dl
 dt
 em
+figcaption
+figure
 h1
 h2
 h3
 h4
 h5
 h6
+h7
+h8
 hr
 i
 iframe
 img
+ins
 kbd
 li
+mark
 ol
 p
 pre
+q
+rb
+rp
+rt
+ruby
 s
+samp
+small
 span
 strike
 strong
 sub
+summary
 sup
 table
 tbody
@@ -39,5 +61,11 @@ td
 tfoot
 th
 thead
+time
 tr
+tt
+u
 ul
+var
+wbr
```