### PR TITLE
gw698-714-change-readme-gif-file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://growi.org">
-    <img src="https://user-images.githubusercontent.com/1638767/38254268-d4476bbe-3793-11e8-964c-8865d690baff.png" width="240px">
+    <img src="https://user-images.githubusercontent.com/42988650/70407506-f154e000-1a87-11ea-8fd1-f137ceee29cf.gif" width="240px">
   </a>
 </p>
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://growi.org">
-    <img src="https://user-images.githubusercontent.com/42988650/70407506-f154e000-1a87-11ea-8fd1-f137ceee29cf.gif" width="240px">
+    <img src="https://user-images.githubusercontent.com/42988650/70596967-7c6ddb80-1c2a-11ea-8009-c0ef016b5ae0.gif" width="240px">
   </a>
 </p>
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://growi.org">
-    <img src="https://user-images.githubusercontent.com/42988650/70596967-7c6ddb80-1c2a-11ea-8009-c0ef016b5ae0.gif" width="240px">
+    <img src="https://user-images.githubusercontent.com/42988650/70600974-6b29cc80-1c34-11ea-94ef-33c39c6a00dc.gif" width="240px">
   </a>
 </p>
 <p align="center">


### PR DESCRIPTION
# Gif の差し替え
https://github.com/weseek/growi/issues/323

こちらの ISSUE にコメントを追加し、ファイル参照元を追加しました。
以下の Gif アニメに差し替える PR です。

指摘後、英語に変更しました。
GROWI の設定も 英語の状態で Gif 再作成しています。

![en_growi_gif](https://user-images.githubusercontent.com/42988650/70597224-25b4d180-1c2b-11ea-9f02-8613b156e591.gif)
