### PR TITLE
Missing initialization for OIDC Strategy

### DIFF
--- a/src/server/crowi/index.js
+++ b/src/server/crowi/index.js
@@ -275,6 +275,7 @@ Crowi.prototype.setupPassport = function() {
     this.passportService.setupGoogleStrategy();
     this.passportService.setupGitHubStrategy();
     this.passportService.setupTwitterStrategy();
+    this.passportService.setupOidcStrategy();
     this.passportService.setupSamlStrategy();
   }
   catch (err) {


### PR DESCRIPTION
Without this changes, we need to save OIDC settings manually to setup strategy.