### PR TITLE
SAMLの属性値を利用したログイン制限機能を実装

### DIFF
--- a/resource/locales/en-US/translation.json
+++ b/resource/locales/en-US/translation.json
@@ -123,7 +123,8 @@
   "Deleted Pages": "Deleted Pages",
   "Sign out": "Logout",
   "form_validation": {
-    "required": "<code>%s</code> is required"
+    "required": "<code>%s</code> is required",
+    "invalid_syntax": "The syntax of <code>%s</code> is invalid."
   },
   "installer": {
     "setup": "Setup",
@@ -455,7 +456,10 @@
       "mapping_detail": "Specification of mappings for %s when creating new users",
       "cert_detail": "PEM-encoded X.509 signing certificate to validate the response from IdP",
       "Use env var if empty": "If the value in the database is empty, the value of the environment variable <code>%s</code> is used.",
-      "note for the only env option": "The setting item that enables or disables the SAML authentication and the highlighted setting items use only the value of environment variables.<br>To change this setting, please change to false or delete the value of the environment variable <code>%s</code> ."
+      "note for the only env option": "The setting item that enables or disables the SAML authentication and the highlighted setting items use only the value of environment variables.<br>To change this setting, please change to false or delete the value of the environment variable <code>%s</code> .",
+      "attr_based_login_control_detail": "Limit who can sign up by using <code>&lt;saml: Attribute&gt;</code> element included in <code>&lt;saml: AttributeStatement&gt;</code> element and its child element <code>&lt;saml: AttributeValue&gt;</code>.",
+      "attr_based_login_control_rule_detail": "A rule is written in the form of concatenating <code>attribute name = value</code> with <code>|</code> and <code>&</code>. The or operator (|) has a lower precedence than the and operator (&).　If operator precedence is equal, left to right associativity is used.",
+      "attr_based_login_control_rule_example": "For example, if a rule is <code>Department = A | Department = B & Position = Leader</code>, users with <code>Department</code> as <code>A</code> or users with <code>Department</code> as <code>B</code> and <code>Position</code> as <code>Leader</code> <strong>can</strong> sign in."
     },
     "Basic": {
       "name": "Basic Authentication",
@@ -515,7 +519,8 @@
       "security:passport-saml:attrMapUsername": "Username",
       "security:passport-saml:attrMapMail": "Mail Address",
       "security:passport-saml:attrMapFirstName": "First Name",
-      "security:passport-saml:attrMapLastName": "Last Name"
+      "security:passport-saml:attrMapLastName": "Last Name",
+      "security:passport-saml:ABLCRule": "Rule"
     }
   },
   "notification_setting": {

--- a/resource/locales/ja/translation.json
+++ b/resource/locales/ja/translation.json
@@ -122,7 +122,8 @@
   "Deleted Pages": "削除済みページ",
   "Sign out": "ログアウト",
   "form_validation": {
-    "required": "<code>%s</code> に値を入力してください"
+    "required": "<code>%s</code> に値を入力してください",
+    "invalid_syntax": "<code>%s</code> の構文が不正です"
   },
   "installer": {
     "setup": "セットアップ",
@@ -450,7 +451,9 @@
       "cert_detail": "IdP からのレスポンスの validation を行うためのPEMエンコードされた X.509 証明書",
       "Use env var if empty": "データベース側の値が空の場合、環境変数 <code>%s</code> の値を利用します",
       "note for the only env option": "現在SAML認証のON/OFFの設定値及びハイライトされている設定値は環境変数の値のみを使用するようになっています<br>この設定を変更する場合は環境変数 <code>%s</code> の値をfalseに変更もしくは削除してください",
-      "attr_based_login_control_expr_detail": "<code>属性名=値</code> を <code>|</code>(論理和)、 <code>&</code>(論理積) で連結した形式で記述してください。演算子の優先順位は論理積が論理和より高く、結合規則は左から右です。<br>例えば <code>Department=A | Department=B & Position=Leader</code> だと <code>Department</code> が <code>A</code> の場合, もしくは<code>Department</code> が <code>B</code> かつ <code>Position</code> が <code>Leader</code> の場合にログインを<strong>許可</strong>します。"
+      "attr_based_login_control_detail": "SAMLの <code>&lt;saml:AttributeStatement&gt;</code> 要素に含まれる <code>&lt;saml:Attribute&gt;</code> 要素と、その子要素 <code>&lt;saml:AttributeValue&gt;</code> を利用してログインの可否を制御します。",
+      "attr_based_login_control_rule_detail": "<code>属性名 = 値</code> を <code>|</code>(論理和)、 <code>&</code>(論理積) で連結した形式で記述してください。演算子の優先順位は論理積が論理和より高く、各演算子の結合規則は左から右です。",
+      "attr_based_login_control_rule_example": "例えば <code>Department=A | Department=B & Position=Leader</code> だと <code>Department</code> が <code>A</code> の場合, もしくは<code>Department</code> が <code>B</code> かつ <code>Position</code> が <code>Leader</code> の場合にログインを<strong>許可</strong>します。"
     },
     "Basic": {
       "name": "Basic 認証",
@@ -499,7 +502,8 @@
       "security:passport-saml:attrMapUsername": "ユーザー名",
       "security:passport-saml:attrMapMail": "メールアドレス",
       "security:passport-saml:attrMapFirstName": "姓",
-      "security:passport-saml:attrMapLastName": "名"
+      "security:passport-saml:attrMapLastName": "名",
+      "security:passport-saml:ABLCRule": "ルール"
     }
   },
   "notification_setting": {

--- a/resource/locales/ja/translation.json
+++ b/resource/locales/ja/translation.json
@@ -449,7 +449,8 @@
       "mapping_detail": "新規ユーザーの%sに関連付ける属性",
       "cert_detail": "IdP からのレスポンスの validation を行うためのPEMエンコードされた X.509 証明書",
       "Use env var if empty": "データベース側の値が空の場合、環境変数 <code>%s</code> の値を利用します",
-      "note for the only env option": "現在SAML認証のON/OFFの設定値及びハイライトされている設定値は環境変数の値のみを使用するようになっています<br>この設定を変更する場合は環境変数 <code>%s</code> の値をfalseに変更もしくは削除してください"
+      "note for the only env option": "現在SAML認証のON/OFFの設定値及びハイライトされている設定値は環境変数の値のみを使用するようになっています<br>この設定を変更する場合は環境変数 <code>%s</code> の値をfalseに変更もしくは削除してください",
+      "attr_based_login_control_expr_detail": "<code>属性名=値</code> を <code>|</code>(論理和)、 <code>&</code>(論理積) で連結した形式で記述してください。演算子の優先順位は論理積が論理和より高く、結合規則は左から右です。<br>例えば <code>Department=A | Department=B & Position=Leader</code> だと <code>Department</code> が <code>A</code> の場合, もしくは<code>Department</code> が <code>B</code> かつ <code>Position</code> が <code>Leader</code> の場合にログインを<strong>許可</strong>します。"
     },
     "Basic": {
       "name": "Basic 認証",

--- a/src/server/form/admin/securityPassportSaml.js
+++ b/src/server/form/admin/securityPassportSaml.js
@@ -14,4 +14,5 @@ module.exports = form(
   field('settingForm[security:passport-saml:cert]').trim(),
   field('settingForm[security:passport-saml:isSameUsernameTreatedAsIdenticalUser]').trim().toBooleanStrict(),
   field('settingForm[security:passport-saml:isSameEmailTreatedAsIdenticalUser]').trim().toBooleanStrict(),
+  field('settingForm[security:passport-saml:ABLCRule]').trim(),
 );

--- a/src/server/routes/admin.js
+++ b/src/server/routes/admin.js
@@ -781,10 +781,8 @@ module.exports = function(crowi, app) {
   /**
    * validate setting form values for SAML
    *
-   * The following are checked.
-   *
    * - For the value of each mandatory items,
-   *     check whether it from the environment variables is empty and form value to update it is empty.
+   *     check whether it from the environment variables is empty and form value to update it is empty
    * - validate the syntax of a attribute-based login control rule
    */
   function validateSamlSettingForm(form, t) {

--- a/src/server/routes/admin.js
+++ b/src/server/routes/admin.js
@@ -797,7 +797,7 @@ module.exports = function(crowi, app) {
     const rule = form.settingForm['security:passport-saml:ABLCRule'];
     // Empty string disables attribute-based login control.
     // So, when rule is empty string, validation is passed.
-    if (rule !== '' && rule != null && crowi.passportService.parseABLCRule(rule) === null) {
+    if (rule !== '' && (rule == null || crowi.passportService.parseABLCRule(rule) === null)) {
       form.errors.push(t('form_validation.invalid_syntax', t('security_setting.form_item_name.security:passport-saml:ABLCRule')));
     }
   }

--- a/src/server/routes/admin.js
+++ b/src/server/routes/admin.js
@@ -800,7 +800,7 @@ module.exports = function(crowi, app) {
     // Empty string disables attribute-based login control.
     // So, when rule is empty string, validation is passed.
     if (rule !== '' && rule != null && crowi.passportService.parseABLCRule(rule) === null) {
-      form.errors.push('Rule syntax is invalid');
+      form.errors.push(t('form_validation.invalid_syntax', t('security_setting.form_item_name.security:passport-saml:ABLCRule')));
     }
   }
 

--- a/src/server/routes/admin.js
+++ b/src/server/routes/admin.js
@@ -797,7 +797,7 @@ module.exports = function(crowi, app) {
     const rule = form.settingForm['security:passport-saml:ABLCRule'];
     // Empty string disables attribute-based login control.
     // So, when rule is empty string, validation is passed.
-    if (rule !== '' && (rule == null || crowi.passportService.parseABLCRule(rule) === null)) {
+    if (rule !== '' && (rule == null || crowi.passportService.parseABLCRule(rule) == null)) {
       form.errors.push(t('form_validation.invalid_syntax', t('security_setting.form_item_name.security:passport-saml:ABLCRule')));
     }
   }

--- a/src/server/routes/admin.js
+++ b/src/server/routes/admin.js
@@ -781,8 +781,11 @@ module.exports = function(crowi, app) {
   /**
    * validate setting form values for SAML
    *
-   * This validation checks, for the value of each mandatory items,
-   * whether it from the environment variables is empty and form value to update it is empty.
+   * The following are checked.
+   * 
+   * - For the value of each mandatory items, 
+   *     check whether it from the environment variables is empty and form value to update it is empty.
+   * - validate the syntax of a attribute-based login control rule
    */
   function validateSamlSettingForm(form, t) {
     for (const key of crowi.passportService.mandatoryConfigKeysForSaml) {
@@ -791,6 +794,13 @@ module.exports = function(crowi, app) {
         const formItemName = t(`security_setting.form_item_name.${key}`);
         form.errors.push(t('form_validation.required', formItemName));
       }
+    }
+
+    const rule = form.settingForm["security:passport-saml:ABLCRule"];
+    // Empty string disables attribute-based login control.
+    // So, when rule is empty string, validation is passed.
+    if (rule !== "" && rule != null && crowi.passportService.parseABLCRule(rule) === null) {
+      form.errors.push("Rule syntax is invalid");
     }
   }
 

--- a/src/server/routes/admin.js
+++ b/src/server/routes/admin.js
@@ -782,8 +782,8 @@ module.exports = function(crowi, app) {
    * validate setting form values for SAML
    *
    * The following are checked.
-   * 
-   * - For the value of each mandatory items, 
+   *
+   * - For the value of each mandatory items,
    *     check whether it from the environment variables is empty and form value to update it is empty.
    * - validate the syntax of a attribute-based login control rule
    */
@@ -796,11 +796,11 @@ module.exports = function(crowi, app) {
       }
     }
 
-    const rule = form.settingForm["security:passport-saml:ABLCRule"];
+    const rule = form.settingForm['security:passport-saml:ABLCRule'];
     // Empty string disables attribute-based login control.
     // So, when rule is empty string, validation is passed.
-    if (rule !== "" && rule != null && crowi.passportService.parseABLCRule(rule) === null) {
-      form.errors.push("Rule syntax is invalid");
+    if (rule !== '' && rule != null && crowi.passportService.parseABLCRule(rule) === null) {
+      form.errors.push('Rule syntax is invalid');
     }
   }
 

--- a/src/server/routes/login-passport.js
+++ b/src/server/routes/login-passport.js
@@ -48,13 +48,8 @@ module.exports = function(crowi, app) {
    * @param {*} req
    * @param {*} res
    */
-  const loginFailure = (req, res, next) => {
-    req.flash('errorMessage', 'Sign in failure.');
-    return res.redirect('/login');
-  };
-
-  const loginFailureByABLC = (req, res, next) => {
-    req.flash('errorMessage', 'Sign in failure due to insufficient privileges.');
+  const loginFailure = (req, res, message) => {
+    req.flash('errorMessage', message || 'Sign in failure.');
     return res.redirect('/login');
   };
 
@@ -255,7 +250,7 @@ module.exports = function(crowi, app) {
       response = await promisifiedPassportAuthentication(strategyName, req, res);
     }
     catch (err) {
-      return loginFailure(req, res, next);
+      return loginFailure(req, res);
     }
 
     const userInfo = {
@@ -275,7 +270,7 @@ module.exports = function(crowi, app) {
 
     const externalAccount = await getOrCreateUser(req, res, userInfo, providerId);
     if (!externalAccount) {
-      return loginFailure(req, res, next);
+      return loginFailure(req, res);
     }
 
     const user = await externalAccount.getPopulatedUser();
@@ -306,7 +301,7 @@ module.exports = function(crowi, app) {
       response = await promisifiedPassportAuthentication(strategyName, req, res);
     }
     catch (err) {
-      return loginFailure(req, res, next);
+      return loginFailure(req, res);
     }
 
     const userInfo = {
@@ -317,7 +312,7 @@ module.exports = function(crowi, app) {
 
     const externalAccount = await getOrCreateUser(req, res, userInfo, providerId);
     if (!externalAccount) {
-      return loginFailure(req, res, next);
+      return loginFailure(req, res);
     }
 
     const user = await externalAccount.getPopulatedUser();
@@ -348,7 +343,7 @@ module.exports = function(crowi, app) {
       response = await promisifiedPassportAuthentication(strategyName, req, res);
     }
     catch (err) {
-      return loginFailure(req, res, next);
+      return loginFailure(req, res);
     }
 
     const userInfo = {
@@ -359,7 +354,7 @@ module.exports = function(crowi, app) {
 
     const externalAccount = await getOrCreateUser(req, res, userInfo, providerId);
     if (!externalAccount) {
-      return loginFailure(req, res, next);
+      return loginFailure(req, res);
     }
 
     const user = await externalAccount.getPopulatedUser();
@@ -395,7 +390,7 @@ module.exports = function(crowi, app) {
     }
     catch (err) {
       debug(err);
-      return loginFailure(req, res, next);
+      return loginFailure(req, res);
     }
 
     const userInfo = {
@@ -408,7 +403,7 @@ module.exports = function(crowi, app) {
 
     const externalAccount = await getOrCreateUser(req, res, userInfo, providerId);
     if (!externalAccount) {
-      return loginFailure(req, res, next);
+      return loginFailure(req, res);
     }
 
     // login
@@ -468,7 +463,7 @@ module.exports = function(crowi, app) {
 
     // Attribute-based Login Control
     if (!crowi.passportService.verifySAMLResponseByABLCRule(response)) {
-      return loginFailureByABLC(req, res);
+      return loginFailure(req, res, 'Sign in failure due to insufficient privileges.');
     }
 
     // login
@@ -513,7 +508,7 @@ module.exports = function(crowi, app) {
 
     const externalAccount = await getOrCreateUser(req, res, userInfo, providerId);
     if (!externalAccount) {
-      return loginFailure(req, res, next);
+      return loginFailure(req, res);
     }
 
     const user = await externalAccount.getPopulatedUser();

--- a/src/server/routes/login-passport.js
+++ b/src/server/routes/login-passport.js
@@ -461,6 +461,11 @@ module.exports = function(crowi, app) {
 
     const user = await externalAccount.getPopulatedUser();
 
+    // Attribute-based Login Control
+    if (!crowi.passportService.verifySAMLResponseByABLCRule(response)) {
+      return loginFailure(req, res);
+    }
+
     // login
     req.logIn(user, (err) => {
       if (err != null) {

--- a/src/server/routes/login-passport.js
+++ b/src/server/routes/login-passport.js
@@ -53,6 +53,11 @@ module.exports = function(crowi, app) {
     return res.redirect('/login');
   };
 
+  const loginFailureByABLC = (req, res, next) => {
+    req.flash('errorMessage', 'Sign in failure due to insufficient privileges.');
+    return res.redirect('/login');
+  };
+
   /**
    * return true(valid) or false(invalid)
    *
@@ -463,7 +468,7 @@ module.exports = function(crowi, app) {
 
     // Attribute-based Login Control
     if (!crowi.passportService.verifySAMLResponseByABLCRule(response)) {
-      return loginFailure(req, res);
+      return loginFailureByABLC(req, res);
     }
 
     // login

--- a/src/server/service/config-loader.js
+++ b/src/server/service/config-loader.js
@@ -247,6 +247,12 @@ const ENV_VAR_NAME_TO_CONFIG_INFO = {
     type:    TYPES.STRING,
     default: null,
   },
+  SAML_ABLC_RULE: {
+    ns:      'crowi',
+    key:     'security:passport-saml:ABLCRule',
+    type:    TYPES.STRING,
+    default: null,
+  },
   GCS_API_KEY_JSON_PATH: {
     ns:      'crowi',
     key:     'gcs:apiKeyJsonPath',

--- a/src/server/service/config-loader.js
+++ b/src/server/service/config-loader.js
@@ -294,7 +294,7 @@ class ConfigLoader {
     };
 
     // In getConfig API, only null is used as a value to indicate that a config is not set.
-    // So, if a value loaded from the database is emtpy,
+    // So, if a value loaded from the database is empty,
     // it is converted to null because an empty string is used as the same meaning in the config model.
     // By this processing, whether a value is loaded from the database or from the environment variable,
     // only null indicates a config is not set.

--- a/src/server/service/config-manager.js
+++ b/src/server/service/config-manager.js
@@ -15,6 +15,7 @@ const KEYS_FOR_SAML_USE_ONLY_ENV_OPTION = [
   'security:passport-saml:attrMapFirstName',
   'security:passport-saml:attrMapLastName',
   'security:passport-saml:cert',
+  'security:passport-saml:ABLCRule'
 ];
 
 class ConfigManager {

--- a/src/server/service/config-manager.js
+++ b/src/server/service/config-manager.js
@@ -15,7 +15,7 @@ const KEYS_FOR_SAML_USE_ONLY_ENV_OPTION = [
   'security:passport-saml:attrMapFirstName',
   'security:passport-saml:attrMapLastName',
   'security:passport-saml:cert',
-  'security:passport-saml:ABLCRule'
+  'security:passport-saml:ABLCRule',
 ];
 
 class ConfigManager {

--- a/src/server/service/config-manager.js
+++ b/src/server/service/config-manager.js
@@ -67,7 +67,7 @@ class ConfigManager {
   }
 
   /**
-   * get a config specified by namespace and regular expresssion
+   * get a config specified by namespace and regular expression
    */
   getConfigByRegExp(namespace, regexp) {
     const result = {};

--- a/src/server/service/passport.js
+++ b/src/server/service/passport.js
@@ -611,41 +611,41 @@ class PassportService {
     if (expr === null) {
       return false;
     }
-    debug({"Parsed Rule": JSON.stringify(expr, null, 2)});
+    debug({ 'Parsed Rule': JSON.stringify(expr, null, 2) });
 
     const attributes = this.extractAttributesFromSAMLResponse(response);
-    debug({"Extracted Attributes": JSON.stringify(attributes, null, 2)});
+    debug({ 'Extracted Attributes': JSON.stringify(attributes, null, 2) });
 
-    let evaluated_expr = false
-    for (const or_op of expr) {
-      let evaluated_or_op = true;
-      for (const and_op of or_op) {
-        if (attributes[and_op[0]] == null) {
-          evaluated_or_op = false
+    let evaluatedExpr = false;
+    for (const orOp of expr) {
+      let evaluatedOrOp = true;
+      for (const andOp of orOp) {
+        if (attributes[andOp[0]] == null) {
+          evaluatedOrOp = false;
           break;
         }
-        evaluated_or_op = evaluated_or_op && attributes[and_op[0]].includes(and_op[1])
+        evaluatedOrOp = evaluatedOrOp && attributes[andOp[0]].includes(andOp[1]);
       }
-      evaluated_expr = evaluated_expr || evaluated_or_op;
+      evaluatedExpr = evaluatedExpr || evaluatedOrOp;
     }
 
-    return evaluated_expr;
+    return evaluatedExpr;
   }
 
   /**
    * Parse a rule string for the attribute-based login control
-   * 
+   *
    * The syntax rules are as follows.
    * <attr> and <value> are any characters except "|", "&", "=".
-   * 
+   *
    * ## Syntax
    *    <expr>   ::= <or_op> | <or_op> "|" <expr>
    *    <or_op>  ::= <and_op> | <and_op> "&" <or_op>
    *    <and_op> ::= <attr> "=" <value>
-   * 
+   *
    * ## Example
    *  In:  "Department = A | Department = B & Position = Leader"
-   *  Out: 
+   *  Out:
    *    [
    *      [
    *        ["Department", "A"]
@@ -655,18 +655,18 @@ class PassportService {
    *        ["Position","Leader"]
    *      ]
    *    ]
-   * 
+   *
    *   In:  Invalid syntax string like a "This is a & bad & rule string."
    *   Out: null
    */
   parseABLCRule(rule) {
-    let expr = rule.split("|");
-    expr = expr.map(or_op => or_op.trim().split("&"));
-    expr = expr.map(or_op => or_op.map(and_op => and_op.trim().split("=")));
-    expr = expr.map(or_op => or_op.map(and_op => and_op.map(v => v.trim())));
-    for (const or_op of expr) {
-      for (const and_op of or_op) {
-        if (and_op.length !== 2) {
+    let expr = rule.split('|');
+    expr = expr.map(orOp => orOp.trim().split('&'));
+    expr = expr.map(orOp => orOp.map(andOp => andOp.trim().split('=')));
+    expr = expr.map(orOp => orOp.map(andOp => andOp.map(v => v.trim())));
+    for (const orOp of expr) {
+      for (const andOp of orOp) {
+        if (andOp.length !== 2) {
           return null;
         }
       }
@@ -677,9 +677,9 @@ class PassportService {
 
   /**
    * Extract attributes from a SAML response
-   * 
+   *
    * The format of extracted attributes is the following.
-   * 
+   *
    * {
    *    "attribute_name1": ["value1", "value2", ...],
    *    "attribute_name2": ["value1", "value2", ...],
@@ -700,14 +700,15 @@ class PassportService {
     const result = {};
     for (const attribute of attributes) {
       const name = attribute.$.Name;
-      const attributeValues = attribute.AttributeValue.map(v => v._)
+      const attributeValues = attribute.AttributeValue.map(v => v._);
       if (result[name] == null) {
         result[name] = attributeValues;
-      }else {
-        result[name] = result[name].concat(attributeValues)
+      }
+      else {
+        result[name] = result[name].concat(attributeValues);
       }
     }
-    
+
     return result;
   }
 

--- a/src/server/service/passport.js
+++ b/src/server/service/passport.js
@@ -608,7 +608,7 @@ class PassportService {
     }
 
     const expr = this.parseABLCRule(rule);
-    if (expr === null) {
+    if (expr == null) {
       return false;
     }
     debug({ 'Parsed Rule': JSON.stringify(expr, null, 2) });

--- a/src/server/views/admin/widget/passport/saml.html
+++ b/src/server/views/admin/widget/passport/saml.html
@@ -353,7 +353,7 @@ pWVdnzS1VCO8fKsJ7YYIr+JmHvseph3kFUOI5RqkCcMZlKUv83aUThsTHw==
 
     <p class="help-block">
       <small>
-        SAMLの <code>&lt;saml:AttributeStatement&gt;</code> 要素に含まれる <code>&lt;saml:Attribute&gt;</code> 要素と、その子要素 <code>&lt;saml:AttributeValue&gt;</code> を利用してログインの可否を制御します。<br>
+        {{ t("security_setting.SAML.attr_based_login_control_detail") }}
       </small>
     </p>
 
@@ -369,7 +369,7 @@ pWVdnzS1VCO8fKsJ7YYIr+JmHvseph3kFUOI5RqkCcMZlKUv83aUThsTHw==
       <tbody>
       <tr>
         <th>
-          Rule
+          {{ t("security_setting.form_item_name.security:passport-saml:ABLCRule") }}
         </th>
         <td>
           <input class="form-control"
@@ -379,7 +379,8 @@ pWVdnzS1VCO8fKsJ7YYIr+JmHvseph3kFUOI5RqkCcMZlKUv83aUThsTHw==
                  {% if useOnlyEnvVars %}readonly{% endif %}>
           <p class="help-block">
             <small>
-              {{ t("security_setting.SAML.attr_based_login_control_expr_detail") }}
+              {{ t("security_setting.SAML.attr_based_login_control_rule_detail") }}<br>
+              {{ t("security_setting.SAML.attr_based_login_control_rule_example") }}
             </small>
           </p>
         </td>

--- a/src/server/views/admin/widget/passport/saml.html
+++ b/src/server/views/admin/widget/passport/saml.html
@@ -349,6 +349,55 @@ pWVdnzS1VCO8fKsJ7YYIr+JmHvseph3kFUOI5RqkCcMZlKUv83aUThsTHw==
       </div>
     </div>
 
+    <h4>Attribute-based Login Control</h4>
+
+    <p class="help-block">
+      <small>
+        SAMLの <code>&lt;saml:AttributeStatement&gt;</code> 要素に含まれる <code>&lt;saml:Attribute&gt;</code> 要素と、その子要素 <code>&lt;saml:AttributeValue&gt;</code> を利用してログインの可否を制御します。<br>
+      </small>
+    </p>
+
+    <table class="table settings-table {% if useOnlyEnvVars %}use-only-env-vars{% endif %}">
+      <colgroup>
+        <col class="item-name">
+        <col class="from-db">
+        <col class="from-env-vars">
+      </colgroup>
+      <thead>
+        <tr><th></th><th>Database</th><th>Environment variables</th></tr>
+      </thead>
+      <tbody>
+      <tr>
+        <th>
+          Rule
+        </th>
+        <td>
+          <input class="form-control"
+                 type="text"
+                 name="settingForm[security:passport-saml:ABLCRule]"
+                 value="{{ getConfigFromDB('crowi', 'security:passport-saml:ABLCRule') || '' }}"
+                 {% if useOnlyEnvVars %}readonly{% endif %}>
+          <p class="help-block">
+            <small>
+              {{ t("security_setting.SAML.attr_based_login_control_expr_detail") }}
+            </small>
+          </p>
+        </td>
+        <td>
+          <input class="form-control"
+                 type="text"
+                 value="{{ getConfigFromEnvVars('crowi', 'security:passport-saml:ABLCRule') || '' }}"
+                 readonly>
+          <p class="help-block">
+            <small>
+              {{ t("security_setting.SAML.Use env var if empty", "SAML_ABLC_RULE") }}
+            </small>
+          </p>
+        </td>
+      </tr>
+      </tbody>
+    </table>
+
   </fieldset>
 
   <div class="form-group" id="btn-update">

--- a/yarn.lock
+++ b/yarn.lock
@@ -2165,7 +2165,7 @@ async@1.5.2, async@^1.4.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
-async@2.6.1, async@^2.1.5:
+async@2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.1.tgz#b245a23ca71930044ec53fa46aa00a3e87c6a610"
   dependencies:
@@ -4100,16 +4100,17 @@ debug@2, debug@2.6.9, debug@^2.0.0, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, de
   dependencies:
     ms "2.0.0"
 
-debug@3.1.0, debug@=3.1.0, debug@^3.1.0, debug@~3.1.0:
+debug@3.1.0, debug@=3.1.0, debug@~3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
   dependencies:
     ms "2.0.0"
 
-debug@^3.2.6:
+debug@^3.1.0, debug@^3.2.6:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
+  integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
   dependencies:
     ms "^2.1.1"
 
@@ -4487,10 +4488,6 @@ ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
 
-ejs@^2.5.6:
-  version "2.5.7"
-  resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.5.7.tgz#cc872c168880ae3c7189762fd5ffc00896c9518a"
-
 ejs@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.6.1.tgz#498ec0d495655abc6f23cd61868d926464071aa0"
@@ -4809,7 +4806,7 @@ esa-nodejs@^0.0.7:
     superagent "^1.2.0"
     superagent-no-cache "^0.1.0"
 
-escape-html@~1.0.3:
+escape-html@^1.0.3, escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
 
@@ -8145,7 +8142,7 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-lodash@4.17.15, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15:
+lodash@4.17.15, lodash@^4.17.10, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -8162,7 +8159,7 @@ lodash@^4.15.0:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
 
-lodash@^4.17.10, lodash@^4.17.5:
+lodash@^4.17.5:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
@@ -8940,6 +8937,7 @@ mquery@3.2.0:
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+  integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
 
 ms@^2.0.0, ms@^2.1.1:
   version "2.1.1"
@@ -9079,6 +9077,7 @@ node-fetch@^2.2.0, node-fetch@^2.3.0:
 node-forge@^0.7.0:
   version "0.7.6"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.7.6.tgz#fdf3b418aee1f94f0ef642cd63486c77ca9724ac"
+  integrity sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw==
 
 node-forge@^0.8.1:
   version "0.8.4"
@@ -10041,16 +10040,17 @@ passport-oauth2@1.x.x:
     utils-merge "1.x.x"
 
 passport-saml@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/passport-saml/-/passport-saml-1.0.0.tgz#3931bfb7046e85840e3b04691c619411082bf2f5"
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/passport-saml/-/passport-saml-1.3.3.tgz#cbea1a2b21ff32b3bc4bfd84dc39c3a370df9935"
+  integrity sha512-54ecY/A6UEsyCehJws6a+J6THvwtYnGl9cnAUxx5DjsuKgZrDs0tSy58K4hCk1XG/LOcdQSF1TR3xlRXgTULhA==
   dependencies:
     debug "^3.1.0"
     passport-strategy "*"
     q "^1.5.0"
-    xml-crypto "^1.0.2"
-    xml-encryption "^0.11.0"
+    xml-crypto "^1.4.0"
+    xml-encryption "^1.0.0"
     xml2js "0.4.x"
-    xmlbuilder "^9.0.4"
+    xmlbuilder "^11.0.0"
     xmldom "0.1.x"
 
 passport-strategy@*, passport-strategy@1.x.x, passport-strategy@^1.0.0:
@@ -11947,6 +11947,7 @@ sax@1.2.1:
 sax@>=0.6.0, sax@^1.2.4, sax@~1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
+  integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
 saxes@^3.1.9:
   version "3.1.11"
@@ -14373,19 +14374,20 @@ xdg-basedir@^4.0.0:
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-4.0.0.tgz#4bc8d9984403696225ef83a1573cbbcb4e79db13"
   integrity sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==
 
-xml-crypto@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/xml-crypto/-/xml-crypto-1.0.2.tgz#248df860b1e3f7326e61bcbd00c234886b0d6e3b"
+xml-crypto@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/xml-crypto/-/xml-crypto-1.4.0.tgz#de1cec8cd31cbd689cd90d3d6e8a27d4ae807de7"
+  integrity sha512-K8FRdRxICVulK4WhiTUcJrRyAIJFPVOqxfurA3x/JlmXBTxy+SkEENF6GeRt7p/rB6WSOUS9g0gXNQw5n+407g==
   dependencies:
     xmldom "0.1.27"
-    xpath.js ">=0.0.3"
+    xpath "0.0.27"
 
-xml-encryption@^0.11.0:
-  version "0.11.2"
-  resolved "https://registry.yarnpkg.com/xml-encryption/-/xml-encryption-0.11.2.tgz#c217f5509547e34b500b829f2c0bca85cca73a21"
+xml-encryption@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/xml-encryption/-/xml-encryption-1.0.0.tgz#fe50d3bbbe2ae06876d6aa95aa3bf958284e1612"
+  integrity sha512-xTqcgKPN3XOswvDPXrhtyvWZ96IFcO9Azv3vS060kOpBsK5T7OxbQDxb59bPLl4b4c2IgmSZC3kJB0n5WPr2Mw==
   dependencies:
-    async "^2.1.5"
-    ejs "^2.5.6"
+    escape-html "^1.0.3"
     node-forge "^0.7.0"
     xmldom "~0.1.15"
     xpath "0.0.27"
@@ -14403,11 +14405,12 @@ xml2js@0.4.17:
     xmlbuilder "^4.1.0"
 
 xml2js@0.4.x:
-  version "0.4.19"
-  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7"
+  version "0.4.23"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.23.tgz#a0c69516752421eb2ac758ee4d4ccf58843eac66"
+  integrity sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==
   dependencies:
     sax ">=0.6.0"
-    xmlbuilder "~9.0.1"
+    xmlbuilder "~11.0.0"
 
 xmlbuilder@4.2.1, xmlbuilder@^4.1.0:
   version "4.2.1"
@@ -14415,30 +14418,34 @@ xmlbuilder@4.2.1, xmlbuilder@^4.1.0:
   dependencies:
     lodash "^4.0.0"
 
-xmlbuilder@^9.0.4, xmlbuilder@~9.0.1:
-  version "9.0.7"
-  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
+xmlbuilder@^11.0.0, xmlbuilder@~11.0.0:
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
+  integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
 
 xmlchars@^2.1.1:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
-xmldom@0.1.27, xmldom@0.1.x, xmldom@~0.1.15:
+xmldom@0.1.27:
   version "0.1.27"
   resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.1.27.tgz#d501f97b3bdb403af8ef9ecc20573187aadac0e9"
+  integrity sha1-1QH5ezvbQDr4757MIFcxh6rawOk=
+
+xmldom@0.1.x, xmldom@~0.1.15:
+  version "0.1.31"
+  resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.1.31.tgz#b76c9a1bd9f0a9737e5a72dc37231cf38375e2ff"
+  integrity sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ==
 
 xmlhttprequest-ssl@~1.5.4:
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.4.tgz#04f560915724b389088715cc0ed7813e9677bf57"
 
-xpath.js@>=0.0.3:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/xpath.js/-/xpath.js-1.1.0.tgz#3816a44ed4bb352091083d002a383dd5104a5ff1"
-
 xpath@0.0.27:
   version "0.0.27"
   resolved "https://registry.yarnpkg.com/xpath/-/xpath-0.0.27.tgz#dd3421fbdcc5646ac32c48531b4d7e9d0c2cfa92"
+  integrity sha512-fg03WRxtkCV6ohClePNAECYsmpKKTv5L8y/X3Dn1hQrec3POx2jHZ/0P2qQ6HvsrU1BmeqXcof3NGGueG6LxwQ==
 
 xss@^1.0.6:
   version "1.0.6"


### PR DESCRIPTION
## 概要
SAML Responseの <code>&lt;saml:AttributeStatement&gt;</code> 要素に含まれる <code>&lt;saml:Attribute&gt;</code> 要素と, その子要素 <code>&lt;saml:AttributeValue&gt;</code> を利用してログイン制限を行う.

- 他のSAMLの設定項目同様にDBと環境変数の両方から設定可能
- <code>属性名 = 値</code> を <code>|</code>(論理和),  <code>&</code>(論理積) で連結した形式で記述する
  -  <code>属性名</code>は<code>&lt;saml:Attribute&gt;</code> 要素のName属性の値
  - <code> 値 </code> は <code>&lt;saml:AttributeValue&gt;</code> の値
