### PR TITLE
Elasticsearch Clientに渡すhttpAuthの作成方法を修正

### DIFF
--- a/src/server/service/search-delegator/elasticsearch.js
+++ b/src/server/service/search-delegator/elasticsearch.js
@@ -91,8 +91,8 @@ class ElasticsearchDelegator {
       host = `${url.protocol}//${url.host}`;
       indexName = url.pathname.substring(1); // omit heading slash
 
-      if (url.auth != null) {
-        httpAuth = url.auth;
+      if (url.username != null && url.password != null) {
+        httpAuth = `${url.username}:${url.password}`;
       }
     }
 


### PR DESCRIPTION
WHATWG URL APIの方だとauthプロパティは使えないのでusernameとpasswordを使うように変更.