### PR TITLE
Support/api v1 reference

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,26 +21,26 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - name: Cache/Restore node_modules
-      id: cache-dependencies
-      uses: actions/cache@v1
-      with:
-        path: node_modules
-        key: ${{ runner.OS }}-node_modules-${{ matrix.node-version }}-${{ hashFiles('**/yarn.lock') }}
-    - name: Get yarn cache dir
-      if: steps.cache-dependencies.outputs.cache-hit != 'true'
-      id: cache-yarn
-      run: echo "::set-output name=dir::$(yarn cache dir)"
-    - name: Cache/Restore yarn cache
-      if: steps.cache-dependencies.outputs.cache-hit != 'true'
-      uses: actions/cache@v1
-      with:
-        path: ${{ steps.cache-yarn.outputs.dir }}
-        key: ${{ runner.os }}-yarn-${{ matrix.node-version }}-${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-yarn-${{ matrix.node-version }}-
+    # - name: Cache/Restore node_modules
+    #   id: cache-dependencies
+    #   uses: actions/cache@v1
+    #   with:
+    #     path: node_modules
+    #     key: ${{ runner.OS }}-node_modules-${{ matrix.node-version }}-${{ hashFiles('**/yarn.lock') }}
+    # - name: Get yarn cache dir
+    #   if: steps.cache-dependencies.outputs.cache-hit != 'true'
+    #   id: cache-yarn
+    #   run: echo "::set-output name=dir::$(yarn cache dir)"
+    # - name: Cache/Restore yarn cache
+    #   if: steps.cache-dependencies.outputs.cache-hit != 'true'
+    #   uses: actions/cache@v1
+    #   with:
+    #     path: ${{ steps.cache-yarn.outputs.dir }}
+    #     key: ${{ runner.os }}-yarn-${{ matrix.node-version }}-${{ hashFiles('**/yarn.lock') }}
+    #     restore-keys: |
+    #       ${{ runner.os }}-yarn-${{ matrix.node-version }}-
     - name: Install dependencies
-      if: steps.cache-dependencies.outputs.cache-hit != 'true'
+      # if: steps.cache-dependencies.outputs.cache-hit != 'true'
       run: |
         yarn add growi-plugin-lsx growi-plugin-pukiwiki-like-linker growi-plugin-attachment-refs react-images@1.0.0 react-motion
     - name: Print dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Remove swagger.json
       run: |
         ls -al tmp
-        rm tmp/swagger.json
+        rm -f tmp/swagger.json
         ls -al tmp
     - name: yarn lint
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Remove swagger.json
       run: |
         ls -al tmp
-        rm tmp\swagger.json
+        rm tmp/swagger.json
         ls -al tmp
     - name: yarn lint
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,12 +48,6 @@ jobs:
         echo -n "node " && node -v
         echo -n "npm " && npm -v
         yarn list --depth=0
-    - name: build swagger.json
-      run: yarn run build:apiv3:jsdoc
-    - name: cat swagger.json
-      run: cat tmp/swagger.json
-    - name: grub
-      run: ls -al src/server/**/*.js
     - name: yarn lint
       run: |
         yarn lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,8 @@ jobs:
       run: yarn run build:apiv3:jsdoc
     - name: cat swagger.json
       run: cat tmp/swagger.json
+    - name: grub
+      run: ls -al src/server/**/*.js
     - name: yarn lint
       run: |
         yarn lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,26 +21,26 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    # - name: Cache/Restore node_modules
-    #   id: cache-dependencies
-    #   uses: actions/cache@v1
-    #   with:
-    #     path: node_modules
-    #     key: ${{ runner.OS }}-node_modules-${{ matrix.node-version }}-${{ hashFiles('**/yarn.lock') }}
-    # - name: Get yarn cache dir
-    #   if: steps.cache-dependencies.outputs.cache-hit != 'true'
-    #   id: cache-yarn
-    #   run: echo "::set-output name=dir::$(yarn cache dir)"
-    # - name: Cache/Restore yarn cache
-    #   if: steps.cache-dependencies.outputs.cache-hit != 'true'
-    #   uses: actions/cache@v1
-    #   with:
-    #     path: ${{ steps.cache-yarn.outputs.dir }}
-    #     key: ${{ runner.os }}-yarn-${{ matrix.node-version }}-${{ hashFiles('**/yarn.lock') }}
-    #     restore-keys: |
-    #       ${{ runner.os }}-yarn-${{ matrix.node-version }}-
+    - name: Cache/Restore node_modules
+      id: cache-dependencies
+      uses: actions/cache@v1
+      with:
+        path: node_modules
+        key: ${{ runner.OS }}-node_modules-${{ matrix.node-version }}-${{ hashFiles('**/yarn.lock') }}
+    - name: Get yarn cache dir
+      if: steps.cache-dependencies.outputs.cache-hit != 'true'
+      id: cache-yarn
+      run: echo "::set-output name=dir::$(yarn cache dir)"
+    - name: Cache/Restore yarn cache
+      if: steps.cache-dependencies.outputs.cache-hit != 'true'
+      uses: actions/cache@v1
+      with:
+        path: ${{ steps.cache-yarn.outputs.dir }}
+        key: ${{ runner.os }}-yarn-${{ matrix.node-version }}-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-${{ matrix.node-version }}-
     - name: Install dependencies
-      # if: steps.cache-dependencies.outputs.cache-hit != 'true'
+      if: steps.cache-dependencies.outputs.cache-hit != 'true'
       run: |
         yarn add growi-plugin-lsx growi-plugin-pukiwiki-like-linker growi-plugin-attachment-refs react-images@1.0.0 react-motion
     - name: Print dependencies
@@ -48,6 +48,11 @@ jobs:
         echo -n "node " && node -v
         echo -n "npm " && npm -v
         yarn list --depth=0
+    - name: Remove swagger.json
+      run: |
+        ls -al tmp
+        rm tmp\swagger.json
+        ls -al tmp
     - name: yarn lint
       run: |
         yarn lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,11 +48,10 @@ jobs:
         echo -n "node " && node -v
         echo -n "npm " && npm -v
         yarn list --depth=0
-    - name: Remove swagger.json
-      run: |
-        ls -al tmp
-        rm -f tmp/swagger.json
-        ls -al tmp
+    - name: build swagger.json
+      run: yarn run build:apiv3:jsdoc
+    - name: cat swagger.json
+      run: cat tmp/swagger.json
     - name: yarn lint
       run: |
         yarn lint

--- a/config/swagger-definition.js
+++ b/config/swagger-definition.js
@@ -1,14 +1,16 @@
 const pkg = require('../package.json');
 
+const apiVersion = process.env.API_VERSION || 3;
+
 module.exports = {
   openapi: '3.0.1',
   info: {
-    title: 'GROWI REST API v3',
+    title: `GROWI REST API v${apiVersion}`,
     version: pkg.version,
   },
   servers: [
     {
-      url: 'https://demo.growi.org/_api/v3/',
+      url: `https://demo.growi.org/_api/v${apiVersion}/`,
     },
   ],
 };

--- a/config/swagger-definition.js
+++ b/config/swagger-definition.js
@@ -13,4 +13,5 @@ module.exports = {
       url: 'https://demo.growi.org',
     },
   ],
+  apis: ['src/server/**/*.js']
 };

--- a/config/swagger-definition.js
+++ b/config/swagger-definition.js
@@ -10,7 +10,7 @@ module.exports = {
   },
   servers: [
     {
-      url: `https://demo.growi.org/_api/v${apiVersion}/`,
+      url: 'https://demo.growi.org',
     },
   ],
 };

--- a/config/swagger-definition.js
+++ b/config/swagger-definition.js
@@ -13,5 +13,4 @@ module.exports = {
       url: 'https://demo.growi.org',
     },
   ],
-  apis: ['src/server/**/*.js'],
 };

--- a/config/swagger-definition.js
+++ b/config/swagger-definition.js
@@ -13,5 +13,5 @@ module.exports = {
       url: 'https://demo.growi.org',
     },
   ],
