### PR TITLE
Support/adjust width for alert

### DIFF
--- a/src/client/js/nologin.jsx
+++ b/src/client/js/nologin.jsx
@@ -6,6 +6,7 @@ import { I18nextProvider } from 'react-i18next';
 import i18nFactory from './util/i18n';
 
 import NoLoginContainer from './services/NoLoginContainer';
+import AppContainer from './services/AppContainer';
 
 import InstallerForm from './components/InstallerForm';
 import LoginForm from './components/LoginForm';
@@ -31,6 +32,8 @@ if (installerFormElem) {
 const loginFormElem = document.getElementById('login-form');
 if (loginFormElem) {
   const noLoginContainer = new NoLoginContainer();
+  const appContainer = new AppContainer();
+  appContainer.init();
 
   const username = loginFormElem.dataset.username;
   const name = loginFormElem.dataset.name;
@@ -52,7 +55,7 @@ if (loginFormElem) {
 
   ReactDOM.render(
     <I18nextProvider i18n={i18n}>
-      <Provider inject={[noLoginContainer]}>
+      <Provider inject={[noLoginContainer, appContainer]}>
         <LoginForm
           username={username}
           name={name}

--- a/src/server/views/login.html
+++ b/src/server/views/login.html
@@ -32,8 +32,7 @@
         <div class="logo mb-3">{% include 'widget/logo.html' %}</div>
         <h1>{{ appService.getAppTitle() }}</h1>
 
-        <div class="row">
-          <div class="login-form-errors col-12">
+          <div class="login-form-errors px-3">
             {% if isLdapSetupFailed() %}
             <div class="alert alert-warning small">
               <strong><i class="icon-fw icon-info"></i>LDAP is enabled but the configuration has something wrong.</strong>
@@ -102,7 +101,6 @@
             </div>
             {% endif %}
           </div>
-        </div>
       </div>
 
       {% set registrationMode = getConfig('crowi', 'security:registrationMode') %}


### PR DESCRIPTION
login 画面でも appContainer.init() を走らせて ライト / ダークを有効にする