### PR TITLE
Support S3-compatible object storage services like MinIO

### DIFF
--- a/resource/locales/en-US/translation.json
+++ b/resource/locales/en-US/translation.json
@@ -427,6 +427,8 @@
     "change_setting": "Caution:if you change this setting not completed, you will not be able to access files you have uploaded so far.",
     "region": "Region",
     "bucket name": "Bucket name",
+    "custom endpoint": "Custom endpoint",
+    "custom_endpoint_change": "Input the URL of the endpoint of an object storage service like MinIO that has a S3-compatible API.  Amazon S3 is used if empty.",
     "Plugin settings": "Plugin settings",
     "Enable plugin loading": "Enable plugin loading",
     "Load plugins": "Load plugins",

--- a/resource/locales/ja/translation.json
+++ b/resource/locales/ja/translation.json
@@ -425,6 +425,8 @@
     "change_setting": "この設定を途中で変更すると、これまでにアップロードしたファイル等へのアクセスができなくなりますのでご注意下さい。",
     "region": "リージョン",
     "bucket name": "バケット名",
+    "custom endpoint": "カスタムエンドポイント",
+    "custom_endpoint_change": "MinIOなど、S3互換APIを持つ他のオブジェクトストレージサービスを使用する場合のみ、そのエンドポイントのURLを入力してください。空欄の場合は、Amazon S3を使用します。",
     "Plugin settings": "プラグイン設定",
     "Enable plugin loading": "プラグインの読み込みを有効にします。",
     "Load plugins": "プラグインを読み込む",

