### PR TITLE
Support/correct api v1 reference

### DIFF
--- a/config/swagger-definition.js
+++ b/config/swagger-definition.js
@@ -1,7 +1,7 @@
 const pkg = require('../package.json');
 
-const apiVersion = process.env.API_VERSION || 3;
-const basePath = (apiVersion === 1 ? '/_api' : `/_api/v${apiVersion}`);
+const apiVersion = process.env.API_VERSION || '3';
+const basePath = (apiVersion === '1' ? '/_api' : `/_api/v${apiVersion}`);
 
 module.exports = {
   openapi: '3.0.1',

--- a/config/swagger-definition.js
+++ b/config/swagger-definition.js
@@ -13,4 +13,18 @@ module.exports = {
       url: 'https://demo.growi.org',
     },
   ],
+  security: [
+    {
+      api_key: [],
+    },
+  ],
+  components: {
+    securitySchemes: {
+      api_key: {
+        type: 'apiKey',
+        name: 'access_token',
+        in: 'query',
+      },
+    },
+  },
 };

--- a/config/swagger-definition.js
+++ b/config/swagger-definition.js
@@ -1,6 +1,7 @@
 const pkg = require('../package.json');
 
 const apiVersion = process.env.API_VERSION || 3;
+const basePath = (apiVersion === 1 ? '/_api' : `/_api/v${apiVersion}`);
 
 module.exports = {
   openapi: '3.0.1',
@@ -10,7 +11,13 @@ module.exports = {
   },
   servers: [
     {
-      url: 'https://demo.growi.org',
+      url: 'https://demo.growi.org{basePath}',
+      variables: {
+        basePath: {
+          default: basePath,
+          description: 'base path',
+        },
+      },
     },
   ],
   security: [

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     "url": "https://github.com/weseek/growi/issues"
   },
   "scripts": {
-    "build:api:jsdoc": "swagger-jsdoc -o tmp/swagger.json -d config/swagger-definition.js \"src/server/**/*.js\"",
-    "build:apiv3:jsdoc": "cross-env API_VERSION=3 npm run build:api:jsdoc",
-    "build:apiv1:jsdoc": "cross-env API_VERSION=1 npm run build:api:jsdoc",
+    "build:api:jsdoc": "swagger-jsdoc -o tmp/swagger.json",
+    "build:apiv3:jsdoc": "npm run build:api:jsdoc -- -d config/swagger-definition.js \"src/server/routes/apiv3/**/*.js\" \"src/server/models/**/*.js\"",
+    "build:apiv1:jsdoc": "npm run build:api:jsdoc -- -d config/swagger-definition-v1.js \"src/server/*/*.js\" \"src/server/models/**/*.js\"",
     "build:dev:app:watch": "npm run build:dev:app -- --watch",
     "build:dev:app": "env-cmd -f config/env.dev.js webpack --config config/webpack.dev.js --progress",
     "build:dev:watch": "npm run build:dev:app:watch",

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     "url": "https://github.com/weseek/growi/issues"
   },
   "scripts": {
-    "build:api:jsdoc": "swagger-jsdoc -o tmp/swagger.json",
-    "build:apiv3:jsdoc": "npm run build:api:jsdoc -- -d config/swagger-definition.js \"src/server/routes/apiv3/**/*.js\" \"src/server/models/**/*.js\"",
-    "build:apiv1:jsdoc": "npm run build:api:jsdoc -- -d config/swagger-definition-v1.js \"src/server/*/*.js\" \"src/server/models/**/*.js\"",
+    "build:api:jsdoc": "swagger-jsdoc -o tmp/swagger.json -d config/swagger-definition.js ",
+    "build:apiv3:jsdoc": "cross-env API_VERSION=3 npm run build:api:jsdoc -- \"src/server/routes/apiv3/**/*.js\" \"src/server/models/**/*.js\"",
+    "build:apiv1:jsdoc": "cross-env API_VERSION=1 npm run build:api:jsdoc -- \"src/server/*/*.js\" \"src/server/models/**/*.js\"",
     "build:dev:app:watch": "npm run build:dev:app -- --watch",
     "build:dev:app": "env-cmd -f config/env.dev.js webpack --config config/webpack.dev.js --progress",
     "build:dev:watch": "npm run build:dev:app:watch",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/weseek/growi/issues"
   },
   "scripts": {
-    "build:api:jsdoc": "swagger-jsdoc -o tmp/swagger.json -d config/swagger-definition.js ",
+    "build:api:jsdoc": "swagger-jsdoc -o tmp/swagger.json -d config/swagger-definition.js",
     "build:apiv3:jsdoc": "cross-env API_VERSION=3 npm run build:api:jsdoc -- \"src/server/routes/apiv3/**/*.js\" \"src/server/models/**/*.js\"",
     "build:apiv1:jsdoc": "cross-env API_VERSION=1 npm run build:api:jsdoc -- \"src/server/*/*.js\" \"src/server/models/**/*.js\"",
     "build:dev:app:watch": "npm run build:dev:app -- --watch",

--- a/src/server/routes/apiv3/admin-home.js
+++ b/src/server/routes/apiv3/admin-home.js
@@ -46,7 +46,7 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *    /_api/v3//admin-home/:
+   *    /_api/v3/admin-home/:
    *      get:
    *        tags: [adminHome]
    *        operationId: getAdminHome

--- a/src/server/routes/apiv3/admin-home.js
+++ b/src/server/routes/apiv3/admin-home.js
@@ -48,7 +48,7 @@ module.exports = (crowi) => {
    *
    *    /_api/v3//admin-home/:
    *      get:
-   *        tags: [adminHome, apiv3]
+   *        tags: [adminHome]
    *        operationId: getAdminHome
    *        summary: /_api/v3//admin-home/
    *        description: Get adminHome parameters

--- a/src/server/routes/apiv3/admin-home.js
+++ b/src/server/routes/apiv3/admin-home.js
@@ -46,11 +46,11 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *    /_api/v3/admin-home/:
+   *    /admin-home/:
    *      get:
    *        tags: [adminHome]
    *        operationId: getAdminHome
-   *        summary: /_api/v3/admin-home/
+   *        summary: /admin-home
    *        description: Get adminHome parameters
    *        responses:
    *          200:

--- a/src/server/routes/apiv3/admin-home.js
+++ b/src/server/routes/apiv3/admin-home.js
@@ -46,9 +46,11 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *    /admin-home/:
+   *    /_api/v3//admin-home/:
    *      get:
-   *        tags: [adminHome]
+   *        tags: [adminHome, apiv3]
+   *        operationId: getAdminHome
+   *        summary: /_api/v3//admin-home/
    *        description: Get adminHome parameters
    *        responses:
    *          200:

--- a/src/server/routes/apiv3/admin-home.js
+++ b/src/server/routes/apiv3/admin-home.js
@@ -48,7 +48,7 @@ module.exports = (crowi) => {
    *
    *    /admin-home/:
    *      get:
-   *        tags: [adminHome]
+   *        tags: [AdminHome]
    *        operationId: getAdminHome
    *        summary: /admin-home
    *        description: Get adminHome parameters

--- a/src/server/routes/apiv3/admin-home.js
+++ b/src/server/routes/apiv3/admin-home.js
@@ -50,7 +50,7 @@ module.exports = (crowi) => {
    *      get:
    *        tags: [adminHome]
    *        operationId: getAdminHome
-   *        summary: /_api/v3//admin-home/
+   *        summary: /_api/v3/admin-home/
    *        description: Get adminHome parameters
    *        responses:
    *          200:

--- a/src/server/routes/apiv3/app-settings.js
+++ b/src/server/routes/apiv3/app-settings.js
@@ -136,11 +136,11 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *    /_api/v3/app-settings:
+   *    /app-settings:
    *      get:
    *        tags: [AppSettings]
    *        operationId: getAppSettings
-   *        summary: /_api/v3/app-settings
+   *        summary: /app-settings
    *        description: get app setting params
    *        responses:
    *          200:
@@ -181,10 +181,10 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *    /_api/v3/app-settings/app-setting:
+   *    /app-settings/app-setting:
    *      put:
    *        tags: [AppSettings]
-   *        summary: /_api/v3/app-settings/app-setting
+   *        summary: /app-settings/app-setting
    *        operationId: updateAppSettings
    *        description: Update app setting
    *        requestBody:
@@ -230,11 +230,11 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *    /_api/v3/app-settings/site-url-setting:
+   *    /app-settings/site-url-setting:
    *      put:
    *        tags: [AppSettings]
    *        operationId: updateAppSettingSiteUrlSetting
-   *        summary: /_api/v3/app-settings/site-url-setting
+   *        summary: /app-settings/site-url-setting
    *        description: Update site url setting
    *        requestBody:
    *          required: true
@@ -322,11 +322,11 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *    /_api/v3/app-settings/mail-setting:
+   *    /app-settings/mail-setting:
    *      put:
    *        tags: [AppSettings]
    *        operationId: updateAppSettingMailSetting
-   *        summary: /_api/v3/app-settings/site-url-setting
+   *        summary: /app-settings/site-url-setting
    *        description: Update mail setting
    *        requestBody:
    *          required: true
@@ -384,11 +384,11 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *    /_api/v3/app-settings/aws-setting:
+   *    /app-settings/aws-setting:
    *      put:
    *        tags: [AppSettings]
    *        operationId: updateAppSettingAwsSetting
-   *        summary: /_api/v3/app-settings/aws-setting
+   *        summary: /app-settings/aws-setting
    *        description: Update aws setting
    *        requestBody:
    *          required: true
@@ -435,11 +435,11 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *    /_api/v3/app-settings/plugin-setting:
+   *    /app-settings/plugin-setting:
    *      put:
    *        tags: [AppSettings]
    *        operationId: updateAppSettingPluginSetting
-   *        summary: /_api/v3/app-settings/plugin-setting
+   *        summary: /app-settings/plugin-setting
    *        description: Update plugin setting
    *        requestBody:
    *          required: true

--- a/src/server/routes/apiv3/app-settings.js
+++ b/src/server/routes/apiv3/app-settings.js
@@ -138,7 +138,7 @@ module.exports = (crowi) => {
    *
    *    /_api/v3/app-settings:
    *      get:
-   *        tags: [AppSettings, apiv3]
+   *        tags: [AppSettings]
    *        operationId: getAppSettings
    *        summary: /_api/v3/app-settings
    *        description: get app setting params
@@ -183,7 +183,7 @@ module.exports = (crowi) => {
    *
    *    /_api/v3/app-settings/app-setting:
    *      put:
-   *        tags: [AppSettings, apiv3]
+   *        tags: [AppSettings]
    *        summary: /_api/v3/app-settings/app-setting
    *        operationId: updateAppSettings
    *        description: Update app setting
@@ -232,7 +232,7 @@ module.exports = (crowi) => {
    *
    *    /_api/v3/app-settings/site-url-setting:
    *      put:
-   *        tags: [AppSettings, apiv3]
+   *        tags: [AppSettings]
    *        operationId: updateAppSettingSiteUrlSetting
    *        summary: /_api/v3/app-settings/site-url-setting
    *        description: Update site url setting
@@ -324,7 +324,7 @@ module.exports = (crowi) => {
    *
    *    /_api/v3/app-settings/mail-setting:
    *      put:
-   *        tags: [AppSettings, apiv3]
+   *        tags: [AppSettings]
    *        operationId: updateAppSettingMailSetting
    *        summary: /_api/v3/app-settings/site-url-setting
    *        description: Update mail setting
@@ -386,7 +386,7 @@ module.exports = (crowi) => {
    *
    *    /_api/v3/app-settings/aws-setting:
    *      put:
-   *        tags: [AppSettings, apiv3]
+   *        tags: [AppSettings]
    *        operationId: updateAppSettingAwsSetting
    *        summary: /_api/v3/app-settings/aws-setting
    *        description: Update aws setting
@@ -437,7 +437,7 @@ module.exports = (crowi) => {
    *
    *    /_api/v3/app-settings/plugin-setting:
    *      put:
-   *        tags: [AppSettings, apiv3]
+   *        tags: [AppSettings]
    *        operationId: updateAppSettingPluginSetting
    *        summary: /_api/v3/app-settings/plugin-setting
    *        description: Update plugin setting

--- a/src/server/routes/apiv3/customize-setting.js
+++ b/src/server/routes/apiv3/customize-setting.js
@@ -133,7 +133,7 @@ module.exports = (crowi) => {
    *
    *    /_api/v3/customize-setting:
    *      get:
-   *        tags: [CustomizeSetting, apiv3]
+   *        tags: [CustomizeSetting]
    *        operationId: getCustomizeSetting
    *        summary: /_api/v3/customize-setting
    *        description: Get customize parameters
@@ -175,7 +175,7 @@ module.exports = (crowi) => {
    *
    *    /_api/v3/customize-setting/layoutTheme:
    *      put:
-   *        tags: [CustomizeSetting, apiv3]
+   *        tags: [CustomizeSetting]
    *        operationId: updateLayoutThemeCustomizeSetting
    *        summary: /_api/v3/customize-setting/layoutTheme
    *        description: Update layout and theme
@@ -219,7 +219,7 @@ module.exports = (crowi) => {
    *
    *    /_api/v3/customize-setting/behavior:
    *      put:
-   *        tags: [CustomizeSetting, apiv3]
+   *        tags: [CustomizeSetting]
    *        operationId: updateBehaviorCustomizeSetting
    *        summary: /_api/v3/customize-setting/behavior
    *        description: Update behavior
@@ -261,7 +261,7 @@ module.exports = (crowi) => {
    *
    *    /_api/v3/customize-setting/function:
    *      put:
-   *        tags: [CustomizeSetting, apiv3]
+   *        tags: [CustomizeSetting]
    *        operationId: updateFunctionCustomizeSetting
    *        summary: /_api/v3/customize-setting/function
    *        description: Update function
@@ -311,7 +311,7 @@ module.exports = (crowi) => {
    *
    *    /_api/v3/customize-setting/highlight:
    *      put:
-   *        tags: [CustomizeSetting, apiv3]
+   *        tags: [CustomizeSetting]
    *        operationId: updateHighlightCustomizeSetting
    *        summary: /_api/v3/customize-setting/highlight
    *        description: Update highlight
@@ -355,7 +355,7 @@ module.exports = (crowi) => {
    *
    *    /_api/v3/customize-setting/customizeTitle:
    *      put:
-   *        tags: [CustomizeSetting, apiv3]
+   *        tags: [CustomizeSetting]
    *        operationId: updateCustomizeTitleCustomizeSetting
    *        summary: /_api/v3/customize-setting/customizeTitle
    *        description: Update customizeTitle
@@ -398,7 +398,7 @@ module.exports = (crowi) => {
    *
    *    /_api/v3/customize-setting/customizeHeader:
    *      put:
-   *        tags: [CustomizeSetting, apiv3]
+   *        tags: [CustomizeSetting]
    *        operationId: updateCustomizeHeaderCustomizeSetting
    *        summary: /_api/v3/customize-setting/customizeHeader
    *        description: Update customizeHeader
@@ -439,7 +439,7 @@ module.exports = (crowi) => {
    *
    *    /_api/v3/customize-setting/customizeCss:
    *      put:
-   *        tags: [CustomizeSetting, apiv3]
+   *        tags: [CustomizeSetting]
    *        operationId: updateCustomizeCssCustomizeSetting
    *        summary: /_api/v3/customize-setting/customizeCss
    *        description: Update customizeCss
@@ -481,7 +481,7 @@ module.exports = (crowi) => {
    *
    *    /_api/v3/customize-setting/customizeScript:
    *      put:
-   *        tags: [CustomizeSetting, apiv3]
+   *        tags: [CustomizeSetting]
    *        operationId: updateCustomizeScriptCustomizeSetting
    *        summary: /_api/v3/customize-setting/customizeScript
    *        description: Update customizeScript

--- a/src/server/routes/apiv3/customize-setting.js
+++ b/src/server/routes/apiv3/customize-setting.js
@@ -131,11 +131,11 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *    /_api/v3/customize-setting:
+   *    /customize-setting:
    *      get:
    *        tags: [CustomizeSetting]
    *        operationId: getCustomizeSetting
-   *        summary: /_api/v3/customize-setting
+   *        summary: /customize-setting
    *        description: Get customize parameters
    *        responses:
    *          200:
@@ -173,11 +173,11 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *    /_api/v3/customize-setting/layoutTheme:
+   *    /customize-setting/layoutTheme:
    *      put:
    *        tags: [CustomizeSetting]
    *        operationId: updateLayoutThemeCustomizeSetting
-   *        summary: /_api/v3/customize-setting/layoutTheme
+   *        summary: /customize-setting/layoutTheme
    *        description: Update layout and theme
    *        requestBody:
    *          required: true
@@ -217,11 +217,11 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *    /_api/v3/customize-setting/behavior:
+   *    /customize-setting/behavior:
    *      put:
    *        tags: [CustomizeSetting]
    *        operationId: updateBehaviorCustomizeSetting
-   *        summary: /_api/v3/customize-setting/behavior
+   *        summary: /customize-setting/behavior
    *        description: Update behavior
    *        requestBody:
    *          required: true
@@ -259,11 +259,11 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *    /_api/v3/customize-setting/function:
+   *    /customize-setting/function:
    *      put:
    *        tags: [CustomizeSetting]
    *        operationId: updateFunctionCustomizeSetting
-   *        summary: /_api/v3/customize-setting/function
+   *        summary: /customize-setting/function
    *        description: Update function
    *        requestBody:
    *          required: true
@@ -309,11 +309,11 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *    /_api/v3/customize-setting/highlight:
+   *    /customize-setting/highlight:
    *      put:
    *        tags: [CustomizeSetting]
    *        operationId: updateHighlightCustomizeSetting
-   *        summary: /_api/v3/customize-setting/highlight
+   *        summary: /customize-setting/highlight
    *        description: Update highlight
    *        requestBody:
    *          required: true
@@ -353,11 +353,11 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *    /_api/v3/customize-setting/customizeTitle:
+   *    /customize-setting/customizeTitle:
    *      put:
    *        tags: [CustomizeSetting]
    *        operationId: updateCustomizeTitleCustomizeSetting
-   *        summary: /_api/v3/customize-setting/customizeTitle
+   *        summary: /customize-setting/customizeTitle
    *        description: Update customizeTitle
    *        requestBody:
    *          required: true
@@ -396,11 +396,11 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *    /_api/v3/customize-setting/customizeHeader:
+   *    /customize-setting/customizeHeader:
    *      put:
    *        tags: [CustomizeSetting]
    *        operationId: updateCustomizeHeaderCustomizeSetting
-   *        summary: /_api/v3/customize-setting/customizeHeader
+   *        summary: /customize-setting/customizeHeader
    *        description: Update customizeHeader
    *        requestBody:
    *          required: true
@@ -437,11 +437,11 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *    /_api/v3/customize-setting/customizeCss:
+   *    /customize-setting/customizeCss:
    *      put:
    *        tags: [CustomizeSetting]
    *        operationId: updateCustomizeCssCustomizeSetting
-   *        summary: /_api/v3/customize-setting/customizeCss
+   *        summary: /customize-setting/customizeCss
    *        description: Update customizeCss
    *        requestBody:
    *          required: true
@@ -479,11 +479,11 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *    /_api/v3/customize-setting/customizeScript:
+   *    /customize-setting/customizeScript:
    *      put:
    *        tags: [CustomizeSetting]
    *        operationId: updateCustomizeScriptCustomizeSetting
-   *        summary: /_api/v3/customize-setting/customizeScript
+   *        summary: /customize-setting/customizeScript
    *        description: Update customizeScript
    *        requestBody:
    *          required: true

--- a/src/server/routes/apiv3/export.js
+++ b/src/server/routes/apiv3/export.js
@@ -64,7 +64,7 @@ module.exports = (crowi) => {
    *
    *  /_api/v3/export/status:
    *    get:
-   *      tags: [Export, apiv3]
+   *      tags: [Export]
    *      operationId: getExportStatus
    *      summary: /_api/v3/export/status
    *      description: get properties of stored zip files for export
@@ -93,7 +93,7 @@ module.exports = (crowi) => {
    *
    *  /_api/v3/export:
    *    post:
-   *      tags: [Export, apiv3]
+   *      tags: [Export]
    *      operationId: createExport
    *      summary: /_api/v3/export
    *      description: generate zipped jsons for collections
@@ -131,7 +131,7 @@ module.exports = (crowi) => {
    *
    *  /_api/v3/export/{fileName}:
    *    delete:
-   *      tags: [Export, apiv3]
+   *      tags: [Export]
    *      operationId: deleteExport
    *      summary: /_api/v3/export/{fileName}
    *      description: delete the file

--- a/src/server/routes/apiv3/export.js
+++ b/src/server/routes/apiv3/export.js
@@ -62,11 +62,11 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *  /_api/v3/export/status:
+   *  /export/status:
    *    get:
    *      tags: [Export]
    *      operationId: getExportStatus
-   *      summary: /_api/v3/export/status
+   *      summary: /export/status
    *      description: get properties of stored zip files for export
    *      responses:
    *        200:
@@ -91,11 +91,11 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *  /_api/v3/export:
+   *  /export:
    *    post:
    *      tags: [Export]
    *      operationId: createExport
-   *      summary: /_api/v3/export
+   *      summary: /export
    *      description: generate zipped jsons for collections
    *      responses:
    *        200:
@@ -129,11 +129,11 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *  /_api/v3/export/{fileName}:
+   *  /export/{fileName}:
    *    delete:
    *      tags: [Export]
    *      operationId: deleteExport
-   *      summary: /_api/v3/export/{fileName}
+   *      summary: /export/{fileName}
    *      description: delete the file
    *      parameters:
    *        - name: fileName

--- a/src/server/routes/apiv3/healthcheck.js
+++ b/src/server/routes/apiv3/healthcheck.js
@@ -18,11 +18,11 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *  /_api/v3/healthcheck:
+   *  /healthcheck:
    *    get:
    *      tags: [Healthcheck]
    *      operationId: getHealthcheck
-   *      summary: /_api/v3/healthcheck
+   *      summary: /healthcheck
    *      description: Check whether the server is healthy or not
    *      parameters:
    *        - name: connectToMiddlewares

--- a/src/server/routes/apiv3/healthcheck.js
+++ b/src/server/routes/apiv3/healthcheck.js
@@ -20,7 +20,7 @@ module.exports = (crowi) => {
    *
    *  /_api/v3/healthcheck:
    *    get:
-   *      tags: [Healthcheck, apiv3]
+   *      tags: [Healthcheck]
    *      operationId: getHealthcheck
    *      summary: /_api/v3/healthcheck
    *      description: Check whether the server is healthy or not

--- a/src/server/routes/apiv3/import.js
+++ b/src/server/routes/apiv3/import.js
@@ -101,11 +101,11 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *  /_api/v3/import/status:
+   *  /import/status:
    *    get:
    *      tags: [Import]
    *      operationId: getImportStatus
-   *      summary: /_api/v3/import/status
+   *      summary: /import/status
    *      description: Get properties of stored zip files for import
    *      responses:
    *        200:
@@ -130,11 +130,11 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *  /_api/v3/import:
+   *  /import:
    *    post:
    *      tags: [Import]
    *      operationId: executeImport
-   *      summary: /_api/v3/import
+   *      summary: /import
    *      description: import a collection from a zipped json
    *      requestBody:
    *        required: true
@@ -241,11 +241,11 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *  /_api/v3/import/upload:
+   *  /import/upload:
    *    post:
    *      tags: [Import]
    *      operationId: uploadImport
-   *      summary: /_api/v3/import/upload
+   *      summary: /import/upload
    *      description: upload a zip file
    *      responses:
    *        200:
@@ -288,11 +288,11 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *  /_api/v3/import/all:
+   *  /import/all:
    *    delete:
    *      tags: [Import]
    *      operationId: deleteImportAll
-   *      summary: /_api/v3/import/all
+   *      summary: /import/all
    *      description: Delete all zip files
    *      responses:
    *        200:

--- a/src/server/routes/apiv3/import.js
+++ b/src/server/routes/apiv3/import.js
@@ -103,7 +103,7 @@ module.exports = (crowi) => {
    *
    *  /_api/v3/import/status:
    *    get:
-   *      tags: [Import, apiv3]
+   *      tags: [Import]
    *      operationId: getImportStatus
    *      summary: /_api/v3/import/status
    *      description: Get properties of stored zip files for import
@@ -132,7 +132,7 @@ module.exports = (crowi) => {
    *
    *  /_api/v3/import:
    *    post:
-   *      tags: [Import, apiv3]
+   *      tags: [Import]
    *      operationId: executeImport
    *      summary: /_api/v3/import
    *      description: import a collection from a zipped json
@@ -243,7 +243,7 @@ module.exports = (crowi) => {
    *
    *  /_api/v3/import/upload:
    *    post:
-   *      tags: [Import, apiv3]
+   *      tags: [Import]
    *      operationId: uploadImport
    *      summary: /_api/v3/import/upload
    *      description: upload a zip file
@@ -290,7 +290,7 @@ module.exports = (crowi) => {
    *
    *  /_api/v3/import/all:
    *    delete:
-   *      tags: [Import, apiv3]
+   *      tags: [Import]
    *      operationId: deleteImportAll
    *      summary: /_api/v3/import/all
    *      description: Delete all zip files

--- a/src/server/routes/apiv3/markdown-setting.js
+++ b/src/server/routes/apiv3/markdown-setting.js
@@ -94,7 +94,7 @@ module.exports = (crowi) => {
    *
    *    /_api/v3/markdown-setting:
    *      get:
-   *        tags: [MarkDownSetting, apiv3]
+   *        tags: [MarkDownSetting]
    *        operationId: getMarkdownSetting
    *        summary: /_api/v3/markdown-setting
    *        description: Get markdown parameters
@@ -129,7 +129,7 @@ module.exports = (crowi) => {
    *
    *    /_api/v3/markdown-setting/lineBreak:
    *      put:
-   *        tags: [MarkDownSetting, apiv3]
+   *        tags: [MarkDownSetting]
    *        operationId: updateLineBreakMarkdownSetting
    *        summary: /_api/v3/markdown-setting/lineBreak
    *        description: Update lineBreak setting
@@ -175,7 +175,7 @@ module.exports = (crowi) => {
    *
    *    /_api/v3/markdown-setting/presentation:
    *      put:
-   *        tags: [MarkDownSetting, apiv3]
+   *        tags: [MarkDownSetting]
    *        operationId: updatePresentationMarkdownSetting
    *        summary: /_api/v3/markdown-setting/presentation
    *        description: Update presentation
@@ -224,7 +224,7 @@ module.exports = (crowi) => {
    *
    *    /_api/v3/markdown-setting/xss:
    *      put:
-   *        tags: [MarkDownSetting, apiv3]
+   *        tags: [MarkDownSetting]
    *        operationId: updateXssMarkdownSetting
    *        summary: /_api/v3/markdown-setting/xss
    *        description: Update xss

--- a/src/server/routes/apiv3/markdown-setting.js
+++ b/src/server/routes/apiv3/markdown-setting.js
@@ -92,11 +92,11 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *    /_api/v3/markdown-setting:
+   *    /markdown-setting:
    *      get:
    *        tags: [MarkDownSetting]
    *        operationId: getMarkdownSetting
-   *        summary: /_api/v3/markdown-setting
+   *        summary: /markdown-setting
    *        description: Get markdown parameters
    *        responses:
    *          200:
@@ -127,11 +127,11 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *    /_api/v3/markdown-setting/lineBreak:
+   *    /markdown-setting/lineBreak:
    *      put:
    *        tags: [MarkDownSetting]
    *        operationId: updateLineBreakMarkdownSetting
-   *        summary: /_api/v3/markdown-setting/lineBreak
+   *        summary: /markdown-setting/lineBreak
    *        description: Update lineBreak setting
    *        requestBody:
    *          required: true
@@ -173,11 +173,11 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *    /_api/v3/markdown-setting/presentation:
+   *    /markdown-setting/presentation:
    *      put:
    *        tags: [MarkDownSetting]
    *        operationId: updatePresentationMarkdownSetting
-   *        summary: /_api/v3/markdown-setting/presentation
+   *        summary: /markdown-setting/presentation
    *        description: Update presentation
    *        requestBody:
    *          required: true
@@ -222,11 +222,11 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *    /_api/v3/markdown-setting/xss:
+   *    /markdown-setting/xss:
    *      put:
    *        tags: [MarkDownSetting]
    *        operationId: updateXssMarkdownSetting
-   *        summary: /_api/v3/markdown-setting/xss
+   *        summary: /markdown-setting/xss
    *        description: Update xss
    *        requestBody:
    *          required: true

--- a/src/server/routes/apiv3/mongo.js
+++ b/src/server/routes/apiv3/mongo.js
@@ -17,11 +17,11 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *  /_api/v3/mongo/collections:
+   *  /mongo/collections:
    *    get:
    *      tags: [Mongo]
    *      operationId: getMongoCollections
-   *      summary: /_api/v3/mongo/collections
+   *      summary: /mongo/collections
    *      description: get mongodb collections names
    *      responses:
    *        200:

--- a/src/server/routes/apiv3/mongo.js
+++ b/src/server/routes/apiv3/mongo.js
@@ -19,7 +19,7 @@ module.exports = (crowi) => {
    *
    *  /_api/v3/mongo/collections:
    *    get:
-   *      tags: [Mongo, apiv3]
+   *      tags: [Mongo]
    *      operationId: getMongoCollections
    *      summary: /_api/v3/mongo/collections
    *      description: get mongodb collections names

--- a/src/server/routes/apiv3/statistics.js
+++ b/src/server/routes/apiv3/statistics.js
@@ -83,11 +83,11 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *  /_api/v3/statistics/user:
+   *  /statistics/user:
    *    get:
    *      tags: [Statistics]
    *      operationId: getStatisticsUser
-   *      summary: /_api/v3/statistics/user
+   *      summary: /statistics/user
    *      description: Get statistics for user
    *      responses:
    *        200:

--- a/src/server/routes/apiv3/statistics.js
+++ b/src/server/routes/apiv3/statistics.js
@@ -85,7 +85,7 @@ module.exports = (crowi) => {
    *
    *  /_api/v3/statistics/user:
    *    get:
-   *      tags: [Statistics, apiv3]
+   *      tags: [Statistics]
    *      operationId: getStatisticsUser
    *      summary: /_api/v3/statistics/user
    *      description: Get statistics for user

--- a/src/server/routes/apiv3/user-group-relation.js
+++ b/src/server/routes/apiv3/user-group-relation.js
@@ -25,7 +25,7 @@ module.exports = (crowi) => {
    *  paths:
    *    /_api/v3/user-group-relations:
    *      get:
-   *        tags: [UserGroupRelation, apiv3]
+   *        tags: [UserGroupRelation]
    *        operationId: listUserGroupRelations
    *        summary: /_api/v3/user-group-relations
    *        description: Gets the user group relations

--- a/src/server/routes/apiv3/user-group-relation.js
+++ b/src/server/routes/apiv3/user-group-relation.js
@@ -23,11 +23,11 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *  paths:
-   *    /_api/v3/user-group-relations:
+   *    /user-group-relations:
    *      get:
    *        tags: [UserGroupRelation]
    *        operationId: listUserGroupRelations
-   *        summary: /_api/v3/user-group-relations
+   *        summary: /user-group-relations
    *        description: Gets the user group relations
    *        responses:
    *          200:

--- a/src/server/routes/apiv3/user-group.js
+++ b/src/server/routes/apiv3/user-group.js
@@ -45,7 +45,7 @@ module.exports = (crowi) => {
    *  paths:
    *    /_api/v3/user-groups:
    *      get:
-   *        tags: [UserGroup, apiv3]
+   *        tags: [UserGroup]
    *        operationId: getUserGroup
    *        summary: /_api/v3/user-groups
    *        description: Get usergroups
@@ -85,7 +85,7 @@ module.exports = (crowi) => {
    *  paths:
    *    /_api/v3/user-groups:
    *      post:
-   *        tags: [UserGroup, apiv3]
+   *        tags: [UserGroup]
    *        operationId: createUserGroup
    *        summary: /_api/v3/user-groups
    *        description: Adds userGroup
@@ -137,7 +137,7 @@ module.exports = (crowi) => {
    *  paths:
    *    /_api/v3/user-groups/{id}:
    *      delete:
-   *        tags: [UserGroup, apiv3]
+   *        tags: [UserGroup]
    *        operationId: deleteUserGroup
    *        summary: /_api/v3/user-groups/{id}
    *        description: Deletes userGroup
@@ -199,7 +199,7 @@ module.exports = (crowi) => {
    *  paths:
    *    /_api/v3/user-groups/{id}:
    *      put:
-   *        tags: [UserGroup, apiv3]
+   *        tags: [UserGroup]
    *        operationId: updateUserGroups
    *        summary: /_api/v3/user-groups/{id}
    *        description: Update userGroup
@@ -256,7 +256,7 @@ module.exports = (crowi) => {
    *  paths:
    *    /_api/v3/user-groups/{id}/users:
    *      get:
-   *        tags: [UserGroup, apiv3]
+   *        tags: [UserGroup]
    *        operationId: getUsersUserGroups
    *        summary: /_api/v3/user-groups/{id}/users
    *        description: Get users related to the userGroup
@@ -306,7 +306,7 @@ module.exports = (crowi) => {
    *  paths:
    *    /_api/v3/user-groups/{id}/unrelated-users:
    *      get:
-   *        tags: [UserGroup, apiv3]
+   *        tags: [UserGroup]
    *        operationId: getUnrelatedUsersUserGroups
    *        summary: /_api/v3/user-groups/{id}/unrelated-users
    *        description: Get users unrelated to the userGroup
@@ -364,7 +364,7 @@ module.exports = (crowi) => {
    *  paths:
    *    /_api/v3/user-groups/{id}/users:
    *      post:
-   *        tags: [UserGroup, apiv3]
+   *        tags: [UserGroup]
    *        operationId: addUserUserGroups
    *        summary: /_api/v3/user-groups/{id}/users
    *        description: Add a user to the userGroup
@@ -433,7 +433,7 @@ module.exports = (crowi) => {
    *  paths:
    *    /_api/v3/user-groups/{id}/users:
    *      delete:
-   *        tags: [UserGroup, apiv3]
+   *        tags: [UserGroup]
    *        operationId: deleteUsersUserGroups
    *        summary: /_api/v3/user-groups/{id}/users
    *        description: remove a user from the userGroup
@@ -495,7 +495,7 @@ module.exports = (crowi) => {
    *  paths:
    *    /_api/v3/user-groups/{id}/user-group-relations:
    *      get:
-   *        tags: [UserGroup, apiv3]
+   *        tags: [UserGroup]
    *        operationId: getUserGroupRelationsUserGroups
    *        summary: /_api/v3/user-groups/{id}/user-group-relations
    *        description: Get the user group relations for the userGroup
@@ -549,7 +549,7 @@ module.exports = (crowi) => {
    *  paths:
    *    /_api/v3/user-groups/{id}/pages:
    *      get:
-   *        tags: [UserGroup, apiv3]
+   *        tags: [UserGroup]
    *        operationId: getPagesUserGroups
    *        summary: /_api/v3/user-groups/{id}/pages
    *        description: Get closed pages for the userGroup

--- a/src/server/routes/apiv3/user-group.js
+++ b/src/server/routes/apiv3/user-group.js
@@ -43,11 +43,11 @@ module.exports = (crowi) => {
    * @swagger
    *
    *  paths:
-   *    /_api/v3/user-groups:
+   *    /user-groups:
    *      get:
    *        tags: [UserGroup]
    *        operationId: getUserGroup
-   *        summary: /_api/v3/user-groups
+   *        summary: /user-groups
    *        description: Get usergroups
    *        responses:
    *          200:
@@ -83,11 +83,11 @@ module.exports = (crowi) => {
    * @swagger
    *
    *  paths:
-   *    /_api/v3/user-groups:
+   *    /user-groups:
    *      post:
    *        tags: [UserGroup]
    *        operationId: createUserGroup
-   *        summary: /_api/v3/user-groups
+   *        summary: /user-groups
    *        description: Adds userGroup
    *        requestBody:
    *          required: true
@@ -135,11 +135,11 @@ module.exports = (crowi) => {
    * @swagger
    *
    *  paths:
-   *    /_api/v3/user-groups/{id}:
+   *    /user-groups/{id}:
    *      delete:
    *        tags: [UserGroup]
    *        operationId: deleteUserGroup
-   *        summary: /_api/v3/user-groups/{id}
+   *        summary: /user-groups/{id}
    *        description: Deletes userGroup
    *        parameters:
    *          - name: id
@@ -197,11 +197,11 @@ module.exports = (crowi) => {
    * @swagger
    *
    *  paths:
-   *    /_api/v3/user-groups/{id}:
+   *    /user-groups/{id}:
    *      put:
    *        tags: [UserGroup]
    *        operationId: updateUserGroups
-   *        summary: /_api/v3/user-groups/{id}
+   *        summary: /user-groups/{id}
    *        description: Update userGroup
    *        parameters:
    *          - name: id
@@ -254,11 +254,11 @@ module.exports = (crowi) => {
    * @swagger
    *
    *  paths:
-   *    /_api/v3/user-groups/{id}/users:
+   *    /user-groups/{id}/users:
    *      get:
    *        tags: [UserGroup]
    *        operationId: getUsersUserGroups
-   *        summary: /_api/v3/user-groups/{id}/users
+   *        summary: /user-groups/{id}/users
    *        description: Get users related to the userGroup
    *        parameters:
    *          - name: id
@@ -304,11 +304,11 @@ module.exports = (crowi) => {
    * @swagger
    *
    *  paths:
-   *    /_api/v3/user-groups/{id}/unrelated-users:
+   *    /user-groups/{id}/unrelated-users:
    *      get:
    *        tags: [UserGroup]
    *        operationId: getUnrelatedUsersUserGroups
-   *        summary: /_api/v3/user-groups/{id}/unrelated-users
+   *        summary: /user-groups/{id}/unrelated-users
    *        description: Get users unrelated to the userGroup
    *        parameters:
    *          - name: id
@@ -362,11 +362,11 @@ module.exports = (crowi) => {
    * @swagger
    *
    *  paths:
-   *    /_api/v3/user-groups/{id}/users:
+   *    /user-groups/{id}/users:
    *      post:
    *        tags: [UserGroup]
    *        operationId: addUserUserGroups
-   *        summary: /_api/v3/user-groups/{id}/users
+   *        summary: /user-groups/{id}/users
    *        description: Add a user to the userGroup
    *        parameters:
    *          - name: id
@@ -431,11 +431,11 @@ module.exports = (crowi) => {
    * @swagger
    *
    *  paths:
-   *    /_api/v3/user-groups/{id}/users:
+   *    /user-groups/{id}/users:
    *      delete:
    *        tags: [UserGroup]
    *        operationId: deleteUsersUserGroups
-   *        summary: /_api/v3/user-groups/{id}/users
+   *        summary: /user-groups/{id}/users
    *        description: remove a user from the userGroup
    *        parameters:
    *          - name: id
@@ -493,11 +493,11 @@ module.exports = (crowi) => {
    * @swagger
    *
    *  paths:
-   *    /_api/v3/user-groups/{id}/user-group-relations:
+   *    /user-groups/{id}/user-group-relations:
    *      get:
    *        tags: [UserGroup]
    *        operationId: getUserGroupRelationsUserGroups
-   *        summary: /_api/v3/user-groups/{id}/user-group-relations
+   *        summary: /user-groups/{id}/user-group-relations
    *        description: Get the user group relations for the userGroup
    *        parameters:
    *          - name: id
@@ -547,11 +547,11 @@ module.exports = (crowi) => {
    * @swagger
    *
    *  paths:
-   *    /_api/v3/user-groups/{id}/pages:
+   *    /user-groups/{id}/pages:
    *      get:
    *        tags: [UserGroup]
    *        operationId: getPagesUserGroups
-   *        summary: /_api/v3/user-groups/{id}/pages
+   *        summary: /user-groups/{id}/pages
    *        description: Get closed pages for the userGroup
    *        parameters:
    *          - name: id

--- a/src/server/routes/apiv3/users.js
+++ b/src/server/routes/apiv3/users.js
@@ -83,7 +83,7 @@ module.exports = (crowi) => {
    *  paths:
    *    /_api/v3/users:
    *      get:
-   *        tags: [Users, apiv3]
+   *        tags: [Users]
    *        operationId: listUsers
    *        summary: /_api/v3/users
    *        description: Get users
@@ -135,7 +135,7 @@ module.exports = (crowi) => {
    *  paths:
    *    /_api/v3/users/invite:
    *      post:
-   *        tags: [Users, apiv3]
+   *        tags: [Users]
    *        operationId: inviteUser
    *        summary: /_api/v3/users/invite
    *        description: Create new users and send Emails
@@ -180,7 +180,7 @@ module.exports = (crowi) => {
    *  paths:
    *    /_api/v3/users/{id}/giveAdmin:
    *      put:
-   *        tags: [Users, apiv3]
+   *        tags: [Users]
    *        operationId: giveAdminUser
    *        summary: /_api/v3/users/{id}/giveAdmin
    *        description: Give user admin
@@ -221,7 +221,7 @@ module.exports = (crowi) => {
    *  paths:
    *    /_api/v3/users/{id}/removeAdmin:
    *      put:
-   *        tags: [Users, apiv3]
+   *        tags: [Users]
    *        operationId: removeAdminUser
    *        summary: /_api/v3/users/{id}/removeAdmin
    *        description: Remove user admin
@@ -262,7 +262,7 @@ module.exports = (crowi) => {
    *  paths:
    *    /_api/v3/users/{id}/activate:
    *      put:
-   *        tags: [Users, apiv3]
+   *        tags: [Users]
    *        operationId: activateUser
    *        summary: /_api/v3/users/{id}/activate
    *        description: Activate user
@@ -311,7 +311,7 @@ module.exports = (crowi) => {
    *  paths:
    *    /_api/v3/users/{id}/deactivate:
    *      put:
-   *        tags: [Users, apiv3]
+   *        tags: [Users]
    *        operationId: deactivateUser
    *        summary: /_api/v3/users/{id}/deactivate
    *        description: Deactivate user
@@ -352,7 +352,7 @@ module.exports = (crowi) => {
    *  paths:
    *    /_api/v3/users/{id}/remove:
    *      delete:
-   *        tags: [Users, apiv3]
+   *        tags: [Users]
    *        operationId: removeUser
    *        summary: /_api/v3/users/{id}/remove
    *        description: Delete user
@@ -397,7 +397,7 @@ module.exports = (crowi) => {
    *  paths:
    *    /_api/v3/users/external-accounts:
    *      get:
-   *        tags: [Users, apiv3]
+   *        tags: [Users]
    *        operationId: listExternalAccountsUsers
    *        summary: /_api/v3/users/external-accounts
    *        description: Get external-account
@@ -431,7 +431,7 @@ module.exports = (crowi) => {
    *  paths:
    *    /_api/v3/users/external-accounts/{id}/remove:
    *      delete:
-   *        tags: [Users, apiv3]
+   *        tags: [Users]
    *        operationId: removeExternalAccountUser
    *        summary: /_api/v3/users/external-accounts/{id}/remove
    *        description: Delete ExternalAccount

--- a/src/server/routes/apiv3/users.js
+++ b/src/server/routes/apiv3/users.js
@@ -81,11 +81,11 @@ module.exports = (crowi) => {
    * @swagger
    *
    *  paths:
-   *    /_api/v3/users:
+   *    /users:
    *      get:
    *        tags: [Users]
    *        operationId: listUsers
-   *        summary: /_api/v3/users
+   *        summary: /users
    *        description: Get users
    *        responses:
    *          200:
@@ -133,11 +133,11 @@ module.exports = (crowi) => {
    * @swagger
    *
    *  paths:
-   *    /_api/v3/users/invite:
+   *    /users/invite:
    *      post:
    *        tags: [Users]
    *        operationId: inviteUser
-   *        summary: /_api/v3/users/invite
+   *        summary: /users/invite
    *        description: Create new users and send Emails
    *        parameters:
    *          - name: shapedEmailList
@@ -178,11 +178,11 @@ module.exports = (crowi) => {
    * @swagger
    *
    *  paths:
-   *    /_api/v3/users/{id}/giveAdmin:
+   *    /users/{id}/giveAdmin:
    *      put:
    *        tags: [Users]
    *        operationId: giveAdminUser
-   *        summary: /_api/v3/users/{id}/giveAdmin
+   *        summary: /users/{id}/giveAdmin
    *        description: Give user admin
    *        parameters:
    *          - name: id
@@ -219,11 +219,11 @@ module.exports = (crowi) => {
    * @swagger
    *
    *  paths:
-   *    /_api/v3/users/{id}/removeAdmin:
+   *    /users/{id}/removeAdmin:
    *      put:
    *        tags: [Users]
    *        operationId: removeAdminUser
-   *        summary: /_api/v3/users/{id}/removeAdmin
+   *        summary: /users/{id}/removeAdmin
    *        description: Remove user admin
    *        parameters:
    *          - name: id
@@ -260,11 +260,11 @@ module.exports = (crowi) => {
    * @swagger
    *
    *  paths:
-   *    /_api/v3/users/{id}/activate:
+   *    /users/{id}/activate:
    *      put:
    *        tags: [Users]
    *        operationId: activateUser
-   *        summary: /_api/v3/users/{id}/activate
+   *        summary: /users/{id}/activate
    *        description: Activate user
    *        parameters:
    *          - name: id
@@ -309,11 +309,11 @@ module.exports = (crowi) => {
    * @swagger
    *
    *  paths:
-   *    /_api/v3/users/{id}/deactivate:
+   *    /users/{id}/deactivate:
    *      put:
    *        tags: [Users]
    *        operationId: deactivateUser
-   *        summary: /_api/v3/users/{id}/deactivate
+   *        summary: /users/{id}/deactivate
    *        description: Deactivate user
    *        parameters:
    *          - name: id
@@ -350,11 +350,11 @@ module.exports = (crowi) => {
    * @swagger
    *
    *  paths:
-   *    /_api/v3/users/{id}/remove:
+   *    /users/{id}/remove:
    *      delete:
    *        tags: [Users]
    *        operationId: removeUser
-   *        summary: /_api/v3/users/{id}/remove
+   *        summary: /users/{id}/remove
    *        description: Delete user
    *        parameters:
    *          - name: id
@@ -395,11 +395,11 @@ module.exports = (crowi) => {
    * @swagger
    *
    *  paths:
-   *    /_api/v3/users/external-accounts:
+   *    /users/external-accounts:
    *      get:
    *        tags: [Users]
    *        operationId: listExternalAccountsUsers
-   *        summary: /_api/v3/users/external-accounts
+   *        summary: /users/external-accounts
    *        description: Get external-account
    *        responses:
    *          200:
@@ -429,11 +429,11 @@ module.exports = (crowi) => {
    * @swagger
    *
    *  paths:
-   *    /_api/v3/users/external-accounts/{id}/remove:
+   *    /users/external-accounts/{id}/remove:
    *      delete:
    *        tags: [Users]
    *        operationId: removeExternalAccountUser
-   *        summary: /_api/v3/users/external-accounts/{id}/remove
+   *        summary: /users/external-accounts/{id}/remove
    *        description: Delete ExternalAccount
    *        parameters:
    *          - name: id

--- a/src/server/routes/attachment.js
+++ b/src/server/routes/attachment.js
@@ -364,6 +364,41 @@ module.exports = function(crowi, app) {
   };
 
   /**
+   * @swagger
+   *
+   *    /_api/attachments.limit:
+   *      get:
+   *        tags: [Attachments]
+   *        operationId: getAttachmentsLimit
+   *        summary: /_api/attachments.limit
+   *        description: Get available capacity of uploaded file with GridFS
+   *        parameters:
+   *          - in: query
+   *            name: fileSize
+   *            schema:
+   *              type: number
+   *              description: file size
+   *              example: 23175
+   *            required: true
+   *        responses:
+   *          200:
+   *            description: Succeeded to get available capacity of uploaded file with GridFS.
+   *            content:
+   *              application/json:
+   *                schema:
+   *                  properties:
+   *                    isUploadable:
+   *                      type: boolean
+   *                      description: uploadable
+   *                      example: true
+   *                    ok:
+   *                      $ref: '#/components/schemas/V1Response/properties/ok'
+   *          403:
+   *            $ref: '#/components/responses/403'
+   *          500:
+   *            $ref: '#/components/responses/500'
+   */
+  /**
    * @api {get} /attachments.limit get available capacity of uploaded file with GridFS
    * @apiName AddAttachments
    * @apiGroup Attachment

--- a/src/server/routes/attachment.js
+++ b/src/server/routes/attachment.js
@@ -249,7 +249,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/attachments.list:
    *      get:
-   *        tags: [Attachments, apiv1]
+   *        tags: [Attachments]
    *        operationId: listAttachments
    *        summary: /_api/attachments.list
    *        description: Get list of attachments in page
@@ -317,7 +317,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/attachments.add:
    *      post:
-   *        tags: [Attachments, apiv1]
+   *        tags: [Attachments]
    *        operationId: addAttachment
    *        summary: /_api/attachments.add
    *        description: Add attachment to the page
@@ -485,7 +485,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/attachments.remove:
    *      post:
-   *        tags: [Attachments, apiv1]
+   *        tags: [Attachments]
    *        operationId: removeAttachment
    *        summary: /_api/attachments.remove
    *        description: Remove attachment

--- a/src/server/routes/attachment.js
+++ b/src/server/routes/attachment.js
@@ -308,11 +308,11 @@ module.exports = function(crowi, app) {
   /**
    * @swagger
    *
-   *    /_api/attachments.list:
+   *    /attachments.list:
    *      get:
    *        tags: [Attachments, CrowiCompatibles]
    *        operationId: listAttachments
-   *        summary: /_api/attachments.list
+   *        summary: /attachments.list
    *        description: Get list of attachments in page
    *        parameters:
    *          - in: query
@@ -366,11 +366,11 @@ module.exports = function(crowi, app) {
   /**
    * @swagger
    *
-   *    /_api/attachments.limit:
+   *    /attachments.limit:
    *      get:
    *        tags: [Attachments]
    *        operationId: getAttachmentsLimit
-   *        summary: /_api/attachments.limit
+   *        summary: /attachments.limit
    *        description: Get available capacity of uploaded file with GridFS
    *        parameters:
    *          - in: query
@@ -411,11 +411,11 @@ module.exports = function(crowi, app) {
   /**
    * @swagger
    *
-   *    /_api/attachments.add:
+   *    /attachments.add:
    *      post:
    *        tags: [Attachments, CrowiCompatibles]
    *        operationId: addAttachment
-   *        summary: /_api/attachments.add
+   *        summary: /attachments.add
    *        description: Add attachment to the page
    *        requestBody:
    *          content:
@@ -537,11 +537,11 @@ module.exports = function(crowi, app) {
   /**
    * @swagger
    *
-   *    /_api/attachments.uploadProfileImage:
+   *    /attachments.uploadProfileImage:
    *      post:
    *        tags: [Attachments]
    *        operationId: uploadProfileImage
-   *        summary: /_api/attachments.uploadProfileImage
+   *        summary: /attachments.uploadProfileImage
    *        description: Upload profile image
    *        requestBody:
    *          content:
@@ -632,11 +632,11 @@ module.exports = function(crowi, app) {
   /**
    * @swagger
    *
-   *    /_api/attachments.remove:
+   *    /attachments.remove:
    *      post:
    *        tags: [Attachments, CrowiCompatibles]
    *        operationId: removeAttachment
-   *        summary: /_api/attachments.remove
+   *        summary: /attachments.remove
    *        description: Remove attachment
    *        requestBody:
    *          content:
@@ -696,11 +696,11 @@ module.exports = function(crowi, app) {
   /**
    * @swagger
    *
-   *    /_api/attachments.removeProfileImage:
+   *    /attachments.removeProfileImage:
    *      post:
    *        tags: [Attachments]
    *        operationId: removeProfileImage
-   *        summary: /_api/attachments.removeProfileImage
+   *        summary: /attachments.removeProfileImage
    *        description: Remove profile image
    *        requestBody:
    *          content:

--- a/src/server/routes/attachment.js
+++ b/src/server/routes/attachment.js
@@ -42,10 +42,6 @@ const ApiResponse = require('../util/apiResponse');
  *            type: string
  *            description: original file name
  *            example: file.txt
- *          filePath:
- *            type: string
- *            description: file path
- *            example: attachment/5e07345972560e001761fa63/6b0b3facf3628699263d760e18efd446.txt
  *          creator:
  *            $ref: '#/components/schemas/User'
  *          page:
@@ -64,6 +60,14 @@ const ApiResponse = require('../util/apiResponse');
  *            type: string
  *            description: attachment URL
  *            example: http://localhost/files/5e0734e072560e001761fa67
+ *          filePathProxied:
+ *            type: string
+ *            description: file path proxied
+ *            example: "/attachment/5e0734e072560e001761fa67"
+ *          downloadPathProxied:
+ *            type: string
+ *            description: download path proxied
+ *            example: "/download/5e0734e072560e001761fa67"
  */
 
 /**

--- a/src/server/routes/attachment.js
+++ b/src/server/routes/attachment.js
@@ -655,6 +655,37 @@ module.exports = function(crowi, app) {
   };
 
   /**
+   * @swagger
+   *
+   *    /_api/attachments.removeProfileImage:
+   *      post:
+   *        tags: [Attachments]
+   *        operationId: removeProfileImage
+   *        summary: /_api/attachments.removeProfileImage
+   *        description: Remove profile image
+   *        requestBody:
+   *          content:
+   *            application/json:
+   *              schema:
+   *                properties:
+   *                  user:
+   *                    type: string
+   *                    description: user to remove profile image
+   *        responses:
+   *          200:
+   *            description: Succeeded to add attachment.
+   *            content:
+   *              application/json:
+   *                schema:
+   *                  properties:
+   *                    ok:
+   *                      $ref: '#/components/schemas/V1Response/properties/ok'
+   *          403:
+   *            $ref: '#/components/responses/403'
+   *          500:
+   *            $ref: '#/components/responses/500'
+   */
+  /**
    * @api {post} /attachments.removeProfileImage Remove profile image attachments
    * @apiGroup Attachment
    * @apiParam {String} attachment_id

--- a/src/server/routes/attachment.js
+++ b/src/server/routes/attachment.js
@@ -249,7 +249,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/attachments.list:
    *      get:
-   *        tags: [Attachments]
+   *        tags: [Attachments, CrowiCompatibles]
    *        operationId: listAttachments
    *        summary: /_api/attachments.list
    *        description: Get list of attachments in page
@@ -317,7 +317,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/attachments.add:
    *      post:
-   *        tags: [Attachments]
+   *        tags: [Attachments, CrowiCompatibles]
    *        operationId: addAttachment
    *        summary: /_api/attachments.add
    *        description: Add attachment to the page
@@ -485,7 +485,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/attachments.remove:
    *      post:
-   *        tags: [Attachments]
+   *        tags: [Attachments, CrowiCompatibles]
    *        operationId: removeAttachment
    *        summary: /_api/attachments.remove
    *        description: Remove attachment

--- a/src/server/routes/attachment.js
+++ b/src/server/routes/attachment.js
@@ -515,7 +515,7 @@ module.exports = function(crowi, app) {
    *                    description: attachment data
    *                  user:
    *                    type: string
-   *                    description: user to set profile
+   *                    description: user to set profile image
    *              encoding:
    *                path:
    *                  contentType: application/x-www-form-urlencoded

--- a/src/server/routes/attachment.js
+++ b/src/server/routes/attachment.js
@@ -66,6 +66,63 @@ const ApiResponse = require('../util/apiResponse');
  *            example: http://localhost/files/5e0734e072560e001761fa67
  */
 
+/**
+ * @swagger
+ *
+ *  components:
+ *    schemas:
+ *      AttachmentProfile:
+ *        description: Attachment
+ *        type: object
+ *        properties:
+ *          id:
+ *            type: string
+ *            description: attachment ID
+ *            example: 5e0734e072560e001761fa67
+ *          _id:
+ *            type: string
+ *            description: attachment ID
+ *            example: 5e0734e072560e001761fa67
+ *          __v:
+ *            type: number
+ *            description: attachment version
+ *            example: 0
+ *          fileFormat:
+ *            type: string
+ *            description: file format in MIME
+ *            example: image/png
+ *          fileName:
+ *            type: string
+ *            description: file name
+ *            example: 601b7c59d43a042c0117e08dd37aad0a.png
+ *          originalName:
+ *            type: string
+ *            description: original file name
+ *            example: profile.png
+ *          creator:
+ *            $ref: '#/components/schemas/User/properties/_id'
+ *          page:
+ *            type: string
+ *            description: page ID attached at
+ *            example: null
+ *          createdAt:
+ *            type: string
+ *            description: date created at
+ *            example: 2010-01-01T00:00:00.000Z
+ *          fileSize:
+ *            type: number
+ *            description: file size
+ *            example: 3494332
+ *          filePathProxied:
+ *            type: string
+ *            description: file path proxied
+ *            example: "/attachment/5e0734e072560e001761fa67"
+ *          downloadPathProxied:
+ *            type: string
+ *            description: download path proxied
+ *            example: "/download/5e0734e072560e001761fa67"
+ */
+
 module.exports = function(crowi, app) {
   const Attachment = crowi.model('Attachment');
   const User = crowi.model('User');
@@ -438,6 +495,59 @@ module.exports = function(crowi, app) {
     return res.json(ApiResponse.success(result));
   };
 
+  /**
+   * @swagger
+   *
+   *    /_api/attachments.uploadProfileImage:
+   *      post:
+   *        tags: [Attachments]
+   *        operationId: uploadProfileImage
+   *        summary: /_api/attachments.uploadProfileImage
+   *        description: Upload profile image
+   *        requestBody:
+   *          content:
+   *            "multipart/form-data":
+   *              schema:
+   *                properties:
+   *                  file:
+   *                    type: string
+   *                    format: binary
+   *                    description: attachment data
+   *                  user:
+   *                    type: string
+   *                    description: user to set profile
+   *              encoding:
+   *                path:
+   *                  contentType: application/x-www-form-urlencoded
+   *            "*\/*":
+   *              schema:
+   *                properties:
+   *                  file:
+   *                    type: string
+   *                    format: binary
+   *                    description: attachment data
+   *                  user:
+   *                    type: string
+   *                    description: user to set profile
+   *              encoding:
+   *                path:
+   *                  contentType: application/x-www-form-urlencoded
+   *        responses:
+   *          200:
+   *            description: Succeeded to add attachment.
+   *            content:
+   *              application/json:
+   *                schema:
+   *                  properties:
+   *                    ok:
+   *                      $ref: '#/components/schemas/V1Response/properties/ok'
+   *                    attachment:
+   *                      $ref: '#/components/schemas/AttachmentProfile'
+   *          403:
+   *            $ref: '#/components/responses/403'
+   *          500:
+   *            $ref: '#/components/responses/500'
+   */
   /**
    * @api {post} /attachments.uploadProfileImage Add attachment for profile image
    * @apiName UploadProfileImage

--- a/src/server/routes/bookmark.js
+++ b/src/server/routes/bookmark.js
@@ -45,7 +45,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/bookmarks.get:
    *      get:
-   *        tags: [Bookmarks, apiv1]
+   *        tags: [Bookmarks]
    *        operationId: getBookmark
    *        summary: /_api/bookmarks.get
    *        description: Get bookmark of the page with the user
@@ -100,7 +100,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/bookmarks.list:
    *      get:
-   *        tags: [Bookmarks, apiv1]
+   *        tags: [Bookmarks]
    *        operationId: listBookmarks
    *        summary: /_api/bookmarks.list
    *        description: Get bookmark list of the page with the user
@@ -151,7 +151,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/bookmarks.add:
    *      post:
-   *        tags: [Bookmarks, apiv1]
+   *        tags: [Bookmarks]
    *        operationId: addBookmark
    *        summary: /_api/bookmarks.add
    *        description: Add bookmark of the page
@@ -206,7 +206,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/bookmarks.remove:
    *      post:
-   *        tags: [Bookmarks, apiv1]
+   *        tags: [Bookmarks]
    *        operationId: removeBookmark
    *        summary: /_api/bookmarks.remove
    *        description: Remove bookmark of the page

--- a/src/server/routes/bookmark.js
+++ b/src/server/routes/bookmark.js
@@ -45,7 +45,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/bookmarks.get:
    *      get:
-   *        tags: [Bookmarks]
+   *        tags: [Bookmarks, CrowiCompatibles]
    *        operationId: getBookmark
    *        summary: /_api/bookmarks.get
    *        description: Get bookmark of the page with the user
@@ -100,7 +100,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/bookmarks.list:
    *      get:
-   *        tags: [Bookmarks]
+   *        tags: [Bookmarks, CrowiCompatibles]
    *        operationId: listBookmarks
    *        summary: /_api/bookmarks.list
    *        description: Get bookmark list of the page with the user
@@ -151,7 +151,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/bookmarks.add:
    *      post:
-   *        tags: [Bookmarks]
+   *        tags: [Bookmarks, CrowiCompatibles]
    *        operationId: addBookmark
    *        summary: /_api/bookmarks.add
    *        description: Add bookmark of the page
@@ -206,7 +206,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/bookmarks.remove:
    *      post:
-   *        tags: [Bookmarks]
+   *        tags: [Bookmarks, CrowiCompatibles]
    *        operationId: removeBookmark
    *        summary: /_api/bookmarks.remove
    *        description: Remove bookmark of the page

--- a/src/server/routes/bookmark.js
+++ b/src/server/routes/bookmark.js
@@ -94,45 +94,6 @@ module.exports = function(crowi, app) {
       });
   };
 
-
-  /**
-   * @swagger
-   *
-   *    /_api/bookmarks.list:
-   *      get:
-   *        tags: [Bookmarks, CrowiCompatibles]
-   *        operationId: listBookmarks
-   *        summary: /_api/bookmarks.list
-   *        description: Get bookmark list of the page with the user
-   *        parameters:
-   *          - in: query
-   *            name: limit
-   *            schema:
-   *              $ref: '#/components/schemas/V1PaginateResult/properties/meta/properties/limit'
-   *          - in: query
-   *            name: offset
-   *            schema:
-   *              $ref: '#/components/schemas/V1PaginateResult/properties/meta/properties/offset'
-   *        responses:
-   *          200:
-   *            description: Succeeded to get bookmark of the page with the user.
-   *            content:
-   *              application/json:
-   *                schema:
-   *                  properties:
-   *                    ok:
-   *                      $ref: '#/components/schemas/V1Response/properties/ok'
-   *                    meta:
-   *                      $ref: '#/components/schemas/V1PaginateResult/properties/meta'
-   *                    data:
-   *                      type: array
-   *                      items:
-   *                        $ref: '#/components/schemas/V1PaginateResult/properties/meta'
-   *          403:
-   *            $ref: '#/components/responses/403'
-   *          500:
-   *            $ref: '#/components/responses/500'
-   */
   actions.api.list = function(req, res) {
     const paginateOptions = ApiPaginate.parseOptions(req.query);
 

--- a/src/server/routes/bookmark.js
+++ b/src/server/routes/bookmark.js
@@ -43,11 +43,11 @@ module.exports = function(crowi, app) {
   /**
    * @swagger
    *
-   *    /_api/bookmarks.get:
+   *    /bookmarks.get:
    *      get:
    *        tags: [Bookmarks, CrowiCompatibles]
    *        operationId: getBookmark
-   *        summary: /_api/bookmarks.get
+   *        summary: /bookmarks.get
    *        description: Get bookmark of the page with the user
    *        parameters:
    *          - in: query
@@ -110,11 +110,11 @@ module.exports = function(crowi, app) {
   /**
    * @swagger
    *
-   *    /_api/bookmarks.add:
+   *    /bookmarks.add:
    *      post:
    *        tags: [Bookmarks, CrowiCompatibles]
    *        operationId: addBookmark
-   *        summary: /_api/bookmarks.add
+   *        summary: /bookmarks.add
    *        description: Add bookmark of the page
    *        parameters:
    *          - in: query
@@ -165,11 +165,11 @@ module.exports = function(crowi, app) {
   /**
    * @swagger
    *
-   *    /_api/bookmarks.remove:
+   *    /bookmarks.remove:
    *      post:
    *        tags: [Bookmarks, CrowiCompatibles]
    *        operationId: removeBookmark
-   *        summary: /_api/bookmarks.remove
+   *        summary: /bookmarks.remove
    *        description: Remove bookmark of the page
    *        requestBody:
    *          content:

--- a/src/server/routes/comment.js
+++ b/src/server/routes/comment.js
@@ -64,7 +64,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/comments.get:
    *      get:
-   *        tags: [Comments]
+   *        tags: [Comments, CrowiCompatibles]
    *        operationId: getComments
    *        summary: /_api/comments.get
    *        description: Get comments of the page of the revision
@@ -158,7 +158,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/comments.add:
    *      post:
-   *        tags: [Comments]
+   *        tags: [Comments, CrowiCompatibles]
    *        operationId: addComment
    *        summary: /_api/comments.add
    *        description: Post comment for the page
@@ -287,7 +287,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/comments.update:
    *      post:
-   *        tags: [Comments]
+   *        tags: [Comments, CrowiCompatibles]
    *        operationId: updateComment
    *        summary: /_api/comments.update
    *        description: Update comment dody
@@ -379,7 +379,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/comments.remove:
    *      post:
-   *        tags: [Comments]
+   *        tags: [Comments, CrowiCompatibles]
    *        operationId: removeComment
    *        summary: /_api/comments.remove
    *        description: Remove specified comment

--- a/src/server/routes/comment.js
+++ b/src/server/routes/comment.js
@@ -64,7 +64,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/comments.get:
    *      get:
-   *        tags: [Comments, apiv1]
+   *        tags: [Comments]
    *        operationId: getComments
    *        summary: /_api/comments.get
    *        description: Get comments of the page of the revision
@@ -158,7 +158,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/comments.add:
    *      post:
-   *        tags: [Comments, apiv1]
+   *        tags: [Comments]
    *        operationId: addComment
    *        summary: /_api/comments.add
    *        description: Post comment for the page
@@ -287,7 +287,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/comments.update:
    *      post:
-   *        tags: [Comments, apiv1]
+   *        tags: [Comments]
    *        operationId: updateComment
    *        summary: /_api/comments.update
    *        description: Update comment dody
@@ -379,7 +379,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/comments.remove:
    *      post:
-   *        tags: [Comments, apiv1]
+   *        tags: [Comments]
    *        operationId: removeComment
    *        summary: /_api/comments.remove
    *        description: Remove specified comment

--- a/src/server/routes/comment.js
+++ b/src/server/routes/comment.js
@@ -62,11 +62,11 @@ module.exports = function(crowi, app) {
   /**
    * @swagger
    *
-   *    /_api/comments.get:
+   *    /comments.get:
    *      get:
    *        tags: [Comments, CrowiCompatibles]
    *        operationId: getComments
-   *        summary: /_api/comments.get
+   *        summary: /comments.get
    *        description: Get comments of the page of the revision
    *        parameters:
    *          - in: query
@@ -156,11 +156,11 @@ module.exports = function(crowi, app) {
   /**
    * @swagger
    *
-   *    /_api/comments.add:
+   *    /comments.add:
    *      post:
    *        tags: [Comments, CrowiCompatibles]
    *        operationId: addComment
-   *        summary: /_api/comments.add
+   *        summary: /comments.add
    *        description: Post comment for the page
    *        requestBody:
    *          content:
@@ -285,11 +285,11 @@ module.exports = function(crowi, app) {
   /**
    * @swagger
    *
-   *    /_api/comments.update:
+   *    /comments.update:
    *      post:
    *        tags: [Comments, CrowiCompatibles]
    *        operationId: updateComment
-   *        summary: /_api/comments.update
+   *        summary: /comments.update
    *        description: Update comment dody
    *        requestBody:
    *          content:
@@ -377,11 +377,11 @@ module.exports = function(crowi, app) {
   /**
    * @swagger
    *
-   *    /_api/comments.remove:
+   *    /comments.remove:
    *      post:
    *        tags: [Comments, CrowiCompatibles]
    *        operationId: removeComment
-   *        summary: /_api/comments.remove
+   *        summary: /comments.remove
    *        description: Remove specified comment
    *        requestBody:
    *          content:

--- a/src/server/routes/hackmd.js
+++ b/src/server/routes/hackmd.js
@@ -8,6 +8,26 @@ const axios = require('axios');
 
 const ApiResponse = require('../util/apiResponse');
 
+/**
+ * @swagger
+ *
+ *  components:
+ *    schemas:
+ *      Hackmd:
+ *        description: Hackmd
+ *        type: object
+ *        properties:
+ *          pageIdOnHackmd:
+ *            type: string
+ *            description: page ID on HackMD
+ *            example: qLnodHLxT6C3hVEVczvbDQ
+ *          revisionIdHackmdSynced:
+ *            $ref: '#/components/schemas/Revision/properties/_id'
+ *          hasDraftOnHackmd:
+ *            type: boolean
+ *            description: has draft on HackMD
+ *            example: false
+ */
 module.exports = function(crowi, app) {
   const Page = crowi.models.Page;
   const pageEvent = crowi.event('page');
@@ -106,6 +126,44 @@ module.exports = function(crowi, app) {
   };
 
   /**
+   * @swagger
+   *
+   *    /_api/hackmd.integrate:
+   *      post:
+   *        tags: [Hackmd]
+   *        operationId: integrateHackmd
+   *        summary: /_api/hackmd.integrate
+   *        description: Integrate hackmd
+   *        requestBody:
+   *          content:
+   *            application/json:
+   *              schema:
+   *                properties:
+   *                  pageId:
+   *                    $ref: '#/components/schemas/Page/properties/_id'
+   *                  page:
+   *                    $ref: '#/components/schemas/Hackmd'
+   *        responses:
+   *          200:
+   *            description: Succeeded to integrate HackMD.
+   *            content:
+   *              application/json:
+   *                schema:
+   *                  properties:
+   *                    ok:
+   *                      $ref: '#/components/schemas/V1Response/properties/ok'
+   *                    pageIdOnHackmd:
+   *                      $ref: '#/components/schemas/Hackmd/properties/pageIdOnHackmd'
+   *                    revisionIdHackmdSynced:
+   *                      $ref: '#/components/schemas/Hackmd/properties/revisionIdHackmdSynced'
+   *                    hasDraftOnHackmd:
+   *                      $ref: '#/components/schemas/Hackmd/properties/hasDraftOnHackmd'
+   *          403:
+   *            $ref: '#/components/responses/403'
+   *          500:
+   *            $ref: '#/components/responses/500'
+   */
+  /**
    * POST /_api/hackmd.integrate
    *
    * Create page on HackMD and start to integrate
@@ -181,6 +239,44 @@ module.exports = function(crowi, app) {
   };
 
   /**
+   * @swagger
+   *
+   *    /_api/hackmd.discard:
+   *      post:
+   *        tags: [Hackmd]
+   *        operationId: discardHackmd
+   *        summary: /_api/hackmd.discard
+   *        description: Discard hackmd
+   *        requestBody:
+   *          content:
+   *            application/json:
+   *              schema:
+   *                properties:
+   *                  pageId:
+   *                    $ref: '#/components/schemas/Page/properties/_id'
+   *                  page:
+   *                    $ref: '#/components/schemas/Hackmd'
+   *        responses:
+   *          200:
+   *            description: Succeeded to integrate HackMD.
+   *            content:
+   *              application/json:
+   *                schema:
+   *                  properties:
+   *                    ok:
+   *                      $ref: '#/components/schemas/V1Response/properties/ok'
+   *                    pageIdOnHackmd:
+   *                      $ref: '#/components/schemas/Hackmd/properties/pageIdOnHackmd'
+   *                    revisionIdHackmdSynced:
+   *                      $ref: '#/components/schemas/Hackmd/properties/revisionIdHackmdSynced'
+   *                    hasDraftOnHackmd:
+   *                      $ref: '#/components/schemas/Hackmd/properties/hasDraftOnHackmd'
+   *          403:
+   *            $ref: '#/components/responses/403'
+   *          500:
+   *            $ref: '#/components/responses/500'
+   */
+  /**
    * POST /_api/hackmd.discard
    *
    * Create page on HackMD and start to integrate
@@ -206,6 +302,38 @@ module.exports = function(crowi, app) {
     }
   };
 
+  /**
+   * @swagger
+   *
+   *    /_api/hackmd.saveOnHackmd:
+   *      post:
+   *        tags: [Hackmd]
+   *        operationId: saveOnHackmd
+   *        summary: /_api/hackmd.saveOnHackmd
+   *        description: Receive when save operation triggered on HackMD
+   *        requestBody:
+   *          content:
+   *            application/json:
+   *              schema:
+   *                properties:
+   *                  pageId:
+   *                    $ref: '#/components/schemas/Page/properties/_id'
+   *                  page:
+   *                    $ref: '#/components/schemas/Hackmd'
+   *        responses:
+   *          200:
+   *            description: Succeeded to receive when save operation triggered on HackMD.
+   *            content:
+   *              application/json:
+   *                schema:
+   *                  properties:
+   *                    ok:
+   *                      $ref: '#/components/schemas/V1Response/properties/ok'
+   *          403:
+   *            $ref: '#/components/responses/403'
+   *          500:
+   *            $ref: '#/components/responses/500'
+   */
   /**
    * POST /_api/hackmd.saveOnHackmd
    *

--- a/src/server/routes/hackmd.js
+++ b/src/server/routes/hackmd.js
@@ -128,11 +128,11 @@ module.exports = function(crowi, app) {
   /**
    * @swagger
    *
-   *    /_api/hackmd.integrate:
+   *    /hackmd.integrate:
    *      post:
    *        tags: [Hackmd]
    *        operationId: integrateHackmd
-   *        summary: /_api/hackmd.integrate
+   *        summary: /hackmd.integrate
    *        description: Integrate hackmd
    *        requestBody:
    *          content:
@@ -241,11 +241,11 @@ module.exports = function(crowi, app) {
   /**
    * @swagger
    *
-   *    /_api/hackmd.discard:
+   *    /hackmd.discard:
    *      post:
    *        tags: [Hackmd]
    *        operationId: discardHackmd
-   *        summary: /_api/hackmd.discard
+   *        summary: /hackmd.discard
    *        description: Discard hackmd
    *        requestBody:
    *          content:
@@ -305,11 +305,11 @@ module.exports = function(crowi, app) {
   /**
    * @swagger
    *
-   *    /_api/hackmd.saveOnHackmd:
+   *    /hackmd.saveOnHackmd:
    *      post:
    *        tags: [Hackmd]
    *        operationId: saveOnHackmd
-   *        summary: /_api/hackmd.saveOnHackmd
+   *        summary: /hackmd.saveOnHackmd
    *        description: Receive when save operation triggered on HackMD
    *        requestBody:
    *          content:

--- a/src/server/routes/me.js
+++ b/src/server/routes/me.js
@@ -67,11 +67,11 @@ module.exports = function(crowi, app) {
   /**
    * @swagger
    *
-   *   /_api/me/user-group-relations:
+   *   /me/user-group-relations:
    *     get:
    *       tags: [Me, CrowiCompatibles]
    *       operationId: getUserGroupRelations
-   *       summary: /_api/me/user-group-relations
+   *       summary: /me/user-group-relations
    *       description: Get user group relations
    *       responses:
    *         200:

--- a/src/server/routes/me.js
+++ b/src/server/routes/me.js
@@ -1,3 +1,53 @@
+/**
+ * @swagger
+ *
+ *  components:
+ *    schemas:
+ *      UserGroup:
+ *        description: UserGroup
+ *        type: object
+ *        properties:
+ *          __v:
+ *            type: number
+ *            description: record version
+ *            example: 0
+ *          _id:
+ *            type: string
+ *            description: user group ID
+ *            example: 5e2d56c1e35da4004ef7e0b0
+ *          createdAt:
+ *            type: string
+ *            description: date created at
+ *            example: 2010-01-01T00:00:00.000Z
+ */
+
+/**
+ * @swagger
+ *
+ *  components:
+ *    schemas:
+ *      UserGroupRelation:
+ *        description: UserGroupRelation
+ *        type: object
+ *        properties:
+ *          __v:
+ *            type: number
+ *            description: record version
+ *            example: 0
+ *          _id:
+ *            type: string
+ *            description: user group relation ID
+ *            example: 5e2d56cbe35da4004ef7e0b1
+ *          relatedGroup:
+ *            $ref: '#/components/schemas/UserGroup'
+ *          relatedUser:
+ *            $ref: '#/components/schemas/User/properties/_id'
+ *          createdAt:
+ *            type: string
+ *            description: date created at
+ *            example: 2010-01-01T00:00:00.000Z
+ */
+
 module.exports = function(crowi, app) {
   const debug = require('debug')('growi:routes:me');
   const logger = require('@alias/logger')('growi:routes:me');
@@ -14,6 +64,33 @@ module.exports = function(crowi, app) {
   const api = {};
   actions.api = api;
 
+  /**
+   * @swagger
+   *
+   *   /_api/me/user-group-relations:
+   *     get:
+   *       tags: [Me, CrowiCompatibles]
+   *       operationId: getUserGroupRelations
+   *       summary: /_api/me/user-group-relations
+   *       description: Get user group relations
+   *       responses:
+   *         200:
+   *           description: Succeeded to get user group relations.
+   *           content:
+   *             application/json:
+   *               schema:
+   *                 properties:
+   *                   ok:
+   *                     $ref: '#/components/schemas/V1Response/properties/ok'
+   *                   userGroupRelations:
+   *                     type: array
+   *                     items:
+   *                       $ref: '#/components/schemas/UserGroupRelation'
+   *         403:
+   *           $ref: '#/components/responses/403'
+   *         500:
+   *           $ref: '#/components/responses/500'
+   */
   /**
    * retrieve user-group-relation documents
    * @param {object} req

--- a/src/server/routes/page.js
+++ b/src/server/routes/page.js
@@ -647,7 +647,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/pages.list:
    *      get:
-   *        tags: [Pages, apiv1]
+   *        tags: [Pages]
    *        operationId: listPages
    *        summary: /_api/pages.list
    *        description: Get list of pages
@@ -737,7 +737,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/pages.create:
    *      post:
-   *        tags: [Pages, apiv1]
+   *        tags: [Pages]
    *        operationId: createPage
    *        summary: /_api/pages.create
    *        description: Create page
@@ -846,7 +846,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/pages.update:
    *      post:
-   *        tags: [Pages, apiv1]
+   *        tags: [Pages]
    *        operationId: updatePage
    *        summary: /_api/pages.update
    *        description: Update page
@@ -974,7 +974,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/pages.get:
    *      get:
-   *        tags: [Pages, apiv1]
+   *        tags: [Pages]
    *        operationId: getPage
    *        summary: /_api/pages.get
    *        description: Get page data
@@ -1098,7 +1098,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/pages.seen:
    *      post:
-   *        tags: [Pages, apiv1]
+   *        tags: [Pages]
    *        operationId: seenPage
    *        summary: /_api/pages.seen
    *        description: Mark as seen user
@@ -1167,7 +1167,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/likes.add:
    *      post:
-   *        tags: [Pages, apiv1]
+   *        tags: [Pages]
    *        operationId: addLike
    *        summary: /_api/likes.add
    *        description: Like page
@@ -1243,7 +1243,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/likes.remove:
    *      post:
-   *        tags: [Pages, apiv1]
+   *        tags: [Pages]
    *        operationId: removeLike
    *        summary: /_api/likes.remove
    *        description: Unlike page
@@ -1311,7 +1311,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/pages.updatePost:
    *      get:
-   *        tags: [Pages, apiv1]
+   *        tags: [Pages]
    *        operationId: getUpdatePostPage
    *        summary: /_api/pages.updatePost
    *        description: Get UpdatePost setting list
@@ -1479,7 +1479,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/pages.rename:
    *      post:
-   *        tags: [Pages, apiv1]
+   *        tags: [Pages]
    *        operationId: renamePage
    *        summary: /_api/pages.rename
    *        description: Rename page

--- a/src/server/routes/page.js
+++ b/src/server/routes/page.js
@@ -1070,7 +1070,7 @@ module.exports = function(crowi, app) {
    *              example: '{"/": "unused value", "/user/unknown": "unused value"}'
    *        responses:
    *          200:
-   *            description: Succeeded to get page data.
+   *            description: Succeeded to get page existence.
    *            content:
    *              application/json:
    *                schema:

--- a/src/server/routes/page.js
+++ b/src/server/routes/page.js
@@ -1110,6 +1110,39 @@ module.exports = function(crowi, app) {
   };
 
   /**
+   * @swagger
+   *
+   *    /_api/pages.getPageTag:
+   *      get:
+   *        tags: [Pages]
+   *        operationId: getPageTag
+   *        summary: /_api/pages.getPageTag
+   *        description: Get page tag
+   *        parameters:
+   *          - in: query
+   *            name: pageId
+   *            schema:
+   *              $ref: '#/components/schemas/Page/properties/_id'
+   *        responses:
+   *          200:
+   *            description: Succeeded to get page tags.
+   *            content:
+   *              application/json:
+   *                schema:
+   *                  properties:
+   *                    ok:
+   *                      $ref: '#/components/schemas/V1Response/properties/ok'
+   *                    tags:
+   *                      type: array
+   *                      description: Tag names
+   *                      items: string
+   *                      example: ['daily', 'report', 'tips']
+   *          403:
+   *            $ref: '#/components/responses/403'
+   *          500:
+   *            $ref: '#/components/responses/500'
+   */
+  /**
    * @api {get} /pages.getPageTag get page tags
    * @apiName GetPageTag
    * @apiGroup Page

--- a/src/server/routes/page.js
+++ b/src/server/routes/page.js
@@ -1082,9 +1082,9 @@ module.exports = function(crowi, app) {
    *                    ok:
    *                      $ref: '#/components/schemas/V1Response/properties/ok'
    *                    pages:
-   *                      type: Object
+   *                      type: string
    *                      description: Properties of page path and existence
-   *                      example: {"/": true, "/user/unknown": false}
+   *                      example: '{"/": true, "/user/unknown": false}'
    *          403:
    *            $ref: '#/components/responses/403'
    *          500:

--- a/src/server/routes/page.js
+++ b/src/server/routes/page.js
@@ -1650,6 +1650,54 @@ module.exports = function(crowi, app) {
     return res.json(ApiResponse.success(result));
   };
 
+  /**
+   * @swagger
+   *
+   *    /_api/pages.recentCreated:
+   *      get:
+   *        tags: [Pages]
+   *        operationId: getRecentCreatedPages
+   *        summary: /_api/pages.recentCreated
+   *        description: Get recent created page list
+   *        parameters:
+   *          - in: query
+   *            name: page_id
+   *            required: true
+   *            schema:
+   *              $ref: '#/components/schemas/Page/properties/_id'
+   *          - in: query
+   *            name: offset
+   *            schema:
+   *              $ref: '#/components/schemas/V1PaginateResult/properties/meta/properties/offset'
+   *          - in: query
+   *            name: limit
+   *            schema:
+   *              $ref: '#/components/schemas/V1PaginateResult/properties/meta/properties/limit'
+   *        responses:
+   *          200:
+   *            description: Succeeded to get recent created page list.
+   *            content:
+   *              application/json:
+   *                schema:
+   *                  properties:
+   *                    ok:
+   *                      $ref: '#/components/schemas/V1Response/properties/ok'
+   *                    pages:
+   *                      type: array
+   *                      description: recent created page list
+   *                      items:
+   *                        $ref: '#/components/schemas/Page'
+   *                    totalCount:
+   *                      $ref: '#/components/schemas/V1PaginateResult/properties/meta/properties/total'
+   *                    offset:
+   *                      $ref: '#/components/schemas/V1PaginateResult/properties/meta/properties/offset'
+   *                    limit:
+   *                      $ref: '#/components/schemas/V1PaginateResult/properties/meta/properties/limit'
+   *          403:
+   *            $ref: '#/components/responses/403'
+   *          500:
+   *            $ref: '#/components/responses/500'
+   */
   api.recentCreated = async function(req, res) {
     const pageId = req.query.page_id;
 

--- a/src/server/routes/page.js
+++ b/src/server/routes/page.js
@@ -126,6 +126,14 @@
  *            type: string
  *            description: date created at
  *            example: 2010-01-01T00:00:00.000Z
+ *
+ *      Tags:
+ *        description: Tags
+ *        type: array
+ *        items:
+ *          type: string
+ *          description: tag name
+ *        example: ['daily', 'report', 'tips']
  */
 
 /* eslint-disable no-use-before-define */
@@ -1133,10 +1141,7 @@ module.exports = function(crowi, app) {
    *                    ok:
    *                      $ref: '#/components/schemas/V1Response/properties/ok'
    *                    tags:
-   *                      type: array
-   *                      description: Tag names
-   *                      items: string
-   *                      example: ['daily', 'report', 'tips']
+   *                      $ref: '#/components/schemas/Tags'
    *          403:
    *            $ref: '#/components/responses/403'
    *          500:
@@ -1659,6 +1664,44 @@ module.exports = function(crowi, app) {
     return page;
   };
 
+  /**
+   * @swagger
+   *
+   *    /_api/pages.duplicate:
+   *      post:
+   *        tags: [Pages]
+   *        operationId: duplicatePage
+   *        summary: /_api/pages.duplicate
+   *        description: Duplicate page
+   *        requestBody:
+   *          content:
+   *            application/json:
+   *              schema:
+   *                properties:
+   *                  page_id:
+   *                    $ref: '#/components/schemas/Page/properties/_id'
+   *                  new_path:
+   *                    $ref: '#/components/schemas/Page/properties/path'
+   *                required:
+   *                  - page_id
+   *        responses:
+   *          200:
+   *            description: Succeeded to duplicate page.
+   *            content:
+   *              application/json:
+   *                schema:
+   *                  properties:
+   *                    ok:
+   *                      $ref: '#/components/schemas/V1Response/properties/ok'
+   *                    page:
+   *                      $ref: '#/components/schemas/Page'
+   *                    tags:
+   *                      $ref: '#/components/schemas/Tags'
+   *          403:
+   *            $ref: '#/components/responses/403'
+   *          500:
+   *            $ref: '#/components/responses/500'
+   */
   /**
    * @api {post} /pages.duplicate Duplicate page
    * @apiName DuplicatePage

--- a/src/server/routes/page.js
+++ b/src/server/routes/page.js
@@ -647,7 +647,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/pages.list:
    *      get:
-   *        tags: [Pages]
+   *        tags: [Pages, CrowiCompatibles]
    *        operationId: listPages
    *        summary: /_api/pages.list
    *        description: Get list of pages
@@ -737,7 +737,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/pages.create:
    *      post:
-   *        tags: [Pages]
+   *        tags: [Pages, CrowiCompatibles]
    *        operationId: createPage
    *        summary: /_api/pages.create
    *        description: Create page
@@ -846,7 +846,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/pages.update:
    *      post:
-   *        tags: [Pages]
+   *        tags: [Pages, CrowiCompatibles]
    *        operationId: updatePage
    *        summary: /_api/pages.update
    *        description: Update page
@@ -974,7 +974,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/pages.get:
    *      get:
-   *        tags: [Pages]
+   *        tags: [Pages, CrowiCompatibles]
    *        operationId: getPage
    *        summary: /_api/pages.get
    *        description: Get page data
@@ -1098,7 +1098,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/pages.seen:
    *      post:
-   *        tags: [Pages]
+   *        tags: [Pages, CrowiCompatibles]
    *        operationId: seenPage
    *        summary: /_api/pages.seen
    *        description: Mark as seen user
@@ -1167,7 +1167,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/likes.add:
    *      post:
-   *        tags: [Pages]
+   *        tags: [Pages, CrowiCompatibles]
    *        operationId: addLike
    *        summary: /_api/likes.add
    *        description: Like page
@@ -1243,7 +1243,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/likes.remove:
    *      post:
-   *        tags: [Pages]
+   *        tags: [Pages, CrowiCompatibles]
    *        operationId: removeLike
    *        summary: /_api/likes.remove
    *        description: Unlike page
@@ -1311,7 +1311,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/pages.updatePost:
    *      get:
-   *        tags: [Pages]
+   *        tags: [Pages, CrowiCompatibles]
    *        operationId: getUpdatePostPage
    *        summary: /_api/pages.updatePost
    *        description: Get UpdatePost setting list
@@ -1479,7 +1479,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/pages.rename:
    *      post:
-   *        tags: [Pages]
+   *        tags: [Pages, CrowiCompatibles]
    *        operationId: renamePage
    *        summary: /_api/pages.rename
    *        description: Rename page

--- a/src/server/routes/page.js
+++ b/src/server/routes/page.js
@@ -645,11 +645,11 @@ module.exports = function(crowi, app) {
   /**
    * @swagger
    *
-   *    /_api/pages.list:
+   *    /pages.list:
    *      get:
    *        tags: [Pages, CrowiCompatibles]
    *        operationId: listPages
-   *        summary: /_api/pages.list
+   *        summary: /pages.list
    *        description: Get list of pages
    *        parameters:
    *          - in: query
@@ -739,11 +739,11 @@ module.exports = function(crowi, app) {
   /**
    * @swagger
    *
-   *    /_api/pages.create:
+   *    /pages.create:
    *      post:
    *        tags: [Pages, CrowiCompatibles]
    *        operationId: createPage
-   *        summary: /_api/pages.create
+   *        summary: /pages.create
    *        description: Create page
    *        requestBody:
    *          content:
@@ -848,11 +848,11 @@ module.exports = function(crowi, app) {
   /**
    * @swagger
    *
-   *    /_api/pages.update:
+   *    /pages.update:
    *      post:
    *        tags: [Pages, CrowiCompatibles]
    *        operationId: updatePage
-   *        summary: /_api/pages.update
+   *        summary: /pages.update
    *        description: Update page
    *        requestBody:
    *          content:
@@ -976,11 +976,11 @@ module.exports = function(crowi, app) {
   /**
    * @swagger
    *
-   *    /_api/pages.get:
+   *    /pages.get:
    *      get:
    *        tags: [Pages, CrowiCompatibles]
    *        operationId: getPage
-   *        summary: /_api/pages.get
+   *        summary: /pages.get
    *        description: Get page data
    *        parameters:
    *          - in: query
@@ -1059,11 +1059,11 @@ module.exports = function(crowi, app) {
   /**
    * @swagger
    *
-   *    /_api/pages.exist:
+   *    /pages.exist:
    *      get:
    *        tags: [Pages]
    *        operationId: getPageExistence
-   *        summary: /_api/pages.exist
+   *        summary: /pages.exist
    *        description: Get page existence
    *        parameters:
    *          - in: query
@@ -1116,11 +1116,11 @@ module.exports = function(crowi, app) {
   /**
    * @swagger
    *
-   *    /_api/pages.getPageTag:
+   *    /pages.getPageTag:
    *      get:
    *        tags: [Pages]
    *        operationId: getPageTag
-   *        summary: /_api/pages.getPageTag
+   *        summary: /pages.getPageTag
    *        description: Get page tag
    *        parameters:
    *          - in: query
@@ -1164,11 +1164,11 @@ module.exports = function(crowi, app) {
   /**
    * @swagger
    *
-   *    /_api/pages.seen:
+   *    /pages.seen:
    *      post:
    *        tags: [Pages, CrowiCompatibles]
    *        operationId: seenPage
-   *        summary: /_api/pages.seen
+   *        summary: /pages.seen
    *        description: Mark as seen user
    *        requestBody:
    *          content:
@@ -1233,11 +1233,11 @@ module.exports = function(crowi, app) {
   /**
    * @swagger
    *
-   *    /_api/likes.add:
+   *    /likes.add:
    *      post:
    *        tags: [Likes, CrowiCompatibles]
    *        operationId: addLike
-   *        summary: /_api/likes.add
+   *        summary: /likes.add
    *        description: Like page
    *        requestBody:
    *          content:
@@ -1309,11 +1309,11 @@ module.exports = function(crowi, app) {
   /**
    * @swagger
    *
-   *    /_api/likes.remove:
+   *    /likes.remove:
    *      post:
    *        tags: [Likes, CrowiCompatibles]
    *        operationId: removeLike
-   *        summary: /_api/likes.remove
+   *        summary: /likes.remove
    *        description: Unlike page
    *        requestBody:
    *          content:
@@ -1377,11 +1377,11 @@ module.exports = function(crowi, app) {
   /**
    * @swagger
    *
-   *    /_api/pages.updatePost:
+   *    /pages.updatePost:
    *      get:
    *        tags: [Pages, CrowiCompatibles]
    *        operationId: getUpdatePostPage
-   *        summary: /_api/pages.updatePost
+   *        summary: /pages.updatePost
    *        description: Get UpdatePost setting list
    *        parameters:
    *          - in: query
@@ -1545,11 +1545,11 @@ module.exports = function(crowi, app) {
   /**
    * @swagger
    *
-   *    /_api/pages.rename:
+   *    /pages.rename:
    *      post:
    *        tags: [Pages, CrowiCompatibles]
    *        operationId: renamePage
-   *        summary: /_api/pages.rename
+   *        summary: /pages.rename
    *        description: Rename page
    *        requestBody:
    *          content:
@@ -1663,11 +1663,11 @@ module.exports = function(crowi, app) {
   /**
    * @swagger
    *
-   *    /_api/pages.duplicate:
+   *    /pages.duplicate:
    *      post:
    *        tags: [Pages]
    *        operationId: duplicatePage
-   *        summary: /_api/pages.duplicate
+   *        summary: /pages.duplicate
    *        description: Duplicate page
    *        requestBody:
    *          content:
@@ -1759,11 +1759,11 @@ module.exports = function(crowi, app) {
   /**
    * @swagger
    *
-   *    /_api/pages.recentCreated:
+   *    /pages.recentCreated:
    *      get:
    *        tags: [Pages]
    *        operationId: getRecentCreatedPages
-   *        summary: /_api/pages.recentCreated
+   *        summary: /pages.recentCreated
    *        description: Get recent created page list
    *        parameters:
    *          - in: query

--- a/src/server/routes/page.js
+++ b/src/server/routes/page.js
@@ -126,14 +126,6 @@
  *            type: string
  *            description: date created at
  *            example: 2010-01-01T00:00:00.000Z
- *
- *      Tags:
- *        description: Tags
- *        type: array
- *        items:
- *          type: string
- *          description: tag name
- *        example: ['daily', 'report', 'tips']
  */
 
 /* eslint-disable no-use-before-define */
@@ -668,6 +660,10 @@ module.exports = function(crowi, app) {
    *            name: user
    *            schema:
    *              $ref: '#/components/schemas/User/properties/username'
+   *          - in: query
+   *            name: limit
+   *            schema:
+   *              $ref: '#/components/schemas/V1PaginateResult/properties/meta/properties/limit'
    *          - in: query
    *            name: offset
    *            schema:

--- a/src/server/routes/page.js
+++ b/src/server/routes/page.js
@@ -1235,7 +1235,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/likes.add:
    *      post:
-   *        tags: [Pages, CrowiCompatibles]
+   *        tags: [Likes, CrowiCompatibles]
    *        operationId: addLike
    *        summary: /_api/likes.add
    *        description: Like page
@@ -1311,7 +1311,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/likes.remove:
    *      post:
-   *        tags: [Pages, CrowiCompatibles]
+   *        tags: [Likes, CrowiCompatibles]
    *        operationId: removeLike
    *        summary: /_api/likes.remove
    *        description: Unlike page

--- a/src/server/routes/page.js
+++ b/src/server/routes/page.js
@@ -1053,6 +1053,40 @@ module.exports = function(crowi, app) {
   };
 
   /**
+   * @swagger
+   *
+   *    /_api/pages.exist:
+   *      get:
+   *        tags: [Pages]
+   *        operationId: getPageExistence
+   *        summary: /_api/pages.exist
+   *        description: Get page existence
+   *        parameters:
+   *          - in: query
+   *            name: pages
+   *            schema:
+   *              type: string
+   *              description: Page paths specified by hash key in JSON format
+   *              example: '{"/": "unused value", "/user/unknown": "unused value"}'
+   *        responses:
+   *          200:
+   *            description: Succeeded to get page data.
+   *            content:
+   *              application/json:
+   *                schema:
+   *                  properties:
+   *                    ok:
+   *                      $ref: '#/components/schemas/V1Response/properties/ok'
+   *                    pages:
+   *                      type: Object
+   *                      description: Properties of page path and existence
+   *                      example: {"/": true, "/user/unknown": false}
+   *          403:
+   *            $ref: '#/components/responses/403'
+   *          500:
+   *            $ref: '#/components/responses/500'
+   */
+  /**
    * @api {get} /pages.exist Get if page exists
    * @apiName GetPage
    * @apiGroup Page

--- a/src/server/routes/revision.js
+++ b/src/server/routes/revision.js
@@ -60,7 +60,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/revisions.get:
    *      get:
-   *        tags: [Revisions, apiv1]
+   *        tags: [Revisions]
    *        operationId: /_api/revisions.get
    *        summary: /_api/revisions.get
    *        description: Get revision
@@ -128,7 +128,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/revisions.ids:
    *      get:
-   *        tags: [Revisions, apiv1]
+   *        tags: [Revisions]
    *        operationId: /_api/revisions.ids
    *        summary: /_api/revisions.ids
    *        description: Get revision id list of the page
@@ -189,7 +189,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/revisions.list:
    *      get:
-   *        tags: [Revisions, apiv1]
+   *        tags: [Revisions]
    *        operationId: /_api/revisions.list
    *        summary: /_api/revisions.list
    *        description: Get revisions

--- a/src/server/routes/revision.js
+++ b/src/server/routes/revision.js
@@ -58,11 +58,11 @@ module.exports = function(crowi, app) {
   /**
    * @swagger
    *
-   *    /_api/revisions.get:
+   *    /revisions.get:
    *      get:
    *        tags: [Revisions, CrowiCompatibles]
-   *        operationId: /_api/revisions.get
-   *        summary: /_api/revisions.get
+   *        operationId: revisions.get
+   *        summary: /revisions.get
    *        description: Get revision
    *        parameters:
    *          - in: query
@@ -126,11 +126,11 @@ module.exports = function(crowi, app) {
   /**
    * @swagger
    *
-   *    /_api/revisions.ids:
+   *    /revisions.ids:
    *      get:
    *        tags: [Revisions, CrowiCompatibles]
-   *        operationId: /_api/revisions.ids
-   *        summary: /_api/revisions.ids
+   *        operationId: revisions.ids
+   *        summary: /revisions.ids
    *        description: Get revision id list of the page
    *        parameters:
    *          - in: query
@@ -187,11 +187,11 @@ module.exports = function(crowi, app) {
   /**
    * @swagger
    *
-   *    /_api/revisions.list:
+   *    /revisions.list:
    *      get:
    *        tags: [Revisions, CrowiCompatibles]
-   *        operationId: /_api/revisions.list
-   *        summary: /_api/revisions.list
+   *        operationId: revisions.list
+   *        summary: /revisions.list
    *        description: Get revisions
    *        parameters:
    *          - in: query

--- a/src/server/routes/revision.js
+++ b/src/server/routes/revision.js
@@ -60,7 +60,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/revisions.get:
    *      get:
-   *        tags: [Revisions]
+   *        tags: [Revisions, CrowiCompatibles]
    *        operationId: /_api/revisions.get
    *        summary: /_api/revisions.get
    *        description: Get revision
@@ -128,7 +128,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/revisions.ids:
    *      get:
-   *        tags: [Revisions]
+   *        tags: [Revisions, CrowiCompatibles]
    *        operationId: /_api/revisions.ids
    *        summary: /_api/revisions.ids
    *        description: Get revision id list of the page
@@ -189,7 +189,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/revisions.list:
    *      get:
-   *        tags: [Revisions]
+   *        tags: [Revisions, CrowiCompatibles]
    *        operationId: /_api/revisions.list
    *        summary: /_api/revisions.list
    *        description: Get revisions

--- a/src/server/routes/search.js
+++ b/src/server/routes/search.js
@@ -76,7 +76,7 @@ module.exports = function(crowi, app) {
    *             $ref: '#/components/schemas/V1PaginateResult/properties/meta/properties/limit'
    *       responses:
    *         200:
-   *           description: Succeeded to get list of users.
+   *           description: Succeeded to get list of pages.
    *           content:
    *             application/json:
    *               schema:

--- a/src/server/routes/search.js
+++ b/src/server/routes/search.js
@@ -55,7 +55,7 @@ module.exports = function(crowi, app) {
    *       summary: /_api/search
    *       description: Search pages
    *       parameters:
-   *         - in: path
+   *         - in: query
    *           name: q
    *           schema:
    *             type: string

--- a/src/server/routes/search.js
+++ b/src/server/routes/search.js
@@ -48,11 +48,11 @@ module.exports = function(crowi, app) {
   /**
    * @swagger
    *
-   *   /_api/search:
+   *   /search:
    *     get:
    *       tags: [Search, CrowiCompatibles]
    *       operationId: searchPages
-   *       summary: /_api/search
+   *       summary: /search
    *       description: Search pages
    *       parameters:
    *         - in: query

--- a/src/server/routes/search.js
+++ b/src/server/routes/search.js
@@ -50,7 +50,7 @@ module.exports = function(crowi, app) {
    *
    *   /_api/search:
    *     get:
-   *       tags: [Pages, CrowiCompatibles]
+   *       tags: [Search, CrowiCompatibles]
    *       operationId: searchPages
    *       summary: /_api/search
    *       description: Search pages

--- a/src/server/routes/search.js
+++ b/src/server/routes/search.js
@@ -1,3 +1,29 @@
+/**
+ * @swagger
+ *
+ *   components:
+ *     schemas:
+ *       ElasticsearchResult:
+ *         description: Elasticsearch result v1
+ *         type: object
+ *         properties:
+ *           meta:
+ *             type: object
+ *             properties:
+ *               took:
+ *                 type: number
+ *                 description: Time Elasticsearch took to execute a search(milliseconds)
+ *                 example: 34
+ *               total:
+ *                 type: number
+ *                 description: Number of documents matching search criteria
+ *                 example: 2
+ *               results:
+ *                 type: number
+ *                 description: Actual array length of search results
+ *                 example: 2
+ *
+ */
 module.exports = function(crowi, app) {
   // var debug = require('debug')('growi:routes:search')
   const Page = crowi.model('Page');
@@ -19,6 +45,60 @@ module.exports = function(crowi, app) {
     });
   };
 
+  /**
+   * @swagger
+   *
+   *   /_api/search:
+   *     get:
+   *       tags: [Pages, CrowiCompatibles]
+   *       operationId: searchPages
+   *       summary: /_api/search
+   *       description: Search pages
+   *       parameters:
+   *         - in: path
+   *           name: q
+   *           schema:
+   *             type: string
+   *             description: keyword
+   *             example: daily report
+   *           required: true
+   *         - in: query
+   *           name: path
+   *           schema:
+   *             $ref: '#/components/schemas/Page/properties/path'
+   *         - in: query
+   *           name: offset
+   *           schema:
+   *             $ref: '#/components/schemas/V1PaginateResult/properties/meta/properties/offset'
+   *         - in: query
+   *           name: limit
+   *           schema:
+   *             $ref: '#/components/schemas/V1PaginateResult/properties/meta/properties/limit'
+   *       responses:
+   *         200:
+   *           description: Succeeded to get list of users.
+   *           content:
+   *             application/json:
+   *               schema:
+   *                 properties:
+   *                   ok:
+   *                     $ref: '#/components/schemas/V1Response/properties/ok'
+   *                   meta:
+   *                     $ref: '#/components/schemas/ElasticsearchResult/properties/meta'
+   *                   totalCount:
+   *                     type: integer
+   *                     description: total count of pages
+   *                     example: 35
+   *                   data:
+   *                     type: array
+   *                     items:
+   *                       $ref: '#/components/schemas/Page'
+   *                     description: page list
+   *         403:
+   *           $ref: '#/components/responses/403'
+   *         500:
+   *           $ref: '#/components/responses/500'
+   */
   /**
    * @api {get} /search search page
    * @apiName Search

--- a/src/server/routes/tag.js
+++ b/src/server/routes/tag.js
@@ -84,6 +84,40 @@ module.exports = function(crowi, app) {
   };
 
   /**
+   * @swagger
+   *
+   *    /_api/tags.update:
+   *      post:
+   *        tags: [Tags]
+   *        operationId: updateTag
+   *        summary: /_api/tags.update
+   *        description: Update tag
+   *        requestBody:
+   *          content:
+   *            application/json:
+   *              schema:
+   *                properties:
+   *                  pageId:
+   *                    $ref: '#/components/schemas/Page/properties/_id'
+   *                  tags:
+   *                    $ref: '#/components/schemas/Tags'
+   *        responses:
+   *          200:
+   *            description: Succeeded to update tag.
+   *            content:
+   *              application/json:
+   *                schema:
+   *                  properties:
+   *                    ok:
+   *                      $ref: '#/components/schemas/V1Response/properties/ok'
+   *                    tags:
+   *                      $ref: '#/components/schemas/Tags'
+   *          403:
+   *            $ref: '#/components/responses/403'
+   *          500:
+   *            $ref: '#/components/responses/500'
+   */
+  /**
    * @api {post} /tags.update update tags on view-mode (not edit-mode)
    * @apiName UpdateTag
    * @apiGroup Tag

--- a/src/server/routes/tag.js
+++ b/src/server/routes/tag.js
@@ -44,11 +44,11 @@ module.exports = function(crowi, app) {
   /**
    * @swagger
    *
-   *    /_api/tags.search:
+   *    /tags.search:
    *      get:
    *        tags: [Tags]
    *        operationId: searchTags
-   *        summary: /_api/tags.search
+   *        summary: /tags.search
    *        description: Search tags
    *        parameters:
    *          - in: query
@@ -90,11 +90,11 @@ module.exports = function(crowi, app) {
   /**
    * @swagger
    *
-   *    /_api/tags.update:
+   *    /tags.update:
    *      post:
    *        tags: [Tags]
    *        operationId: updateTag
-   *        summary: /_api/tags.update
+   *        summary: /tags.update
    *        description: Update tag
    *        requestBody:
    *          content:
@@ -154,11 +154,11 @@ module.exports = function(crowi, app) {
   /**
    * @swagger
    *
-   *    /_api/tags.list:
+   *    /tags.list:
    *      get:
    *        tags: [Tags]
    *        operationId: listTags
-   *        summary: /_api/tags.list
+   *        summary: /tags.list
    *        description: Get tags
    *        parameters:
    *          - in: query

--- a/src/server/routes/tag.js
+++ b/src/server/routes/tag.js
@@ -53,6 +53,10 @@ module.exports = function(crowi, app) {
    *        parameters:
    *          - in: query
    *            name: q
+   *            schema:
+   *              type: string
+   *              description: keyword
+   *              example: daily
    *            description: keyword to search
    *        responses:
    *          200:

--- a/src/server/routes/tag.js
+++ b/src/server/routes/tag.js
@@ -1,3 +1,32 @@
+/**
+ * @swagger
+ *
+ *  components:
+ *    schemas:
+ *      Tags:
+ *        description: Tags
+ *        type: array
+ *        items:
+ *          $ref: '#/components/schemas/Tag/properties/name'
+ *        example: ['daily', 'report', 'tips']
+ *
+ *      Tag:
+ *        description: Tag
+ *        type: object
+ *        properties:
+ *          _id:
+ *            type: string
+ *            description: tag ID
+ *            example: 5e2d6aede35da4004ef7e0b7
+ *          name:
+ *            type: string
+ *            description: tag name
+ *            example: daily
+ *          count:
+ *            type: number
+ *            description: Count of tagged pages
+ *            example: 3
+ */
 module.exports = function(crowi, app) {
 
   const Tag = crowi.model('Tag');
@@ -12,6 +41,35 @@ module.exports = function(crowi, app) {
     return res.render('tags');
   };
 
+  /**
+   * @swagger
+   *
+   *    /_api/tags.search:
+   *      get:
+   *        tags: [Tags]
+   *        operationId: searchTags
+   *        summary: /_api/tags.search
+   *        description: Search tags
+   *        parameters:
+   *          - in: query
+   *            name: q
+   *            description: keyword to search
+   *        responses:
+   *          200:
+   *            description: Succeeded to tag list.
+   *            content:
+   *              application/json:
+   *                schema:
+   *                  properties:
+   *                    ok:
+   *                      $ref: '#/components/schemas/V1Response/properties/ok'
+   *                    tags:
+   *                      $ref: '#/components/schemas/Tags'
+   *          403:
+   *            $ref: '#/components/responses/403'
+   *          500:
+   *            $ref: '#/components/responses/500'
+   */
   /**
    * @api {get} /tags.search search tags
    * @apiName SearchTag
@@ -55,6 +113,42 @@ module.exports = function(crowi, app) {
     return res.json(ApiResponse.success(result));
   };
 
+  /**
+   * @swagger
+   *
+   *    /_api/tags.list:
+   *      get:
+   *        tags: [Tags]
+   *        operationId: listTags
+   *        summary: /_api/tags.list
+   *        description: Get tags
+   *        parameters:
+   *          - in: query
+   *            name: limit
+   *            schema:
+   *              $ref: '#/components/schemas/V1PaginateResult/properties/meta/properties/limit'
+   *          - in: query
+   *            name: offset
+   *            schema:
+   *              $ref: '#/components/schemas/V1PaginateResult/properties/meta/properties/offset'
+   *        responses:
+   *          200:
+   *            description: Succeeded to tag list.
+   *            content:
+   *              application/json:
+   *                schema:
+   *                  properties:
+   *                    ok:
+   *                      $ref: '#/components/schemas/V1Response/properties/ok'
+   *                    data:
+   *                      type: array
+   *                      items:
+   *                        $ref: '#/components/schemas/Tag'
+   *          403:
+   *            $ref: '#/components/responses/403'
+   *          500:
+   *            $ref: '#/components/responses/500'
+   */
   /**
    * @api {get} /tags.list get tagnames and count pages relate each tag
    * @apiName tagList

--- a/src/server/routes/user.js
+++ b/src/server/routes/user.js
@@ -86,11 +86,11 @@ module.exports = function(crowi, app) {
   /**
    * @swagger
    *
-   *    /_api/users.list:
+   *    /users.list:
    *      get:
    *        tags: [Users, CrowiCompatibles]
    *        operationId: listUsersV1
-   *        summary: /_api/users.list
+   *        summary: /users.list
    *        description: Get list of users
    *        parameters:
    *          - in: query

--- a/src/server/routes/user.js
+++ b/src/server/routes/user.js
@@ -84,7 +84,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/users.list:
    *      get:
-   *        tags: [Users]
+   *        tags: [Users, CrowiCompatibles]
    *        operationId: listUsersV1
    *        summary: /_api/users.list
    *        description: Get list of users

--- a/src/server/routes/user.js
+++ b/src/server/routes/user.js
@@ -84,7 +84,7 @@ module.exports = function(crowi, app) {
    *
    *    /_api/users.list:
    *      get:
-   *        tags: [Users, apiv1]
+   *        tags: [Users]
    *        operationId: listUsersV1
    *        summary: /_api/users.list
    *        description: Get list of users

--- a/src/server/routes/user.js
+++ b/src/server/routes/user.js
@@ -7,6 +7,10 @@
  *        description: User
  *        type: object
  *        properties:
+ *          __v:
+ *            type: number
+ *            description: record version
+ *            example: 0
  *          _id:
  *            type: string
  *            description: user ID

--- a/src/server/routes/user.js
+++ b/src/server/routes/user.js
@@ -1,3 +1,46 @@
+/**
+ * @swagger
+ *
+ *  components:
+ *    schemas:
+ *      User:
+ *        description: User
+ *        type: object
+ *        properties:
+ *          _id:
+ *            type: string
+ *            description: user ID
+ *            example: 5ae5fccfc5577b0004dbd8ab
+ *          lang:
+ *            type: string
+ *            description: language
+ *            example: 'en-US'
+ *          status:
+ *            type: integer
+ *            description: status
+ *            example: 0
+ *          admin:
+ *            type: boolean
+ *            description: whether the admin
+ *            example: false
+ *          email:
+ *            type: string
+ *            description: E-Mail address
+ *            example: alice@aaa.aaa
+ *          username:
+ *            type: string
+ *            description: username
+ *            example: alice
+ *          name:
+ *            type: string
+ *            description: full name
+ *            example: Alice
+ *          createdAt:
+ *            type: string
+ *            description: date created at
+ *            example: 2010-01-01T00:00:00.000Z
+ */
+
 module.exports = function(crowi, app) {
   const User = crowi.model('User');
   const Bookmark = crowi.model('Bookmark');


### PR DESCRIPTION
Now, API v3 documents include v1 info, and v1 document is not completed.

This PR separate API v1, v3 document, and complement API v1 document.

# API versioning

API v1 document is defined follow.

* It's URL is start with `/_api`, but It is not includes API v3 (`/_api/v3/*`)
* It includes Crowi compatible APIs
* It can access by API token

And API v3 document is defined follow.

* It's URL is start with `/_api/v3`
* Source files placed under directory `growi/src/server/routes/apiv3/`
* It can access by API token

# API Document schema

## API v1

* All API v1 are included
    * cf. JSDoc is build by command `npm run build:apiv1:jsdoc`.
* Each API path has tag based on resource path
    * ex. `/pages.list` has `Pages` tag, and `/likes.add` has `Likes` tag.
* Crowi compatible APIs have `CrowiCompatible` tag too
    * So, all Crowi compatible APIs are showed by open `CrowiCompatible` menu in left pane

## API v3

* All API v3 are included
    * cf. JSDoc is build by command `npm run build:apiv3:jsdoc`.
* Each API path has tag based on resource path
    * ex. `/admin-home` has `AdminHome` tag.

# Build result

[redoc-static.zip](https://github.com/weseek/growi/files/4114053/redoc-static.zip)
