### PR TITLE
Add `@media print`

### DIFF
--- a/src/client/styles/scss/_hljs.scss
+++ b/src/client/styles/scss/_hljs.scss
@@ -18,6 +18,10 @@ pre.hljs {
     background: #ccc;
     opacity: 0.6;
   }
+
+  @media print {
+    font-family: none;
+  }
 }
 
 // styles for highlightjs-line-numbers


### PR DESCRIPTION
Browser is Chrome.
"```" part was garbled during printing.
The setting of font seemed to be the cause.
Therefore, set the setting to 'none' when printing.

# Markdown

\`\`\`json
{
    "hoge": 1,
    "fuga": "FUGA",
    "piyo": 3.333
}
\`\`\`


\`\`\`js
console.log('hoge')
\`\`\`

# Display

## Browser
<img width="542" alt="スクリーンショット 2019-10-25 12 32 10" src="https://user-images.githubusercontent.com/846454/67542002-f4894c00-f725-11e9-9d2e-dc5ca5e38b3c.png">

## Printing
<img width="303" alt="スクリーンショット 2019-10-25 12 32 47" src="https://user-images.githubusercontent.com/846454/67542009-fa7f2d00-f725-11e9-84e0-d019a459862b.png">