### PR TITLE
Feat/gw 3842 adjust modalheader margin

### DIFF
--- a/src/client/js/components/PageAccessoriesModal.jsx
+++ b/src/client/js/components/PageAccessoriesModal.jsx
@@ -106,7 +106,7 @@ const PageAccessoriesModal = (props) => {
           <Nav className="nav-title" id="nav-title">
             {Object.entries(navTabMapping).map(([key, value]) => {
               return (
-                <NavItem key={key} type="button" className={`nav-link ${activeTab === key && 'active'}`}>
+                <NavItem key={key} type="button" className={`p-0 nav-link ${activeTab === key && 'active'}`}>
                   <NavLink onClick={() => { switchActiveTab(key) }}>
                     {value.icon}
                     {t(value.i18n)}
@@ -115,6 +115,7 @@ const PageAccessoriesModal = (props) => {
               );
             })}
             <Button
+              className="my-auto ml-auto mr-3"
               close
               onClick={closeModalHandler}
             />

--- a/src/client/js/components/PageAccessoriesModal.jsx
+++ b/src/client/js/components/PageAccessoriesModal.jsx
@@ -102,7 +102,7 @@ const PageAccessoriesModal = (props) => {
   return (
     <React.Fragment>
       <Modal size="xl" isOpen={props.isOpen} toggle={closeModalHandler} className="grw-page-accessories-modal">
-        <ModalBody>
+        <ModalBody className="p-0">
           <Nav className="nav-title" id="nav-title">
             {Object.entries(navTabMapping).map(([key, value]) => {
               return (
@@ -114,14 +114,13 @@ const PageAccessoriesModal = (props) => {
                 </NavItem>
               );
             })}
-
             <Button
               close
               onClick={closeModalHandler}
             />
-
           </Nav>
           <hr id="grw-nav-slide-hr" className="my-0" style={{ width: `${sliderWidth}%`, marginLeft: `${sliderMarginLeft}%` }} />
+          <hr className="modal-split-hr m-0" />
           <TabContent activeTab={activeTab}>
             <TabPane tabId="pagelist">
               {pageAccessoriesContainer.state.activeComponents.has('pagelist') && <PageList />}

--- a/src/client/js/components/PageAccessoriesModal.jsx
+++ b/src/client/js/components/PageAccessoriesModal.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import {
-  Modal, ModalBody, Nav, NavItem, NavLink, TabContent, TabPane,
+  Button, Modal, ModalBody, Nav, NavItem, NavLink, TabContent, TabPane,
 } from 'reactstrap';
 
 import { withTranslation } from 'react-i18next';
@@ -95,61 +95,61 @@ const PageAccessoriesModal = (props) => {
       <Modal size="xl" isOpen={props.isOpen} toggle={closeModalHandler} className="grw-page-accessories-modal">
         <ModalBody>
           <Nav className="nav-title" id="nav-title">
-            <div className="aaaaaaaaaa">
-              <NavItem type="button" className={`nav-link ${activeTab === 'pagelist' && 'active'}`}>
-                <NavLink
-                  onClick={() => {
-                    switchActiveTab('pagelist');
-                  }}
-                >
-                  <PageListIcon />
-                  {t('page_list')}
-                </NavLink>
-              </NavItem>
-              <NavItem type="button" className={`nav-link ${activeTab === 'timeline' && 'active'}`}>
-                <NavLink
-                  onClick={() => {
-                    switchActiveTab('timeline');
-                  }}
-                >
-                  <TimeLineIcon />
-                  {t('Timeline View')}
-                </NavLink>
-              </NavItem>
-              <NavItem type="button" className={`nav-link ${activeTab === 'page-history' && 'active'}`}>
-                <NavLink
-                  onClick={() => {
-                    switchActiveTab('page-history');
-                  }}
-                >
-                  <RecentChangesIcon />
-                  {t('History')}
-                </NavLink>
-              </NavItem>
-              <NavItem type="button" className={`nav-link ${activeTab === 'attachment' && 'active'}`}>
-                <NavLink
-                  onClick={() => {
-                    switchActiveTab('attachment');
-                  }}
-                >
-                  <AttachmentIcon />
-                  {t('attachment_data')}
-                </NavLink>
-              </NavItem>
-              <NavItem type="button" className={`nav-link ${activeTab === 'share-link' && 'active'}`}>
-                <NavLink
-                  onClick={() => {
-                    switchActiveTab('share-link');
-                  }}
-                >
-                  <ShareLinkIcon />
-                  {t('share_links.share_link_management')}
-                </NavLink>
-              </NavItem>
-            </div>
-            <button type="button" className="close " data-dismiss="modal" aria-label="Close">
-              <span aria-hidden="true">&times;</span>
-            </button>
+            <NavItem type="button" className={`nav-link ${activeTab === 'pagelist' && 'active'}`}>
+              <NavLink
+                onClick={() => {
+                  switchActiveTab('pagelist');
+                }}
+              >
+                <PageListIcon />
+                {t('page_list')}
+              </NavLink>
+            </NavItem>
+            <NavItem type="button" className={`nav-link ${activeTab === 'timeline' && 'active'}`}>
+              <NavLink
+                onClick={() => {
+                  switchActiveTab('timeline');
+                }}
+              >
+                <TimeLineIcon />
+                {t('Timeline View')}
+              </NavLink>
+            </NavItem>
+            <NavItem type="button" className={`nav-link ${activeTab === 'page-history' && 'active'}`}>
+              <NavLink
+                onClick={() => {
+                  switchActiveTab('page-history');
+                }}
+              >
+                <RecentChangesIcon />
+                {t('History')}
+              </NavLink>
+            </NavItem>
+            <NavItem type="button" className={`nav-link ${activeTab === 'attachment' && 'active'}`}>
+              <NavLink
+                onClick={() => {
+                  switchActiveTab('attachment');
+                }}
+              >
+                <AttachmentIcon />
+                {t('attachment_data')}
+              </NavLink>
+            </NavItem>
+            <NavItem type="button" className={`nav-link ${activeTab === 'share-link' && 'active'}`}>
+              <NavLink
+                onClick={() => {
+                  switchActiveTab('share-link');
+                }}
+              >
+                <ShareLinkIcon />
+                {t('share_links.share_link_management')}
+              </NavLink>
+            </NavItem>
+
+            <Button
+              close
+              onClick={closeModalHandler}
+            />
           </Nav>
           <hr id="grw-nav-slide-hr" className="my-0"></hr>
           <div className="page-list-container-create">

--- a/src/client/js/components/PageAccessoriesModal.jsx
+++ b/src/client/js/components/PageAccessoriesModal.jsx
@@ -95,56 +95,61 @@ const PageAccessoriesModal = (props) => {
       <Modal size="xl" isOpen={props.isOpen} toggle={closeModalHandler} className="grw-page-accessories-modal">
         <ModalBody>
           <Nav className="nav-title" id="nav-title">
-            <NavItem type="button" className={`nav-link ${activeTab === 'pagelist' && 'active'}`}>
-              <NavLink
-                onClick={() => {
-                  switchActiveTab('pagelist');
-                }}
-              >
-                <PageListIcon />
-                {t('page_list')}
-              </NavLink>
-            </NavItem>
-            <NavItem type="button" className={`nav-link ${activeTab === 'timeline' && 'active'}`}>
-              <NavLink
-                onClick={() => {
-                  switchActiveTab('timeline');
-                }}
-              >
-                <TimeLineIcon />
-                {t('Timeline View')}
-              </NavLink>
-            </NavItem>
-            <NavItem type="button" className={`nav-link ${activeTab === 'page-history' && 'active'}`}>
-              <NavLink
-                onClick={() => {
-                  switchActiveTab('page-history');
-                }}
-              >
-                <RecentChangesIcon />
-                {t('History')}
-              </NavLink>
-            </NavItem>
-            <NavItem type="button" className={`nav-link ${activeTab === 'attachment' && 'active'}`}>
-              <NavLink
-                onClick={() => {
-                  switchActiveTab('attachment');
-                }}
-              >
-                <AttachmentIcon />
-                {t('attachment_data')}
-              </NavLink>
-            </NavItem>
-            <NavItem type="button" className={`nav-link ${activeTab === 'share-link' && 'active'}`}>
-              <NavLink
-                onClick={() => {
-                  switchActiveTab('share-link');
-                }}
-              >
-                <ShareLinkIcon />
-                {t('share_links.share_link_management')}
-              </NavLink>
-            </NavItem>
+            <div className="aaaaaaaaaa">
+              <NavItem type="button" className={`nav-link ${activeTab === 'pagelist' && 'active'}`}>
+                <NavLink
+                  onClick={() => {
+                    switchActiveTab('pagelist');
+                  }}
+                >
+                  <PageListIcon />
+                  {t('page_list')}
+                </NavLink>
+              </NavItem>
+              <NavItem type="button" className={`nav-link ${activeTab === 'timeline' && 'active'}`}>
+                <NavLink
+                  onClick={() => {
+                    switchActiveTab('timeline');
+                  }}
+                >
+                  <TimeLineIcon />
+                  {t('Timeline View')}
+                </NavLink>
+              </NavItem>
+              <NavItem type="button" className={`nav-link ${activeTab === 'page-history' && 'active'}`}>
+                <NavLink
+                  onClick={() => {
+                    switchActiveTab('page-history');
+                  }}
+                >
+                  <RecentChangesIcon />
+                  {t('History')}
+                </NavLink>
+              </NavItem>
+              <NavItem type="button" className={`nav-link ${activeTab === 'attachment' && 'active'}`}>
+                <NavLink
+                  onClick={() => {
+                    switchActiveTab('attachment');
+                  }}
+                >
+                  <AttachmentIcon />
+                  {t('attachment_data')}
+                </NavLink>
+              </NavItem>
+              <NavItem type="button" className={`nav-link ${activeTab === 'share-link' && 'active'}`}>
+                <NavLink
+                  onClick={() => {
+                    switchActiveTab('share-link');
+                  }}
+                >
+                  <ShareLinkIcon />
+                  {t('share_links.share_link_management')}
+                </NavLink>
+              </NavItem>
+            </div>
+            <button type="button" className="close " data-dismiss="modal" aria-label="Close">
+              <span aria-hidden="true">&times;</span>
+            </button>
           </Nav>
           <hr id="grw-nav-slide-hr" className="my-0"></hr>
           <div className="page-list-container-create">

--- a/src/client/js/components/PageAccessoriesModal.jsx
+++ b/src/client/js/components/PageAccessoriesModal.jsx
@@ -121,7 +121,7 @@ const PageAccessoriesModal = (props) => {
               onClick={closeModalHandler}
             />
           </Nav>
-          <hr id="grw-nav-slide-hr" className="my-0" style={{ width: `${sliderWidth}%`, marginLeft: `${sliderMarginLeft}%` }} />
+          <hr id="grw-nav-slide-hr" className="my-0 grw-nav-slide-hr" style={{ width: `${sliderWidth}%`, marginLeft: `${sliderMarginLeft}%` }} />
           <hr className="modal-split-hr m-0" />
           <TabContent activeTab={activeTab}>
             <TabPane tabId="pagelist">

--- a/src/client/js/components/PageAccessoriesModal.jsx
+++ b/src/client/js/components/PageAccessoriesModal.jsx
@@ -121,7 +121,7 @@ const PageAccessoriesModal = (props) => {
               onClick={closeModalHandler}
             />
           </Nav>
-          <hr id="grw-nav-slide-hr" className="my-0 grw-nav-slide-hr" style={{ width: `${sliderWidth}%`, marginLeft: `${sliderMarginLeft}%` }} />
+          <hr className="my-0 grw-nav-slide-hr" style={{ width: `${sliderWidth}%`, marginLeft: `${sliderMarginLeft}%` }} />
           <hr className="modal-split-hr m-0" />
           <TabContent activeTab={activeTab}>
             <TabPane tabId="pagelist">

--- a/src/client/js/components/PageAccessoriesModal.jsx
+++ b/src/client/js/components/PageAccessoriesModal.jsx
@@ -152,28 +152,26 @@ const PageAccessoriesModal = (props) => {
             />
           </Nav>
           <hr id="grw-nav-slide-hr" className="my-0"></hr>
-          <div className="page-list-container-create">
-            <TabContent activeTab={activeTab}>
+          <TabContent activeTab={activeTab}>
 
-              <TabPane tabId="pagelist">
-                {pageAccessoriesContainer.state.activeComponents.has('pagelist') && <PageList />}
-              </TabPane>
-              <TabPane tabId="timeline" className="p-4">
-                {pageAccessoriesContainer.state.activeComponents.has('timeline') && <PageTimeline /> }
-              </TabPane>
-              <TabPane tabId="page-history">
-                <div className="overflow-auto">
-                  {pageAccessoriesContainer.state.activeComponents.has('page-history') && <PageHistory /> }
-                </div>
-              </TabPane>
-              <TabPane tabId="attachment" className="p-4">
-                {pageAccessoriesContainer.state.activeComponents.has('attachment') && <PageAttachment />}
-              </TabPane>
-              <TabPane tabId="share-link" className="p-4">
-                {pageAccessoriesContainer.state.activeComponents.has('share-link') && <ShareLink />}
-              </TabPane>
-            </TabContent>
-          </div>
+            <TabPane tabId="pagelist">
+              {pageAccessoriesContainer.state.activeComponents.has('pagelist') && <PageList />}
+            </TabPane>
+            <TabPane tabId="timeline" className="p-4">
+              {pageAccessoriesContainer.state.activeComponents.has('timeline') && <PageTimeline /> }
+            </TabPane>
+            <TabPane tabId="page-history">
+              <div className="overflow-auto">
+                {pageAccessoriesContainer.state.activeComponents.has('page-history') && <PageHistory /> }
+              </div>
+            </TabPane>
+            <TabPane tabId="attachment" className="p-4">
+              {pageAccessoriesContainer.state.activeComponents.has('attachment') && <PageAttachment />}
+            </TabPane>
+            <TabPane tabId="share-link" className="p-4">
+              {pageAccessoriesContainer.state.activeComponents.has('share-link') && <ShareLink />}
+            </TabPane>
+          </TabContent>
         </ModalBody>
       </Modal>
     </React.Fragment>

--- a/src/client/js/components/PageAccessoriesModal.jsx
+++ b/src/client/js/components/PageAccessoriesModal.jsx
@@ -147,26 +147,28 @@ const PageAccessoriesModal = (props) => {
             </NavItem>
           </Nav>
           <hr id="grw-nav-slide-hr" className="my-0"></hr>
-          <TabContent activeTab={activeTab}>
+          <div className="page-list-container-create">
+            <TabContent activeTab={activeTab}>
 
-            <TabPane tabId="pagelist">
-              {pageAccessoriesContainer.state.activeComponents.has('pagelist') && <PageList />}
-            </TabPane>
-            <TabPane tabId="timeline" className="p-4">
-              {pageAccessoriesContainer.state.activeComponents.has('timeline') && <PageTimeline /> }
-            </TabPane>
-            <TabPane tabId="page-history">
-              <div className="overflow-auto">
-                {pageAccessoriesContainer.state.activeComponents.has('page-history') && <PageHistory /> }
-              </div>
-            </TabPane>
-            <TabPane tabId="attachment" className="p-4">
-              {pageAccessoriesContainer.state.activeComponents.has('attachment') && <PageAttachment />}
-            </TabPane>
-            <TabPane tabId="share-link" className="p-4">
-              {pageAccessoriesContainer.state.activeComponents.has('share-link') && <ShareLink />}
-            </TabPane>
-          </TabContent>
+              <TabPane tabId="pagelist">
+                {pageAccessoriesContainer.state.activeComponents.has('pagelist') && <PageList />}
+              </TabPane>
+              <TabPane tabId="timeline" className="p-4">
+                {pageAccessoriesContainer.state.activeComponents.has('timeline') && <PageTimeline /> }
+              </TabPane>
+              <TabPane tabId="page-history">
+                <div className="overflow-auto">
+                  {pageAccessoriesContainer.state.activeComponents.has('page-history') && <PageHistory /> }
+                </div>
+              </TabPane>
+              <TabPane tabId="attachment" className="p-4">
+                {pageAccessoriesContainer.state.activeComponents.has('attachment') && <PageAttachment />}
+              </TabPane>
+              <TabPane tabId="share-link" className="p-4">
+                {pageAccessoriesContainer.state.activeComponents.has('share-link') && <ShareLink />}
+              </TabPane>
+            </TabContent>
+          </div>
         </ModalBody>
       </Modal>
     </React.Fragment>

--- a/src/client/styles/scss/_layout_growi.scss
+++ b/src/client/styles/scss/_layout_growi.scss
@@ -24,6 +24,18 @@
   }
 
   .grw-page-accessories-modal {
+    .modal-body {
+      padding: 0rem;
+    }
+    .nav-title {
+      //li.button etc
+      li.nav-link {
+        padding: 0rem;
+        a.nav-link {
+          padding: 1rem 1.5rem;
+        }
+      }
+    }
     .table-top-icon {
       margin-right: 5px;
     }

--- a/src/client/styles/scss/_layout_growi.scss
+++ b/src/client/styles/scss/_layout_growi.scss
@@ -23,29 +23,6 @@
     }
   }
 
-  .grw-page-accessories-modal {
-    .modal-body {
-      padding: 0rem;
-    }
-    .nav-title {
-      //li.button etc
-      li.nav-link {
-        padding: 0rem;
-        a.nav-link {
-          padding: 1rem 1.5rem;
-        }
-      }
-    }
-    .table-top-icon {
-      margin-right: 5px;
-    }
-
-    #grw-nav-slide-hr {
-      border-top: 0rem;
-      transition: 0.3s ease-in-out;
-    }
-  }
-
   .revision-toc {
     position: sticky;
     // growisubnavigation + grw-navbar-boder

--- a/src/client/styles/scss/_layout_growi.scss
+++ b/src/client/styles/scss/_layout_growi.scss
@@ -41,6 +41,7 @@
     }
 
     #grw-nav-slide-hr {
+      border-top: 0rem;
       transition: 0.3s ease-in-out;
     }
   }

--- a/src/client/styles/scss/_page_accessaries_modal.scss
+++ b/src/client/styles/scss/_page_accessaries_modal.scss
@@ -8,7 +8,7 @@
       }
     }
   }
-  #grw-nav-slide-hr {
+  .grw-nav-slide-hr {
     border-top: 0rem;
     border-bottom: 3px solid;
     transition: 0.3s ease-in-out;

--- a/src/client/styles/scss/_page_accessaries_modal.scss
+++ b/src/client/styles/scss/_page_accessaries_modal.scss
@@ -1,4 +1,22 @@
 .grw-page-accessories-modal {
+  .nav-title {
+    flex-wrap: nowrap;
+    .aaaaaaaaaa {
+      li {
+        display: inline;
+      }
+      margin-right: auto;
+    }
+    //flex-wrap: wrap;
+    //position: relative;
+    .close {
+      //padding: 0rem 1.5rem;
+      //position: absolute;
+      // auto on the left force icon to the right even when there is no .modal-title
+      margin: auto 1.5rem;
+    }
+  }
+
   .nav-link svg {
     width: 20px;
     height: 20px;

--- a/src/client/styles/scss/_page_accessaries_modal.scss
+++ b/src/client/styles/scss/_page_accessaries_modal.scss
@@ -29,26 +29,3 @@
     margin-right: 5px;
   }
 }
-
-// .grw-page-accessories-modal {
-//   // .modal-body {
-//   //   padding: 0rem;
-//   // }
-//   .nav-title {
-
-//     li.nav-link {
-//       padding: 0rem;
-//       a.nav-link {
-//         padding: 1rem 1.5rem;
-//       }
-//     }
-//   }
-//   .table-top-icon {
-//     margin-right: 5px;
-//   }
-
-//   #grw-nav-slide-hr {
-//     border-top: 0rem;
-//     transition: 0.3s ease-in-out;
-//   }
-// }

--- a/src/client/styles/scss/_page_accessaries_modal.scss
+++ b/src/client/styles/scss/_page_accessaries_modal.scss
@@ -1,19 +1,12 @@
 .grw-page-accessories-modal {
   .nav-title {
     flex-wrap: nowrap;
-    .aaaaaaaaaa {
-      li {
-        display: inline;
-      }
-      margin-right: auto;
+
+    li {
+      display: inline;
     }
-    //flex-wrap: wrap;
-    //position: relative;
     .close {
-      //padding: 0rem 1.5rem;
-      //position: absolute;
-      // auto on the left force icon to the right even when there is no .modal-title
-      margin: auto 1.5rem;
+      margin: auto 1.5rem auto auto;
     }
   }
 

--- a/src/client/styles/scss/_page_accessaries_modal.scss
+++ b/src/client/styles/scss/_page_accessaries_modal.scss
@@ -4,15 +4,51 @@
 
     li {
       display: inline;
+
+      padding: 0rem;
+      a.nav-link {
+        padding: 1rem 1.5rem;
+      }
     }
     .close {
       margin: auto 1.5rem auto auto;
     }
   }
+  .table-top-icon {
+    margin-right: 5px;
+  }
 
+  #grw-nav-slide-hr {
+    border-top: 0rem;
+    border-bottom: 3px solid;
+    transition: 0.3s ease-in-out;
+  }
   .nav-link svg {
     width: 17px;
     height: 17px;
     margin-right: 5px;
   }
 }
+
+// .grw-page-accessories-modal {
+//   // .modal-body {
+//   //   padding: 0rem;
+//   // }
+//   .nav-title {
+
+//     li.nav-link {
+//       padding: 0rem;
+//       a.nav-link {
+//         padding: 1rem 1.5rem;
+//       }
+//     }
+//   }
+//   .table-top-icon {
+//     margin-right: 5px;
+//   }
+
+//   #grw-nav-slide-hr {
+//     border-top: 0rem;
+//     transition: 0.3s ease-in-out;
+//   }
+// }

--- a/src/client/styles/scss/_page_accessaries_modal.scss
+++ b/src/client/styles/scss/_page_accessaries_modal.scss
@@ -3,21 +3,11 @@
     flex-wrap: nowrap;
 
     li {
-      display: inline;
-
-      padding: 0rem;
       a.nav-link {
         padding: 1rem 1.5rem;
       }
     }
-    .close {
-      margin: auto 1.5rem auto auto;
-    }
   }
-  .table-top-icon {
-    margin-right: 5px;
-  }
-
   #grw-nav-slide-hr {
     border-top: 0rem;
     border-bottom: 3px solid;

--- a/src/client/styles/scss/_page_accessaries_modal.scss
+++ b/src/client/styles/scss/_page_accessaries_modal.scss
@@ -11,8 +11,8 @@
   }
 
   .nav-link svg {
-    width: 20px;
-    height: 20px;
+    width: 17px;
+    height: 17px;
     margin-right: 5px;
   }
 }

