### PR TITLE
Fix/adjust height of modal body

### DIFF
--- a/src/client/js/components/Admin/Security/LdapAuthTestModal.jsx
+++ b/src/client/js/components/Admin/Security/LdapAuthTestModal.jsx
@@ -43,8 +43,8 @@ class LdapAuthTestModal extends React.Component {
 
     return (
       <Modal show={this.props.isOpen} onHide={this.props.onClose}>
-        <Modal.Header className="modal-header" closeButton>
-          <Modal.Title>
+        <Modal.Header className="bg-info modal-header" closeButton>
+          <Modal.Title className="text-white">
             Test LDAP Account
           </Modal.Title>
         </Modal.Header>
@@ -56,7 +56,6 @@ class LdapAuthTestModal extends React.Component {
             onChangePassword={this.onChangePassword}
           />
         </Modal.Body>
-        <Modal.Footer />
       </Modal>
     );
   }

--- a/src/client/styles/scss/_modal.scss
+++ b/src/client/styles/scss/_modal.scss
@@ -1,0 +1,6 @@
+.modal-body {
+  // Adjust the height by subtracting the footer and the footer
+  // show https://stackoverflow.com/questions/24166568/set-bootstrap-modal-body-height-by-percentage/26078942
+  max-height: calc(100% - 120px);
+  overflow-y: auto;
+}

--- a/src/client/styles/scss/style-app.scss
+++ b/src/client/styles/scss/style-app.scss
@@ -45,6 +45,7 @@
 @import 'tag';
 @import 'staff_credit';
 @import 'draft';
+@import 'modal';
 
 /*
  * for Guest User Mode


### PR DESCRIPTION
Fix #2003 
<img width="756" alt="スクリーンショット 2020-04-23 11 15 34" src="https://user-images.githubusercontent.com/48426654/80052017-96aeb300-8554-11ea-9044-60c01f5c31cf.png">
<img width="756" alt="スクリーンショット 2020-04-23 11 13 06" src="https://user-images.githubusercontent.com/48426654/80052020-99110d00-8554-11ea-80be-1eabff095f41.png">

master には override.bootstrap がなかったので 仮で _modal.scss に置きました。
bootstrap4 でどうなっているかの調査タスク作成しました
https://youtrack.weseek.co.jp/issue/GW-1979
