### PR TITLE
Support/adjust input style

### DIFF
--- a/src/client/js/components/Admin/App/AppSetting.jsx
+++ b/src/client/js/components/Admin/App/AppSetting.jsx
@@ -38,9 +38,9 @@ class AppSetting extends React.Component {
 
     return (
       <React.Fragment>
-        <div className="row form-group mb-5">
-          <label className="col-3 col-form-label">{t('admin:app_setting.site_name')}</label>
-          <div className="col-6">
+        <div className="form-group row">
+          <label className="text-left text-md-right col-md-3 col-form-label">{t('admin:app_setting.site_name')}</label>
+          <div className="col-md-6">
             <input
               className="form-control"
               type="text"
@@ -53,8 +53,8 @@ class AppSetting extends React.Component {
         </div>
 
         <div className="row form-group mb-5">
-          <label className="col-3 col-form-label">{t('admin:app_setting.confidential_name')}</label>
-          <div className="col-6">
+          <label className="text-left text-md-right col-md-3 col-form-label">{t('admin:app_setting.confidential_name')}</label>
+          <div className="col-md-6">
             <input
               className="form-control"
               type="text"
@@ -67,8 +67,8 @@ class AppSetting extends React.Component {
         </div>
 
         <div className="row form-group mb-5">
-          <label className="col-3 col-form-label">{t('admin:app_setting.default_language')}</label>
-          <div className="col-6">
+          <label className="text-left text-md-right col-md-3 col-form-label">{t('admin:app_setting.default_language')}</label>
+          <div className="col-md-6">
             <div className="custom-control custom-radio custom-control-inline">
               <input
                 type="radio"
@@ -97,8 +97,8 @@ class AppSetting extends React.Component {
         </div>
 
         <div className="row form-group mb-5">
-          <label className="col-3 col-form-label">{t('admin:app_setting.file_uploading')}</label>
-          <div className="col-6">
+          <label className="text-left text-md-right col-md-3 col-form-label">{t('admin:app_setting.file_uploading')}</label>
+          <div className="col-md-6">
             <div className="custom-control custom-checkbox custom-checkbox-info">
               <input
                 type="checkbox"


### PR DESCRIPTION
- 小さい画面
<img width="573" alt="スクリーンショット 2020-04-20 16 20 15" src="https://user-images.githubusercontent.com/48426654/79725166-c9be3000-8323-11ea-8b2a-5f69faa5a114.png">

- 大きい画面
<img width="911" alt="スクリーンショット 2020-04-20 16 20 41" src="https://user-images.githubusercontent.com/48426654/79725172-caef5d00-8323-11ea-8019-ee2ccb20595d.png">

input の上に label が乗るように修正した。
問題なければ、他の場所も同じように修正する