### PR TITLE
Fix Last-Modified header for attachments

### DIFF
--- a/src/server/routes/attachment.js
+++ b/src/server/routes/attachment.js
@@ -215,7 +215,7 @@ module.exports = function(crowi, app) {
   function setHeaderToRes(res, attachment, forceDownload) {
     res.set({
       ETag: `Attachment-${attachment._id}`,
-      'Last-Modified': attachment.createdAt,
+      'Last-Modified': attachment.createdAt.toUTCString(),
     });
 
     // download


### PR DESCRIPTION
## 概要
attachmentsのレスポンスヘッダの Last-Modified に設定する値の形式を変更した.
```
# before
{ 'Last-Modified': 'Sat Jun 20 2020 17:37:13 GMT+0900 (GMT+09:00)'}

# after
{ 'Last-Modified': 'Sat, 20 Jun 2020 08:32:14 GMT' }
```

## 詳細
現在, attachmentsのレスポンスヘッダの Last-Modified にはDateオブジェクトを渡している.
https://github.com/weseek/growi/blob/86037b82d25ac889e5a0dd596b6d7c5570f5dcfc/src/server/routes/attachment.js#L215-L219

このDateオブジェクトはExpressのres.setの中で文字列に変換される.
https://github.com/expressjs/express/blob/351396f971280ab79faddcf9782ea50f4e88358d/lib/response.js#L749-L767

こうしてできた値は以下のようなフォーマットになる.
```
Sat Jun 20 2020 17:37:13 GMT+0900 (GMT+09:00)
```

これはRFCにて定義された Last-Modified のフォーマットに反している.
- https://tools.ietf.org/html/rfc7232#appendix-C
- https://tools.ietf.org/html/rfc7231#section-7.1.1.1

また, Node.js v14からはDateの文字列表現が以下のようにi18nの影響を受けるようになったため([参考](https://nodejs.org/docs/latest-v14.x/api/intl.html)), 上記の実装だと利用環境によってはマルチバイト文字が入ってしまう.
```
$ node
Welcome to Node.js v12.16.3.
Type ".help" for more information.
> (new Date()).toString()
'Sat Jun 20 2020 17:52:18 GMT+0900 (GMT+09:00)'
>
$ node
Welcome to Node.js v14.3.0.
Type ".help" for more information.
> (new Date()).toString()
'Sat Jun 20 2020 17:52:06 GMT+0900 (日本標準時)'
> 
```

マルチバイト文字が入る場合, 以下のようにattachmentsのレスポンス作成時にエラーとなり画像等が表示されなくなる.
```
08:40:02.264Z ERROR growi:
  Unhandled Rejection: Promise: Promise {
    <rejected> TypeError [ERR_INVALID_CHAR]: Invalid character in header content ["Last-Modified"]
        at ServerResponse.setHeader (_http_outgoing.js:536:3)
        at ServerResponse.header (/Users/utsushiiro/growi/node_modules/express/lib/response.js:767:10)
        at ServerResponse.header (/Users/utsushiiro/growi/node_modules/express/lib/response.js:770:12)
        at setHeaderToRes (/Users/utsushiiro/growi/src/server/routes/attachment.js:217:9)
        at responseForAttachment (/Users/utsushiiro/growi/src/server/routes/attachment.js:188:5)
        at runMicrotasks (<anonymous>)
        at processTicksAndRejections (internal/process/task_queues.js:97:5) {
      code: 'ERR_INVALID_CHAR'
    }
  } Reason: TypeError [ERR_INVALID_CHAR]: Invalid character in header content ["Last-Modified"]
      at ServerResponse.setHeader (_http_outgoing.js:536:3)
      at ServerResponse.header (/Users/utsushiiro/growi/node_modules/express/lib/response.js:767:10)
      at ServerResponse.header (/Users/utsushiiro/growi/node_modules/express/lib/response.js:770:12)
      at setHeaderToRes (/Users/utsushiiro/growi/src/server/routes/attachment.js:217:9)
      at responseForAttachment (/Users/utsushiiro/growi/src/server/routes/attachment.js:188:5)
      at runMicrotasks (<anonymous>)
      at processTicksAndRejections (internal/process/task_queues.js:97:5) {
    code: 'ERR_INVALID_CHAR'
  }
TypeError [ERR_INVALID_CHAR]: Invalid character in header content ["Last-Modified"]
    at ServerResponse.setHeader (_http_outgoing.js:536:3)
    at ServerResponse.header (/Users/utsushiiro/growi/node_modules/express/lib/response.js:767:10)
    at ServerResponse.header (/Users/utsushiiro/growi/node_modules/express/lib/response.js:770:12)
    at setHeaderToRes (/Users/utsushiiro/growi/src/server/routes/attachment.js:217:9)
    at responseForAttachment (/Users/utsushiiro/growi/src/server/routes/attachment.js:188:5)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal/process/task_queues.js:97:5) {
  code: 'ERR_INVALID_CHAR'
}
```

上記の問題を修正するため, res.headerにDateオブジェクトを直接渡すのではなく, toUTCStringによって正しい形式の文字列を渡すようにした.
