### PR TITLE
Changed TOC height in user home and other pages.

### DIFF
--- a/src/client/js/components/TableOfContents.jsx
+++ b/src/client/js/components/TableOfContents.jsx
@@ -32,6 +32,9 @@ const TableOfContents = (props) => {
     const containerTop = containerElem.getBoundingClientRect().top;
 
     // window height - revisionToc top - .system-version - .grw-fab-container height - top-of-table-contents height
+    if (isUserPage) {
+      return window.innerHeight - containerTop - 20 - 155 - 26 - 40;
+    }
     return window.innerHeight - containerTop - 20 - 155 - 26;
   }, []);
 


### PR DESCRIPTION
# GW-3755 TOCの高さ上限を設定する

作業ブランチに問題があったため、ブランチを変えプルリク新規作成
変更前のブランチ `feat/gw-3755-toc-maxheight-for-userhome `
UserHome専用のボタン（Bookmark,RecentCreate）移動に伴い、TOC高さ上限の調整
## ユーザーホームのTOC
![image](https://user-images.githubusercontent.com/65531771/92884887-3bbb2100-f44d-11ea-88a2-2fafd00c51be.png)
## 他ページのTOC
![image](https://user-images.githubusercontent.com/65531771/92884776-234b0680-f44d-11ea-9c73-32b402d5a97d.png)