### PR TITLE
Support/adjust rbt highlight text

### DIFF
--- a/src/client/styles/scss/_override-rbt.scss
+++ b/src/client/styles/scss/_override-rbt.scss
@@ -13,7 +13,3 @@
 .rbt-aux {
   display: none;
 }
-
-mark.rbt-highlight-text {
-  color: black;
-}

--- a/src/client/styles/scss/_override-rbt.scss
+++ b/src/client/styles/scss/_override-rbt.scss
@@ -13,3 +13,7 @@
 .rbt-aux {
   display: none;
 }
+
+mark.rbt-highlight-text {
+  color: black;
+}

--- a/src/client/styles/scss/theme/_apply-colors.scss
+++ b/src/client/styles/scss/theme/_apply-colors.scss
@@ -300,6 +300,14 @@ body.on-edit {
 }
 
 /*
+ * react bootstrap typeahead
+ */
+mark.rbt-highlight-text {
+  // Temporarily the highlight color is black
+  color: black;
+}
+
+/*
  * GROWI page attachments
  */
 .page-attachments-row {


### PR DESCRIPTION
<img width="539" alt="スクリーンショット 2020-04-16 18 03 41" src="https://user-images.githubusercontent.com/48426654/79437243-e3eacc00-800c-11ea-8a7c-be20e60c2d3a.png">
<img width="539" alt="スクリーンショット 2020-04-16 18 04 00" src="https://user-images.githubusercontent.com/48426654/79437248-e51bf900-800c-11ea-8d2d-06c7d8b5ee25.png">

テーマ毎に色を変えるべきなのか...?
そうだとしたらhighlight の bg-color も一緒に修正