### PR TITLE
Fix event listener leak

### DIFF
--- a/src/server/crowi/express-init.js
+++ b/src/server/crowi/express-init.js
@@ -98,7 +98,7 @@ module.exports = function(crowi, app) {
 
   // configure express-session
   app.use((req, res, next) => {
-    // test whether the route is listed in avoidSessionTroutes
+    // test whether the route is listed in avoidSessionRoutes
     for (const regex of avoidSessionRoutes) {
       if (regex.test(req.path)) {
         return next();

--- a/src/server/crowi/express-init.js
+++ b/src/server/crowi/express-init.js
@@ -97,6 +97,7 @@ module.exports = function(crowi, app) {
   app.use(cookieParser());
 
   // configure express-session
+  const sessionMiddleware = expressSession(crowi.sessionConfig);
   app.use((req, res, next) => {
     // test whether the route is listed in avoidSessionRoutes
     for (const regex of avoidSessionRoutes) {
@@ -105,7 +106,7 @@ module.exports = function(crowi, app) {
       }
     }
 
-    expressSession(crowi.sessionConfig)(req, res, next);
+    sessionMiddleware(req, res, next);
   });
 
   // passport


### PR DESCRIPTION
## 概要

セッション管理にMongoDBを用いている場合に, MongoDBへのコネクションを確立できない状態でGROWIに複数回アクセスすると, 以下のようにイベントリスナのリークが起きていた(Redisを利用している場合は未検証).

```
(node:7908) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 disconnect listeners added to [MongoStore]. Use emitter.setMaxListeners() to increase limit
```

[こちらのIssueのケース](https://github.com/expressjs/session/issues/623)と同様に, リクエストが来るたびにexpress-sessionの[セットアップ処理](https://github.com/expressjs/session/blob/master/index.js#L87)を呼んでしまっていることが原因なので, 一度しか呼ばないように修正した.
