### PR TITLE
modify openapii format in app-settings.js

### DIFF
--- a/src/server/routes/apiv3/app-settings.js
+++ b/src/server/routes/apiv3/app-settings.js
@@ -37,7 +37,7 @@ const ErrorV3 = require('../../models/vo/error-apiv3');
  *          fileUpload:
  *            type: boolean
  *            description: enable upload file except image file
- *     SiteUrlSettingParams:
+ *      SiteUrlSettingParams:
  *        type: object
  *        properties:
  *          siteUrl:
@@ -46,7 +46,7 @@ const ErrorV3 = require('../../models/vo/error-apiv3');
  *          envSiteUrl:
  *            type: String
  *            description: environment variable 'APP_SITE_URL'
- *     MailSettingParams:
+ *      MailSettingParams:
  *        type: object
  *        properties:
  *          fromAddress:
@@ -66,6 +66,7 @@ const ErrorV3 = require('../../models/vo/error-apiv3');
  *            description: password of client's smtp server
  *      AwsSettingParams:
  *        type: object
+ *        properties:
  *          region:
  *            type: String
  *            description: region of AWS S3
@@ -83,6 +84,7 @@ const ErrorV3 = require('../../models/vo/error-apiv3');
  *            description: secret key for authentification of AWS
  *      PluginSettingParams:
  *        type: object
+ *        properties:
  *          isEnabledPlugins:
  *            type: String
  *            description: enable use plugins


### PR DESCRIPTION
Format for API document in `app-settings.js` is wrong.

The PR will modify this miss takes.

Confirmed to enable to build `swagger.json`.

* before fix

```bash
> yarn run build:apiv3:jsdoc
yarn run v1.19.1
$ swagger-jsdoc -o tmp/swagger.json -d config/swagger-definition.js src/server/**/*.js
components:
   schemas:
     AppSettingParams:
       type: object
       properties:
         title:
           type: String
           description: site name show on page header and tilte of HTML
         confidential:
           type: String
           description: confidential show on page header
         globalLang:
           type: String
           description: language set when create user
         fileUpload:
           type: boolean
           description: enable upload file except image file
    SiteUrlSettingParams: -------------- Pay attention at this place
       type: object
       properties:
         siteUrl:
           type: String
           description: Site URL. e.g. https://example.com, https://example.com:8080
         envSiteUrl:
           type: String
           description: environment variable 'APP_SITE_URL'
    MailSettingParams:
       type: object
       properties:
         fromAddress:
           type: String
           description: e-mail address used as from address of mail which sent from GROWI app
         smtpHost:
           type: String
           description: host name of client's smtp server
         smtpPort:
           type: String
           description: port of client's smtp server
         smtpUser:
           type: String
           description: user name of client's smtp server
         smtpPassword:
           type: String
           description: password of client's smtp server
     AwsSettingParams:
       type: object
         region:
           type: String
           description: region of AWS S3
         customEndpoint:
           type: String
           description: custom endpoint of AWS S3
         bucket:
           type: String
           description: AWS S3 bucket name
         accessKeyId:
           type: String
           description: accesskey id for authentification of AWS
         secretKey:
           type: String
           description: secret key for authentification of AWS
     PluginSettingParams:
       type: object
         isEnabledPlugins:
           type: String
           description: enable use plugins

D:\usr\DevApp\repos_github\weseek\growi\node_modules\swagger-jsdoc\lib\index.js:37
    throw new Error(err);
    ^

Error: YAMLException: bad indentation of a mapping entry at line 18, column 5:
        SiteUrlSettingParams:
        ^
    at module.exports.options (D:\usr\DevApp\repos_github\weseek\growi\node_modules\swagger-jsdoc\lib\index.js:37:11)
    at createSpecification (D:\usr\DevApp\repos_github\weseek\growi\node_modules\swagger-jsdoc\bin\swagger-jsdoc.js:44:34)
    at fs.readFile (D:\usr\DevApp\repos_github\weseek\growi\node_modules\swagger-jsdoc\bin\swagger-jsdoc.js:169:10)
    at FSReqWrap.readFileAfterClose [as oncomplete] (internal/fs/read_file_context.js:53:3)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

yarn run v1.19.1pos_github\weseek\growi>yarn run build:apiv3:jsdoc
```

* after fix

```bash
> yarn run build:apiv3:jsdoc
$ swagger-jsdoc -o tmp/swagger.json -d config/swagger-definition.js src/server/**/*.js
Swagger specification is ready.
Done in 0.73s.
```