### PR TITLE
Supports nginx internal redirect and Apache SendFile.

### DIFF
--- a/src/server/routes/attachment.js
+++ b/src/server/routes/attachment.js
@@ -4,7 +4,6 @@
 const logger = require('@alias/logger')('growi:routes:attachment');
 
 const fs = require('fs');
-const path = require('path');
 
 const ApiResponse = require('../util/apiResponse');
 
@@ -133,7 +132,7 @@ module.exports = function(crowi, app) {
   const User = crowi.model('User');
   const Page = crowi.model('Page');
   const fileUploader = require('../service/file-uploader')(crowi, app);
-  const configManager = crowi.configManager;
+
 
   /**
    * Check the user is accessible to the related page
@@ -194,8 +193,8 @@ module.exports = function(crowi, app) {
       return res.sendStatus(304);
     }
 
-    if (isEnableInternalRedirect()) {
-      return responseForInternalRedirect(res, attachment);
+    if (fileUploader.canRespond()) {
+      return fileUploader.respond(res, attachment);
     }
 
     let fileStream;
@@ -208,33 +207,6 @@ module.exports = function(crowi, app) {
     }
 
     return fileStream.pipe(res);
-  }
-
-  /**
-   * check whether to use internal redirect of nginx or Apache.
-   */
-  function isEnableInternalRedirect() {
-    return process.env.FILE_UPLOAD == "local" && configManager.getConfig('crowi', 'app:useInternalRedirect');
-  }
-
-  /**
-   * responce using internal redirect of nginx or Apache.
-   *
-   * @param {Response} res
-   * @param {Attachment} attachment
-   */
-  function responseForInternalRedirect(res, attachment) {
-    const config = crowi.getConfig();
-    const dirName = (attachment.page != null) ? 'attachment' : 'user';
-    let internalPathRoot = configManager.getConfig('crowi', 'app:internalRedirectPath');
-    if (internalPathRoot.slice(-1) != "/") {
-      internalPathRoot += "/";
-    }
-    const internalPath = `${internalPathRoot}uploads/${dirName}/${attachment.fileName}`;
-    const storagePath = path.posix.join(crowi.publicDir, 'uploads', dirName, attachment.fileName);
-    res.set('X-Accel-Redirect', internalPath);
-    res.set('X-Sendfile', storagePath);
-    return res.end();
   }
 
   /**

--- a/src/server/service/config-loader.js
+++ b/src/server/service/config-loader.js
@@ -137,6 +137,18 @@ const ENV_VAR_NAME_TO_CONFIG_INFO = {
     type:    TYPES.BOOLEAN,
     default: false,
   },
+  USE_INTERNAL_REDIRECT: {
+    ns:      'crowi',
+    key:     'app:useInternalRedirect',
+    type:    TYPES.BOOLEAN,
+    default: false,
+  },
+  INTERNAL_REDIRECT_PATH: {
+    ns:      'crowi',
+    key:     'app:internalRedirectPath',
+    type:    TYPES.STRING,
+    default: "/growi-internal/",
+  },
   ELASTICSEARCH_URI: {
     ns:      'crowi',
     key:     'app:elasticsearchUri',

--- a/src/server/service/file-uploader/local.js
+++ b/src/server/service/file-uploader/local.js
@@ -108,10 +108,10 @@ module.exports = function(crowi) {
    */
   lib.respond = (res, attachment) => {
     // Responce using internal redirect of nginx or Apache.
-    const dirName = (attachment.page != null) ? 'attachment' : 'user';
+    const storagePath = getFilePathOnStorage(attachment);
+    const relativePath = path.relative(crowi.publicDir, storagePath);
     const internalPathRoot = lib.configManager.getConfig('crowi', 'app:internalRedirectPath');
-    const internalPath = urljoin(internalPathRoot, "uploads", dirName, attachment.fileName)
-    const storagePath = path.posix.join(crowi.publicDir, 'uploads', dirName, attachment.fileName);
+    const internalPath = urljoin(internalPathRoot, relativePath)
     res.set('X-Accel-Redirect', internalPath);
     res.set('X-Sendfile', storagePath);
     return res.end();

--- a/src/server/service/file-uploader/uploader.js
+++ b/src/server/service/file-uploader/uploader.js
@@ -54,6 +54,21 @@ class Uploader {
 
   }
 
+  /**
+   * Checks if Uploader can respond to the HTTP request.
+   */
+  canRespond() {
+    return false;
+  }
+
+  /**
+   * Respond to the HTTP request.
+   * @param {Response} res
+   * @param {Response} attachment
+   */
+  respond(res, attachment) {
+    throw new Error('Implement this');
+  }
 }
 
 module.exports = Uploader;


### PR DESCRIPTION
## 説明

アップロード済みの添付ファイルの配信方法としてnginxの内部リダイレクト、もしくはApacheのSendFileを使用するオプションを追加します．

#2470
　
## 背景

Growiが直接容量の大きい添付ファイルを配信すると速度が遅いので改善したい

## 対象となる環境

- Growiをnginxのリバースプロキシを通して運用している場合
- FILE_UPLOAD=local

## 追加したオプション (環境変数)

| オプション名|  説明|  デフォルト値|
| -- | -- | -- |
| USE_INTERNAL_REDIRECT | true の場合、nginxの内部リダイレクト機能，もしくはApacheのSendFile機能を使用して添付ファイルを配信します．| false |
| INTERNAL_REDIRECT_PATH | nginxの内部リダイレクト先のURLパスを指定します．ApacheのSendFile機能を使用する場合，このオプションは無視されます．| /growi-internal/ |

## 想定される使用方法

上記のオプションを適切に設定した後，下記の要領でサーバーの設定を更新する

### nginxの場合

serverディレクティブ内に下記を追加する

```
location ~ ^/growi-internal/(.*) {
    alias (Growiのファイルパス)/public/$1;
}
```
location ディレクティブのパスは上記の`INTERNAL_REDIRECT_PATH`と一致するように設定します．

### Apacheの場合

```
XSendFile on
XSendFilePath (Growiのファイルパス)/public
```