### PR TITLE
add space before "status"

### DIFF
--- a/src/server/models/user.js
+++ b/src/server/models/user.js
@@ -20,7 +20,7 @@ module.exports = function(crowi) {
   const STATUS_DELETED = 4;
   const STATUS_INVITED = 5;
   const USER_PUBLIC_FIELDS = '_id image isEmailPublished isGravatarEnabled googleId name username email introduction'
-  + 'status lang createdAt lastLoginAt admin imageUrlCached';
+  + ' status lang createdAt lastLoginAt admin imageUrlCached';
 
   const PAGE_ITEMS = 50;
 


### PR DESCRIPTION
GW-3584 ユーザー管理画面で、ステータスが表示されないBugを修正