### PR TITLE
grid division menu responsive size

### DIFF
--- a/src/client/js/components/PageEditor/GridEditModal.jsx
+++ b/src/client/js/components/PageEditor/GridEditModal.jsx
@@ -181,12 +181,13 @@ export default class GridEditModal extends React.PureComponent {
 
 function GridDivisionMenu() {
   const gridDivisions = geu.mappingAllGridDivisionPatterns;
+  const numberOfGridDivisions = geu.numberOfGridDivisions;
   return (
     <div className="row">
       {gridDivisions.map((gridDivion, i) => {
         return (
           <div className="col-md-4 text-center">
-            <h6 className="dropdown-header">{i + 2}分割</h6>
+            <h6 className="dropdown-header">{numberOfGridDivisions[i]}分割</h6>
             {gridDivion.map((gridOneDivision) => {
               return (
                 <a className="dropdown-item" href="#">

--- a/src/client/js/components/PageEditor/GridEditModal.jsx
+++ b/src/client/js/components/PageEditor/GridEditModal.jsx
@@ -182,28 +182,26 @@ export default class GridEditModal extends React.PureComponent {
 function GridDivisionMenu() {
   const gridDivisions = geu.mappingAllGridDivisionPatterns;
   return (
-    <div className="container">
-      <div className="row">
-        {gridDivisions.map((gridDivion, i) => {
-          return (
-            <div className="col-md-4 text-center">
-              <h6 className="dropdown-header">{i + 2}分割</h6>
-              {gridDivion.map((gridOneDivision) => {
-                return (
-                  <a className="dropdown-item" href="#">
-                    <div className="row">
-                      {gridOneDivision.map((gtd) => {
-                        const className = `bg-info col-${gtd} border`;
-                        return <span className={className}>{gtd}</span>;
-                      })}
-                    </div>
-                  </a>
-                );
-              })}
-            </div>
-          );
-        })}
-      </div>
+    <div className="row">
+      {gridDivisions.map((gridDivion, i) => {
+        return (
+          <div className="col-md-4 text-center">
+            <h6 className="dropdown-header">{i + 2}分割</h6>
+            {gridDivion.map((gridOneDivision) => {
+              return (
+                <a className="dropdown-item" href="#">
+                  <div className="row">
+                    {gridOneDivision.map((gtd) => {
+                      const className = `bg-info col-${gtd} border`;
+                      return <span className={className}>{gtd}</span>;
+                    })}
+                  </div>
+                </a>
+              );
+            })}
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/src/client/js/components/PageEditor/GridEditModal.jsx
+++ b/src/client/js/components/PageEditor/GridEditModal.jsx
@@ -181,14 +181,13 @@ export default class GridEditModal extends React.PureComponent {
 
 function GridDivisionMenu() {
   const gridDivisions = geu.mappingAllGridDivisionPatterns;
-  const numberOfGridDivisions = geu.numberOfGridDivisions;
   return (
     <div className="row">
       {gridDivisions.map((gridDivion, i) => {
         return (
           <div className="col-md-4 text-center">
-            <h6 className="dropdown-header">{numberOfGridDivisions[i]}分割</h6>
-            {gridDivion.map((gridOneDivision) => {
+            <h6 className="dropdown-header">{gridDivion.numberOfGridDivisions}分割</h6>
+            {gridDivion.mapping.map((gridOneDivision) => {
               return (
                 <a className="dropdown-item" href="#">
                   <div className="row">

--- a/src/client/js/components/PageEditor/GridEditorUtil.js
+++ b/src/client/js/components/PageEditor/GridEditorUtil.js
@@ -8,17 +8,19 @@ class GridEditorUtil {
     this.lineBeginPartOfGridRE = /^:::(\s.*)editable-row$/;
     this.lineEndPartOfGridRE = /^:::$/;
     this.mappingAllGridDivisionPatterns = [
-      [
-        [2, 10], [4, 8], [6, 6], [8, 4], [10, 2],
-      ],
-      [
-        [2, 5, 5], [5, 2, 5], [5, 5, 2], [4, 4, 4], [3, 3, 6], [3, 6, 3], [6, 3, 3],
-      ],
-      [
-        [2, 2, 4, 4], [4, 4, 2, 2], [2, 4, 2, 4], [4, 2, 4, 2], [3, 3, 3, 3], [2, 2, 2, 6], [6, 2, 2, 2],
-      ],
+      {
+        numberOfGridDivisions: 2,
+        mapping: [[2, 10], [4, 8], [6, 6], [8, 4], [10, 2]]
+      },
+      {
+        numberOfGridDivisions: 3,
+        mapping: [[2, 5, 5], [5, 2, 5], [5, 5, 2], [4, 4, 4], [3, 3, 6], [3, 6, 3], [6, 3, 3]]
+      },
+      {
+        numberOfGridDivisions: 4,
+        mapping: [[2, 2, 4, 4], [4, 4, 2, 2], [2, 4, 2, 4], [4, 2, 4, 2], [3, 3, 3, 3], [2, 2, 2, 6], [6, 2, 2, 2]]
+      }
     ];
-    this.numberOfGridDivisions = [2, 3, 4];
     this.isInGridBlock = this.isInGridBlock.bind(this);
     this.replaceGridWithHtmlWithEditor = this.replaceGridWithHtmlWithEditor.bind(this);
   }

--- a/src/client/js/components/PageEditor/GridEditorUtil.js
+++ b/src/client/js/components/PageEditor/GridEditorUtil.js
@@ -10,16 +10,16 @@ class GridEditorUtil {
     this.mappingAllGridDivisionPatterns = [
       {
         numberOfGridDivisions: 2,
-        mapping: [[2, 10], [4, 8], [6, 6], [8, 4], [10, 2]]
+        mapping: [[2, 10], [4, 8], [6, 6], [8, 4], [10, 2]],
       },
       {
         numberOfGridDivisions: 3,
-        mapping: [[2, 5, 5], [5, 2, 5], [5, 5, 2], [4, 4, 4], [3, 3, 6], [3, 6, 3], [6, 3, 3]]
+        mapping: [[2, 5, 5], [5, 2, 5], [5, 5, 2], [4, 4, 4], [3, 3, 6], [3, 6, 3], [6, 3, 3]],
       },
       {
         numberOfGridDivisions: 4,
-        mapping: [[2, 2, 4, 4], [4, 4, 2, 2], [2, 4, 2, 4], [4, 2, 4, 2], [3, 3, 3, 3], [2, 2, 2, 6], [6, 2, 2, 2]]
-      }
+        mapping: [[2, 2, 4, 4], [4, 4, 2, 2], [2, 4, 2, 4], [4, 2, 4, 2], [3, 3, 3, 3], [2, 2, 2, 6], [6, 2, 2, 2]],
+      },
     ];
     this.isInGridBlock = this.isInGridBlock.bind(this);
     this.replaceGridWithHtmlWithEditor = this.replaceGridWithHtmlWithEditor.bind(this);

--- a/src/client/js/components/PageEditor/GridEditorUtil.js
+++ b/src/client/js/components/PageEditor/GridEditorUtil.js
@@ -18,6 +18,7 @@ class GridEditorUtil {
         [2, 2, 4, 4], [4, 4, 2, 2], [2, 4, 2, 4], [4, 2, 4, 2], [3, 3, 3, 3], [2, 2, 2, 6], [6, 2, 2, 2],
       ],
     ];
+    this.numberOfGridDivisions = [2, 3, 4];
     this.isInGridBlock = this.isInGridBlock.bind(this);
     this.replaceGridWithHtmlWithEditor = this.replaceGridWithHtmlWithEditor.bind(this);
   }

--- a/src/client/styles/scss/_on-edit.scss
+++ b/src/client/styles/scss/_on-edit.scss
@@ -325,7 +325,15 @@ body.on-edit {
   }
 
   .grid-division-menu {
-    //[TODO: responsive by gw-3244]
     width: 1000px;
+    @include media-breakpoint-down(md) {
+      width: 650%;
+    }
+    @include media-breakpoint-down(sm) {
+      width: 300%;
+    }
+    @include media-breakpoint-down(xs) {
+      width: 200%;
+    }
   }
 }

--- a/src/client/styles/scss/_on-edit.scss
+++ b/src/client/styles/scss/_on-edit.scss
@@ -325,15 +325,9 @@ body.on-edit {
   }
 
   .grid-division-menu {
-    width: 1000px;
-    @include media-breakpoint-down(md) {
-      width: 650%;
-    }
-    @include media-breakpoint-down(sm) {
-      width: 300%;
-    }
-    @include media-breakpoint-down(xs) {
-      width: 200%;
+    width: 60vw;
+    @include media-breakpoint-down(lg) {
+      width: 80vw;
     }
   }
 }


### PR DESCRIPTION
## xs
<img width="372" alt="スクリーンショット 2020-07-17 18 26 14" src="https://user-images.githubusercontent.com/27404438/87773531-42b72000-c85e-11ea-9e52-35714d3fecb0.png">

## sm
<img width="623" alt="スクリーンショット 2020-07-17 18 26 28" src="https://user-images.githubusercontent.com/27404438/87773535-45b21080-c85e-11ea-8afe-43c065f78449.png">

## md
<img width="804" alt="スクリーンショット 2020-07-17 18 26 47" src="https://user-images.githubusercontent.com/27404438/87773545-48ad0100-c85e-11ea-8865-885a8aa888ac.png">

## lg~
<img width="1347" alt="スクリーンショット 2020-07-17 18 27 05" src="https://user-images.githubusercontent.com/27404438/87773551-4ba7f180-c85e-11ea-9344-d3522c0dbad6.png">
