### PR TITLE
be responsive

### DIFF
--- a/src/client/js/components/Admin/Notification/SlackAppConfiguration.jsx
+++ b/src/client/js/components/Admin/Notification/SlackAppConfiguration.jsx
@@ -116,8 +116,8 @@ class SlackAppConfiguration extends React.Component {
               </div>
 
               <div className="row mb-5">
-                <label className="col-3 text-right">OAuth Access Token</label>
-                <div className="col-6">
+                <label className="col-md-3 text-left text-md-right">OAuth Access Token</label>
+                <div className="col-md-6">
                   <input
                     className="form-control"
                     type="text"

--- a/src/client/js/components/Admin/Notification/SlackAppConfiguration.jsx
+++ b/src/client/js/components/Admin/Notification/SlackAppConfiguration.jsx
@@ -64,8 +64,8 @@ class SlackAppConfiguration extends React.Component {
             <h2 className="border-bottom mb-5">{t('notification_setting.slack_incoming_configuration')}</h2>
 
             <div className="row mb-3">
-              <label className="col-3 text-right">Webhook URL</label>
-              <div className="col-6">
+              <label className="col-md-3 text-left text-md-right">Webhook URL</label>
+              <div className="col-md-6">
                 <input
                   className="form-control"
                   type="text"
@@ -76,7 +76,7 @@ class SlackAppConfiguration extends React.Component {
             </div>
 
             <div className="row mb-3">
-              <div className="offset-3 col-6 text-left">
+              <div className="offset-md-3 col-md-6 text-left">
                 <div className="custom-control custom-checkbox custom-checkbox-success">
                   <input
                     type="checkbox"


### PR DESCRIPTION
- 小さいサイズ
![スクリーンショット 2020-04-22 14 45 32](https://user-images.githubusercontent.com/27404438/79945230-5265d900-84a8-11ea-8200-78f85cbd7a30.png)


- 中くらい
![スクリーンショット 2020-
![スクリーンショット 2020-04-22 14 45 32](https://user-images.githubusercontent.com/27404438/79945230-5265d900-84a8-11ea-8200-78f85cbd7a30.png)
04-22 14 45 15](https://user-images.githubusercontent.com/27404438/79945175-382bfb00-84a8-11ea-9d56-f45c679bfb55.png)


- 大
![スクリーンショット 2020-04-22 14 44 53](https://user-images.githubusercontent.com/27404438/79945180-3a8e5500-84a8-11ea-9fca-e61c9752a025.png)
