### PR TITLE
fix/初回起動時に発生する差異の解消

### DIFF
--- a/src/server/service/global-notification/global-notification-mail.js
+++ b/src/server/service/global-notification/global-notification-mail.js
@@ -47,12 +47,13 @@ class GlobalNotificationMailService {
    * @return  {{ subject: string, template: string, vars: object }}
    */
   generateOption(event, path, triggeredBy, { comment, oldPath }) {
+    const defaultLang = this.crowi.configManager.getConfig('crowi', 'app:globalLang');
     // validate for all events
     if (event == null || path == null || triggeredBy == null) {
       throw new Error(`invalid vars supplied to GlobalNotificationMailService.generateOption for event ${event}`);
     }
 
-    const template = nodePath.join(this.crowi.localeDir, `${this.defaultLang}/notifications/${event}.txt`);
+    const template = nodePath.join(this.crowi.localeDir, `${defaultLang}/notifications/${event}.txt`);
     let subject;
     let vars = {
       appTitle: this.crowi.appService.getAppTitle(),


### PR DESCRIPTION
## 懸念サマリ
GlobalNotificationMailService のコンストラクタで `this.defaultLang = crowi.configManager.getConfig('crowi', 'app:globalLang');` をやっているため、初回起動時は想定される動作をしないのではないか

## フロー憶測
1. 初回起動
    - 未インストールのまま `GlobalNotificationMailService` インスタンスが生成される
    - そのため、`app:globalLang` が取れないか、もしくは `configModel.getDefaultCrowiConfigsObject()` によりデフォルト値の `en-US` が `defaultLang` にセットされる
2. インストール時に日本語を選択することで、DB の `app:globalLang` と `GlobalNotificationMailService .defaultLang` との間で齟齬が発生
3. メール送信時に期待する動作にならない
4. サーバーを再起動すると、DB の内容を読んで再度 `GlobalNotificationMailService` インスタンスが生成されるため期待する動作をしそう