-  apis: ['src/server/**/*.js']
+  apis: ['src/server/**/*.js'],
 };

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "url": "https://github.com/weseek/growi/issues"
   },
   "scripts": {
-    "build:apiv3:jsdoc": "swagger-jsdoc -o tmp/swagger.json -d config/swagger-definition.js src/server/**/*.js",
+    "build:api:jsdoc": "swagger-jsdoc -o tmp/swagger.json -d config/swagger-definition.js src/server/**/*.js",
+    "build:apiv3:jsdoc": "cross-env API_VERSION=3 npm run build:api:jsdoc",
+    "build:apiv1:jsdoc": "cross-env API_VERSION=1 npm run build:api:jsdoc",
     "build:dev:app:watch": "npm run build:dev:app -- --watch",
     "build:dev:app": "env-cmd -f config/env.dev.js webpack --config config/webpack.dev.js --progress",
     "build:dev:watch": "npm run build:dev:app:watch",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/weseek/growi/issues"
   },
   "scripts": {
-    "build:api:jsdoc": "swagger-jsdoc -o tmp/swagger.json -d config/swagger-definition.js",
+    "build:api:jsdoc": "swagger-jsdoc -o tmp/swagger.json -d config/swagger-definition.js \"src/server/**/*.js\"",
     "build:apiv3:jsdoc": "cross-env API_VERSION=3 npm run build:api:jsdoc",
     "build:apiv1:jsdoc": "cross-env API_VERSION=1 npm run build:api:jsdoc",
     "build:dev:app:watch": "npm run build:dev:app -- --watch",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/weseek/growi/issues"
   },
   "scripts": {
-    "build:api:jsdoc": "swagger-jsdoc -o tmp/swagger.json -d config/swagger-definition.js src/server/**/*.js",
+    "build:api:jsdoc": "swagger-jsdoc -o tmp/swagger.json -d config/swagger-definition.js",
     "build:apiv3:jsdoc": "cross-env API_VERSION=3 npm run build:api:jsdoc",
     "build:apiv1:jsdoc": "cross-env API_VERSION=1 npm run build:api:jsdoc",
     "build:dev:app:watch": "npm run build:dev:app -- --watch",

--- a/src/server/models/openapi/paginate-result.js
+++ b/src/server/models/openapi/paginate-result.js
@@ -5,6 +5,7 @@
  *  components:
  *    schemas:
  *      PaginateResult:
+ *        description: PaginateResult
  *        type: object
  *        properties:
  *          docs:

--- a/src/server/models/openapi/paginate-result.js
+++ b/src/server/models/openapi/paginate-result.js
@@ -65,7 +65,7 @@
  *                example: 35
  *              limit:
  *                type: integer
- *                description:
+ *                description: Limit that was used
  *                example: 10
  *              offset:
  *                type: integer

--- a/src/server/models/openapi/paginate-result.js
+++ b/src/server/models/openapi/paginate-result.js
@@ -45,4 +45,33 @@
  *          meta:
  *            type: number
  *            description: Object of pagination meta data (Default false).
+ *
+ */
+
+/**
+ * @swagger
+ *
+ *  components:
+ *    schemas:
+ *      V1PaginateResult:
+ *        type: object
+ *        properties:
+ *          meta:
+ *            type: object
+ *            properties:
+ *              total:
+ *                type: integer
+ *                description: Total number of documents in collection that match a query
+ *                example: 35
+ *              limit:
+ *                type: integer
+ *                description:
+ *                example: 10
+ *              offset:
+ *                type: integer
+ *                description: Only if specified or default page/offset values were used
+ *                example: 20
+ *          data:
+ *            type: object
+ *            description: Object of pagination meta data.
  */

--- a/src/server/models/openapi/paginate-result.js
+++ b/src/server/models/openapi/paginate-result.js
@@ -54,6 +54,7 @@
  *  components:
  *    schemas:
  *      V1PaginateResult:
+ *        description: Paginate result v1
  *        type: object
  *        properties:
  *          meta:

--- a/src/server/models/openapi/v1-response.js
+++ b/src/server/models/openapi/v1-response.js
@@ -1,0 +1,16 @@
+/**
+ * @swagger
+ *
+ *  components:
+ *    schemas:
+ *      V1Response:
+ *        ok:
+ *          type: boolean
+ *          description: API is succeeded
+ *          example: true
+ *    responses:
+ *      403:
+ *        description: 'Forbidden'
+ *      500:
+ *        description: 'Internal Server Error'
+ */

--- a/src/server/models/openapi/v1-response.js
+++ b/src/server/models/openapi/v1-response.js
@@ -4,10 +4,12 @@
  *  components:
  *    schemas:
  *      V1Response:
- *        ok:
- *          type: boolean
- *          description: API is succeeded
- *          example: true
+ *        type: object
+ *        properties:
+ *          ok:
+ *            type: boolean
+ *            description: API is succeeded
+ *            example: true
  *    responses:
  *      403:
  *        description: 'Forbidden'

--- a/src/server/models/openapi/v1-response.js
+++ b/src/server/models/openapi/v1-response.js
@@ -4,6 +4,7 @@
  *  components:
  *    schemas:
  *      V1Response:
+ *        description: Response v1
  *        type: object
  *        properties:
  *          ok:

--- a/src/server/routes/apiv3/app-settings.js
+++ b/src/server/routes/apiv3/app-settings.js
@@ -26,13 +26,13 @@ const ErrorV3 = require('../../models/vo/error-apiv3');
  *        type: object
  *        properties:
  *          title:
- *            type: String
+ *            type: string
  *            description: site name show on page header and tilte of HTML
  *          confidential:
- *            type: String
+ *            type: string
  *            description: confidential show on page header
  *          globalLang:
- *            type: String
+ *            type: string
  *            description: language set when create user
  *          fileUpload:
  *            type: boolean
@@ -41,52 +41,52 @@ const ErrorV3 = require('../../models/vo/error-apiv3');
  *        type: object
  *        properties:
  *          siteUrl:
- *            type: String
+ *            type: string
  *            description: Site URL. e.g. https://example.com, https://example.com:8080
  *          envSiteUrl:
- *            type: String
+ *            type: string
  *            description: environment variable 'APP_SITE_URL'
  *      MailSettingParams:
  *        type: object
  *        properties:
  *          fromAddress:
- *            type: String
+ *            type: string
  *            description: e-mail address used as from address of mail which sent from GROWI app
  *          smtpHost:
- *            type: String
+ *            type: string
  *            description: host name of client's smtp server
  *          smtpPort:
- *            type: String
+ *            type: string
  *            description: port of client's smtp server
  *          smtpUser:
- *            type: String
+ *            type: string
  *            description: user name of client's smtp server
  *          smtpPassword:
- *            type: String
+ *            type: string
  *            description: password of client's smtp server
  *      AwsSettingParams:
  *        type: object
  *        properties:
  *          region:
- *            type: String
+ *            type: string
  *            description: region of AWS S3
  *          customEndpoint:
- *            type: String
+ *            type: string
  *            description: custom endpoint of AWS S3
  *          bucket:
- *            type: String
+ *            type: string
  *            description: AWS S3 bucket name
  *          accessKeyId:
- *            type: String
+ *            type: string
  *            description: accesskey id for authentification of AWS
  *          secretKey:
- *            type: String
+ *            type: string
  *            description: secret key for authentification of AWS
  *      PluginSettingParams:
  *        type: object
  *        properties:
  *          isEnabledPlugins:
- *            type: String
+ *            type: string
  *            description: enable use plugins
  */
 

--- a/src/server/routes/apiv3/app-settings.js
+++ b/src/server/routes/apiv3/app-settings.js
@@ -23,6 +23,7 @@ const ErrorV3 = require('../../models/vo/error-apiv3');
  *  components:
  *    schemas:
  *      AppSettingParams:
+ *        description: AppSettingParams
  *        type: object
  *        properties:
  *          title:
@@ -38,6 +39,7 @@ const ErrorV3 = require('../../models/vo/error-apiv3');
  *            type: boolean
  *            description: enable upload file except image file
  *      SiteUrlSettingParams:
+ *        description: SiteUrlSettingParams
  *        type: object
  *        properties:
  *          siteUrl:
@@ -47,6 +49,7 @@ const ErrorV3 = require('../../models/vo/error-apiv3');
  *            type: string
  *            description: environment variable 'APP_SITE_URL'
  *      MailSettingParams:
+ *        description: MailSettingParams
  *        type: object
  *        properties:
  *          fromAddress:
@@ -65,6 +68,7 @@ const ErrorV3 = require('../../models/vo/error-apiv3');
  *            type: string
  *            description: password of client's smtp server
  *      AwsSettingParams:
+ *        description: AwsSettingParams
  *        type: object
  *        properties:
  *          region:
@@ -83,6 +87,7 @@ const ErrorV3 = require('../../models/vo/error-apiv3');
  *            type: string
  *            description: secret key for authentification of AWS
  *      PluginSettingParams:
+ *        description: PluginSettingParams
  *        type: object
  *        properties:
  *          isEnabledPlugins:
@@ -131,9 +136,11 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *    /app-settings/:
+   *    /_api/v3/app-settings:
    *      get:
-   *        tags: [AppSettings]
+   *        tags: [AppSettings, apiv3]
+   *        operationId: getAppSettings
+   *        summary: /_api/v3/app-settings
    *        description: get app setting params
    *        responses:
    *          200:
@@ -174,9 +181,11 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *    /app-settings/app-setting:
+   *    /_api/v3/app-settings/app-setting:
    *      put:
-   *        tags: [AppSettings]
+   *        tags: [AppSettings, apiv3]
+   *        summary: /_api/v3/app-settings/app-setting
+   *        operationId: updateAppSettings
    *        description: Update app setting
    *        requestBody:
    *          required: true
@@ -221,9 +230,11 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *    /app-settings/site-url-setting:
+   *    /_api/v3/app-settings/site-url-setting:
    *      put:
-   *        tags: [AppSettings]
+   *        tags: [AppSettings, apiv3]
+   *        operationId: updateAppSettingSiteUrlSetting
+   *        summary: /_api/v3/app-settings/site-url-setting
    *        description: Update site url setting
    *        requestBody:
    *          required: true
@@ -311,10 +322,12 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *    /app-settings/site-url-setting:
+   *    /_api/v3/app-settings/mail-setting:
    *      put:
-   *        tags: [AppSettings]
-   *        description: Update site url setting
+   *        tags: [AppSettings, apiv3]
+   *        operationId: updateAppSettingMailSetting
+   *        summary: /_api/v3/app-settings/site-url-setting
+   *        description: Update mail setting
    *        requestBody:
    *          required: true
    *          content:
@@ -323,7 +336,7 @@ module.exports = (crowi) => {
    *                $ref: '#/components/schemas/MailSettingParams'
    *        responses:
    *          200:
-   *            description: Succeeded to update site url setting
+   *            description: Succeeded to update mail setting
    *            content:
    *              application/json:
    *                schema:
@@ -371,9 +384,11 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *    /app-settings/aws-setting:
+   *    /_api/v3/app-settings/aws-setting:
    *      put:
-   *        tags: [AppSettings]
+   *        tags: [AppSettings, apiv3]
+   *        operationId: updateAppSettingAwsSetting
+   *        summary: /_api/v3/app-settings/aws-setting
    *        description: Update aws setting
    *        requestBody:
    *          required: true
@@ -420,9 +435,11 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *    /app-settings/plugin-setting:
+   *    /_api/v3/app-settings/plugin-setting:
    *      put:
-   *        tags: [AppSettings]
+   *        tags: [AppSettings, apiv3]
+   *        operationId: updateAppSettingPluginSetting
+   *        summary: /_api/v3/app-settings/plugin-setting
    *        description: Update plugin setting
    *        requestBody:
    *          required: true

--- a/src/server/routes/apiv3/customize-setting.js
+++ b/src/server/routes/apiv3/customize-setting.js
@@ -22,6 +22,7 @@ const ErrorV3 = require('../../models/vo/error-apiv3');
  *  components:
  *    schemas:
  *      CustomizeLayoutTheme:
+ *        description: CustomizeLayoutTheme
  *        type: object
  *        properties:
  *          layoutType:
@@ -29,11 +30,13 @@ const ErrorV3 = require('../../models/vo/error-apiv3');
  *          themeType:
  *            type: string
  *      CustomizeBehavior:
+ *        description: CustomizeBehavior
  *        type: object
  *        properties:
  *          behaviorType:
  *            type: string
  *      CustomizeFunction:
+ *        description: CustomizeFunction
  *        type: object
  *        properties:
  *          isEnabledTimeline:
@@ -47,6 +50,7 @@ const ErrorV3 = require('../../models/vo/error-apiv3');
  *          isEnabledStaleNotification:
  *            type: boolean
  *      CustomizeHighlight:
+ *        description: CustomizeHighlight
  *        type: object
  *        properties:
  *          styleName:
@@ -54,21 +58,25 @@ const ErrorV3 = require('../../models/vo/error-apiv3');
  *          styleBorder:
  *            type: boolean
  *      CustomizeTitle:
+ *        description: CustomizeTitle
  *        type: object
  *        properties:
  *          customizeTitle:
  *            type: string
  *      CustomizeHeader:
+ *        description: CustomizeHeader
  *        type: object
  *        properties:
  *          customizeHeader:
  *            type: string
  *      CustomizeCss:
+ *        description: CustomizeCss
  *        type: object
  *        properties:
  *          customizeCss:
  *            type: string
  *      CustomizeScript:
+ *        description: CustomizeScript
  *        type: object
  *        properties:
  *          customizeScript:
@@ -123,9 +131,11 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *    /customize-setting/:
+   *    /_api/v3/customize-setting:
    *      get:
-   *        tags: [CustomizeSetting]
+   *        tags: [CustomizeSetting, apiv3]
+   *        operationId: getCustomizeSetting
+   *        summary: /_api/v3/customize-setting
    *        description: Get customize paramators
    *        responses:
    *          200:
@@ -163,23 +173,25 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *    /customize-setting/layoutTheme:
+   *    /_api/v3/customize-setting/layoutTheme:
    *      put:
-   *        tags: [CustomizeSetting]
+   *        tags: [CustomizeSetting, apiv3]
+   *        operationId: updateLayoutThemeCustomizeSetting
+   *        summary: /_api/v3/customize-setting/layoutTheme
    *        description: Update layout and theme
    *        requestBody:
    *          required: true
    *          content:
    *            application/json:
-   *              schama:
-   *                $ref: '#/components/schemas/CustomizeLayoutTheme'
-   *      responses:
-   *        200:
-   *          description: Succeeded to update layout and theme
-   *          content:
-   *            application/json:
    *              schema:
    *                $ref: '#/components/schemas/CustomizeLayoutTheme'
+   *        responses:
+   *          200:
+   *            description: Succeeded to update layout and theme
+   *            content:
+   *              application/json:
+   *                schema:
+   *                  $ref: '#/components/schemas/CustomizeLayoutTheme'
    */
   router.put('/layoutTheme', loginRequiredStrictly, adminRequired, csrf, validator.layoutTheme, ApiV3FormValidator, async(req, res) => {
     const requestParams = {
@@ -205,23 +217,25 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *    /customize-setting/behavior:
+   *    /_api/v3/customize-setting/behavior:
    *      put:
-   *        tags: [CustomizeSetting]
+   *        tags: [CustomizeSetting, apiv3]
+   *        operationId: updateBehaviorCustomizeSetting
+   *        summary: /_api/v3/customize-setting/behavior
    *        description: Update behavior
    *        requestBody:
    *          required: true
    *          content:
    *            application/json:
-   *              schama:
-   *                $ref: '#/components/schemas/CustomizeBehavior'
-   *      responses:
-   *        200:
-   *          description: Succeeded to update behavior
-   *          content:
-   *            application/json:
    *              schema:
    *                $ref: '#/components/schemas/CustomizeBehavior'
+   *        responses:
+   *          200:
+   *            description: Succeeded to update behavior
+   *            content:
+   *              application/json:
+   *                schema:
+   *                  $ref: '#/components/schemas/CustomizeBehavior'
    */
   router.put('/behavior', loginRequiredStrictly, adminRequired, csrf, validator.behavior, ApiV3FormValidator, async(req, res) => {
     const requestParams = {
@@ -245,23 +259,25 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *    /customize-setting/function:
+   *    /_api/v3/customize-setting/function:
    *      put:
-   *        tags: [CustomizeSetting]
+   *        tags: [CustomizeSetting, apiv3]
+   *        operationId: updateFunctionCustomizeSetting
+   *        summary: /_api/v3/customize-setting/function
    *        description: Update function
    *        requestBody:
    *          required: true
    *          content:
    *            application/json:
-   *              schama:
-   *                $ref: '#/components/schemas/CustomizeFunction'
-   *      responses:
-   *        200:
-   *          description: Succeeded to update function
-   *          content:
-   *            application/json:
    *              schema:
    *                $ref: '#/components/schemas/CustomizeFunction'
+   *        responses:
+   *          200:
+   *            description: Succeeded to update function
+   *            content:
+   *              application/json:
+   *                schema:
+   *                  $ref: '#/components/schemas/CustomizeFunction'
    */
   router.put('/function', loginRequiredStrictly, adminRequired, csrf, validator.function, ApiV3FormValidator, async(req, res) => {
     const requestParams = {
@@ -293,23 +309,25 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *    /customize-setting/highlight:
+   *    /_api/v3/customize-setting/highlight:
    *      put:
-   *        tags: [CustomizeSetting]
+   *        tags: [CustomizeSetting, apiv3]
+   *        operationId: updateHighlightCustomizeSetting
+   *        summary: /_api/v3/customize-setting/highlight
    *        description: Update highlight
    *        requestBody:
    *          required: true
    *          content:
    *            application/json:
-   *              schama:
-   *                $ref: '#/components/schemas/CustomizeHighlight'
-   *      responses:
-   *        200:
-   *          description: Succeeded to update highlight
-   *          content:
-   *            application/json:
    *              schema:
    *                $ref: '#/components/schemas/CustomizeHighlight'
+   *        responses:
+   *          200:
+   *            description: Succeeded to update highlight
+   *            content:
+   *              application/json:
+   *                schema:
+   *                  $ref: '#/components/schemas/CustomizeHighlight'
    */
   router.put('/highlight', loginRequiredStrictly, adminRequired, csrf, validator.highlight, ApiV3FormValidator, async(req, res) => {
     const requestParams = {
@@ -335,9 +353,11 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *    /customize-setting/customizeTitle:
+   *    /_api/v3/customize-setting/customizeTitle:
    *      put:
-   *        tags: [CustomizeSetting]
+   *        tags: [CustomizeSetting, apiv3]
+   *        operationId: updateCustomizeTitleCustomizeSetting
+   *        summary: /_api/v3/customize-setting/customizeTitle
    *        description: Update customizeTitle
    *        requestBody:
    *          required: true
@@ -345,13 +365,13 @@ module.exports = (crowi) => {
    *            application/json:
    *              schema:
    *                $ref: '#/components/schemas/CustomizeTitle'
-   *      responses:
-   *        200:
-   *          description: Succeeded to update customizeTitle
-   *          content:
-   *            application/json:
-   *              schema:
-   *                $ref: '#/components/schemas/CustomizeTitle'
+   *        responses:
+   *          200:
+   *            description: Succeeded to update customizeTitle
+   *            content:
+   *              application/json:
+   *                schema:
+   *                  $ref: '#/components/schemas/CustomizeTitle'
    */
   router.put('/customize-title', loginRequiredStrictly, adminRequired, csrf, validator.customizeTitle, ApiV3FormValidator, async(req, res) => {
     const requestParams = {
@@ -376,23 +396,25 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *    /customize-setting/customizeHeader:
+   *    /_api/v3/customize-setting/customizeHeader:
    *      put:
-   *        tags: [CustomizeSetting]
+   *        tags: [CustomizeSetting, apiv3]
+   *        operationId: updateCustomizeHeaderCustomizeSetting
+   *        summary: /_api/v3/customize-setting/customizeHeader
    *        description: Update customizeHeader
    *        requestBody:
    *          required: true
    *          content:
    *            application/json:
-   *              schama:
-   *                $ref: '#/components/schemas/CustomizeHeader'
-   *      responses:
-   *        200:
-   *          description: Succeeded to update customize header
-   *          content:
-   *            application/json:
    *              schema:
    *                $ref: '#/components/schemas/CustomizeHeader'
+   *        responses:
+   *          200:
+   *            description: Succeeded to update customize header
+   *            content:
+   *              application/json:
+   *                schema:
+   *                  $ref: '#/components/schemas/CustomizeHeader'
    */
   router.put('/customize-header', loginRequiredStrictly, adminRequired, csrf, validator.customizeHeader, ApiV3FormValidator, async(req, res) => {
     const requestParams = {
@@ -415,23 +437,25 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *    /customize-setting/customizeCss:
+   *    /_api/v3/customize-setting/customizeCss:
    *      put:
-   *        tags: [CustomizeSetting]
+   *        tags: [CustomizeSetting, apiv3]
+   *        operationId: updateCustomizeCssCustomizeSetting
+   *        summary: /_api/v3/customize-setting/customizeCss
    *        description: Update customizeCss
    *        requestBody:
    *          required: true
    *          content:
    *            application/json:
-   *              schama:
-   *                $ref: '#/components/schemas/CustomizeCss'
-   *      responses:
-   *        200:
-   *          description: Succeeded to update customize css
-   *          content:
-   *            application/json:
    *              schema:
    *                $ref: '#/components/schemas/CustomizeCss'
+   *        responses:
+   *          200:
+   *            description: Succeeded to update customize css
+   *            content:
+   *              application/json:
+   *                schema:
+   *                  $ref: '#/components/schemas/CustomizeCss'
    */
   router.put('/customize-css', loginRequiredStrictly, adminRequired, csrf, validator.customizeCss, ApiV3FormValidator, async(req, res) => {
     const requestParams = {
@@ -455,23 +479,25 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *    /customize-setting/customizeScript:
+   *    /_api/v3/customize-setting/customizeScript:
    *      put:
-   *        tags: [CustomizeSetting]
+   *        tags: [CustomizeSetting, apiv3]
+   *        operationId: updateCustomizeScriptCustomizeSetting
+   *        summary: /_api/v3/customize-setting/customizeScript
    *        description: Update customizeScript
    *        requestBody:
    *          required: true
    *          content:
    *            application/json:
-   *              schama:
-   *                $ref: '#/components/schemas/CustomizeScript'
-   *      responses:
-   *        200:
-   *          description: Succeeded to update customize script
-   *          content:
-   *            application/json:
    *              schema:
    *                $ref: '#/components/schemas/CustomizeScript'
+   *        responses:
+   *          200:
+   *            description: Succeeded to update customize script
+   *            content:
+   *              application/json:
+   *                schema:
+   *                  $ref: '#/components/schemas/CustomizeScript'
    */
   router.put('/customize-script', loginRequiredStrictly, adminRequired, csrf, validator.customizeScript, ApiV3FormValidator, async(req, res) => {
     const requestParams = {

--- a/src/server/routes/apiv3/export.js
+++ b/src/server/routes/apiv3/export.js
@@ -19,6 +19,7 @@ const router = express.Router();
  *  components:
  *    schemas:
  *      ExportStatus:
+ *        description: ExportStatus
  *        type: object
  *        properties:
  *          zipFileStats:
@@ -61,9 +62,11 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *  /export/status:
+   *  /_api/v3/export/status:
    *    get:
-   *      tags: [Export]
+   *      tags: [Export, apiv3]
+   *      operationId: getExportStatus
+   *      summary: /_api/v3/export/status
    *      description: get properties of stored zip files for export
    *      responses:
    *        200:
@@ -88,9 +91,11 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *  /export:
+   *  /_api/v3/export:
    *    post:
-   *      tags: [Export]
+   *      tags: [Export, apiv3]
+   *      operationId: createExport
+   *      summary: /_api/v3/export
    *      description: generate zipped jsons for collections
    *      responses:
    *        200:
@@ -124,9 +129,11 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *  /export/{fileName}:
+   *  /_api/v3/export/{fileName}:
    *    delete:
-   *      tags: [Export]
+   *      tags: [Export, apiv3]
+   *      operationId: deleteExport
+   *      summary: /_api/v3/export/{fileName}
    *      description: delete the file
    *      parameters:
    *        - name: fileName

--- a/src/server/routes/apiv3/healthcheck.js
+++ b/src/server/routes/apiv3/healthcheck.js
@@ -18,9 +18,11 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *  /healthcheck:
+   *  /_api/v3/healthcheck:
    *    get:
-   *      tags: [Healthcheck]
+   *      tags: [Healthcheck, apiv3]
+   *      operationId: getHealthcheck
+   *      summary: /_api/v3/healthcheck
    *      description: Check whether the server is healthy or not
    *      parameters:
    *        - name: connectToMiddlewares

--- a/src/server/routes/apiv3/import.js
+++ b/src/server/routes/apiv3/import.js
@@ -24,6 +24,7 @@ const router = express.Router();
  *  components:
  *    schemas:
  *      ImportStatus:
+ *        description: ImportStatus
  *        type: object
  *        properties:
  *          zipFileStat:
@@ -100,9 +101,11 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *  /import/status:
+   *  /_api/v3/import/status:
    *    get:
-   *      tags: [Import]
+   *      tags: [Import, apiv3]
+   *      operationId: getImportStatus
+   *      summary: /_api/v3/import/status
    *      description: Get properties of stored zip files for import
    *      responses:
    *        200:
@@ -127,9 +130,11 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *  /import:
+   *  /_api/v3/import:
    *    post:
-   *      tags: [Import]
+   *      tags: [Import, apiv3]
+   *      operationId: executeImport
+   *      summary: /_api/v3/import
    *      description: import a collection from a zipped json
    *      requestBody:
    *        required: true
@@ -236,9 +241,11 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *  /import/upload:
+   *  /_api/v3/import/upload:
    *    post:
-   *      tags: [Import]
+   *      tags: [Import, apiv3]
+   *      operationId: uploadImport
+   *      summary: /_api/v3/import/upload
    *      description: upload a zip file
    *      responses:
    *        200:
@@ -281,9 +288,11 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *  /import/all:
+   *  /_api/v3/import/all:
    *    delete:
-   *      tags: [Import]
+   *      tags: [Import, apiv3]
+   *      operationId: deleteImportAll
+   *      summary: /_api/v3/import/all
    *      description: Delete all zip files
    *      responses:
    *        200:

--- a/src/server/routes/apiv3/markdown-setting.js
+++ b/src/server/routes/apiv3/markdown-setting.js
@@ -39,6 +39,7 @@ const validator = {
  *  components:
  *    schemas:
  *      LineBreakParams:
+ *        description: LineBreakParams
  *        type: object
  *        properties:
  *          isEnabledLinebreaks:
@@ -48,6 +49,7 @@ const validator = {
  *            type: boolean
  *            description: enable lineBreak in comment
  *      PresentationParams:
+ *        description: PresentationParams
  *        type: object
  *        properties:
  *          pageBreakSeparator:
@@ -57,6 +59,7 @@ const validator = {
  *            type: string
  *            description: string of pageBreakCustomSeparator
  *      XssParams:
+ *        description: XssParams
  *        type: object
  *        properties:
  *          isEnabledPrevention:
@@ -89,9 +92,11 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *    /markdown-setting/:
+   *    /_api/v3/markdown-setting:
    *      get:
-   *        tags: [MarkDownSettind]
+   *        tags: [MarkDownSetting, apiv3]
+   *        operationId: getMarkdownSetting
+   *        summary: /_api/v3/markdown-setting
    *        description: Get markdown paramators
    *        responses:
    *          200:
@@ -122,9 +127,11 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *    /markdown-setting/lineBreak:
+   *    /_api/v3/markdown-setting/lineBreak:
    *      put:
-   *        tags: [MarkDownSetting]
+   *        tags: [MarkDownSetting, apiv3]
+   *        operationId: updateLineBreakMarkdownSetting
+   *        summary: /_api/v3/markdown-setting/lineBreak
    *        description: Update lineBreak setting
    *        requestBody:
    *          required: true
@@ -166,9 +173,11 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *    /markdown-setting/presentation:
+   *    /_api/v3/markdown-setting/presentation:
    *      put:
-   *        tags: [MarkDownSetting]
+   *        tags: [MarkDownSetting, apiv3]
+   *        operationId: updatePresentationMarkdownSetting
+   *        summary: /_api/v3/markdown-setting/presentation
    *        description: Update presentation
    *        requestBody:
    *          required: true
@@ -213,9 +222,11 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *    /markdown-setting/xss:
+   *    /_api/v3/markdown-setting/xss:
    *      put:
-   *        tags: [MarkDownSetting]
+   *        tags: [MarkDownSetting, apiv3]
+   *        operationId: updateXssMarkdownSetting
+   *        summary: /_api/v3/markdown-setting/xss
    *        description: Update xss
    *        requestBody:
    *          required: true

--- a/src/server/routes/apiv3/mongo.js
+++ b/src/server/routes/apiv3/mongo.js
@@ -17,9 +17,11 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *  /mongo/collections:
+   *  /_api/v3/mongo/collections:
    *    get:
-   *      tags: [Mongo]
+   *      tags: [Mongo, apiv3]
+   *      operationId: getMongoCollections
+   *      summary: /_api/v3/mongo/collections
    *      description: get mongodb collections names
    *      responses:
    *        200:

--- a/src/server/routes/apiv3/statistics.js
+++ b/src/server/routes/apiv3/statistics.js
@@ -83,9 +83,11 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *  /statistics/user:
+   *  /_api/v3/statistics/user:
    *    get:
-   *      tags: [Statistics]
+   *      tags: [Statistics, apiv3]
+   *      operationId: getStatisticsUser
+   *      summary: /_api/v3/statistics/user
    *      description: Get statistics for user
    *      responses:
    *        200:

--- a/src/server/routes/apiv3/user-group-relation.js
+++ b/src/server/routes/apiv3/user-group-relation.js
@@ -23,9 +23,11 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *  paths:
-   *    /user-group-relations:
+   *    /_api/v3/user-group-relations:
    *      get:
-   *        tags: [UserGroupRelation]
+   *        tags: [UserGroupRelation, apiv3]
+   *        operationId: listUserGroupRelations
+   *        summary: /_api/v3/user-group-relations
    *        description: Gets the user group relations
    *        responses:
    *          200:

--- a/src/server/routes/apiv3/user-group.js
+++ b/src/server/routes/apiv3/user-group.js
@@ -43,9 +43,11 @@ module.exports = (crowi) => {
    * @swagger
    *
    *  paths:
-   *    /user-groups:
+   *    /_api/v3/user-groups:
    *      get:
-   *        tags: [UserGroup]
+   *        tags: [UserGroup, apiv3]
+   *        operationId: getUserGroup
+   *        summary: /_api/v3/user-groups
    *        description: Get usergroups
    *        responses:
    *          200:
@@ -81,9 +83,11 @@ module.exports = (crowi) => {
    * @swagger
    *
    *  paths:
-   *    /user-groups:
+   *    /_api/v3/user-groups:
    *      post:
-   *        tags: [UserGroup]
+   *        tags: [UserGroup, apiv3]
+   *        operationId: createUserGroup
+   *        summary: /_api/v3/user-groups
    *        description: Adds userGroup
    *        requestBody:
    *          required: true
@@ -131,9 +135,11 @@ module.exports = (crowi) => {
    * @swagger
    *
    *  paths:
-   *    /user-groups/{id}:
+   *    /_api/v3/user-groups/{id}:
    *      delete:
-   *        tags: [UserGroup]
+   *        tags: [UserGroup, apiv3]
+   *        operationId: deleteUserGroup
+   *        summary: /_api/v3/user-groups/{id}
    *        description: Deletes userGroup
    *        parameters:
    *          - name: id
@@ -191,9 +197,11 @@ module.exports = (crowi) => {
    * @swagger
    *
    *  paths:
-   *    /user-groups/{id}:
+   *    /_api/v3/user-groups/{id}:
    *      put:
-   *        tags: [UserGroup]
+   *        tags: [UserGroup, apiv3]
+   *        operationId: updateUserGroups
+   *        summary: /_api/v3/user-groups/{id}
    *        description: Update userGroup
    *        parameters:
    *          - name: id
@@ -246,9 +254,11 @@ module.exports = (crowi) => {
    * @swagger
    *
    *  paths:
-   *    /user-groups/{id}/users:
+   *    /_api/v3/user-groups/{id}/users:
    *      get:
-   *        tags: [UserGroup]
+   *        tags: [UserGroup, apiv3]
+   *        operationId: getUsersUserGroups
+   *        summary: /_api/v3/user-groups/{id}/users
    *        description: Get users related to the userGroup
    *        parameters:
    *          - name: id
@@ -294,9 +304,11 @@ module.exports = (crowi) => {
    * @swagger
    *
    *  paths:
-   *    /user-groups/{id}/unrelated-users:
+   *    /_api/v3/user-groups/{id}/unrelated-users:
    *      get:
-   *        tags: [UserGroup]
+   *        tags: [UserGroup, apiv3]
+   *        operationId: getUnrelatedUsersUserGroups
+   *        summary: /_api/v3/user-groups/{id}/unrelated-users
    *        description: Get users unrelated to the userGroup
    *        parameters:
    *          - name: id
@@ -350,9 +362,11 @@ module.exports = (crowi) => {
    * @swagger
    *
    *  paths:
-   *    /user-groups/{id}/users:
+   *    /_api/v3/user-groups/{id}/users:
    *      post:
-   *        tags: [UserGroup]
+   *        tags: [UserGroup, apiv3]
+   *        operationId: addUserUserGroups
+   *        summary: /_api/v3/user-groups/{id}/users
    *        description: Add a user to the userGroup
    *        parameters:
    *          - name: id
@@ -417,9 +431,11 @@ module.exports = (crowi) => {
    * @swagger
    *
    *  paths:
-   *    /user-groups/{id}/users:
+   *    /_api/v3/user-groups/{id}/users:
    *      delete:
-   *        tags: [UserGroup]
+   *        tags: [UserGroup, apiv3]
+   *        operationId: deleteUsersUserGroups
+   *        summary: /_api/v3/user-groups/{id}/users
    *        description: remove a user from the userGroup
    *        parameters:
    *          - name: id
@@ -477,9 +493,11 @@ module.exports = (crowi) => {
    * @swagger
    *
    *  paths:
-   *    /user-groups/{id}/user-group-relations:
+   *    /_api/v3/user-groups/{id}/user-group-relations:
    *      get:
-   *        tags: [UserGroup]
+   *        tags: [UserGroup, apiv3]
+   *        operationId: getUserGroupRelationsUserGroups
+   *        summary: /_api/v3/user-groups/{id}/user-group-relations
    *        description: Get the user group relations for the userGroup
    *        parameters:
    *          - name: id
@@ -529,9 +547,11 @@ module.exports = (crowi) => {
    * @swagger
    *
    *  paths:
-   *    /user-groups/{id}/pages:
+   *    /_api/v3/user-groups/{id}/pages:
    *      get:
-   *        tags: [UserGroup]
+   *        tags: [UserGroup, apiv3]
+   *        operationId: getPagesUserGroups
+   *        summary: /_api/v3/user-groups/{id}/pages
    *        description: Get closed pages for the userGroup
    *        parameters:
    *          - name: id

--- a/src/server/routes/apiv3/users.js
+++ b/src/server/routes/apiv3/users.js
@@ -21,6 +21,51 @@ const validator = {};
  *    name: Users
  */
 
+/**
+ * @swagger
+ *
+ *  components:
+ *    schemas:
+ *      User:
+ *        type: object
+ *        properties:
+ *          _id:
+ *            type: string
+ *            description: user ID
+ *            example: '0123456789abcdef01234567'
+ *          __v:
+ *            type: integer
+ *            description: DB record version
+ *            example: 0
+ *          lang:
+ *            type: string
+ *            description: language
+ *            example: 'en-US'
+ *          status:
+ *            type: integer
+ *            description: status
+ *            example: 0
+ *          admin:
+ *            type: boolean
+ *            description: whether the admin
+ *          email:
+ *            type: string
+ *            description: E-Mail address
+ *            example: 'alice@aaa.aaa'
+ *          username:
+ *            type: string
+ *            description: username
+ *            example: 'alice'
+ *          name:
+ *            type: string
+ *            description: full name
+ *            example: 'Alice'
+ *          createdAt:
+ *            type: string
+ *            description: date created at
+ *            example: '2010-01-01T00:00:00.000Z'
+ */
+
 module.exports = (crowi) => {
   const loginRequiredStrictly = require('../../middleware/login-required')(crowi);
   const adminRequired = require('../../middleware/admin-required')(crowi);

--- a/src/server/routes/apiv3/users.js
+++ b/src/server/routes/apiv3/users.js
@@ -32,7 +32,7 @@ const validator = {};
  *          _id:
  *            type: string
  *            description: user ID
- *            example: '0123456789abcdef01234567'
+ *            example: 5ae5fccfc5577b0004dbd8ab
  *          __v:
  *            type: integer
  *            description: DB record version
@@ -48,22 +48,23 @@ const validator = {};
  *          admin:
  *            type: boolean
  *            description: whether the admin
+ *            example: false
  *          email:
  *            type: string
  *            description: E-Mail address
- *            example: 'alice@aaa.aaa'
+ *            example: alice@aaa.aaa
  *          username:
  *            type: string
  *            description: username
- *            example: 'alice'
+ *            example: alice
  *          name:
  *            type: string
  *            description: full name
- *            example: 'Alice'
+ *            example: Alice
  *          createdAt:
  *            type: string
  *            description: date created at
- *            example: '2010-01-01T00:00:00.000Z'
+ *            example: 2010-01-01T00:00:00.000Z
  */
 
 module.exports = (crowi) => {

--- a/src/server/routes/apiv3/users.js
+++ b/src/server/routes/apiv3/users.js
@@ -27,6 +27,7 @@ const validator = {};
  *  components:
  *    schemas:
  *      User:
+ *        description: User
  *        type: object
  *        properties:
  *          _id:
@@ -82,7 +83,9 @@ module.exports = (crowi) => {
    *  paths:
    *    /_api/v3/users:
    *      get:
-   *        tags: [Users]
+   *        tags: [Users, apiv3]
+   *        operationId: listUsers
+   *        summary: /_api/v3/users
    *        description: Get users
    *        responses:
    *          200:
@@ -132,7 +135,9 @@ module.exports = (crowi) => {
    *  paths:
    *    /_api/v3/users/invite:
    *      post:
-   *        tags: [Users]
+   *        tags: [Users, apiv3]
+   *        operationId: inviteUser
+   *        summary: /_api/v3/users/invite
    *        description: Create new users and send Emails
    *        parameters:
    *          - name: shapedEmailList
@@ -175,7 +180,9 @@ module.exports = (crowi) => {
    *  paths:
    *    /_api/v3/users/{id}/giveAdmin:
    *      put:
-   *        tags: [Users]
+   *        tags: [Users, apiv3]
+   *        operationId: giveAdminUser
+   *        summary: /_api/v3/users/{id}/giveAdmin
    *        description: Give user admin
    *        parameters:
    *          - name: id
@@ -214,7 +221,9 @@ module.exports = (crowi) => {
    *  paths:
    *    /_api/v3/users/{id}/removeAdmin:
    *      put:
-   *        tags: [Users]
+   *        tags: [Users, apiv3]
+   *        operationId: removeAdminUser
+   *        summary: /_api/v3/users/{id}/removeAdmin
    *        description: Remove user admin
    *        parameters:
    *          - name: id
@@ -253,7 +262,9 @@ module.exports = (crowi) => {
    *  paths:
    *    /_api/v3/users/{id}/activate:
    *      put:
-   *        tags: [Users]
+   *        tags: [Users, apiv3]
+   *        operationId: activateUser
+   *        summary: /_api/v3/users/{id}/activate
    *        description: Activate user
    *        parameters:
    *          - name: id
@@ -300,7 +311,9 @@ module.exports = (crowi) => {
    *  paths:
    *    /_api/v3/users/{id}/deactivate:
    *      put:
-   *        tags: [Users]
+   *        tags: [Users, apiv3]
+   *        operationId: deactivateUser
+   *        summary: /_api/v3/users/{id}/deactivate
    *        description: Deactivate user
    *        parameters:
    *          - name: id
@@ -339,7 +352,9 @@ module.exports = (crowi) => {
    *  paths:
    *    /_api/v3/users/{id}/remove:
    *      delete:
-   *        tags: [Users]
+   *        tags: [Users, apiv3]
+   *        operationId: removeUser
+   *        summary: /_api/v3/users/{id}/remove
    *        description: Delete user
    *        parameters:
    *          - name: id
@@ -380,9 +395,11 @@ module.exports = (crowi) => {
    * @swagger
    *
    *  paths:
-   *    /_api/v3/users:
+   *    /_api/v3/users/external-accounts:
    *      get:
-   *        tags: [Users]
+   *        tags: [Users, apiv3]
+   *        operationId: listExternalAccountsUsers
+   *        summary: /_api/v3/users/external-accounts
    *        description: Get external-account
    *        responses:
    *          200:
@@ -414,7 +431,9 @@ module.exports = (crowi) => {
    *  paths:
    *    /_api/v3/users/external-accounts/{id}/remove:
    *      delete:
-   *        tags: [Users]
+   *        tags: [Users, apiv3]
+   *        operationId: removeExternalAccountUser
+   *        summary: /_api/v3/users/external-accounts/{id}/remove
    *        description: Delete ExternalAccount
    *        parameters:
    *          - name: id

--- a/src/server/routes/apiv3/users.js
+++ b/src/server/routes/apiv3/users.js
@@ -33,10 +33,6 @@ const validator = {};
  *            type: string
  *            description: user ID
  *            example: 5ae5fccfc5577b0004dbd8ab
- *          __v:
- *            type: integer
- *            description: DB record version
- *            example: 0
  *          lang:
  *            type: string
  *            description: language

--- a/src/server/routes/attachment.js
+++ b/src/server/routes/attachment.js
@@ -250,6 +250,7 @@ module.exports = function(crowi, app) {
    *    /_api/attachments.list:
    *      get:
    *        tags: [Attachments]
+   *        operationId: /_api/attachments.list
    *        summary: /_api/attachments.list
    *        description: Get list of attachments in page
    *        parameters:
@@ -317,6 +318,7 @@ module.exports = function(crowi, app) {
    *    components:
    *      schemas:
    *        AttachmentAddParams:
+   *          description: AttachmentAddParams
    *          type: object
    *          properties:
    *            page_id:
@@ -337,6 +339,7 @@ module.exports = function(crowi, app) {
    *    /_api/attachments.add:
    *      post:
    *        tags: [Attachments]
+   *        operationId: /_api/attachments.add
    *        summary: /_api/attachments.add
    *        description: Add attachment to the page
    *        requestBody:
@@ -483,6 +486,7 @@ module.exports = function(crowi, app) {
    *    /_api/attachments.remove:
    *      post:
    *        tags: [Attachments]
+   *        operationId: /_api/attachments.remove
    *        summary: /_api/attachments.remove
    *        description: Remove attachment
    *        requestBody:

--- a/src/server/routes/attachment.js
+++ b/src/server/routes/attachment.js
@@ -315,44 +315,46 @@ module.exports = function(crowi, app) {
   /**
    * @swagger
    *
-   *    components:
-   *      schemas:
-   *        AttachmentAddParams:
-   *          description: AttachmentAddParams
-   *          type: object
-   *          properties:
-   *            page_id:
-   *              nullable: true
-   *              $ref: '#/components/schemas/Page/properties/_id'
-   *            path:
-   *              nullable: true
-   *              $ref: '#/components/schemas/Page/properties/path'
-   *            file:
-   *              type: string
-   *              format: binary
-   *              description: attachment data
-   *          encoding:
-   *            path:
-   *              contentType: application/x-www-form-urlencoded
-   */
-
-  /**
-   * @swagger
-   *
    *    /_api/attachments.add:
    *      post:
    *        tags: [Attachments, apiv1]
-   *        operationId: /_api/attachments.add
+   *        operationId: addAttachment
    *        summary: /_api/attachments.add
    *        description: Add attachment to the page
    *        requestBody:
    *          content:
    *            "multipart/form-data":
    *              schema:
-   *                $ref: '#/components/schemas/AttachmentAddParams'
+   *                properties:
+   *                  page_id:
+   *                    nullable: true
+   *                    type: string
+   *                  path:
+   *                    nullable: true
+   *                    type: string
+   *                  file:
+   *                    type: string
+   *                    format: binary
+   *                    description: attachment data
+   *              encoding:
+   *                path:
+   *                  contentType: application/x-www-form-urlencoded
    *            "*\/*":
    *              schema:
-   *                $ref: '#/components/schemas/AttachmentAddParams'
+   *                properties:
+   *                  page_id:
+   *                    nullable: true
+   *                    type: string
+   *                  path:
+   *                    nullable: true
+   *                    type: string
+   *                  file:
+   *                    type: string
+   *                    format: binary
+   *                    description: attachment data
+   *              encoding:
+   *                path:
+   *                  contentType: application/x-www-form-urlencoded
    *        responses:
    *          200:
    *            description: Succeeded to add attachment.

--- a/src/server/routes/attachment.js
+++ b/src/server/routes/attachment.js
@@ -265,7 +265,7 @@ module.exports = function(crowi, app) {
    *                schema:
    *                  properties:
    *                    ok:
-   *                      $ref: '#/components/schemas/V1Response/ok'
+   *                      $ref: '#/components/schemas/V1Response/properties/ok'
    *                    attachments:
    *                      type: array
    *                      items:
@@ -360,7 +360,7 @@ module.exports = function(crowi, app) {
    *                schema:
    *                  properties:
    *                    ok:
-   *                      $ref: '#/components/schemas/V1Response/ok'
+   *                      $ref: '#/components/schemas/V1Response/properties/ok'
    *                    page:
    *                      $ref: '#/components/schemas/Page'
    *                    attachment:
@@ -501,7 +501,7 @@ module.exports = function(crowi, app) {
    *                schema:
    *                  properties:
    *                    ok:
-   *                      $ref: '#/components/schemas/V1Response/ok'
+   *                      $ref: '#/components/schemas/V1Response/properties/ok'
    *          403:
    *            $ref: '#/components/responses/403'
    *          500:

--- a/src/server/routes/attachment.js
+++ b/src/server/routes/attachment.js
@@ -251,7 +251,6 @@ module.exports = function(crowi, app) {
    *        tags: [Attachments]
    *        description: Get list of attachments in page
    *        requestBody:
-   *          required: true
    *          content:
    *            application/json:
    *              schema:
@@ -321,7 +320,6 @@ module.exports = function(crowi, app) {
    *        tags: [Attachments]
    *        description: Add attachment to the page
    *        requestBody:
-   *          required: true
    *          content:
    *            application/json:
    *              schema:
@@ -467,7 +465,6 @@ module.exports = function(crowi, app) {
    *        tags: [Attachments]
    *        description: Remove attachment
    *        requestBody:
-   *          required: true
    *          content:
    *            application/json:
    *              schema:

--- a/src/server/routes/attachment.js
+++ b/src/server/routes/attachment.js
@@ -32,19 +32,19 @@ const ApiResponse = require('../util/apiResponse');
  *          fileFormat:
  *            type: string
  *            description: file format in MIME
- *            example: image/png
+ *            example: text/plain
  *          fileName:
  *            type: string
  *            description: file name
- *            example: 601b7c59d43a042c0117e08dd37aad0aimage.png
+ *            example: 601b7c59d43a042c0117e08dd37aad0aimage.txt
  *          originalName:
  *            type: string
  *            description: original file name
- *            example: image.png
+ *            example: file.txt
  *          filePath:
  *            type: string
  *            description: file path
- *            example: attachment/5e07345972560e001761fa63/6b0b3facf3628699263d760e18efd446.png
+ *            example: attachment/5e07345972560e001761fa63/6b0b3facf3628699263d760e18efd446.txt
  *          creator:
  *            $ref: '#/components/schemas/User'
  *          page:
@@ -249,16 +249,14 @@ module.exports = function(crowi, app) {
    *    /_api/attachments.list:
    *      get:
    *        tags: [Attachments]
+   *        summary: /_api/attachments.list
    *        description: Get list of attachments in page
-   *        requestBody:
-   *          content:
-   *            application/json:
-   *              schema:
-   *                properties:
-   *                  page_id:
-   *                    $ref: '#/components/schemas/Page/properties/_id'
-   *                required:
-   *                  - page_id
+   *        parameters:
+   *          - in: query
+   *            name: page_id
+   *            schema:
+   *              $ref: '#/components/schemas/Page/properties/_id'
+   *            required: true
    *        responses:
    *          200:
    *            description: Succeeded to get list of attachments.
@@ -315,24 +313,45 @@ module.exports = function(crowi, app) {
   /**
    * @swagger
    *
+   *    components:
+   *      schemas:
+   *        AttachmentAddParams:
+   *          type: object
+   *          properties:
+   *            page_id:
+   *              $ref: '#/components/schemas/Page/properties/_id'
+   *            path:
+   *              $ref: '#/components/schemas/Page/properties/path'
+   *            file:
+   *              type: string
+   *              format: binary
+   *              description: attachment data
+   *            access_token:
+   *              type: string
+   */
+
+  /**
+   * @swagger
+   *
    *    /_api/attachments.add:
    *      post:
    *        tags: [Attachments]
+   *        summary: /_api/attachments.add
    *        description: Add attachment to the page
    *        requestBody:
    *          content:
-   *            application/json:
+   *            multipart/form-data:
    *              schema:
-   *                properties:
-   *                  page_id:
-   *                    $ref: '#/components/schemas/Page/properties/_id'
-   *                  file:
-   *                    type: string
-   *                    format: binary
-   *                    description: attachment data
-   *                required:
-   *                  - page_id
-   *                  - file
+   *                $ref: '#/components/schemas/AttachmentAddParams'
+   *              encoding:
+   *                file:
+   *                  contentType: text/plain, image/png
+   *            "*\/*":
+   *              schema:
+   *                $ref: '#/components/schemas/AttachmentAddParams'
+   *              encoding:
+   *                file:
+   *                  contentType: text/plain, image/png
    *        responses:
    *          200:
    *            description: Succeeded to add attachment.
@@ -463,6 +482,7 @@ module.exports = function(crowi, app) {
    *    /_api/attachments.remove:
    *      post:
    *        tags: [Attachments]
+   *        summary: /_api/attachments.remove
    *        description: Remove attachment
    *        requestBody:
    *          content:

--- a/src/server/routes/attachment.js
+++ b/src/server/routes/attachment.js
@@ -322,15 +322,18 @@ module.exports = function(crowi, app) {
    *          type: object
    *          properties:
    *            page_id:
+   *              nullable: true
    *              $ref: '#/components/schemas/Page/properties/_id'
    *            path:
+   *              nullable: true
    *              $ref: '#/components/schemas/Page/properties/path'
    *            file:
    *              type: string
    *              format: binary
    *              description: attachment data
-   *            access_token:
-   *              type: string
+   *          encoding:
+   *            path:
+   *              contentType: application/x-www-form-urlencoded
    */
 
   /**
@@ -344,18 +347,12 @@ module.exports = function(crowi, app) {
    *        description: Add attachment to the page
    *        requestBody:
    *          content:
-   *            multipart/form-data:
+   *            "multipart/form-data":
    *              schema:
    *                $ref: '#/components/schemas/AttachmentAddParams'
-   *              encoding:
-   *                file:
-   *                  contentType: text/plain, image/png
    *            "*\/*":
    *              schema:
    *                $ref: '#/components/schemas/AttachmentAddParams'
-   *              encoding:
-   *                file:
-   *                  contentType: text/plain, image/png
    *        responses:
    *          200:
    *            description: Succeeded to add attachment.

--- a/src/server/routes/attachment.js
+++ b/src/server/routes/attachment.js
@@ -249,7 +249,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/attachments.list:
    *      get:
-   *        tags: [Attachments]
+   *        tags: [Attachments, apiv1]
    *        operationId: /_api/attachments.list
    *        summary: /_api/attachments.list
    *        description: Get list of attachments in page
@@ -341,7 +341,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/attachments.add:
    *      post:
-   *        tags: [Attachments]
+   *        tags: [Attachments, apiv1]
    *        operationId: /_api/attachments.add
    *        summary: /_api/attachments.add
    *        description: Add attachment to the page
@@ -482,7 +482,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/attachments.remove:
    *      post:
-   *        tags: [Attachments]
+   *        tags: [Attachments, apiv1]
    *        operationId: /_api/attachments.remove
    *        summary: /_api/attachments.remove
    *        description: Remove attachment

--- a/src/server/routes/attachment.js
+++ b/src/server/routes/attachment.js
@@ -258,6 +258,8 @@ module.exports = function(crowi, app) {
    *                properties:
    *                  page_id:
    *                    $ref: '#/components/schemas/Page/properties/_id'
+   *                required:
+   *                  - page_id
    *        responses:
    *          200:
    *            description: Succeeded to get list of attachments.
@@ -330,6 +332,9 @@ module.exports = function(crowi, app) {
    *                    type: string
    *                    format: binary
    *                    description: attachment data
+   *                required:
+   *                  - page_id
+   *                  - file
    *        responses:
    *          200:
    *            description: Succeeded to add attachment.
@@ -469,6 +474,8 @@ module.exports = function(crowi, app) {
    *                properties:
    *                  attachment_id:
    *                    $ref: '#/components/schemas/Attachment/properties/_id'
+   *                required:
+   *                  - attachment_id
    *        responses:
    *          200:
    *            description: Succeeded to remove attachment.

--- a/src/server/routes/attachment.js
+++ b/src/server/routes/attachment.js
@@ -7,6 +7,54 @@ const fs = require('fs');
 
 const ApiResponse = require('../util/apiResponse');
 
+/**
+ * @swagger
+ *  tags:
+ *    name: Attachments
+ */
+
+/**
+ * @swagger
+ *
+ *  components:
+ *    schemas:
+ *      Attachment:
+ *        type: object
+ *        properties:
+ *          _id:
+ *            type: string
+ *            description: attachment ID
+ *          __v:
+ *            type: integer
+ *            description: attachment version
+ *          fileFormat:
+ *            type: string
+ *            description: file format in MIME
+ *          fileName:
+ *            type: string
+ *            description: file name
+ *          originalName:
+ *            type: string
+ *            description: original file name
+ *          filePath:
+ *            type: string
+ *            description: file path
+ *          creator:
+ *            $ref: '#/components/schemas/User'
+ *          page:
+ *            type: string
+ *            description: page ID attached at
+ *          createdAt:
+ *            type: string
+ *            description: date created at
+ *          fileSize:
+ *            type: integer
+ *            description: file size
+ *          url:
+ *            type: string
+ *            description: attachment URL
+ */
+
 module.exports = function(crowi, app) {
   const Attachment = crowi.model('Attachment');
   const User = crowi.model('User');
@@ -186,6 +234,41 @@ module.exports = function(crowi, app) {
   };
 
   /**
+   * @swagger
+   *
+   *    /_api/attachments.list:
+   *      get:
+   *        tags: [Attachments]
+   *        description: Get list of attachments in page
+   *        requestBody:
+   *          required: true
+   *          content:
+   *            application/json:
+   *              schema:
+   *                properties:
+   *                  page_id:
+   *                    type: string
+   *                    description: page object ID
+   *        responses:
+   *          200:
+   *            description: Succeeded to get list of attachments.
+   *            content:
+   *              application/json:
+   *                schema:
+   *                  properties:
+   *                    ok:
+   *                      $ref: '#/components/schemas/V1Response/ok'
+   *                    attachments:
+   *                      type: array
+   *                      items:
+   *                        $ref: '#/components/schemas/Attachment'
+   *                      description: attachment list
+   *          403:
+   *            $ref: '#/components/responses/403'
+   *          500:
+   *            $ref: '#/components/responses/500'
+   */
+  /**
    * @api {get} /attachments.list Get attachments of the page
    * @apiName ListAttachments
    * @apiGroup Attachment
@@ -219,6 +302,50 @@ module.exports = function(crowi, app) {
     return res.json(ApiResponse.success(await fileUploader.checkLimit(fileSize)));
   };
 
+  /**
+   * @swagger
+   *
+   *    /_api/attachments.add:
+   *      post:
+   *        tags: [Attachments]
+   *        description: Add attachment to the page
+   *        requestBody:
+   *          required: true
+   *          content:
+   *            application/json:
+   *              schema:
+   *                properties:
+   *                  page_id:
+   *                    type: string
+   *                    description: page object ID
+   *                  file:
+   *                    type: string
+   *                    format: binary
+   *                    description: attachment data
+   *        responses:
+   *          200:
+   *            description: Succeeded to add attachment.
+   *            content:
+   *              application/json:
+   *                schema:
+   *                  properties:
+   *                    ok:
+   *                      $ref: '#/components/schemas/V1Response/ok'
+   *                    page:
+   *                      $ref: '#/components/schemas/Page'
+   *                    attachment:
+   *                      $ref: '#/components/schemas/Attachment'
+   *                    url:
+   *                      type: string
+   *                      description: attachment URL
+   *                    pageCreated:
+   *                      type: boolean
+   *                      description: whether the page was created
+   *          403:
+   *            $ref: '#/components/responses/403'
+   *          500:
+   *            $ref: '#/components/responses/500'
+   */
   /**
    * @api {post} /attachments.add Add attachment to the page
    * @apiName AddAttachments
@@ -320,6 +447,36 @@ module.exports = function(crowi, app) {
     return res.json(ApiResponse.success(result));
   };
 
+  /**
+   * @swagger
+   *
+   *    /_api/attachments.remove:
+   *      post:
+   *        tags: [Attachments]
+   *        description: Remove attachment
+   *        requestBody:
+   *          required: true
+   *          content:
+   *            application/json:
+   *              schema:
+   *                properties:
+   *                  attachment_id:
+   *                    type: string
+   *                    description: attachment ID
+   *        responses:
+   *          200:
+   *            description: Succeeded to remove attachment.
+   *            content:
+   *              application/json:
+   *                schema:
+   *                  properties:
+   *                    ok:
+   *                      $ref: '#/components/schemas/V1Response/ok'
+   *          403:
+   *            $ref: '#/components/responses/403'
+   *          500:
+   *            $ref: '#/components/responses/500'
+   */
   /**
    * @api {post} /attachments.remove Remove attachments
    * @apiName RemoveAttachments

--- a/src/server/routes/attachment.js
+++ b/src/server/routes/attachment.js
@@ -24,35 +24,45 @@ const ApiResponse = require('../util/apiResponse');
  *          _id:
  *            type: string
  *            description: attachment ID
+ *            example: 5e0734e072560e001761fa67
  *          __v:
  *            type: integer
  *            description: attachment version
+ *            example: 0
  *          fileFormat:
  *            type: string
  *            description: file format in MIME
+ *            example: image/png
  *          fileName:
  *            type: string
  *            description: file name
+ *            example: 601b7c59d43a042c0117e08dd37aad0aimage.png
  *          originalName:
  *            type: string
  *            description: original file name
+ *            example: image.png
  *          filePath:
  *            type: string
  *            description: file path
+ *            example: attachment/5e07345972560e001761fa63/6b0b3facf3628699263d760e18efd446.png
  *          creator:
  *            $ref: '#/components/schemas/User'
  *          page:
  *            type: string
  *            description: page ID attached at
+ *            example: 5e07345972560e001761fa63
  *          createdAt:
  *            type: string
  *            description: date created at
+ *            example: 2010-01-01T00:00:00.000Z
  *          fileSize:
  *            type: integer
  *            description: file size
+ *            example: 3494332
  *          url:
  *            type: string
  *            description: attachment URL
+ *            example: http://localhost/files/5e0734e072560e001761fa67
  */
 
 module.exports = function(crowi, app) {
@@ -247,8 +257,7 @@ module.exports = function(crowi, app) {
    *              schema:
    *                properties:
    *                  page_id:
-   *                    type: string
-   *                    description: page object ID
+   *                    $ref: '#/components/schemas/Page/properties/_id'
    *        responses:
    *          200:
    *            description: Succeeded to get list of attachments.
@@ -316,8 +325,7 @@ module.exports = function(crowi, app) {
    *              schema:
    *                properties:
    *                  page_id:
-   *                    type: string
-   *                    description: page object ID
+   *                    $ref: '#/components/schemas/Page/properties/_id'
    *                  file:
    *                    type: string
    *                    format: binary
@@ -336,8 +344,7 @@ module.exports = function(crowi, app) {
    *                    attachment:
    *                      $ref: '#/components/schemas/Attachment'
    *                    url:
-   *                      type: string
-   *                      description: attachment URL
+   *                      $ref: '#/components/schemas/Attachment/properties/url'
    *                    pageCreated:
    *                      type: boolean
    *                      description: whether the page was created
@@ -461,8 +468,7 @@ module.exports = function(crowi, app) {
    *              schema:
    *                properties:
    *                  attachment_id:
-   *                    type: string
-   *                    description: attachment ID
+   *                    $ref: '#/components/schemas/Attachment/properties/_id'
    *        responses:
    *          200:
    *            description: Succeeded to remove attachment.

--- a/src/server/routes/attachment.js
+++ b/src/server/routes/attachment.js
@@ -19,6 +19,7 @@ const ApiResponse = require('../util/apiResponse');
  *  components:
  *    schemas:
  *      Attachment:
+ *        description: Attachment
  *        type: object
  *        properties:
  *          _id:

--- a/src/server/routes/attachment.js
+++ b/src/server/routes/attachment.js
@@ -26,7 +26,7 @@ const ApiResponse = require('../util/apiResponse');
  *            description: attachment ID
  *            example: 5e0734e072560e001761fa67
  *          __v:
- *            type: integer
+ *            type: number
  *            description: attachment version
  *            example: 0
  *          fileFormat:
@@ -56,7 +56,7 @@ const ApiResponse = require('../util/apiResponse');
  *            description: date created at
  *            example: 2010-01-01T00:00:00.000Z
  *          fileSize:
- *            type: integer
+ *            type: number
  *            description: file size
  *            example: 3494332
  *          url:

--- a/src/server/routes/attachment.js
+++ b/src/server/routes/attachment.js
@@ -250,7 +250,7 @@ module.exports = function(crowi, app) {
    *    /_api/attachments.list:
    *      get:
    *        tags: [Attachments, apiv1]
-   *        operationId: /_api/attachments.list
+   *        operationId: listAttachments
    *        summary: /_api/attachments.list
    *        description: Get list of attachments in page
    *        parameters:
@@ -371,6 +371,7 @@ module.exports = function(crowi, app) {
    *                    pageCreated:
    *                      type: boolean
    *                      description: whether the page was created
+   *                      example: false
    *          403:
    *            $ref: '#/components/responses/403'
    *          500:
@@ -483,7 +484,7 @@ module.exports = function(crowi, app) {
    *    /_api/attachments.remove:
    *      post:
    *        tags: [Attachments, apiv1]
-   *        operationId: /_api/attachments.remove
+   *        operationId: removeAttachment
    *        summary: /_api/attachments.remove
    *        description: Remove attachment
    *        requestBody:

--- a/src/server/routes/bookmark.js
+++ b/src/server/routes/bookmark.js
@@ -61,7 +61,7 @@ module.exports = function(crowi, app) {
    *                schema:
    *                  properties:
    *                    ok:
-   *                      $ref: '#/components/schemas/V1Response/ok'
+   *                      $ref: '#/components/schemas/V1Response/properties/ok'
    *                    bookmark:
    *                      $ref: '#/components/schemas/Bookmark'
    *          403:
@@ -118,7 +118,7 @@ module.exports = function(crowi, app) {
    *                schema:
    *                  properties:
    *                    ok:
-   *                      $ref: '#/components/schemas/V1Response/ok'
+   *                      $ref: '#/components/schemas/V1Response/properties/ok'
    *                    meta:
    *                      $ref: '#/components/schemas/V1PaginateResult/properties/meta'
    *                    data:
@@ -165,7 +165,7 @@ module.exports = function(crowi, app) {
    *                schema:
    *                  properties:
    *                    ok:
-   *                      $ref: '#/components/schemas/V1Response/ok'
+   *                      $ref: '#/components/schemas/V1Response/properties/ok'
    *                    bookmark:
    *                      $ref: '#/components/schemas/Bookmark'
    *          403:
@@ -222,7 +222,7 @@ module.exports = function(crowi, app) {
    *                schema:
    *                  properties:
    *                    ok:
-   *                      $ref: '#/components/schemas/V1Response/ok'
+   *                      $ref: '#/components/schemas/V1Response/properties/ok'
    *          403:
    *            $ref: '#/components/responses/403'
    *          500:

--- a/src/server/routes/bookmark.js
+++ b/src/server/routes/bookmark.js
@@ -46,7 +46,7 @@ module.exports = function(crowi, app) {
    *    /_api/bookmarks.get:
    *      get:
    *        tags: [Bookmarks, apiv1]
-   *        operationId: /_api/bookmarks.get
+   *        operationId: getBookmark
    *        summary: /_api/bookmarks.get
    *        description: Get bookmark of the page with the user
    *        parameters:
@@ -101,7 +101,7 @@ module.exports = function(crowi, app) {
    *    /_api/bookmarks.list:
    *      get:
    *        tags: [Bookmarks, apiv1]
-   *        operationId: /_api/bookmarks.list
+   *        operationId: listBookmarks
    *        summary: /_api/bookmarks.list
    *        description: Get bookmark list of the page with the user
    *        parameters:
@@ -152,7 +152,7 @@ module.exports = function(crowi, app) {
    *    /_api/bookmarks.add:
    *      post:
    *        tags: [Bookmarks, apiv1]
-   *        operationId: /_api/bookmarks.add
+   *        operationId: addBookmark
    *        summary: /_api/bookmarks.add
    *        description: Add bookmark of the page
    *        parameters:
@@ -207,7 +207,7 @@ module.exports = function(crowi, app) {
    *    /_api/bookmarks.remove:
    *      post:
    *        tags: [Bookmarks, apiv1]
-   *        operationId: /_api/bookmarks.remove
+   *        operationId: removeBookmark
    *        summary: /_api/bookmarks.remove
    *        description: Remove bookmark of the page
    *        requestBody:

--- a/src/server/routes/bookmark.js
+++ b/src/server/routes/bookmark.js
@@ -46,6 +46,7 @@ module.exports = function(crowi, app) {
    *    /_api/bookmarks.get:
    *      get:
    *        tags: [Bookmarks]
+   *        operationId: /_api/bookmarks.get
    *        summary: /_api/bookmarks.get
    *        description: Get bookmark of the page with the user
    *        parameters:
@@ -100,6 +101,7 @@ module.exports = function(crowi, app) {
    *    /_api/bookmarks.list:
    *      get:
    *        tags: [Bookmarks]
+   *        operationId: /_api/bookmarks.list
    *        summary: /_api/bookmarks.list
    *        description: Get bookmark list of the page with the user
    *        parameters:
@@ -150,6 +152,7 @@ module.exports = function(crowi, app) {
    *    /_api/bookmarks.add:
    *      post:
    *        tags: [Bookmarks]
+   *        operationId: /_api/bookmarks.add
    *        summary: /_api/bookmarks.add
    *        description: Add bookmark of the page
    *        parameters:
@@ -204,6 +207,7 @@ module.exports = function(crowi, app) {
    *    /_api/bookmarks.remove:
    *      post:
    *        tags: [Bookmarks]
+   *        operationId: /_api/bookmarks.remove
    *        summary: /_api/bookmarks.remove
    *        description: Remove bookmark of the page
    *        requestBody:

--- a/src/server/routes/bookmark.js
+++ b/src/server/routes/bookmark.js
@@ -1,3 +1,35 @@
+/**
+ * @swagger
+ *  tags:
+ *    name: Bookmarks
+ */
+
+/**
+ * @swagger
+ *
+ *  components:
+ *    schemas:
+ *      Bookmark:
+ *        type: object
+ *        properties:
+ *          _id:
+ *            type: string
+ *            description: page ID
+ *            example: 5e07345972560e001761fa63
+ *          __v:
+ *            type: integer
+ *            description: DB record version
+ *            example: 0
+ *          createdAt:
+ *            type: string
+ *            description: date created at
+ *            example: 2010-01-01T00:00:00.000Z
+ *          page:
+ *            $ref: '#/components/schemas/Page/properties/_id'
+ *          user:
+ *            $ref: '#/components/schemas/User/properties/_id'
+ */
+
 module.exports = function(crowi, app) {
   const debug = require('debug')('growi:routes:bookmark');
   const Bookmark = crowi.model('Bookmark');
@@ -7,6 +39,39 @@ module.exports = function(crowi, app) {
   const actions = {};
   actions.api = {};
 
+  /**
+   * @swagger
+   *
+   *    /_api/bookmarks.get:
+   *      get:
+   *        tags: [Bookmarks]
+   *        description: Get bookmark of the page with the user
+   *        requestBody:
+   *          required: true
+   *          content:
+   *            application/json:
+   *              schema:
+   *                properties:
+   *                  page_id:
+   *                    $ref: '#/components/schemas/Page/properties/_id'
+   *                required:
+   *                  - page_id
+   *        responses:
+   *          200:
+   *            description: Succeeded to get bookmark of the page with the user.
+   *            content:
+   *              application/json:
+   *                schema:
+   *                  properties:
+   *                    ok:
+   *                      $ref: '#/components/schemas/V1Response/ok'
+   *                    bookmark:
+   *                      $ref: '#/components/schemas/Bookmark'
+   *          403:
+   *            $ref: '#/components/responses/403'
+   *          500:
+   *            $ref: '#/components/responses/500'
+   */
   /**
    * @api {get} /bookmarks.get Get bookmark of the page with the user
    * @apiName GetBookmarks
@@ -30,8 +95,43 @@ module.exports = function(crowi, app) {
       });
   };
 
+
   /**
+   * @swagger
    *
+   *    /_api/bookmarks.list:
+   *      get:
+   *        tags: [Bookmarks]
+   *        description: Get bookmark list of the page with the user
+   *        requestBody:
+   *          required: true
+   *          content:
+   *            application/json:
+   *              schema:
+   *                properties:
+   *                  limit:
+   *                    $ref: '#/components/schemas/V1PaginateResult/properties/meta/properties/limit'
+   *                  offset:
+   *                    $ref: '#/components/schemas/V1PaginateResult/properties/meta/properties/offset'
+   *        responses:
+   *          200:
+   *            description: Succeeded to get bookmark of the page with the user.
+   *            content:
+   *              application/json:
+   *                schema:
+   *                  properties:
+   *                    ok:
+   *                      $ref: '#/components/schemas/V1Response/ok'
+   *                    meta:
+   *                      $ref: '#/components/schemas/V1PaginateResult/properties/meta'
+   *                    data:
+   *                      type: array
+   *                      items:
+   *                        $ref: '#/components/schemas/V1PaginateResult/properties/meta'
+   *          403:
+   *            $ref: '#/components/responses/403'
+   *          500:
+   *            $ref: '#/components/responses/500'
    */
   actions.api.list = function(req, res) {
     const paginateOptions = ApiPaginate.parseOptions(req.query);
@@ -46,6 +146,39 @@ module.exports = function(crowi, app) {
       });
   };
 
+  /**
+   * @swagger
+   *
+   *    /_api/bookmarks.add:
+   *      post:
+   *        tags: [Bookmarks]
+   *        description: Add bookmark of the page
+   *        requestBody:
+   *          required: true
+   *          content:
+   *            application/json:
+   *              schema:
+   *                properties:
+   *                  page_id:
+   *                    $ref: '#/components/schemas/Page/properties/_id'
+   *                required:
+   *                  - page_id
+   *        responses:
+   *          200:
+   *            description: Succeeded to add bookmark of the page.
+   *            content:
+   *              application/json:
+   *                schema:
+   *                  properties:
+   *                    ok:
+   *                      $ref: '#/components/schemas/V1Response/ok'
+   *                    bookmark:
+   *                      $ref: '#/components/schemas/Bookmark'
+   *          403:
+   *            $ref: '#/components/responses/403'
+   *          500:
+   *            $ref: '#/components/responses/500'
+   */
   /**
    * @api {post} /bookmarks.add Add bookmark of the page
    * @apiName AddBookmark
@@ -70,6 +203,37 @@ module.exports = function(crowi, app) {
     return res.json(ApiResponse.success(result));
   };
 
+  /**
+   * @swagger
+   *
+   *    /_api/bookmarks.remove:
+   *      post:
+   *        tags: [Bookmarks]
+   *        description: Remove bookmark of the page
+   *        requestBody:
+   *          required: true
+   *          content:
+   *            application/json:
+   *              schema:
+   *                properties:
+   *                  page_id:
+   *                    $ref: '#/components/schemas/Page/properties/_id'
+   *                required:
+   *                  - page_id
+   *        responses:
+   *          200:
+   *            description: Succeeded to remove bookmark of the page.
+   *            content:
+   *              application/json:
+   *                schema:
+   *                  properties:
+   *                    ok:
+   *                      $ref: '#/components/schemas/V1Response/ok'
+   *          403:
+   *            $ref: '#/components/responses/403'
+   *          500:
+   *            $ref: '#/components/responses/500'
+   */
   /**
    * @api {post} /bookmarks.remove Remove bookmark of the page
    * @apiName RemoveBookmark

--- a/src/server/routes/bookmark.js
+++ b/src/server/routes/bookmark.js
@@ -17,7 +17,7 @@
  *            description: page ID
  *            example: 5e07345972560e001761fa63
  *          __v:
- *            type: integer
+ *            type: number
  *            description: DB record version
  *            example: 0
  *          createdAt:

--- a/src/server/routes/bookmark.js
+++ b/src/server/routes/bookmark.js
@@ -45,16 +45,14 @@ module.exports = function(crowi, app) {
    *    /_api/bookmarks.get:
    *      get:
    *        tags: [Bookmarks]
+   *        summary: /_api/bookmarks.get
    *        description: Get bookmark of the page with the user
-   *        requestBody:
-   *          content:
-   *            application/json:
-   *              schema:
-   *                properties:
-   *                  page_id:
-   *                    $ref: '#/components/schemas/Page/properties/_id'
-   *                required:
-   *                  - page_id
+   *        parameters:
+   *          - in: query
+   *            name: page_id
+   *            required: true
+   *            schema:
+   *              $ref: '#/components/schemas/Page/properties/_id'
    *        responses:
    *          200:
    *            description: Succeeded to get bookmark of the page with the user.
@@ -101,16 +99,17 @@ module.exports = function(crowi, app) {
    *    /_api/bookmarks.list:
    *      get:
    *        tags: [Bookmarks]
+   *        summary: /_api/bookmarks.list
    *        description: Get bookmark list of the page with the user
-   *        requestBody:
-   *          content:
-   *            application/json:
-   *              schema:
-   *                properties:
-   *                  limit:
-   *                    $ref: '#/components/schemas/V1PaginateResult/properties/meta/properties/limit'
-   *                  offset:
-   *                    $ref: '#/components/schemas/V1PaginateResult/properties/meta/properties/offset'
+   *        parameters:
+   *          - in: query
+   *            name: limit
+   *            schema:
+   *              $ref: '#/components/schemas/V1PaginateResult/properties/meta/properties/limit'
+   *          - in: query
+   *            name: offset
+   *            schema:
+   *              $ref: '#/components/schemas/V1PaginateResult/properties/meta/properties/offset'
    *        responses:
    *          200:
    *            description: Succeeded to get bookmark of the page with the user.
@@ -150,16 +149,14 @@ module.exports = function(crowi, app) {
    *    /_api/bookmarks.add:
    *      post:
    *        tags: [Bookmarks]
+   *        summary: /_api/bookmarks.add
    *        description: Add bookmark of the page
-   *        requestBody:
-   *          content:
-   *            application/json:
-   *              schema:
-   *                properties:
-   *                  page_id:
-   *                    $ref: '#/components/schemas/Page/properties/_id'
-   *                required:
-   *                  - page_id
+   *        parameters:
+   *          - in: query
+   *            name: page_id
+   *            schema:
+   *              $ref: '#/components/schemas/Page/properties/_id'
+   *            required: true
    *        responses:
    *          200:
    *            description: Succeeded to add bookmark of the page.
@@ -206,6 +203,7 @@ module.exports = function(crowi, app) {
    *    /_api/bookmarks.remove:
    *      post:
    *        tags: [Bookmarks]
+   *        summary: /_api/bookmarks.remove
    *        description: Remove bookmark of the page
    *        requestBody:
    *          content:

--- a/src/server/routes/bookmark.js
+++ b/src/server/routes/bookmark.js
@@ -10,6 +10,7 @@
  *  components:
  *    schemas:
  *      Bookmark:
+ *        description: Bookmark
  *        type: object
  *        properties:
  *          _id:

--- a/src/server/routes/bookmark.js
+++ b/src/server/routes/bookmark.js
@@ -45,7 +45,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/bookmarks.get:
    *      get:
-   *        tags: [Bookmarks]
+   *        tags: [Bookmarks, apiv1]
    *        operationId: /_api/bookmarks.get
    *        summary: /_api/bookmarks.get
    *        description: Get bookmark of the page with the user
@@ -100,7 +100,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/bookmarks.list:
    *      get:
-   *        tags: [Bookmarks]
+   *        tags: [Bookmarks, apiv1]
    *        operationId: /_api/bookmarks.list
    *        summary: /_api/bookmarks.list
    *        description: Get bookmark list of the page with the user
@@ -151,7 +151,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/bookmarks.add:
    *      post:
-   *        tags: [Bookmarks]
+   *        tags: [Bookmarks, apiv1]
    *        operationId: /_api/bookmarks.add
    *        summary: /_api/bookmarks.add
    *        description: Add bookmark of the page
@@ -206,7 +206,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/bookmarks.remove:
    *      post:
-   *        tags: [Bookmarks]
+   *        tags: [Bookmarks, apiv1]
    *        operationId: /_api/bookmarks.remove
    *        summary: /_api/bookmarks.remove
    *        description: Remove bookmark of the page

--- a/src/server/routes/bookmark.js
+++ b/src/server/routes/bookmark.js
@@ -47,7 +47,6 @@ module.exports = function(crowi, app) {
    *        tags: [Bookmarks]
    *        description: Get bookmark of the page with the user
    *        requestBody:
-   *          required: true
    *          content:
    *            application/json:
    *              schema:
@@ -104,7 +103,6 @@ module.exports = function(crowi, app) {
    *        tags: [Bookmarks]
    *        description: Get bookmark list of the page with the user
    *        requestBody:
-   *          required: true
    *          content:
    *            application/json:
    *              schema:
@@ -154,7 +152,6 @@ module.exports = function(crowi, app) {
    *        tags: [Bookmarks]
    *        description: Add bookmark of the page
    *        requestBody:
-   *          required: true
    *          content:
    *            application/json:
    *              schema:
@@ -211,7 +208,6 @@ module.exports = function(crowi, app) {
    *        tags: [Bookmarks]
    *        description: Remove bookmark of the page
    *        requestBody:
-   *          required: true
    *          content:
    *            application/json:
    *              schema:

--- a/src/server/routes/comment.js
+++ b/src/server/routes/comment.js
@@ -65,7 +65,7 @@
    *    /_api/comments.get:
    *      get:
    *        tags: [Comments, apiv1]
-   *        operationId: /_api/comments.get
+   *        operationId: getComments
    *        summary: /_api/comments.get
    *        description: Get comments of the page of the revision
    *        parameters:
@@ -159,7 +159,7 @@
    *    /_api/comments.add:
    *      post:
    *        tags: [Comments, apiv1]
-   *        operationId: /_api/comments.add
+   *        operationId: addComment
    *        summary: /_api/comments.add
    *        description: Post comment for the page
    *        requestBody:
@@ -288,7 +288,7 @@
    *    /_api/comments.update:
    *      post:
    *        tags: [Comments, apiv1]
-   *        operationId: /_api/comments.update
+   *        operationId: updateComment
    *        summary: /_api/comments.update
    *        description: Update comment dody
    *        requestBody:
@@ -380,7 +380,7 @@
    *    /_api/comments.remove:
    *      post:
    *        tags: [Comments, apiv1]
-   *        operationId: /_api/comments.remove
+   *        operationId: removeComment
    *        summary: /_api/comments.remove
    *        description: Remove specified comment
    *        requestBody:

--- a/src/server/routes/comment.js
+++ b/src/server/routes/comment.js
@@ -10,6 +10,7 @@
  *  components:
  *    schemas:
  *      Comment:
+ *        description: Comment
  *        type: object
  *        properties:
  *          _id:

--- a/src/server/routes/comment.js
+++ b/src/server/routes/comment.js
@@ -17,7 +17,7 @@
  *            description: revision ID
  *            example: 5e079a0a0afa6700170a75fb
  *          __v:
- *            type: integer
+ *            type: number
  *            description: DB record version
  *            example: 0
  *          page:
@@ -31,7 +31,7 @@
  *            description: comment
  *            example: good
  *          commentPosition:
- *            type: integer
+ *            type: number
  *            description: comment position
  *            example: 0
  *          createdAt:

--- a/src/server/routes/comment.js
+++ b/src/server/routes/comment.js
@@ -66,7 +66,6 @@
    *        tags: [Comments]
    *        description: Get comments of the page of the revision
    *        requestBody:
-   *          required: true
    *          content:
    *            application/json:
    *              schema:
@@ -159,7 +158,6 @@
    *        tags: [Comments]
    *        description: Post comment for the page
    *        requestBody:
-   *          required: true
    *          content:
    *            application/json:
    *              schema:
@@ -287,7 +285,6 @@
    *        tags: [Comments]
    *        description: Update comment dody
    *        requestBody:
-   *          required: true
    *          content:
    *            application/json:
    *              schema:
@@ -378,7 +375,6 @@
    *        tags: [Comments]
    *        description: Remove specified comment
    *        requestBody:
-   *          required: true
    *          content:
    *            application/json:
    *              schema:

--- a/src/server/routes/comment.js
+++ b/src/server/routes/comment.js
@@ -65,6 +65,7 @@
    *    /_api/comments.get:
    *      get:
    *        tags: [Comments]
+   *        operationId: /_api/comments.get
    *        summary: /_api/comments.get
    *        description: Get comments of the page of the revision
    *        parameters:
@@ -158,6 +159,7 @@
    *    /_api/comments.add:
    *      post:
    *        tags: [Comments]
+   *        operationId: /_api/comments.add
    *        summary: /_api/comments.add
    *        description: Post comment for the page
    *        requestBody:
@@ -286,6 +288,7 @@
    *    /_api/comments.update:
    *      post:
    *        tags: [Comments]
+   *        operationId: /_api/comments.update
    *        summary: /_api/comments.update
    *        description: Update comment dody
    *        requestBody:
@@ -377,6 +380,7 @@
    *    /_api/comments.remove:
    *      post:
    *        tags: [Comments]
+   *        operationId: /_api/comments.remove
    *        summary: /_api/comments.remove
    *        description: Remove specified comment
    *        requestBody:

--- a/src/server/routes/comment.js
+++ b/src/server/routes/comment.js
@@ -77,7 +77,7 @@
    *                    $ref: '#/components/schemas/Revision/properties/_id'
    *        responses:
    *          200:
-   *            description: Succeeded to get comments of the page of the revisiona.
+   *            description: Succeeded to get comments of the page of the revision.
    *            content:
    *              application/json:
    *                schema:

--- a/src/server/routes/comment.js
+++ b/src/server/routes/comment.js
@@ -41,7 +41,7 @@
  *            example: 2010-01-01T00:00:00.000Z
  */
 
- module.exports = function(crowi, app) {
+module.exports = function(crowi, app) {
   const logger = require('@alias/logger')('growi:routes:comment');
   const Comment = crowi.model('Comment');
   const User = crowi.model('User');

--- a/src/server/routes/comment.js
+++ b/src/server/routes/comment.js
@@ -1,4 +1,46 @@
-module.exports = function(crowi, app) {
+/**
+ * @swagger
+ *  tags:
+ *    name: Comments
+ */
+
+/**
+ * @swagger
+ *
+ *  components:
+ *    schemas:
+ *      Comment:
+ *        type: object
+ *        properties:
+ *          _id:
+ *            type: string
+ *            description: revision ID
+ *            example: 5e079a0a0afa6700170a75fb
+ *          __v:
+ *            type: integer
+ *            description: DB record version
+ *            example: 0
+ *          page:
+ *            $ref: '#/components/schemas/Page/properties/_id'
+ *          creator:
+ *            $ref: '#/components/schemas/User/properties/_id'
+ *          revision:
+ *            $ref: '#/components/schemas/Revision/properties/_id'
+ *          comment:
+ *            type: string
+ *            description: comment
+ *            example: good
+ *          commentPosition:
+ *            type: integer
+ *            description: comment position
+ *            example: 0
+ *          createdAt:
+ *            type: string
+ *            description: date created at
+ *            example: 2010-01-01T00:00:00.000Z
+ */
+
+ module.exports = function(crowi, app) {
   const logger = require('@alias/logger')('growi:routes:comment');
   const Comment = crowi.model('Comment');
   const User = crowi.model('User');
@@ -16,6 +58,41 @@ module.exports = function(crowi, app) {
   actions.api = api;
   api.validators = {};
 
+  /**
+   * @swagger
+   *
+   *    /_api/comments.get:
+   *      get:
+   *        tags: [Comments]
+   *        description: Get comments of the page of the revision
+   *        requestBody:
+   *          required: true
+   *          content:
+   *            application/json:
+   *              schema:
+   *                properties:
+   *                  page_id:
+   *                    $ref: '#/components/schemas/Page/properties/_id'
+   *                  revision_id:
+   *                    $ref: '#/components/schemas/Revision/properties/_id'
+   *        responses:
+   *          200:
+   *            description: Succeeded to get comments of the page of the revisiona.
+   *            content:
+   *              application/json:
+   *                schema:
+   *                  properties:
+   *                    ok:
+   *                      $ref: '#/components/schemas/V1Response/ok'
+   *                    comments:
+   *                      type: array
+   *                      items:
+   *                        $ref: '#/components/schemas/Comment'
+   *          403:
+   *            $ref: '#/components/responses/403'
+   *          500:
+   *            $ref: '#/components/responses/500'
+   */
   /**
    * @api {get} /comments.get Get comments of the page of the revision
    * @apiName GetComments
@@ -74,6 +151,48 @@ module.exports = function(crowi, app) {
     return validator;
   };
 
+  /**
+   * @swagger
+   *
+   *    /_api/comments.add:
+   *      post:
+   *        tags: [Comments]
+   *        description: Post comment for the page
+   *        requestBody:
+   *          required: true
+   *          content:
+   *            application/json:
+   *              schema:
+   *                properties:
+   *                  commentForm:
+   *                    type: object
+   *                    properties:
+   *                      page_id:
+   *                        $ref: '#/components/schemas/Page/properties/_id'
+   *                      revision_id:
+   *                        $ref: '#/components/schemas/Revision/properties/_id'
+   *                      comment:
+   *                        $ref: '#/components/schemas/Comment/properties/comment'
+   *                      comment_position:
+   *                        $ref: '#/components/schemas/Comment/properties/commentPosition'
+   *                required:
+   *                  - commentForm
+   *        responses:
+   *          200:
+   *            description: Succeeded to post comment for the page.
+   *            content:
+   *              application/json:
+   *                schema:
+   *                  properties:
+   *                    ok:
+   *                      $ref: '#/components/schemas/V1Response/ok'
+   *                    comment:
+   *                      $ref: '#/components/schemas/Comment'
+   *          403:
+   *            $ref: '#/components/responses/403'
+   *          500:
+   *            $ref: '#/components/responses/500'
+   */
   /**
    * @api {post} /comments.add Post comment for the page
    * @apiName PostComment
@@ -161,6 +280,51 @@ module.exports = function(crowi, app) {
   };
 
   /**
+   * @swagger
+   *
+   *    /_api/comments.update:
+   *      post:
+   *        tags: [Comments]
+   *        description: Update comment dody
+   *        requestBody:
+   *          required: true
+   *          content:
+   *            application/json:
+   *              schema:
+   *                properties:
+   *                  form:
+   *                    type: object
+   *                    properties:
+   *                      commentForm:
+   *                        type: object
+   *                        properties:
+   *                          page_id:
+   *                            $ref: '#/components/schemas/Page/properties/_id'
+   *                          revision_id:
+   *                            $ref: '#/components/schemas/Revision/properties/_id'
+   *                          comment:
+   *                            $ref: '#/components/schemas/Comment/properties/comment'
+   *                          comment_position:
+   *                            $ref: '#/components/schemas/Comment/properties/commentPosition'
+   *                required:
+   *                  - form
+   *        responses:
+   *          200:
+   *            description: Succeeded to update comment dody.
+   *            content:
+   *              application/json:
+   *                schema:
+   *                  properties:
+   *                    ok:
+   *                      $ref: '#/components/schemas/V1Response/ok'
+   *                    comment:
+   *                      $ref: '#/components/schemas/Comment'
+   *          403:
+   *            $ref: '#/components/responses/403'
+   *          500:
+   *            $ref: '#/components/responses/500'
+   */
+  /**
    * @api {post} /comments.update Update comment dody
    * @apiName UpdateComment
    * @apiGroup Comment
@@ -206,6 +370,39 @@ module.exports = function(crowi, app) {
     // process notification if needed
   };
 
+  /**
+   * @swagger
+   *
+   *    /_api/comments.remove:
+   *      post:
+   *        tags: [Comments]
+   *        description: Remove specified comment
+   *        requestBody:
+   *          required: true
+   *          content:
+   *            application/json:
+   *              schema:
+   *                properties:
+   *                  comment_id:
+   *                    $ref: '#/components/schemas/Comment/properties/_id'
+   *                required:
+   *                  - comment_id
+   *        responses:
+   *          200:
+   *            description: Succeeded to remove specified comment.
+   *            content:
+   *              application/json:
+   *                schema:
+   *                  properties:
+   *                    ok:
+   *                      $ref: '#/components/schemas/V1Response/ok'
+   *                    comment:
+   *                      $ref: '#/components/schemas/Comment'
+   *          403:
+   *            $ref: '#/components/responses/403'
+   *          500:
+   *            $ref: '#/components/responses/500'
+   */
   /**
    * @api {post} /comments.remove Remove specified comment
    * @apiName RemoveComment

--- a/src/server/routes/comment.js
+++ b/src/server/routes/comment.js
@@ -83,7 +83,7 @@
    *                schema:
    *                  properties:
    *                    ok:
-   *                      $ref: '#/components/schemas/V1Response/ok'
+   *                      $ref: '#/components/schemas/V1Response/properties/ok'
    *                    comments:
    *                      type: array
    *                      items:
@@ -185,7 +185,7 @@
    *                schema:
    *                  properties:
    *                    ok:
-   *                      $ref: '#/components/schemas/V1Response/ok'
+   *                      $ref: '#/components/schemas/V1Response/properties/ok'
    *                    comment:
    *                      $ref: '#/components/schemas/Comment'
    *          403:
@@ -316,7 +316,7 @@
    *                schema:
    *                  properties:
    *                    ok:
-   *                      $ref: '#/components/schemas/V1Response/ok'
+   *                      $ref: '#/components/schemas/V1Response/properties/ok'
    *                    comment:
    *                      $ref: '#/components/schemas/Comment'
    *          403:
@@ -395,7 +395,7 @@
    *                schema:
    *                  properties:
    *                    ok:
-   *                      $ref: '#/components/schemas/V1Response/ok'
+   *                      $ref: '#/components/schemas/V1Response/properties/ok'
    *                    comment:
    *                      $ref: '#/components/schemas/Comment'
    *          403:

--- a/src/server/routes/comment.js
+++ b/src/server/routes/comment.js
@@ -64,7 +64,7 @@
    *
    *    /_api/comments.get:
    *      get:
-   *        tags: [Comments]
+   *        tags: [Comments, apiv1]
    *        operationId: /_api/comments.get
    *        summary: /_api/comments.get
    *        description: Get comments of the page of the revision
@@ -158,7 +158,7 @@
    *
    *    /_api/comments.add:
    *      post:
-   *        tags: [Comments]
+   *        tags: [Comments, apiv1]
    *        operationId: /_api/comments.add
    *        summary: /_api/comments.add
    *        description: Post comment for the page
@@ -287,7 +287,7 @@
    *
    *    /_api/comments.update:
    *      post:
-   *        tags: [Comments]
+   *        tags: [Comments, apiv1]
    *        operationId: /_api/comments.update
    *        summary: /_api/comments.update
    *        description: Update comment dody
@@ -379,7 +379,7 @@
    *
    *    /_api/comments.remove:
    *      post:
-   *        tags: [Comments]
+   *        tags: [Comments, apiv1]
    *        operationId: /_api/comments.remove
    *        summary: /_api/comments.remove
    *        description: Remove specified comment

--- a/src/server/routes/comment.js
+++ b/src/server/routes/comment.js
@@ -64,16 +64,17 @@
    *    /_api/comments.get:
    *      get:
    *        tags: [Comments]
+   *        summary: /_api/comments.get
    *        description: Get comments of the page of the revision
-   *        requestBody:
-   *          content:
-   *            application/json:
-   *              schema:
-   *                properties:
-   *                  page_id:
-   *                    $ref: '#/components/schemas/Page/properties/_id'
-   *                  revision_id:
-   *                    $ref: '#/components/schemas/Revision/properties/_id'
+   *        parameters:
+   *          - in: query
+   *            name: page_id
+   *            schema:
+   *              $ref: '#/components/schemas/Page/properties/_id'
+   *          - in: query
+   *            name: revision_id
+   *            schema:
+   *              $ref: '#/components/schemas/Revision/properties/_id'
    *        responses:
    *          200:
    *            description: Succeeded to get comments of the page of the revision.
@@ -156,6 +157,7 @@
    *    /_api/comments.add:
    *      post:
    *        tags: [Comments]
+   *        summary: /_api/comments.add
    *        description: Post comment for the page
    *        requestBody:
    *          content:
@@ -283,6 +285,7 @@
    *    /_api/comments.update:
    *      post:
    *        tags: [Comments]
+   *        summary: /_api/comments.update
    *        description: Update comment dody
    *        requestBody:
    *          content:
@@ -373,6 +376,7 @@
    *    /_api/comments.remove:
    *      post:
    *        tags: [Comments]
+   *        summary: /_api/comments.remove
    *        description: Remove specified comment
    *        requestBody:
    *          content:

--- a/src/server/routes/page.js
+++ b/src/server/routes/page.js
@@ -17,11 +17,11 @@
  *            description: page ID
  *            example: 5e07345972560e001761fa63
  *          __v:
- *            type: integer
+ *            type: number
  *            description: DB record version
  *            example: 0
  *          commentCount:
- *            type: integer
+ *            type: number
  *            description: count of comments
  *            example: 3
  *          createdAt:
@@ -35,7 +35,7 @@
  *            description: extend data
  *            example: {}
  *          grant:
- *            type: integer
+ *            type: number
  *            description: grant
  *            example: 1
  *          grantedUsers:
@@ -93,7 +93,7 @@
  *            description: update post ID
  *            example: 5e0734e472560e001761fa68
  *          __v:
- *            type: integer
+ *            type: number
  *            description: DB record version
  *            example: 0
  *          pathPattern:

--- a/src/server/routes/page.js
+++ b/src/server/routes/page.js
@@ -1,3 +1,73 @@
+/**
+ * @swagger
+ *
+ *  components:
+ *    schemas:
+ *      Page:
+ *        type: object
+ *        properties:
+ *          _id:
+ *            type: string
+ *            description: page ID
+ *          __v:
+ *            type: integer
+ *            description: DB record version
+ *          commentCount:
+ *            type: integer
+ *            description: count of comments
+ *          createdAt:
+ *            type: string
+ *            description: date created at
+ *          creator:
+ *            $ref: '#/components/schemas/User'
+ *          extended:
+ *            type: object
+ *            description: extend data
+ *          grant:
+ *            type: integer
+ *            description: grant
+ *          grantedUsers:
+ *            type: array
+ *            description: granted users
+ *            items:
+ *              type: string
+ *              description: user ID
+ *          lastUpdateUser:
+ *            $ref: '#/components/schemas/User'
+ *          liker:
+ *            type: array
+ *            description: granted users
+ *            items:
+ *              type: string
+ *              description: user ID
+ *          path:
+ *            type: string
+ *            description: page path
+ *          redirectTo:
+ *            type: string
+ *            description: redirect path
+ *          revision:
+ *            type: object
+ *            description: revision
+ *          seenUsers:
+ *            type: array
+ *            description: granted users
+ *            items:
+ *              type: string
+ *              description: user ID
+ *          status:
+ *            type: string
+ *            description: status
+ *            enum:
+ *              - 'wip'
+ *              - 'published'
+ *              - 'deleted'
+ *              - 'deprecated'
+ *          updatedAt:
+ *            type: string
+ *            description: date updated at
+ */
+
 /* eslint-disable no-use-before-define */
 module.exports = function(crowi, app) {
   const debug = require('debug')('growi:routes:page');

--- a/src/server/routes/page.js
+++ b/src/server/routes/page.js
@@ -647,7 +647,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/pages.list:
    *      get:
-   *        tags: [Pages]
+   *        tags: [Pages, apiv1]
    *        operationId: /_api/pages.list
    *        summary: /_api/pages.list
    *        description: Get list of pages
@@ -737,7 +737,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/pages.create:
    *      post:
-   *        tags: [Pages]
+   *        tags: [Pages, apiv1]
    *        operationId: /_api/pages.create
    *        summary: /_api/pages.create
    *        description: Create page
@@ -846,7 +846,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/pages.update:
    *      post:
-   *        tags: [Pages]
+   *        tags: [Pages, apiv1]
    *        operationId: /_api/pages.update
    *        summary: /_api/pages.update
    *        description: Update page
@@ -974,7 +974,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/pages.get:
    *      get:
-   *        tags: [Pages]
+   *        tags: [Pages, apiv1]
    *        operationId: /_api/pages.get
    *        summary: /_api/pages.get
    *        description: Get page data
@@ -1098,7 +1098,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/pages.seen:
    *      post:
-   *        tags: [Pages]
+   *        tags: [Pages, apiv1]
    *        operationId: /_api/pages.seen
    *        summary: /_api/pages.seen
    *        description: Mark as seen user
@@ -1167,7 +1167,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/likes.add:
    *      post:
-   *        tags: [Pages]
+   *        tags: [Pages, apiv1]
    *        operationId: /_api/likes.add
    *        summary: /_api/likes.add
    *        description: Like page
@@ -1243,7 +1243,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/likes.remove:
    *      post:
-   *        tags: [Pages]
+   *        tags: [Pages, apiv1]
    *        operationId: /_api/likes.remove
    *        summary: /_api/likes.remove
    *        description: Unlike page
@@ -1311,7 +1311,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/pages.updatePost:
    *      get:
-   *        tags: [Pages]
+   *        tags: [Pages, apiv1]
    *        operationId: /_api/pages.updatePost
    *        summary: /_api/pages.updatePost
    *        description: Get UpdatePost setting list
@@ -1372,7 +1372,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/pages.remove:
    *      post:
-   *        tags: [Pages]
+   *        tags: [Pages, apiv1]
    *        operationId: /_api/pages.remove
    *        summary: /_api/pages.remov
    *        description: Remove page
@@ -1476,7 +1476,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/pages.revertRemove:
    *      post:
-   *        tags: [Pages]
+   *        tags: [Pages, apiv1]
    *        operationId: /_api/pages.revertRemove
    *        summary: /_api/pages.revertRemove
    *        description: Revert removed page
@@ -1549,7 +1549,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/pages.rename:
    *      post:
-   *        tags: [Pages]
+   *        tags: [Pages, apiv1]
    *        operationId: /_api/pages.rename
    *        summary: /_api/pages.rename
    *        description: Rename page
@@ -1701,7 +1701,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/pages.unlink:
    *      post:
-   *        tags: [Pages]
+   *        tags: [Pages, apiv1]
    *        operationId: /_api/pages.unlink
    *        summary: /_api/pages.unlink
    *        description: Remove the redirecting page

--- a/src/server/routes/page.js
+++ b/src/server/routes/page.js
@@ -646,18 +646,21 @@ module.exports = function(crowi, app) {
    *    /_api/pages.list:
    *      get:
    *        tags: [Pages]
+   *        summary: /_api/pages.list
    *        description: Get list of pages
-   *        requestBody:
-   *          content:
-   *            application/json:
-   *              schema:
-   *                properties:
-   *                  path:
-   *                    $ref: '#/components/schemas/Page/properties/path'
-   *                  user:
-   *                    $ref: '#/components/schemas/User/properties/username'
-   *                  offset:
-   *                    $ref: '#/components/schemas/V1PaginateResult/properties/meta/properties/offset'
+   *        parameters:
+   *          - in: query
+   *            name: path
+   *            schema:
+   *              $ref: '#/components/schemas/Page/properties/path'
+   *          - in: query
+   *            name: user
+   *            schema:
+   *              $ref: '#/components/schemas/User/properties/username'
+   *          - in: query
+   *            name: offset
+   *            schema:
+   *              $ref: '#/components/schemas/V1PaginateResult/properties/meta/properties/offset'
    *        responses:
    *          200:
    *            description: Succeeded to get list of pages.
@@ -732,6 +735,7 @@ module.exports = function(crowi, app) {
    *    /_api/pages.create:
    *      post:
    *        tags: [Pages]
+   *        summary: /_api/pages.create
    *        description: Create page
    *        requestBody:
    *          content:
@@ -839,6 +843,7 @@ module.exports = function(crowi, app) {
    *    /_api/pages.update:
    *      post:
    *        tags: [Pages]
+   *        summary: /_api/pages.update
    *        description: Update page
    *        requestBody:
    *          content:
@@ -965,18 +970,21 @@ module.exports = function(crowi, app) {
    *    /_api/pages.get:
    *      get:
    *        tags: [Pages]
+   *        summary: /_api/pages.get
    *        description: Get page data
-   *        requestBody:
-   *          content:
-   *            application/json:
-   *              schema:
-   *                properties:
-   *                  page_id:
-   *                    $ref: '#/components/schemas/Page/properties/_id'
-   *                  path:
-   *                    $ref: '#/components/schemas/Page/properties/path'
-   *                  revision_id:
-   *                    $ref: '#/components/schemas/Revision/properties/_id'
+   *        parameters:
+   *          - in: query
+   *            name: page_id
+   *            schema:
+   *              $ref: '#/components/schemas/Page/properties/_id'
+   *          - in: query
+   *            name: path
+   *            schema:
+   *              $ref: '#/components/schemas/Page/properties/path'
+   *          - in: query
+   *            name: revision_id
+   *            schema:
+   *              $ref: '#/components/schemas/Revision/properties/_id'
    *        responses:
    *          200:
    *            description: Succeeded to get page data.
@@ -1085,6 +1093,7 @@ module.exports = function(crowi, app) {
    *    /_api/pages.seen:
    *      post:
    *        tags: [Pages]
+   *        summary: /_api/pages.seen
    *        description: Mark as seen user
    *        requestBody:
    *          content:
@@ -1152,6 +1161,7 @@ module.exports = function(crowi, app) {
    *    /_api/likes.add:
    *      post:
    *        tags: [Pages]
+   *        summary: /_api/likes.add
    *        description: Like page
    *        requestBody:
    *          content:
@@ -1226,6 +1236,7 @@ module.exports = function(crowi, app) {
    *    /_api/likes.remove:
    *      post:
    *        tags: [Pages]
+   *        summary: /_api/likes.remove
    *        description: Unlike page
    *        requestBody:
    *          content:
@@ -1292,14 +1303,13 @@ module.exports = function(crowi, app) {
    *    /_api/pages.updatePost:
    *      get:
    *        tags: [Pages]
+   *        summary: /_api/pages.updatePost
    *        description: Get UpdatePost setting list
-   *        requestBody:
-   *          content:
-   *            application/json:
-   *              schema:
-   *                properties:
-   *                  path:
-   *                    $ref: '#/components/schemas/Page/properties/path'
+   *        parameters:
+   *          - in: query
+   *            name: path
+   *            schema:
+   *              $ref: '#/components/schemas/Page/properties/path'
    *        responses:
    *          200:
    *            description: Succeeded to get UpdatePost setting list.
@@ -1353,6 +1363,7 @@ module.exports = function(crowi, app) {
    *    /_api/pages.remove:
    *      post:
    *        tags: [Pages]
+   *        summary: /_api/pages.remov
    *        description: Remove page
    *        requestBody:
    *          content:
@@ -1455,6 +1466,7 @@ module.exports = function(crowi, app) {
    *    /_api/pages.revertRemove:
    *      post:
    *        tags: [Pages]
+   *        summary: /_api/pages.revertRemove
    *        description: Revert removed page
    *        requestBody:
    *          content:
@@ -1526,6 +1538,7 @@ module.exports = function(crowi, app) {
    *    /_api/pages.rename:
    *      post:
    *        tags: [Pages]
+   *        summary: /_api/pages.rename
    *        description: Rename page
    *        requestBody:
    *          content:
@@ -1676,6 +1689,7 @@ module.exports = function(crowi, app) {
    *    /_api/pages.unlink:
    *      post:
    *        tags: [Pages]
+   *        summary: /_api/pages.unlink
    *        description: Remove the redirecting page
    *        requestBody:
    *          content:

--- a/src/server/routes/page.js
+++ b/src/server/routes/page.js
@@ -57,11 +57,11 @@
  *          path:
  *            type: string
  *            description: page path
- *            example: /user/alice/test
+ *            example: /
  *          redirectTo:
  *            type: string
  *            description: redirect path
- *            example: /user/alice/test2
+ *            example: ""
  *          revision:
  *            $ref: '#/components/schemas/Revision'
  *          seenUsers:

--- a/src/server/routes/page.js
+++ b/src/server/routes/page.js
@@ -1368,42 +1368,6 @@ module.exports = function(crowi, app) {
   };
 
   /**
-   * @swagger
-   *
-   *    /_api/pages.remove:
-   *      post:
-   *        tags: [Pages, apiv1]
-   *        operationId: /_api/pages.remove
-   *        summary: /_api/pages.remov
-   *        description: Remove page
-   *        requestBody:
-   *          content:
-   *            application/json:
-   *              schema:
-   *                properties:
-   *                  page_id:
-   *                    $ref: '#/components/schemas/Page/properties/_id'
-   *                  revision_id:
-   *                    $ref: '#/components/schemas/Revision/properties/_id'
-   *                required:
-   *                  - page_id
-   *        responses:
-   *          200:
-   *            description: Succeeded to remove page.
-   *            content:
-   *              application/json:
-   *                schema:
-   *                  properties:
-   *                    ok:
-   *                      $ref: '#/components/schemas/V1Response/properties/ok'
-   *                    page:
-   *                      $ref: '#/components/schemas/Page'
-   *          403:
-   *            $ref: '#/components/responses/403'
-   *          500:
-   *            $ref: '#/components/responses/500'
-   */
-  /**
    * @api {post} /pages.remove Remove page
    * @apiName RemovePage
    * @apiGroup Page
@@ -1471,40 +1435,6 @@ module.exports = function(crowi, app) {
     await globalNotificationService.fire(GlobalNotificationSetting.EVENT.PAGE_DELETE, page.path, req.user);
   };
 
-  /**
-   * @swagger
-   *
-   *    /_api/pages.revertRemove:
-   *      post:
-   *        tags: [Pages, apiv1]
-   *        operationId: /_api/pages.revertRemove
-   *        summary: /_api/pages.revertRemove
-   *        description: Revert removed page
-   *        requestBody:
-   *          content:
-   *            application/json:
-   *              schema:
-   *                properties:
-   *                  page_id:
-   *                    $ref: '#/components/schemas/Page/properties/_id'
-   *                required:
-   *                  - page_id
-   *        responses:
-   *          200:
-   *            description: Succeeded to revert removed page.
-   *            content:
-   *              application/json:
-   *                schema:
-   *                  properties:
-   *                    ok:
-   *                      $ref: '#/components/schemas/V1Response/properties/ok'
-   *                    page:
-   *                      $ref: '#/components/schemas/Page'
-   *          403:
-   *            $ref: '#/components/responses/403'
-   *          500:
-   *            $ref: '#/components/responses/500'
-   */
   /**
    * @api {post} /pages.revertRemove Revert removed page
    * @apiName RevertRemovePage
@@ -1696,42 +1626,6 @@ module.exports = function(crowi, app) {
     return api.create(req, res);
   };
 
-  /**
-   * @swagger
-   *
-   *    /_api/pages.unlink:
-   *      post:
-   *        tags: [Pages, apiv1]
-   *        operationId: /_api/pages.unlink
-   *        summary: /_api/pages.unlink
-   *        description: Remove the redirecting page
-   *        requestBody:
-   *          content:
-   *            application/json:
-   *              schema:
-   *                properties:
-   *                  page_id:
-   *                    $ref: '#/components/schemas/Page/properties/_id'
-   *                  revision_id:
-   *                    $ref: '#/components/schemas/Revision/properties/_id'
-   *                required:
-   *                  - page_id
-   *        responses:
-   *          200:
-   *            description: Succeeded to remove the redirecting page.
-   *            content:
-   *              application/json:
-   *                schema:
-   *                  properties:
-   *                    ok:
-   *                      $ref: '#/components/schemas/V1Response/properties/ok'
-   *                    page:
-   *                      $ref: '#/components/schemas/Page'
-   *          403:
-   *            $ref: '#/components/responses/403'
-   *          500:
-   *            $ref: '#/components/responses/500'
-   */
   /**
    * @api {post} /pages.unlink Remove the redirecting page
    * @apiName UnlinkPage

--- a/src/server/routes/page.js
+++ b/src/server/routes/page.js
@@ -669,7 +669,7 @@ module.exports = function(crowi, app) {
    *                schema:
    *                  properties:
    *                    ok:
-   *                      $ref: '#/components/schemas/V1Response/ok'
+   *                      $ref: '#/components/schemas/V1Response/properties/ok'
    *                    pages:
    *                      type: array
    *                      items:
@@ -759,7 +759,7 @@ module.exports = function(crowi, app) {
    *                schema:
    *                  properties:
    *                    ok:
-   *                      $ref: '#/components/schemas/V1Response/ok'
+   *                      $ref: '#/components/schemas/V1Response/properties/ok'
    *                    page:
    *                      $ref: '#/components/schemas/Page'
    *          403:
@@ -869,7 +869,7 @@ module.exports = function(crowi, app) {
    *                schema:
    *                  properties:
    *                    ok:
-   *                      $ref: '#/components/schemas/V1Response/ok'
+   *                      $ref: '#/components/schemas/V1Response/properties/ok'
    *                    page:
    *                      $ref: '#/components/schemas/Page'
    *          403:
@@ -993,7 +993,7 @@ module.exports = function(crowi, app) {
    *                schema:
    *                  properties:
    *                    ok:
-   *                      $ref: '#/components/schemas/V1Response/ok'
+   *                      $ref: '#/components/schemas/V1Response/properties/ok'
    *                    page:
    *                      $ref: '#/components/schemas/Page'
    *          403:
@@ -1112,7 +1112,7 @@ module.exports = function(crowi, app) {
    *                schema:
    *                  properties:
    *                    ok:
-   *                      $ref: '#/components/schemas/V1Response/ok'
+   *                      $ref: '#/components/schemas/V1Response/properties/ok'
    *                    seenUser:
    *                      $ref: '#/components/schemas/Page/properties/seenUsers'
    *          403:
@@ -1180,7 +1180,7 @@ module.exports = function(crowi, app) {
    *                schema:
    *                  properties:
    *                    ok:
-   *                      $ref: '#/components/schemas/V1Response/ok'
+   *                      $ref: '#/components/schemas/V1Response/properties/ok'
    *                    page:
    *                      $ref: '#/components/schemas/Page'
    *          403:
@@ -1255,7 +1255,7 @@ module.exports = function(crowi, app) {
    *                schema:
    *                  properties:
    *                    ok:
-   *                      $ref: '#/components/schemas/V1Response/ok'
+   *                      $ref: '#/components/schemas/V1Response/properties/ok'
    *                    page:
    *                      $ref: '#/components/schemas/Page'
    *          403:
@@ -1318,7 +1318,7 @@ module.exports = function(crowi, app) {
    *                schema:
    *                  properties:
    *                    ok:
-   *                      $ref: '#/components/schemas/V1Response/ok'
+   *                      $ref: '#/components/schemas/V1Response/properties/ok'
    *                    updatePost:
    *                      $ref: '#/components/schemas/UpdatePost'
    *          403:
@@ -1384,7 +1384,7 @@ module.exports = function(crowi, app) {
    *                schema:
    *                  properties:
    *                    ok:
-   *                      $ref: '#/components/schemas/V1Response/ok'
+   *                      $ref: '#/components/schemas/V1Response/properties/ok'
    *                    page:
    *                      $ref: '#/components/schemas/Page'
    *          403:
@@ -1485,7 +1485,7 @@ module.exports = function(crowi, app) {
    *                schema:
    *                  properties:
    *                    ok:
-   *                      $ref: '#/components/schemas/V1Response/ok'
+   *                      $ref: '#/components/schemas/V1Response/properties/ok'
    *                    page:
    *                      $ref: '#/components/schemas/Page'
    *          403:
@@ -1568,7 +1568,7 @@ module.exports = function(crowi, app) {
    *                schema:
    *                  properties:
    *                    ok:
-   *                      $ref: '#/components/schemas/V1Response/ok'
+   *                      $ref: '#/components/schemas/V1Response/properties/ok'
    *                    page:
    *                      $ref: '#/components/schemas/Page'
    *          403:
@@ -1710,7 +1710,7 @@ module.exports = function(crowi, app) {
    *                schema:
    *                  properties:
    *                    ok:
-   *                      $ref: '#/components/schemas/V1Response/ok'
+   *                      $ref: '#/components/schemas/V1Response/properties/ok'
    *                    page:
    *                      $ref: '#/components/schemas/Page'
    *          403:

--- a/src/server/routes/page.js
+++ b/src/server/routes/page.js
@@ -1,42 +1,14 @@
 /**
  * @swagger
+ *  tags:
+ *    name: Pages
+ */
+
+/**
+ * @swagger
  *
  *  components:
  *    schemas:
- *      Revision:
- *        type: object
- *        properties:
- *          _id:
- *            type: string
- *            description: revision ID
- *            example: 5e0734e472560e001761fa68
- *          __v:
- *            type: integer
- *            description: DB record version
- *            example: 0
- *          author:
- *            type: object
- *            description: author
- *            example: nil
- *          body:
- *            type: string
- *            description: content body
- *            example: |
- *              \# test
- *
- *              test
- *          createdAt:
- *            type: string
- *            description: date created at
- *            example: 2010-01-01T00:00:00.000Z
- *          format:
- *            type: string
- *            description: format
- *            example: markdown
- *          path:
- *            type: string
- *            description: path
- *            example: /user/alice/test
  *      Page:
  *        type: object
  *        properties:
@@ -85,11 +57,11 @@
  *          path:
  *            type: string
  *            description: page path
- *            example: /user/testdemocrowi/test
+ *            example: /user/alice/test
  *          redirectTo:
  *            type: string
  *            description: redirect path
- *            example: /user/testdemocrowi/test2
+ *            example: /user/alice/test2
  *          revision:
  *            $ref: '#/components/schemas/Revision'
  *          seenUsers:
@@ -111,6 +83,81 @@
  *          updatedAt:
  *            type: string
  *            description: date updated at
+ *            example: 2010-01-01T00:00:00.000Z
+ *
+ *      Revision:
+ *        type: object
+ *        properties:
+ *          _id:
+ *            type: string
+ *            description: revision ID
+ *            example: 5e0734e472560e001761fa68
+ *          __v:
+ *            type: integer
+ *            description: DB record version
+ *            example: 0
+ *          author:
+ *            type: object
+ *            description: author
+ *            example: nil
+ *          body:
+ *            type: string
+ *            description: content body
+ *            example: |
+ *              \# test
+ *
+ *              test
+ *          createdAt:
+ *            type: string
+ *            description: date created at
+ *            example: 2010-01-01T00:00:00.000Z
+ *          format:
+ *            type: string
+ *            description: format
+ *            example: markdown
+ *          path:
+ *            type: string
+ *            description: path
+ *            example: /user/alice/test
+ *
+ *      UpdatePost:
+ *        type: object
+ *        properties:
+ *          _id:
+ *            type: object
+ *            description: update post ID
+ *            example: 5e0734e472560e001761fa68
+ *          __v:
+ *            type: integer
+ *            description: DB record version
+ *            example: 0
+ *          pathPattern:
+ *            type: string
+ *            description: path pattern
+ *            example: /test
+ *          patternPrefix:
+ *            type: string
+ *            description: patternPrefix prefix
+ *            example: /
+ *          patternPrefix2:
+ *            type: string
+ *            description: path
+ *            example: test
+ *          channel:
+ *            type: string
+ *            description: channel
+ *            example: general
+ *          provider:
+ *            type: string
+ *            description: provider
+ *            enum:
+ *              - slack
+ *            example: slack
+ *          creator:
+ *            $ref: '#/components/schemas/User'
+ *          createdAt:
+ *            type: string
+ *            description: date created at
  *            example: 2010-01-01T00:00:00.000Z
  */
 
@@ -629,6 +676,42 @@ module.exports = function(crowi, app) {
   actions.api = api;
 
   /**
+   * @swagger
+   *
+   *    /_api/pages.list:
+   *      get:
+   *        tags: [Pages]
+   *        description: Get list of pages
+   *        requestBody:
+   *          required: true
+   *          content:
+   *            application/json:
+   *              schema:
+   *                properties:
+   *                  path:
+   *                    $ref: '#/components/schemas/Page/properties/path'
+   *                  user:
+   *                    $ref: '#/components/schemas/User/properties/username'
+   *        responses:
+   *          200:
+   *            description: Succeeded to get list of pages.
+   *            content:
+   *              application/json:
+   *                schema:
+   *                  properties:
+   *                    ok:
+   *                      $ref: '#/components/schemas/V1Response/ok'
+   *                    pages:
+   *                      type: array
+   *                      items:
+   *                        $ref: '#/components/schemas/Page'
+   *                      description: page list
+   *          403:
+   *            $ref: '#/components/responses/403'
+   *          500:
+   *            $ref: '#/components/responses/500'
+   */
+  /**
    * @api {get} /pages.list List pages by user
    * @apiName ListPage
    * @apiGroup Page
@@ -677,6 +760,44 @@ module.exports = function(crowi, app) {
     }
   };
 
+  /**
+   * @swagger
+   *
+   *    /_api/pages.create:
+   *      post:
+   *        tags: [Pages]
+   *        description: Create page
+   *        requestBody:
+   *          required: true
+   *          content:
+   *            application/json:
+   *              schema:
+   *                properties:
+   *                  body:
+   *                    $ref: '#/components/schemas/Revision/properties/body'
+   *                  path:
+   *                    $ref: '#/components/schemas/Page/properties/path'
+   *                  grant:
+   *                    $ref: '#/components/schemas/Page/properties/grant'
+   *                required:
+   *                  - body
+   *                  - path
+   *        responses:
+   *          200:
+   *            description: Succeeded to create page.
+   *            content:
+   *              application/json:
+   *                schema:
+   *                  properties:
+   *                    ok:
+   *                      $ref: '#/components/schemas/V1Response/ok'
+   *                    page:
+   *                      $ref: '#/components/schemas/Page'
+   *          403:
+   *            $ref: '#/components/responses/403'
+   *          500:
+   *            $ref: '#/components/responses/500'
+   */
   /**
    * @api {post} /pages.create Create new page
    * @apiName CreatePage
@@ -747,6 +868,46 @@ module.exports = function(crowi, app) {
     }
   };
 
+  /**
+   * @swagger
+   *
+   *    /_api/pages.update:
+   *      post:
+   *        tags: [Pages]
+   *        description: Update page
+   *        requestBody:
+   *          required: true
+   *          content:
+   *            application/json:
+   *              schema:
+   *                properties:
+   *                  body:
+   *                    $ref: '#/components/schemas/Revision/properties/body'
+   *                  page_id:
+   *                    $ref: '#/components/schemas/Page/properties/_id'
+   *                  revision_id:
+   *                    $ref: '#/components/schemas/Revision/properties/_id'
+   *                  grant:
+   *                    $ref: '#/components/schemas/Page/properties/grant'
+   *                required:
+   *                  - body
+   *                  - page_id
+   *        responses:
+   *          200:
+   *            description: Succeeded to update page.
+   *            content:
+   *              application/json:
+   *                schema:
+   *                  properties:
+   *                    ok:
+   *                      $ref: '#/components/schemas/V1Response/ok'
+   *                    page:
+   *                      $ref: '#/components/schemas/Page'
+   *          403:
+   *            $ref: '#/components/responses/403'
+   *          500:
+   *            $ref: '#/components/responses/500'
+   */
   /**
    * @api {post} /pages.update Update page
    * @apiName UpdatePage
@@ -835,6 +996,41 @@ module.exports = function(crowi, app) {
   };
 
   /**
+   * @swagger
+   *
+   *    /_api/pages.get:
+   *      get:
+   *        tags: [Pages]
+   *        description: Get page data
+   *        requestBody:
+   *          required: true
+   *          content:
+   *            application/json:
+   *              schema:
+   *                properties:
+   *                  page_id:
+   *                    $ref: '#/components/schemas/Page/properties/_id'
+   *                  path:
+   *                    $ref: '#/components/schemas/Page/properties/path'
+   *                  revision_id:
+   *                    $ref: '#/components/schemas/Revision/properties/_id'
+   *        responses:
+   *          200:
+   *            description: Succeeded to get page data.
+   *            content:
+   *              application/json:
+   *                schema:
+   *                  properties:
+   *                    ok:
+   *                      $ref: '#/components/schemas/V1Response/ok'
+   *                    page:
+   *                      $ref: '#/components/schemas/Page'
+   *          403:
+   *            $ref: '#/components/responses/403'
+   *          500:
+   *            $ref: '#/components/responses/500'
+   */
+  /**
    * @api {get} /pages.get Get page data
    * @apiName GetPage
    * @apiGroup Page
@@ -921,6 +1117,39 @@ module.exports = function(crowi, app) {
   };
 
   /**
+   * @swagger
+   *
+   *    /_api/pages.seen:
+   *      post:
+   *        tags: [Pages]
+   *        description: Mark as seen user
+   *        requestBody:
+   *          required: true
+   *          content:
+   *            application/json:
+   *              schema:
+   *                properties:
+   *                  page_id:
+   *                    $ref: '#/components/schemas/Page/properties/_id'
+   *                required:
+   *                  - page_id
+   *        responses:
+   *          200:
+   *            description: Succeeded to be page seen.
+   *            content:
+   *              application/json:
+   *                schema:
+   *                  properties:
+   *                    ok:
+   *                      $ref: '#/components/schemas/V1Response/ok'
+   *                    seenUser:
+   *                      $ref: '#/components/schemas/Page/properties/seenUsers'
+   *          403:
+   *            $ref: '#/components/responses/403'
+   *          500:
+   *            $ref: '#/components/responses/500'
+   */
+  /**
    * @api {post} /pages.seen Mark as seen user
    * @apiName SeenPage
    * @apiGroup Page
@@ -955,6 +1184,39 @@ module.exports = function(crowi, app) {
     return res.json(ApiResponse.success(result));
   };
 
+  /**
+   * @swagger
+   *
+   *    /_api/likes.add:
+   *      post:
+   *        tags: [Pages]
+   *        description: Like page
+   *        requestBody:
+   *          required: true
+   *          content:
+   *            application/json:
+   *              schema:
+   *                properties:
+   *                  page_id:
+   *                    $ref: '#/components/schemas/Page/properties/_id'
+   *                required:
+   *                  - page_id
+   *        responses:
+   *          200:
+   *            description: Succeeded to be page liked.
+   *            content:
+   *              application/json:
+   *                schema:
+   *                  properties:
+   *                    ok:
+   *                      $ref: '#/components/schemas/V1Response/ok'
+   *                    page:
+   *                      $ref: '#/components/schemas/Page'
+   *          403:
+   *            $ref: '#/components/responses/403'
+   *          500:
+   *            $ref: '#/components/responses/500'
+   */
   /**
    * @api {post} /likes.add Like page
    * @apiName LikePage
@@ -998,6 +1260,39 @@ module.exports = function(crowi, app) {
   };
 
   /**
+   * @swagger
+   *
+   *    /_api/likes.remove:
+   *      post:
+   *        tags: [Pages]
+   *        description: Unlike page
+   *        requestBody:
+   *          required: true
+   *          content:
+   *            application/json:
+   *              schema:
+   *                properties:
+   *                  page_id:
+   *                    $ref: '#/components/schemas/Page/properties/_id'
+   *                required:
+   *                  - page_id
+   *        responses:
+   *          200:
+   *            description: Succeeded to not be page liked.
+   *            content:
+   *              application/json:
+   *                schema:
+   *                  properties:
+   *                    ok:
+   *                      $ref: '#/components/schemas/V1Response/ok'
+   *                    page:
+   *                      $ref: '#/components/schemas/Page'
+   *          403:
+   *            $ref: '#/components/responses/403'
+   *          500:
+   *            $ref: '#/components/responses/500'
+   */
+  /**
    * @api {post} /likes.remove Unlike page
    * @apiName UnlikePage
    * @apiGroup Page
@@ -1032,6 +1327,37 @@ module.exports = function(crowi, app) {
   };
 
   /**
+   * @swagger
+   *
+   *    /_api/pages.updatePost:
+   *      get:
+   *        tags: [Pages]
+   *        description: Get UpdatePost setting list
+   *        requestBody:
+   *          required: true
+   *          content:
+   *            application/json:
+   *              schema:
+   *                properties:
+   *                  path:
+   *                    $ref: '#/components/schemas/Page/properties/path'
+   *        responses:
+   *          200:
+   *            description: Succeeded to get UpdatePost setting list.
+   *            content:
+   *              application/json:
+   *                schema:
+   *                  properties:
+   *                    ok:
+   *                      $ref: '#/components/schemas/V1Response/ok'
+   *                    updatePost:
+   *                      $ref: '#/components/schemas/UpdatePost'
+   *          403:
+   *            $ref: '#/components/responses/403'
+   *          500:
+   *            $ref: '#/components/responses/500'
+   */
+  /**
    * @api {get} /pages.updatePost
    * @apiName Get UpdatePost setting list
    * @apiGroup Page
@@ -1062,6 +1388,41 @@ module.exports = function(crowi, app) {
       });
   };
 
+  /**
+   * @swagger
+   *
+   *    /_api/pages.remove:
+   *      post:
+   *        tags: [Pages]
+   *        description: Remove page
+   *        requestBody:
+   *          required: true
+   *          content:
+   *            application/json:
+   *              schema:
+   *                properties:
+   *                  page_id:
+   *                    $ref: '#/components/schemas/Page/properties/_id'
+   *                  revision_id:
+   *                    $ref: '#/components/schemas/Revision/properties/_id'
+   *                required:
+   *                  - page_id
+   *        responses:
+   *          200:
+   *            description: Succeeded to remove page.
+   *            content:
+   *              application/json:
+   *                schema:
+   *                  properties:
+   *                    ok:
+   *                      $ref: '#/components/schemas/V1Response/ok'
+   *                    page:
+   *                      $ref: '#/components/schemas/Page'
+   *          403:
+   *            $ref: '#/components/responses/403'
+   *          500:
+   *            $ref: '#/components/responses/500'
+   */
   /**
    * @api {post} /pages.remove Remove page
    * @apiName RemovePage
@@ -1131,6 +1492,39 @@ module.exports = function(crowi, app) {
   };
 
   /**
+   * @swagger
+   *
+   *    /_api/pages.revertRemove:
+   *      post:
+   *        tags: [Pages]
+   *        description: Revert removed page
+   *        requestBody:
+   *          required: true
+   *          content:
+   *            application/json:
+   *              schema:
+   *                properties:
+   *                  page_id:
+   *                    $ref: '#/components/schemas/Page/properties/_id'
+   *                required:
+   *                  - page_id
+   *        responses:
+   *          200:
+   *            description: Succeeded to revert removed page.
+   *            content:
+   *              application/json:
+   *                schema:
+   *                  properties:
+   *                    ok:
+   *                      $ref: '#/components/schemas/V1Response/ok'
+   *                    page:
+   *                      $ref: '#/components/schemas/Page'
+   *          403:
+   *            $ref: '#/components/responses/403'
+   *          500:
+   *            $ref: '#/components/responses/500'
+   */
+  /**
    * @api {post} /pages.revertRemove Revert removed page
    * @apiName RevertRemovePage
    * @apiGroup Page
@@ -1169,6 +1563,50 @@ module.exports = function(crowi, app) {
     return res.json(ApiResponse.success(result));
   };
 
+  /**
+   * @swagger
+   *
+   *    /_api/pages.rename:
+   *      post:
+   *        tags: [Pages]
+   *        description: Rename page
+   *        requestBody:
+   *          required: true
+   *          content:
+   *            application/json:
+   *              schema:
+   *                properties:
+   *                  page_id:
+   *                    $ref: '#/components/schemas/Page/properties/_id'
+   *                  path:
+   *                    $ref: '#/components/schemas/Page/properties/path'
+   *                  revision_id:
+   *                    $ref: '#/components/schemas/Revision/properties/_id'
+   *                  new_path:
+   *                    type: string
+   *                    description: new path
+   *                    example: /user/alice/new_test
+   *                  create_redirect:
+   *                    type: boolean
+   *                    description: whether redirect page
+   *                required:
+   *                  - page_id
+   *        responses:
+   *          200:
+   *            description: Succeeded to rename page.
+   *            content:
+   *              application/json:
+   *                schema:
+   *                  properties:
+   *                    ok:
+   *                      $ref: '#/components/schemas/V1Response/ok'
+   *                    page:
+   *                      $ref: '#/components/schemas/Page'
+   *          403:
+   *            $ref: '#/components/responses/403'
+   *          500:
+   *            $ref: '#/components/responses/500'
+   */
   /**
    * @api {post} /pages.rename Rename page
    * @apiName RenamePage
@@ -1276,6 +1714,41 @@ module.exports = function(crowi, app) {
     return api.create(req, res);
   };
 
+  /**
+   * @swagger
+   *
+   *    /_api/pages.unlink:
+   *      post:
+   *        tags: [Pages]
+   *        description: Remove the redirecting page
+   *        requestBody:
+   *          required: true
+   *          content:
+   *            application/json:
+   *              schema:
+   *                properties:
+   *                  page_id:
+   *                    $ref: '#/components/schemas/Page/properties/_id'
+   *                  revision_id:
+   *                    $ref: '#/components/schemas/Revision/properties/_id'
+   *                required:
+   *                  - page_id
+   *        responses:
+   *          200:
+   *            description: Succeeded to remove the redirecting page.
+   *            content:
+   *              application/json:
+   *                schema:
+   *                  properties:
+   *                    ok:
+   *                      $ref: '#/components/schemas/V1Response/ok'
+   *                    page:
+   *                      $ref: '#/components/schemas/Page'
+   *          403:
+   *            $ref: '#/components/responses/403'
+   *          500:
+   *            $ref: '#/components/responses/500'
+   */
   /**
    * @api {post} /pages.unlink Remove the redirecting page
    * @apiName UnlinkPage

--- a/src/server/routes/page.js
+++ b/src/server/routes/page.js
@@ -10,6 +10,7 @@
  *  components:
  *    schemas:
  *      Page:
+ *        description: Page
  *        type: object
  *        properties:
  *          _id:
@@ -86,6 +87,7 @@
  *            example: 2010-01-01T00:00:00.000Z
  *
  *      UpdatePost:
+ *        description: UpdatePost
  *        type: object
  *        properties:
  *          _id:

--- a/src/server/routes/page.js
+++ b/src/server/routes/page.js
@@ -3,35 +3,76 @@
  *
  *  components:
  *    schemas:
+ *      Revision:
+ *        type: object
+ *        properties:
+ *          _id:
+ *            type: string
+ *            description: revision ID
+ *            example: 5e0734e472560e001761fa68
+ *          __v:
+ *            type: integer
+ *            description: DB record version
+ *            example: 0
+ *          author:
+ *            type: object
+ *            description: author
+ *            example: nil
+ *          body:
+ *            type: string
+ *            description: content body
+ *            example: |
+ *              \# test
+ *
+ *              test
+ *          createdAt:
+ *            type: string
+ *            description: date created at
+ *            example: 2010-01-01T00:00:00.000Z
+ *          format:
+ *            type: string
+ *            description: format
+ *            example: markdown
+ *          path:
+ *            type: string
+ *            description: path
+ *            example: /user/alice/test
  *      Page:
  *        type: object
  *        properties:
  *          _id:
  *            type: string
  *            description: page ID
+ *            example: 5e07345972560e001761fa63
  *          __v:
  *            type: integer
  *            description: DB record version
+ *            example: 0
  *          commentCount:
  *            type: integer
  *            description: count of comments
+ *            example: 3
  *          createdAt:
  *            type: string
  *            description: date created at
+ *            example: 2010-01-01T00:00:00.000Z
  *          creator:
  *            $ref: '#/components/schemas/User'
  *          extended:
  *            type: object
  *            description: extend data
+ *            example: {}
  *          grant:
  *            type: integer
  *            description: grant
+ *            example: 1
  *          grantedUsers:
  *            type: array
  *            description: granted users
  *            items:
  *              type: string
  *              description: user ID
+ *            example: ["5ae5fccfc5577b0004dbd8ab"]
  *          lastUpdateUser:
  *            $ref: '#/components/schemas/User'
  *          liker:
@@ -40,21 +81,24 @@
  *            items:
  *              type: string
  *              description: user ID
+ *            example: []
  *          path:
  *            type: string
  *            description: page path
+ *            example: /user/testdemocrowi/test
  *          redirectTo:
  *            type: string
  *            description: redirect path
+ *            example: /user/testdemocrowi/test2
  *          revision:
- *            type: object
- *            description: revision
+ *            $ref: '#/components/schemas/Revision'
  *          seenUsers:
  *            type: array
  *            description: granted users
  *            items:
  *              type: string
  *              description: user ID
+ *            example: 5ae5fccfc5577b0004dbd8ab
  *          status:
  *            type: string
  *            description: status
@@ -63,9 +107,11 @@
  *              - 'published'
  *              - 'deleted'
  *              - 'deprecated'
+ *            example: published
  *          updatedAt:
  *            type: string
  *            description: date updated at
+ *            example: 2010-01-01T00:00:00.000Z
  */
 
 /* eslint-disable no-use-before-define */

--- a/src/server/routes/page.js
+++ b/src/server/routes/page.js
@@ -648,7 +648,7 @@ module.exports = function(crowi, app) {
    *    /_api/pages.list:
    *      get:
    *        tags: [Pages, apiv1]
-   *        operationId: /_api/pages.list
+   *        operationId: listPages
    *        summary: /_api/pages.list
    *        description: Get list of pages
    *        parameters:
@@ -738,7 +738,7 @@ module.exports = function(crowi, app) {
    *    /_api/pages.create:
    *      post:
    *        tags: [Pages, apiv1]
-   *        operationId: /_api/pages.create
+   *        operationId: createPage
    *        summary: /_api/pages.create
    *        description: Create page
    *        requestBody:
@@ -847,7 +847,7 @@ module.exports = function(crowi, app) {
    *    /_api/pages.update:
    *      post:
    *        tags: [Pages, apiv1]
-   *        operationId: /_api/pages.update
+   *        operationId: updatePage
    *        summary: /_api/pages.update
    *        description: Update page
    *        requestBody:
@@ -975,7 +975,7 @@ module.exports = function(crowi, app) {
    *    /_api/pages.get:
    *      get:
    *        tags: [Pages, apiv1]
-   *        operationId: /_api/pages.get
+   *        operationId: getPage
    *        summary: /_api/pages.get
    *        description: Get page data
    *        parameters:
@@ -1099,7 +1099,7 @@ module.exports = function(crowi, app) {
    *    /_api/pages.seen:
    *      post:
    *        tags: [Pages, apiv1]
-   *        operationId: /_api/pages.seen
+   *        operationId: seenPage
    *        summary: /_api/pages.seen
    *        description: Mark as seen user
    *        requestBody:
@@ -1168,7 +1168,7 @@ module.exports = function(crowi, app) {
    *    /_api/likes.add:
    *      post:
    *        tags: [Pages, apiv1]
-   *        operationId: /_api/likes.add
+   *        operationId: addLike
    *        summary: /_api/likes.add
    *        description: Like page
    *        requestBody:
@@ -1244,7 +1244,7 @@ module.exports = function(crowi, app) {
    *    /_api/likes.remove:
    *      post:
    *        tags: [Pages, apiv1]
-   *        operationId: /_api/likes.remove
+   *        operationId: removeLike
    *        summary: /_api/likes.remove
    *        description: Unlike page
    *        requestBody:
@@ -1312,7 +1312,7 @@ module.exports = function(crowi, app) {
    *    /_api/pages.updatePost:
    *      get:
    *        tags: [Pages, apiv1]
-   *        operationId: /_api/pages.updatePost
+   *        operationId: getUpdatePostPage
    *        summary: /_api/pages.updatePost
    *        description: Get UpdatePost setting list
    *        parameters:
@@ -1550,7 +1550,7 @@ module.exports = function(crowi, app) {
    *    /_api/pages.rename:
    *      post:
    *        tags: [Pages, apiv1]
-   *        operationId: /_api/pages.rename
+   *        operationId: renamePage
    *        summary: /_api/pages.rename
    *        description: Rename page
    *        requestBody:

--- a/src/server/routes/page.js
+++ b/src/server/routes/page.js
@@ -85,41 +85,6 @@
  *            description: date updated at
  *            example: 2010-01-01T00:00:00.000Z
  *
- *      Revision:
- *        type: object
- *        properties:
- *          _id:
- *            type: string
- *            description: revision ID
- *            example: 5e0734e472560e001761fa68
- *          __v:
- *            type: integer
- *            description: DB record version
- *            example: 0
- *          author:
- *            type: object
- *            description: author
- *            example: nil
- *          body:
- *            type: string
- *            description: content body
- *            example: |
- *              \# test
- *
- *              test
- *          createdAt:
- *            type: string
- *            description: date created at
- *            example: 2010-01-01T00:00:00.000Z
- *          format:
- *            type: string
- *            description: format
- *            example: markdown
- *          path:
- *            type: string
- *            description: path
- *            example: /user/alice/test
- *
  *      UpdatePost:
  *        type: object
  *        properties:

--- a/src/server/routes/page.js
+++ b/src/server/routes/page.js
@@ -648,6 +648,7 @@ module.exports = function(crowi, app) {
    *    /_api/pages.list:
    *      get:
    *        tags: [Pages]
+   *        operationId: /_api/pages.list
    *        summary: /_api/pages.list
    *        description: Get list of pages
    *        parameters:
@@ -737,6 +738,7 @@ module.exports = function(crowi, app) {
    *    /_api/pages.create:
    *      post:
    *        tags: [Pages]
+   *        operationId: /_api/pages.create
    *        summary: /_api/pages.create
    *        description: Create page
    *        requestBody:
@@ -845,6 +847,7 @@ module.exports = function(crowi, app) {
    *    /_api/pages.update:
    *      post:
    *        tags: [Pages]
+   *        operationId: /_api/pages.update
    *        summary: /_api/pages.update
    *        description: Update page
    *        requestBody:
@@ -972,6 +975,7 @@ module.exports = function(crowi, app) {
    *    /_api/pages.get:
    *      get:
    *        tags: [Pages]
+   *        operationId: /_api/pages.get
    *        summary: /_api/pages.get
    *        description: Get page data
    *        parameters:
@@ -1095,6 +1099,7 @@ module.exports = function(crowi, app) {
    *    /_api/pages.seen:
    *      post:
    *        tags: [Pages]
+   *        operationId: /_api/pages.seen
    *        summary: /_api/pages.seen
    *        description: Mark as seen user
    *        requestBody:
@@ -1163,6 +1168,7 @@ module.exports = function(crowi, app) {
    *    /_api/likes.add:
    *      post:
    *        tags: [Pages]
+   *        operationId: /_api/likes.add
    *        summary: /_api/likes.add
    *        description: Like page
    *        requestBody:
@@ -1238,6 +1244,7 @@ module.exports = function(crowi, app) {
    *    /_api/likes.remove:
    *      post:
    *        tags: [Pages]
+   *        operationId: /_api/likes.remove
    *        summary: /_api/likes.remove
    *        description: Unlike page
    *        requestBody:
@@ -1305,6 +1312,7 @@ module.exports = function(crowi, app) {
    *    /_api/pages.updatePost:
    *      get:
    *        tags: [Pages]
+   *        operationId: /_api/pages.updatePost
    *        summary: /_api/pages.updatePost
    *        description: Get UpdatePost setting list
    *        parameters:
@@ -1365,6 +1373,7 @@ module.exports = function(crowi, app) {
    *    /_api/pages.remove:
    *      post:
    *        tags: [Pages]
+   *        operationId: /_api/pages.remove
    *        summary: /_api/pages.remov
    *        description: Remove page
    *        requestBody:
@@ -1468,6 +1477,7 @@ module.exports = function(crowi, app) {
    *    /_api/pages.revertRemove:
    *      post:
    *        tags: [Pages]
+   *        operationId: /_api/pages.revertRemove
    *        summary: /_api/pages.revertRemove
    *        description: Revert removed page
    *        requestBody:
@@ -1540,6 +1550,7 @@ module.exports = function(crowi, app) {
    *    /_api/pages.rename:
    *      post:
    *        tags: [Pages]
+   *        operationId: /_api/pages.rename
    *        summary: /_api/pages.rename
    *        description: Rename page
    *        requestBody:
@@ -1691,6 +1702,7 @@ module.exports = function(crowi, app) {
    *    /_api/pages.unlink:
    *      post:
    *        tags: [Pages]
+   *        operationId: /_api/pages.unlink
    *        summary: /_api/pages.unlink
    *        description: Remove the redirecting page
    *        requestBody:

--- a/src/server/routes/page.js
+++ b/src/server/routes/page.js
@@ -70,7 +70,7 @@
  *            items:
  *              type: string
  *              description: user ID
- *            example: 5ae5fccfc5577b0004dbd8ab
+ *            example: ["5ae5fccfc5577b0004dbd8ab"]
  *          status:
  *            type: string
  *            description: status
@@ -89,7 +89,7 @@
  *        type: object
  *        properties:
  *          _id:
- *            type: object
+ *            type: string
  *            description: update post ID
  *            example: 5e0734e472560e001761fa68
  *          __v:
@@ -648,7 +648,6 @@ module.exports = function(crowi, app) {
    *        tags: [Pages]
    *        description: Get list of pages
    *        requestBody:
-   *          required: true
    *          content:
    *            application/json:
    *              schema:
@@ -657,6 +656,8 @@ module.exports = function(crowi, app) {
    *                    $ref: '#/components/schemas/Page/properties/path'
    *                  user:
    *                    $ref: '#/components/schemas/User/properties/username'
+   *                  offset:
+   *                    $ref: '#/components/schemas/V1PaginateResult/properties/meta/properties/offset'
    *        responses:
    *          200:
    *            description: Succeeded to get list of pages.
@@ -733,7 +734,6 @@ module.exports = function(crowi, app) {
    *        tags: [Pages]
    *        description: Create page
    *        requestBody:
-   *          required: true
    *          content:
    *            application/json:
    *              schema:
@@ -841,7 +841,6 @@ module.exports = function(crowi, app) {
    *        tags: [Pages]
    *        description: Update page
    *        requestBody:
-   *          required: true
    *          content:
    *            application/json:
    *              schema:
@@ -968,7 +967,6 @@ module.exports = function(crowi, app) {
    *        tags: [Pages]
    *        description: Get page data
    *        requestBody:
-   *          required: true
    *          content:
    *            application/json:
    *              schema:
@@ -1089,7 +1087,6 @@ module.exports = function(crowi, app) {
    *        tags: [Pages]
    *        description: Mark as seen user
    *        requestBody:
-   *          required: true
    *          content:
    *            application/json:
    *              schema:
@@ -1157,7 +1154,6 @@ module.exports = function(crowi, app) {
    *        tags: [Pages]
    *        description: Like page
    *        requestBody:
-   *          required: true
    *          content:
    *            application/json:
    *              schema:
@@ -1232,7 +1228,6 @@ module.exports = function(crowi, app) {
    *        tags: [Pages]
    *        description: Unlike page
    *        requestBody:
-   *          required: true
    *          content:
    *            application/json:
    *              schema:
@@ -1299,7 +1294,6 @@ module.exports = function(crowi, app) {
    *        tags: [Pages]
    *        description: Get UpdatePost setting list
    *        requestBody:
-   *          required: true
    *          content:
    *            application/json:
    *              schema:
@@ -1361,7 +1355,6 @@ module.exports = function(crowi, app) {
    *        tags: [Pages]
    *        description: Remove page
    *        requestBody:
-   *          required: true
    *          content:
    *            application/json:
    *              schema:
@@ -1464,7 +1457,6 @@ module.exports = function(crowi, app) {
    *        tags: [Pages]
    *        description: Revert removed page
    *        requestBody:
-   *          required: true
    *          content:
    *            application/json:
    *              schema:
@@ -1536,7 +1528,6 @@ module.exports = function(crowi, app) {
    *        tags: [Pages]
    *        description: Rename page
    *        requestBody:
-   *          required: true
    *          content:
    *            application/json:
    *              schema:
@@ -1687,7 +1678,6 @@ module.exports = function(crowi, app) {
    *        tags: [Pages]
    *        description: Remove the redirecting page
    *        requestBody:
-   *          required: true
    *          content:
    *            application/json:
    *              schema:

--- a/src/server/routes/revision.js
+++ b/src/server/routes/revision.js
@@ -1,3 +1,50 @@
+/**
+ * @swagger
+ *  tags:
+ *    name: Revisions
+ */
+
+/**
+ * @swagger
+ *
+ *  components:
+ *    schemas:
+ *      Revision:
+ *        type: object
+ *        properties:
+ *          _id:
+ *            type: string
+ *            description: revision ID
+ *            example: 5e0734e472560e001761fa68
+ *          __v:
+ *            type: integer
+ *            description: DB record version
+ *            example: 0
+ *          author:
+ *            type: object
+ *            description: author
+ *            example: nil
+ *          body:
+ *            type: string
+ *            description: content body
+ *            example: |
+ *              \# test
+ *
+ *              test
+ *          createdAt:
+ *            type: string
+ *            description: date created at
+ *            example: 2010-01-01T00:00:00.000Z
+ *          format:
+ *            type: string
+ *            description: format
+ *            example: markdown
+ *          path:
+ *            type: string
+ *            description: path
+ *            example: /user/alice/test
+ */
+
 module.exports = function(crowi, app) {
   const debug = require('debug')('growi:routes:revision');
   const logger = require('@alias/logger')('growi:routes:revision');
@@ -9,6 +56,42 @@ module.exports = function(crowi, app) {
   const actions = {};
   actions.api = {};
 
+  /**
+   * @swagger
+   *
+   *    /_api/revisions.get:
+   *      get:
+   *        tags: [Revisions]
+   *        description: Get revision
+   *        requestBody:
+   *          required: true
+   *          content:
+   *            application/json:
+   *              schema:
+   *                properties:
+   *                  page_id:
+   *                    $ref: '#/components/schemas/Page/properties/_id'
+   *                  revision_id:
+   *                    $ref: '#/components/schemas/Revision/properties/_id'
+   *                required:
+   *                  - page_id
+   *                  - revision_id
+   *        responses:
+   *          200:
+   *            description: Succeeded to get revision.
+   *            content:
+   *              application/json:
+   *                schema:
+   *                  properties:
+   *                    ok:
+   *                      $ref: '#/components/schemas/V1Response/ok'
+   *                    revision:
+   *                      $ref: '#/components/schemas/Revision'
+   *          403:
+   *            $ref: '#/components/responses/403'
+   *          500:
+   *            $ref: '#/components/responses/500'
+   */
   /**
    * @api {get} /revisions.get Get revision
    * @apiName GetRevision
@@ -42,6 +125,41 @@ module.exports = function(crowi, app) {
   };
 
   /**
+   * @swagger
+   *
+   *    /_api/revisions.ids:
+   *      get:
+   *        tags: [Revisions]
+   *        description: Get revision id list of the page
+   *        requestBody:
+   *          required: true
+   *          content:
+   *            application/json:
+   *              schema:
+   *                properties:
+   *                  page_id:
+   *                    $ref: '#/components/schemas/Page/properties/_id'
+   *                required:
+   *                  - page_id
+   *        responses:
+   *          200:
+   *            description: Succeeded to get revision id list of the page.
+   *            content:
+   *              application/json:
+   *                schema:
+   *                  properties:
+   *                    ok:
+   *                      $ref: '#/components/schemas/V1Response/ok'
+   *                    revisions:
+   *                      type: array
+   *                      items:
+   *                        $ref: '#/components/schemas/Revision'
+   *          403:
+   *            $ref: '#/components/responses/403'
+   *          500:
+   *            $ref: '#/components/responses/500'
+   */
+  /**
    * @api {get} /revisions.ids Get revision id list of the page
    * @apiName ids
    * @apiGroup Revision
@@ -69,6 +187,43 @@ module.exports = function(crowi, app) {
     }
   };
 
+  /**
+   * @swagger
+   *
+   *    /_api/revisions.list:
+   *      get:
+   *        tags: [Revisions]
+   *        description: Get revisions
+   *        requestBody:
+   *          required: true
+   *          content:
+   *            application/json:
+   *              schema:
+   *                properties:
+   *                  page_id:
+   *                    $ref: '#/components/schemas/Page/properties/_id'
+   *                  revision_ids:
+   *                    type: string
+   *                    description: revision ids
+   *                    example: 5e0734e472560e001761fa68,5e079a0a0afa6700170a75fb
+   *        responses:
+   *          200:
+   *            description: Succeeded to get revisions.
+   *            content:
+   *              application/json:
+   *                schema:
+   *                  properties:
+   *                    ok:
+   *                      $ref: '#/components/schemas/V1Response/ok'
+   *                    revisions:
+   *                      type: array
+   *                      items:
+   *                        $ref: '#/components/schemas/Revision'
+   *          403:
+   *            $ref: '#/components/responses/403'
+   *          500:
+   *            $ref: '#/components/responses/500'
+   */
   /**
    * @api {get} /revisions.list Get revisions
    * @apiName ListRevision

--- a/src/server/routes/revision.js
+++ b/src/server/routes/revision.js
@@ -21,9 +21,7 @@
  *            description: DB record version
  *            example: 0
  *          author:
- *            type: object
- *            description: author
- *            example: nil
+ *            $ref: '#/components/schemas/User/properties/_id'
  *          body:
  *            type: string
  *            description: content body

--- a/src/server/routes/revision.js
+++ b/src/server/routes/revision.js
@@ -31,10 +31,6 @@
  *              # test
  *
  *              test
- *          createdAt:
- *            type: string
- *            description: date created at
- *            example: 2010-01-01T00:00:00.000Z
  *          format:
  *            type: string
  *            description: format
@@ -43,6 +39,10 @@
  *            type: string
  *            description: path
  *            example: /user/alice/test
+ *          createdAt:
+ *            type: string
+ *            description: date created at
+ *            example: 2010-01-01T00:00:00.000Z
  */
 
 module.exports = function(crowi, app) {

--- a/src/server/routes/revision.js
+++ b/src/server/routes/revision.js
@@ -28,7 +28,7 @@
  *            type: string
  *            description: content body
  *            example: |
- *              \# test
+ *              # test
  *
  *              test
  *          createdAt:

--- a/src/server/routes/revision.js
+++ b/src/server/routes/revision.js
@@ -62,7 +62,6 @@ module.exports = function(crowi, app) {
    *        tags: [Revisions]
    *        description: Get revision
    *        requestBody:
-   *          required: true
    *          content:
    *            application/json:
    *              schema:
@@ -130,7 +129,6 @@ module.exports = function(crowi, app) {
    *        tags: [Revisions]
    *        description: Get revision id list of the page
    *        requestBody:
-   *          required: true
    *          content:
    *            application/json:
    *              schema:
@@ -193,7 +191,6 @@ module.exports = function(crowi, app) {
    *        tags: [Revisions]
    *        description: Get revisions
    *        requestBody:
-   *          required: true
    *          content:
    *            application/json:
    *              schema:

--- a/src/server/routes/revision.js
+++ b/src/server/routes/revision.js
@@ -60,19 +60,19 @@ module.exports = function(crowi, app) {
    *    /_api/revisions.get:
    *      get:
    *        tags: [Revisions]
+   *        summary: /_api/revisions.get
    *        description: Get revision
-   *        requestBody:
-   *          content:
-   *            application/json:
-   *              schema:
-   *                properties:
-   *                  page_id:
-   *                    $ref: '#/components/schemas/Page/properties/_id'
-   *                  revision_id:
-   *                    $ref: '#/components/schemas/Revision/properties/_id'
-   *                required:
-   *                  - page_id
-   *                  - revision_id
+   *        parameters:
+   *          - in: query
+   *            name: page_id
+   *            schema:
+   *              $ref: '#/components/schemas/Page/properties/_id'
+   *            required: true
+   *          - in: query
+   *            name: revision_id
+   *            schema:
+   *              $ref: '#/components/schemas/Revision/properties/_id'
+   *            required: true
    *        responses:
    *          200:
    *            description: Succeeded to get revision.
@@ -127,16 +127,14 @@ module.exports = function(crowi, app) {
    *    /_api/revisions.ids:
    *      get:
    *        tags: [Revisions]
+   *        summary: /_api/revisions.ids
    *        description: Get revision id list of the page
-   *        requestBody:
-   *          content:
-   *            application/json:
-   *              schema:
-   *                properties:
-   *                  page_id:
-   *                    $ref: '#/components/schemas/Page/properties/_id'
-   *                required:
-   *                  - page_id
+   *        parameters:
+   *          - in: query
+   *            name: page_id
+   *            schema:
+   *              $ref: '#/components/schemas/Page/properties/_id'
+   *            required: true
    *        responses:
    *          200:
    *            description: Succeeded to get revision id list of the page.
@@ -189,18 +187,19 @@ module.exports = function(crowi, app) {
    *    /_api/revisions.list:
    *      get:
    *        tags: [Revisions]
+   *        summary: /_api/revisions.list
    *        description: Get revisions
-   *        requestBody:
-   *          content:
-   *            application/json:
-   *              schema:
-   *                properties:
-   *                  page_id:
-   *                    $ref: '#/components/schemas/Page/properties/_id'
-   *                  revision_ids:
-   *                    type: string
-   *                    description: revision ids
-   *                    example: 5e0734e472560e001761fa68,5e079a0a0afa6700170a75fb
+   *        parameters:
+   *          - in: query
+   *            name: page_id
+   *            schema:
+   *              $ref: '#/components/schemas/Page/properties/_id'
+   *          - in: query
+   *            name: revision_ids
+   *            schema:
+   *              type: string
+   *              description: revision ids
+   *              example: 5e0734e472560e001761fa68,5e079a0a0afa6700170a75fb
    *        responses:
    *          200:
    *            description: Succeeded to get revisions.

--- a/src/server/routes/revision.js
+++ b/src/server/routes/revision.js
@@ -17,7 +17,7 @@
  *            description: revision ID
  *            example: 5e0734e472560e001761fa68
  *          __v:
- *            type: integer
+ *            type: number
  *            description: DB record version
  *            example: 0
  *          author:

--- a/src/server/routes/revision.js
+++ b/src/server/routes/revision.js
@@ -61,6 +61,7 @@ module.exports = function(crowi, app) {
    *    /_api/revisions.get:
    *      get:
    *        tags: [Revisions]
+   *        operationId: /_api/revisions.get
    *        summary: /_api/revisions.get
    *        description: Get revision
    *        parameters:
@@ -128,6 +129,7 @@ module.exports = function(crowi, app) {
    *    /_api/revisions.ids:
    *      get:
    *        tags: [Revisions]
+   *        operationId: /_api/revisions.ids
    *        summary: /_api/revisions.ids
    *        description: Get revision id list of the page
    *        parameters:
@@ -188,6 +190,7 @@ module.exports = function(crowi, app) {
    *    /_api/revisions.list:
    *      get:
    *        tags: [Revisions]
+   *        operationId: /_api/revisions.list
    *        summary: /_api/revisions.list
    *        description: Get revisions
    *        parameters:

--- a/src/server/routes/revision.js
+++ b/src/server/routes/revision.js
@@ -81,7 +81,7 @@ module.exports = function(crowi, app) {
    *                schema:
    *                  properties:
    *                    ok:
-   *                      $ref: '#/components/schemas/V1Response/ok'
+   *                      $ref: '#/components/schemas/V1Response/properties/ok'
    *                    revision:
    *                      $ref: '#/components/schemas/Revision'
    *          403:
@@ -143,7 +143,7 @@ module.exports = function(crowi, app) {
    *                schema:
    *                  properties:
    *                    ok:
-   *                      $ref: '#/components/schemas/V1Response/ok'
+   *                      $ref: '#/components/schemas/V1Response/properties/ok'
    *                    revisions:
    *                      type: array
    *                      items:
@@ -208,7 +208,7 @@ module.exports = function(crowi, app) {
    *                schema:
    *                  properties:
    *                    ok:
-   *                      $ref: '#/components/schemas/V1Response/ok'
+   *                      $ref: '#/components/schemas/V1Response/properties/ok'
    *                    revisions:
    *                      type: array
    *                      items:

--- a/src/server/routes/revision.js
+++ b/src/server/routes/revision.js
@@ -60,7 +60,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/revisions.get:
    *      get:
-   *        tags: [Revisions]
+   *        tags: [Revisions, apiv1]
    *        operationId: /_api/revisions.get
    *        summary: /_api/revisions.get
    *        description: Get revision
@@ -128,7 +128,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/revisions.ids:
    *      get:
-   *        tags: [Revisions]
+   *        tags: [Revisions, apiv1]
    *        operationId: /_api/revisions.ids
    *        summary: /_api/revisions.ids
    *        description: Get revision id list of the page
@@ -189,7 +189,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/revisions.list:
    *      get:
-   *        tags: [Revisions]
+   *        tags: [Revisions, apiv1]
    *        operationId: /_api/revisions.list
    *        summary: /_api/revisions.list
    *        description: Get revisions

--- a/src/server/routes/revision.js
+++ b/src/server/routes/revision.js
@@ -10,6 +10,7 @@
  *  components:
  *    schemas:
  *      Revision:
+ *        description: Revision
  *        type: object
  *        properties:
  *          _id:

--- a/src/server/routes/user.js
+++ b/src/server/routes/user.js
@@ -42,7 +42,7 @@ module.exports = function(crowi, app) {
    *    /_api/users.list:
    *      get:
    *        tags: [Users, apiv1]
-   *        operationId: /_api/users.list
+   *        operationId: listUsersV1
    *        summary: /_api/users.list
    *        description: Get list of users
    *        parameters:

--- a/src/server/routes/user.js
+++ b/src/server/routes/user.js
@@ -37,6 +37,41 @@ module.exports = function(crowi, app) {
   };
 
   /**
+   * @swagger
+   *
+   *    /_api/users.list:
+   *      get:
+   *        tags: [Users, apiv1]
+   *        operationId: /_api/users.list
+   *        summary: /_api/users.list
+   *        description: Get list of users
+   *        parameters:
+   *          - in: query
+   *            name: user_ids
+   *            schema:
+   *              type: string
+   *              description: user IDs
+   *              example: 5e06fcc7516d64004dbf4da6,5e098d53baa2ac004e7d24ad
+   *        responses:
+   *          200:
+   *            description: Succeeded to get list of users.
+   *            content:
+   *              application/json:
+   *                schema:
+   *                  properties:
+   *                    ok:
+   *                      $ref: '#/components/schemas/V1Response/properties/ok'
+   *                    users:
+   *                      type: array
+   *                      items:
+   *                        $ref: '#/components/schemas/User'
+   *                      description: user list
+   *          403:
+   *            $ref: '#/components/responses/403'
+   *          500:
+   *            $ref: '#/components/responses/500'
+   */
+  /**
    * @api {get} /users.list Get user list
    * @apiName GetUserList
    * @apiGroup User


### PR DESCRIPTION
Now, only API v3 references are there.
(https://docs.growi.org/en/api/rest-v3.html)

This PR support API v1 references.

I recognize GROWI API v1 are defined as follows.

* Compatible Crowi API
    * cf. https://github.com/crowi/crowi/blob/master/lib/routes/index.ts

Mainly changed follows.

* Add API v1 references for `swagger-jsdoc` and tagging `apiv1` to these.
* Tagging `apiv3` to API v3 references.

The result of building API documents is [here](https://github.com/weseek/growi/files/4015059/redoc-static.zip).
