### PR TITLE
Fix pages.update API

### DIFF
--- a/src/server/routes/page.js
+++ b/src/server/routes/page.js
@@ -790,6 +790,7 @@ module.exports = function(crowi, app) {
    *                required:
    *                  - body
    *                  - page_id
+   *                  - revision_id
    *        responses:
    *          200:
    *            description: Succeeded to update page.
@@ -833,8 +834,8 @@ module.exports = function(crowi, app) {
     const socketClientId = req.body.socketClientId || undefined;
     const pageTags = req.body.pageTags || undefined;
 
-    if (pageId === null || pageBody === null) {
-      return res.json(ApiResponse.error('page_id and body are required.'));
+    if (pageId === null || pageBody === null || revisionId === null) {
+      return res.json(ApiResponse.error('page_id, body and revision_id are required.'));
     }
 
     // check page existence


### PR DESCRIPTION
## 概要

`pages.update`は現在`body`と `page_id`が必須パラメータになっているが, `revision_id`も必須のため, これを追加した.

## 詳細

以下のようなペイロードで`pages.update`にリクエストを行うと

```
{
	"body": "hoge",
	"page_id": "5edc8a3eb9f6209e66d0cea6"
}
```

以下のようなレスポンスが返ってくる

```
{
    "ok": false,
    "error": "TypeError: Cannot read property 'body' of null"
}
```

サーバのログを見ると以下のようなエラーが発生している.

```
[2020-06-07T07:00:17.195Z] ERROR: growi:routes:page/41102 on Localhost:
  error on _api/pages.update TypeError: Cannot read property 'body' of null
      at api.update (/Users/utsushiiro/growi/src/server/routes/page.js:861:69)
      at processTicksAndRejections (internal/process/task_queues.js:97:5)
```

該当部分を見ると, revision_idが未指定の場合はpreviousRevisionがnullになるので, previousRevision.bodyのプロパティアクセスでエラーになっている.
https://github.com/weseek/growi/blob/ee86a33c12cc477635eac7b667a0faeeda43f1b5/src/server/routes/page.js#L858-L866

以上よりrevision_idの指定は必須のため, swaggerドキュメントと最初のバリデーション部分を修正した.

これにより, 同種のリクエストを行った場合に以下のようなレスポンスとなる.
```
{
    "ok": false,
    "error": "page_id, body and revision_id are required."
}
```
