### PR TITLE
Fix #1738: Bug: DrawioModal is not opened when editing blank page

### DIFF
--- a/src/client/js/components/PageEditor/MarkdownDrawioUtil.js
+++ b/src/client/js/components/PageEditor/MarkdownDrawioUtil.js
@@ -83,7 +83,10 @@ class MarkdownDrawioUtil {
    * return boolean value whether the cursor position is in a drawio
    */
   isInDrawioBlock(editor) {
-    return (this.getBod(editor) !== this.getEod(editor));
+    const bod = this.getBod(editor);
+    const eod = this.getEod(editor);
+
+    return (JSON.stringify(bod) !== JSON.stringify(eod));
   }
 
   /**


### PR DESCRIPTION
fix #1738 

# How to fix

Fix string evaluation in JSON.stringify.
The comparison is based on the assumption that the order of the objects does not change.
Because `getBod` and` getEod` return objects in a comparable.

# Cause

Had compared the identity of the objects