### PR TITLE
gw-698-714-change-readme-gif

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://growi.org">
-    <img src="https://user-images.githubusercontent.com/1638767/38254268-d4476bbe-3793-11e8-964c-8865d690baff.png" width="240px">
+    <img src="https://user-images.githubusercontent.com/42988650/70407506-f154e000-1a87-11ea-8fd1-f137ceee29cf.gif" width="240px">
   </a>
 </p>
 <p align="center">


### PR DESCRIPTION
# Gif 差し替え
https://github.com/weseek/growi/issues/323
にコメント追加し、Gif 配置場所としました。

以下の Gif に差し替えようとする PR です。

![growi_wiki_gif](https://user-images.githubusercontent.com/42988650/70407841-3a596400-1a89-11ea-890b-5e5b2e4efff4.gif)
