### PR TITLE
Imprv/confidential long pattern

### DIFF
--- a/src/client/styles/scss/_search.scss
+++ b/src/client/styles/scss/_search.scss
@@ -147,7 +147,7 @@
       border-radius: 0 25px 25px 0;
     }
   }
-  .input-group.flex-nowrap .search-typeahead .rbt-menu.dropdown-menu {
+  .bg-dark.collapse .input-group.flex-nowrap .search-typeahead .rbt-menu.dropdown-menu {
     width: 100%;
     .dropdown-item {
       word-break: break-all;

--- a/src/client/styles/scss/_search.scss
+++ b/src/client/styles/scss/_search.scss
@@ -113,7 +113,7 @@
   .grw-search-top-fixed {
     // centering on navbar
     top: $grw-navbar-height / 2;
-    left: 50vw;
+    left: 33vw;
     z-index: $zindex-fixed + 1;
     transform: translate(-50%, -50%);
 
@@ -127,7 +127,7 @@
       }
 
       @include media-breakpoint-up(md) {
-        width: 300px;
+        width: 250px;
       }
       @include media-breakpoint-up(lg) {
         // focus
@@ -258,8 +258,8 @@
       }
       
       td {
-        border-top: none !important;
         padding-top: 0 !important;
+        border-top: none !important;
       }
     }
   }

--- a/src/client/styles/scss/_search.scss
+++ b/src/client/styles/scss/_search.scss
@@ -147,6 +147,13 @@
       border-radius: 0 25px 25px 0;
     }
   }
+  .input-group.flex-nowrap .search-typeahead .rbt-menu.dropdown-menu {
+    width: 100%;
+    .dropdown-item {
+      word-break: break-all;
+      white-space: pre-line;
+    }
+  }
 }
 
 .search-result {


### PR DESCRIPTION
モバイル時、検索の結果を画面外へはみ出ないようにした
<img width="369" alt="スクリーンショット 2020-06-03 15 24 21" src="https://user-images.githubusercontent.com/27404438/83603326-35e0b480-a5af-11ea-9920-eaef60b72e9f.png">
コンフィデンシャル表示をある程度の長さまではnavbar内で崩れないように修正
<img width="794" alt="スクリーンショット 2020-06-03 15 31 20" src="https://user-images.githubusercontent.com/27404438/83603383-4e50cf00-a5af-11ea-8750-4b31e094d41b.png">
