### PR TITLE
Fix #1755: draw.ioを含むページを編集するときに編集画面のスクロール位置が移動してしまう

### DIFF
--- a/src/client/js/components/Drawio.jsx
+++ b/src/client/js/components/Drawio.jsx
@@ -33,7 +33,16 @@ class Drawio extends React.Component {
   componentDidMount() {
     const DrawioViewer = window.GraphViewer;
     if (DrawioViewer != null) {
-      DrawioViewer.processElements();
+      const mxgraphs = this.drawioContainer.getElementsByClassName('mxgraph');
+      if (mxgraphs.length > 0) {
+        // GROWI では、mxgraph element は最初のものをレンダリングする前提とする
+        const div = mxgraphs[0];
+
+        if (div != null) {
+          div.innerHTML = '';
+          DrawioViewer.createViewerForElement(div);
+        }
+      }
     }
   }
 
@@ -55,9 +64,6 @@ class Drawio extends React.Component {
           className="drawio"
           style={this.style}
           ref={(c) => { this.drawioContainer = c }}
-          onScroll={(event) => {
-            event.preventDefault();
-          }}
           // eslint-disable-next-line react/no-danger
           dangerouslySetInnerHTML={{ __html: this.renderContents() }}
         >

--- a/src/client/js/util/interceptor/drawio-interceptor.js
+++ b/src/client/js/util/interceptor/drawio-interceptor.js
@@ -17,11 +17,21 @@ export class DrawioInterceptor extends BasicInterceptor {
     this.previousPreviewContext = null;
     this.appContainer = appContainer;
 
-    const DrawioViewer = window.GraphViewer;
-    if (DrawioViewer != null) {
-      // viewer.min.js の Resize による Scroll イベントを抑止するために無効化する
-      DrawioViewer.useResizeSensor = false;
-    }
+    // draw.io の viewer.min.js から呼ばれるコールバックを定義する
+    // refs: https://github.com/jgraph/drawio/blob/v12.9.1/etc/build/build.xml#L219-L232
+    window.onDrawioViewerLoad = function() {
+      const DrawioViewer = window.GraphViewer;
+
+      if (DrawioViewer != null) {
+        // viewer.min.js の Resize による Scroll イベントを抑止するために
+        // useResizeSensor と checkVisibleState を無効化する
+        DrawioViewer.useResizeSensor = false;
+        DrawioViewer.prototype.checkVisibleState = false;
+
+        // 初回レンダリング時に mxfile をレンダリングする
+        DrawioViewer.processElements();
+      }
+    };
   }
 
   /**


### PR DESCRIPTION
Fix #1755 

# Before fix

![20200324_fix_growi_drawio_integration_before](https://user-images.githubusercontent.com/1567423/77430365-6a512b00-6e1e-11ea-82e8-2448d405402c.gif)

# After fix

![20200324_fix_growi_drawio_integration_after](https://user-images.githubusercontent.com/1567423/77430391-763ced00-6e1e-11ea-8b6f-4e1dba817314.gif)