--- a/src/server/form/admin/aws.js
+++ b/src/server/form/admin/aws.js
@@ -4,6 +4,7 @@ const field = form.field;
 
 module.exports = form(
   field('settingForm[aws:region]', 'リージョン').trim().is(/^[a-z]+-[a-z]+-\d+$/, 'リージョンには、AWSリージョン名を入力してください。 例: ap-northeast-1'),
+  field('settingForm[aws:customEndpoint]', 'カスタムエンドポイント').trim().is(/^(https?:\/\/[^\/]+|)$/, 'カスタムエンドポイントは、http(s)://で始まるURLを指定してください。また、末尾の/は不要です。'),
   field('settingForm[aws:bucket]', 'バケット名').trim(),
   field('settingForm[aws:accessKeyId]', 'Access Key Id').trim().is(/^[\da-zA-Z]+$/),
   field('settingForm[aws:secretAccessKey]', 'Secret Access Key').trim(),

--- a/src/server/form/admin/aws.js
+++ b/src/server/form/admin/aws.js
@@ -4,7 +4,7 @@ const field = form.field;
 
 module.exports = form(
   field('settingForm[aws:region]', 'リージョン').trim().is(/^[a-z]+-[a-z]+-\d+$/, 'リージョンには、AWSリージョン名を入力してください。 例: ap-northeast-1'),
-  field('settingForm[aws:customEndpoint]', 'カスタムエンドポイント').trim().is(/^(https?:\/\/[^\/]+|)$/, 'カスタムエンドポイントは、http(s)://で始まるURLを指定してください。また、末尾の/は不要です。'),
+  field('settingForm[aws:customEndpoint]', 'カスタムエンドポイント').trim().is(/^(https?:\/\/[^/]+|)$/, 'カスタムエンドポイントは、http(s)://で始まるURLを指定してください。また、末尾の/は不要です。'),
   field('settingForm[aws:bucket]', 'バケット名').trim(),
   field('settingForm[aws:accessKeyId]', 'Access Key Id').trim().is(/^[\da-zA-Z]+$/),
   field('settingForm[aws:secretAccessKey]', 'Secret Access Key').trim(),

--- a/src/server/models/config.js
+++ b/src/server/models/config.js
@@ -74,6 +74,7 @@ module.exports = function(crowi) {
       'aws:region'          : 'ap-northeast-1',
       'aws:accessKeyId'     : undefined,
       'aws:secretAccessKey' : undefined,
+      'aws:customEndpoint'  : undefined,
 
       'mail:from'         : undefined,
       'mail:smtpHost'     : undefined,

--- a/src/server/service/file-uploader/aws.js
+++ b/src/server/service/file-uploader/aws.js
@@ -92,14 +92,17 @@ module.exports = function(crowi) {
    * @return {stream.Readable} readable stream
    */
   lib.findDeliveryFile = async function(attachment) {
-    // construct url
+    const s3 = S3Factory(this.getIsUploadable());
     const awsConfig = getAwsConfig();
-    const baseUrl = awsConfig.customEndpoint || `https://${awsConfig.bucket}.s3.amazonaws.com`;
-    const url = urljoin(baseUrl, getFilePathOnStorage(attachment));
+    const filePath = getFilePathOnStorage(attachment);
 
-    let response;
+    let stream;
     try {
-      response = await axios.get(url, { responseType: 'stream' });
+      const params = {
+        Bucket: awsConfig.bucket,
+        Key: filePath,
+      };
+      stream = s3.getObject(params).createReadStream();
     }
     catch (err) {
       logger.error(err);
@@ -107,7 +110,7 @@ module.exports = function(crowi) {
     }
 
     // return stream.Readable
-    return response.data;
+    return stream;
   };
 
   /**

--- a/src/server/service/file-uploader/aws.js
+++ b/src/server/service/file-uploader/aws.js
@@ -1,6 +1,5 @@
 const logger = require('@alias/logger')('growi:service:fileUploaderAws');
 
-const axios = require('axios');
 const urljoin = require('url-join');
 const aws = require('aws-sdk');
 

--- a/src/server/service/file-uploader/aws.js
+++ b/src/server/service/file-uploader/aws.js
@@ -15,6 +15,7 @@ module.exports = function(crowi) {
       secretAccessKey: configManager.getConfig('crowi', 'aws:secretAccessKey'),
       region: configManager.getConfig('crowi', 'aws:region'),
       bucket: configManager.getConfig('crowi', 'aws:bucket'),
+      customEndpoint: configManager.getConfig('crowi', 'aws:customEndpoint'),
     };
   }
 
@@ -29,9 +30,11 @@ module.exports = function(crowi) {
       accessKeyId: awsConfig.accessKeyId,
       secretAccessKey: awsConfig.secretAccessKey,
       region: awsConfig.region,
+      s3ForcePathStyle: awsConfig.customEndpoint ? true : undefined,
     });
 
-    return new aws.S3();
+    // undefined & null & '' => default endpoint (genuine S3)
+    return new aws.S3({ endpoint: awsConfig.customEndpoint || undefined });
   }
 
   function getFilePathOnStorage(attachment) {
@@ -91,7 +94,7 @@ module.exports = function(crowi) {
   lib.findDeliveryFile = async function(attachment) {
     // construct url
     const awsConfig = getAwsConfig();
-    const baseUrl = `https://${awsConfig.bucket}.s3.amazonaws.com`;
+    const baseUrl = awsConfig.customEndpoint || `https://${awsConfig.bucket}.s3.amazonaws.com`;
     const url = urljoin(baseUrl, getFilePathOnStorage(attachment));
 
     let response;

--- a/src/server/service/file-uploader/uploader.js
+++ b/src/server/service/file-uploader/uploader.js
@@ -13,7 +13,9 @@ class Uploader {
     if (method === 'aws' && (
       !this.configManager.getConfig('crowi', 'aws:accessKeyId')
         || !this.configManager.getConfig('crowi', 'aws:secretAccessKey')
-        || !this.configManager.getConfig('crowi', 'aws:region')
+        || (
+          !this.configManager.getConfig('crowi', 'aws:region')
+            && !this.configManager.getConfig('crowi', 'aws:customEndpoint'))
         || !this.configManager.getConfig('crowi', 'aws:bucket'))) {
       return false;
     }

--- a/src/server/util/middlewares.js
+++ b/src/server/util/middlewares.js
@@ -277,7 +277,7 @@ module.exports = (crowi, app) => {
 
   middlewares.awsEnabled = function() {
     return function(req, res, next) {
-      if (configManager.getConfig('crowi', 'aws:region') !== ''
+      if ((configManager.getConfig('crowi', 'aws:region') !== '' || this.configManager.getConfig('crowi', 'aws:customEndpoint') !== '')
           && configManager.getConfig('crowi', 'aws:bucket') !== ''
           && configManager.getConfig('crowi', 'aws:accessKeyId') !== ''
           && configManager.getConfig('crowi', 'aws:secretAccessKey') !== '') {

--- a/src/server/views/admin/app.html
+++ b/src/server/views/admin/app.html
@@ -253,6 +253,19 @@
         </div>
 
         <div class="form-group">
+          <label for="settingForm[aws:customEndpoint]" class="col-xs-3 control-label">{{ t('app_setting.custom endpoint') }}</label>
+          <div class="col-xs-6">
+            <input class="form-control"
+                   id="settingForm[aws:customEndpoint]"
+                   type="text"
+                   name="settingForm[aws:customEndpoint]"
+                   placeholder="例: http://localhost:9000"
+                   value="{{ getConfig('crowi', 'aws:customEndpoint') | default('') }}">
+                   <p class="help-block">{{ t("app_setting.custom_endpoint_change") }}</p>
+          </div>
+        </div>
+
+        <div class="form-group">
           <label for="settingForm[aws:bucket]" class="col-xs-3 control-label">{{ t('app_setting.bucket name') }}</label>
           <div class="col-xs-6">
             <input class="form-control"


### PR DESCRIPTION
Related: #770 

- Append an new setting, custom endpoint
- Replace the direct access to files in S3 via URL, which depends on the static website hosting feature (MinIO won't have), with `s3.getObject()`.

I made it sure that images were successfully uploaded by drag-and-dropped to MinIO and they appeared properly after uploaded.

I don't know if we may use `s3.getObject()` instead of `axios.get([object URL])` in terms of, e.g., cost.

- 新しい設定項目「カスタムエンドポイント」を追加
- S3中のファイルのURLに直接アクセス(MinIOがサポートしないウェブサイトの静的ホスティング機能に依存)→`s3.getObject()` に置き換え

ドラッグ&ドロップでアップロードした画像がMinIOに正常にアップロードされ、その後正常に表示されることは確認できました。

ただし、料金等の面から、`axios.get([オブジェクトのURL])`の代わりに`s3.getObject()`を使ってよいのかはわかりません。