### PR TITLE
Workaround MathJax rendering.

### DIFF
--- a/src/client/js/components/Page/RevisionBody.jsx
+++ b/src/client/js/components/Page/RevisionBody.jsx
@@ -35,7 +35,19 @@ export default class RevisionBody extends React.PureComponent {
 
   renderMathJax() {
     const MathJax = window.MathJax;
-    MathJax.Hub.Queue(['Typeset', MathJax.Hub, this.element]);
+    // Workaround MathJax Rendering (Errors still occur, but MathJax can be rendered)
+    //
+    // Reason:
+    //   Addition of draw.io Integration causes initialization conflict between MathJax of draw.io and MathJax of GROWI.
+    //   So, before MathJax is initialized, execute renderMathJaxWithDebounce again.
+    //   Avoiding initialization of MathJax of draw.io solves the problem.
+    //   refs: https://github.com/jgraph/drawio/pull/831
+    if (MathJax != null && MathJax.Hub != null) {
+      MathJax.Hub.Queue(['Typeset', MathJax.Hub, this.element]);
+    }
+    else {
+      this.renderMathJaxWithDebounce();
+    }
   }
 
   generateInnerHtml(html) {


### PR DESCRIPTION
# Target version

* 3.7.0 or higher

# About

* With this fix, it can be changed from "almost no rendering" to "sometimes not rendering"
* refs: #1808 #1754
    * do not close this issue.
* Errors still occur, but MathJax can be rendered.
* Rendering is in CHTML format because MathJax of draw.io is used.
    * SVG cannot be used because it uses MathJax of draw.io

# Reason (from by comment)

* Addition of draw.io Integration causes initialization conflict between MathJax of draw.io and MathJax of GROWI.
* So, before MathJax is initialized, execute renderMathJaxWithDebounce again.
* Avoiding initialization of MathJax of draw.io solves the problem.
* refs: https://github.com/jgraph/drawio/pull/831 https://github.com/jgraph/drawio/pull/833