--- a/src/client/styles/scss/theme/_apply-colors.scss
+++ b/src/client/styles/scss/theme/_apply-colors.scss
@@ -291,7 +291,7 @@ pre:not(.hljs):not(.CodeMirror-line) {
     background-color: $bordercolor-nav-tabs;
   }
 
-  #grw-nav-slide-hr {
+  .grw-nav-slide-hr {
     border-color: $color-link;
   }
 }

--- a/src/client/styles/scss/theme/_apply-colors.scss
+++ b/src/client/styles/scss/theme/_apply-colors.scss
@@ -287,8 +287,12 @@ pre:not(.hljs):not(.CodeMirror-line) {
   .nav-link svg {
     fill: $color-link;
   }
+  .page-list-container-create {
+    border-top: 1px solid $bordercolor-nav-tabs;
+  }
+
   #grw-nav-slide-hr {
-    border-bottom: 2px solid $color-link;
+    border-bottom: 3px solid $color-link;
   }
 }
 

--- a/src/client/styles/scss/theme/_apply-colors.scss
+++ b/src/client/styles/scss/theme/_apply-colors.scss
@@ -287,12 +287,12 @@ pre:not(.hljs):not(.CodeMirror-line) {
   .nav-link svg {
     fill: $color-link;
   }
-  .page-list-container-create {
-    border-top: 1px solid $bordercolor-nav-tabs;
+  .modal-split-hr {
+    background-color: $bordercolor-nav-tabs;
   }
 
   #grw-nav-slide-hr {
-    border-bottom: 3px solid $color-link;
+    border-color: $color-link;
   }
 }
 


### PR DESCRIPTION
# GW-3842 デザイン修正：ヘッダー(nav-title)の表示を修正

# 実装画面
※ボディ部分の見た目は後続タスクで調整。
![image](https://user-images.githubusercontent.com/65531771/93302679-57e80500-f835-11ea-86c3-de5335382bf9.png)
- ヘッダーは左右にマージンを設けず、画面端まで使用して表示
- tabタイトルの上下のアキを、上下1.5rem , 左右1rem に
- nav-slide-hrの太さを3pxに
- border-bottomを追加
- 閉じるボタンを追加

# デザイン
![image](https://user-images.githubusercontent.com/65531771/93302885-9978b000-f835-11ea-89db-f23cbdd95ada.png)
![image](https://user-images.githubusercontent.com/65531771/93302913-a2698180-f835-11ea-85fb-6eeb9bdcf142.png)
