### PR TITLE
Upgrade Mathjax (2 -> 3)

### DIFF
--- a/resource/cdn-manifests.js
+++ b/resource/cdn-manifests.js
@@ -39,7 +39,7 @@ module.exports = {
     },
     {
       name: 'mathjax',
-      url: 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.2/MathJax.js',
+      url: 'https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js',
       args: {
         async: true,
         integrity: '',

--- a/src/server/views/widget/headers/mathjax.html
+++ b/src/server/views/widget/headers/mathjax.html
@@ -1,16 +1,21 @@
 <!-- Mathjax -->
-<script type="text/x-mathjax-config" async>
-  MathJax.Hub.Config({
-    skipStartupTypeset: true,
-    extensions: ["tex2jax.js"],
-    jax: ["input/TeX", "output/SVG"],
-    tex2jax: {
-      processEscapes: true
+<script type="text/javascript">
+  window.MathJax = {
+    startup: {
+      typeset: false
     },
-    showMathMenu: false,
-    showMathMenuMSIE: false,
-    showProcessingMessages: false,
-    messageStyle: "none"
-  });
+    tex: {
+      processEscapes: true,
+      inlineMath: [['$', '$'], ['\\(', '\\)']]
+    },
+    options: {
+      renderActions: {
+        addMenu: [],
+        checkLoading: []
+      },
+      ignoreHtmlClass: 'tex2jax_ignore',
+      processHtmlClass: 'tex2jax_process'
+    }
+  };
 </script>
 {{ cdnScriptTag('mathjax') }}


### PR DESCRIPTION
* fix #2494 #1754
* Suppress MathJax related errors by upgrading MathJax to 3

---

* MathJax を draw.io に先行して 3 にアップグレードすることで、
  MathJax 関連のエラーを抑止します。

---

変化が無いことの確認 ( Confirm that there is no change )
# before (from demo.growi.org)

![20200728_mathjax_demo_growi_org](https://user-images.githubusercontent.com/1567423/88668503-afaf9d00-d11d-11ea-9a91-2c5a0a529cc0.png)

# after

![20200728_mathjax3](https://user-images.githubusercontent.com/1567423/88668591-c81fb780-d11d-11ea-8af4-66e297b6d5a6.png)
