### PR TITLE
Add syntax highlighting for Kotlin and Swift

### DIFF
--- a/resource/cdn-manifests.js
+++ b/resource/cdn-manifests.js
@@ -28,6 +28,8 @@ module.exports = {
         + 'gh/highlightjs/cdn-release@9.13.0/build/languages/scss.min.js,'
         + 'gh/highlightjs/cdn-release@9.13.0/build/languages/typescript.min.js,'
         + 'gh/highlightjs/cdn-release@9.13.0/build/languages/yaml.min.js,'
+        + 'gh/highlightjs/cdn-release@9.13.0/build/languages/swift.min.js,'
+        + 'gh/highlightjs/cdn-release@9.13.0/build/languages/kotlin.min.js,'
         + 'npm/highlightjs-line-numbers.js@2.6.0/dist/highlightjs-line-numbers.min.js',
       args: {
         async: true,


### PR DESCRIPTION
It seems the number of mobile app projects which is using Kotlin and/or Swift is increasing. So I think it is better to add these languages to syntax highlighting.
