### PR TITLE
Imprv/gw3843 add scrol on each modal body

### DIFF
--- a/src/client/js/components/PageAccessoriesModal.jsx
+++ b/src/client/js/components/PageAccessoriesModal.jsx
@@ -147,7 +147,7 @@ const PageAccessoriesModal = (props) => {
             </NavItem>
           </Nav>
           <hr id="grw-nav-slide-hr" className="my-0"></hr>
-          <TabContent activeTab={activeTab} className="overflow-auto" style={{ maxHeight: '500px' }}>
+          <TabContent activeTab={activeTab} className="overflow-auto grw-tab-content-style">
             <TabPane tabId="pagelist">
               {pageAccessoriesContainer.state.activeComponents.has('pagelist') && <PageList />}
             </TabPane>

--- a/src/client/js/components/PageAccessoriesModal.jsx
+++ b/src/client/js/components/PageAccessoriesModal.jsx
@@ -103,7 +103,7 @@ const PageAccessoriesModal = (props) => {
     <React.Fragment>
       <Modal size="xl" isOpen={props.isOpen} toggle={closeModalHandler} className="grw-page-accessories-modal">
         {/* [TODO: insert a modal header and move nav tabs there  by gw-3890] */}
-        <ModalBody className="overflow-auto grw-tab-content-style">
+        <ModalBody className="overflow-auto grw-modal-body-style">
           <Nav className="nav-title" id="nav-title">
             {Object.entries(navTabMapping).map(([key, value]) => {
               return (

--- a/src/client/js/components/PageAccessoriesModal.jsx
+++ b/src/client/js/components/PageAccessoriesModal.jsx
@@ -147,8 +147,7 @@ const PageAccessoriesModal = (props) => {
             </NavItem>
           </Nav>
           <hr id="grw-nav-slide-hr" className="my-0"></hr>
-          <TabContent activeTab={activeTab}>
-
+          <TabContent activeTab={activeTab} className="overflow-auto" style={{ maxHeight: '500px' }}>
             <TabPane tabId="pagelist">
               {pageAccessoriesContainer.state.activeComponents.has('pagelist') && <PageList />}
             </TabPane>

--- a/src/client/js/components/PageAccessoriesModal.jsx
+++ b/src/client/js/components/PageAccessoriesModal.jsx
@@ -155,9 +155,7 @@ const PageAccessoriesModal = (props) => {
               {pageAccessoriesContainer.state.activeComponents.has('timeline') && <PageTimeline /> }
             </TabPane>
             <TabPane tabId="page-history">
-              <div className="overflow-auto">
-                {pageAccessoriesContainer.state.activeComponents.has('page-history') && <PageHistory /> }
-              </div>
+              {pageAccessoriesContainer.state.activeComponents.has('page-history') && <PageHistory /> }
             </TabPane>
             <TabPane tabId="attachment" className="p-4">
               {pageAccessoriesContainer.state.activeComponents.has('attachment') && <PageAttachment />}

--- a/src/client/js/components/PageAccessoriesModal.jsx
+++ b/src/client/js/components/PageAccessoriesModal.jsx
@@ -102,7 +102,7 @@ const PageAccessoriesModal = (props) => {
   return (
     <React.Fragment>
       <Modal size="xl" isOpen={props.isOpen} toggle={closeModalHandler} className="grw-page-accessories-modal">
-        <ModalBody>
+        <ModalBody className="overflow-auto grw-tab-content-style">
           <Nav className="nav-title" id="nav-title">
             {Object.entries(navTabMapping).map(([key, value]) => {
               return (

--- a/src/client/js/components/PageAccessoriesModal.jsx
+++ b/src/client/js/components/PageAccessoriesModal.jsx
@@ -102,6 +102,7 @@ const PageAccessoriesModal = (props) => {
   return (
     <React.Fragment>
       <Modal size="xl" isOpen={props.isOpen} toggle={closeModalHandler} className="grw-page-accessories-modal">
+        {/* [TODO: insert a modal header and move nav tabs there  by gw-3890] */}
         <ModalBody className="overflow-auto grw-tab-content-style">
           <Nav className="nav-title" id="nav-title">
             {Object.entries(navTabMapping).map(([key, value]) => {

--- a/src/client/styles/scss/_page.scss
+++ b/src/client/styles/scss/_page.scss
@@ -93,11 +93,6 @@
     background-color: white;
   }
 }
-// revision-history on pageAccsesoriesModal
-.d2h-code-side-linenumber {
-  position: static;
-  display: table-cell;
-}
 
 /**
  * for table with handsontable modal button

--- a/src/client/styles/scss/_page.scss
+++ b/src/client/styles/scss/_page.scss
@@ -93,6 +93,11 @@
     background-color: white;
   }
 }
+// revision-history on pageAccsesoriesModal
+.d2h-code-side-linenumber {
+  position: static;
+  display: table-cell;
+}
 
 /**
  * for table with handsontable modal button

--- a/src/client/styles/scss/_page_accessaries_modal.scss
+++ b/src/client/styles/scss/_page_accessaries_modal.scss
@@ -5,10 +5,9 @@
     margin-right: 5px;
   }
 
-  // .grw-tab-content-style {
-  //   max-width: 1140px;
-  //   max-height: 595px;
-  // }
+  .grw-tab-content-style {
+    max-height: 595px;
+  }
 }
 
 // revision-history diff

--- a/src/client/styles/scss/_page_accessaries_modal.scss
+++ b/src/client/styles/scss/_page_accessaries_modal.scss
@@ -6,7 +6,7 @@
   }
 
   .grw-tab-content-style {
-    max-height: 595px;
+    max-height: 595vh;
   }
 }
 

--- a/src/client/styles/scss/_page_accessaries_modal.scss
+++ b/src/client/styles/scss/_page_accessaries_modal.scss
@@ -6,11 +6,12 @@
   }
 
   .grw-tab-content-style {
-    max-height: 595vh;
+    max-height: 80vh;
   }
 }
 
-// revision-history diff
+// revision-history
+// to stay d2h-code-side-line-number in the revision history diff area
 .d2h-wrapper {
   position: relative;
 }

--- a/src/client/styles/scss/_page_accessaries_modal.scss
+++ b/src/client/styles/scss/_page_accessaries_modal.scss
@@ -5,10 +5,10 @@
     margin-right: 5px;
   }
 
-  .grw-tab-content-style {
-    max-width: 1140px;
-    max-height: 595px;
-  }
+  // .grw-tab-content-style {
+  //   max-width: 1140px;
+  //   max-height: 595px;
+  // }
 }
 
 // revision-history diff

--- a/src/client/styles/scss/_page_accessaries_modal.scss
+++ b/src/client/styles/scss/_page_accessaries_modal.scss
@@ -6,7 +6,7 @@
   }
 
   .grw-modal-body-style {
-    max-height: 80vh;
+    max-height: calc(100vh - 100px);
   }
 }
 

--- a/src/client/styles/scss/_page_accessaries_modal.scss
+++ b/src/client/styles/scss/_page_accessaries_modal.scss
@@ -4,4 +4,14 @@
     height: 20px;
     margin-right: 5px;
   }
+
+  .grw-tab-content-style {
+    max-width: 1140px;
+    max-height: 595px;
+  }
+  // revision-history on pageAccsesoriesModal
+  .d2h-code-side-linenumber {
+    position: static;
+    display: table-cell;
+  }
 }

--- a/src/client/styles/scss/_page_accessaries_modal.scss
+++ b/src/client/styles/scss/_page_accessaries_modal.scss
@@ -9,7 +9,8 @@
     max-width: 1140px;
     max-height: 595px;
   }
-  // revision-history on pageAccsesoriesModal
+
+  // revision-history diff
   .d2h-code-side-linenumber {
     position: static;
     display: table-cell;

--- a/src/client/styles/scss/_page_accessaries_modal.scss
+++ b/src/client/styles/scss/_page_accessaries_modal.scss
@@ -5,7 +5,7 @@
     margin-right: 5px;
   }
 
-  .grw-tab-content-style {
+  .grw-modal-body-style {
     max-height: 80vh;
   }
 }

--- a/src/client/styles/scss/_page_accessaries_modal.scss
+++ b/src/client/styles/scss/_page_accessaries_modal.scss
@@ -9,10 +9,9 @@
     max-width: 1140px;
     max-height: 595px;
   }
+}
 
-  // revision-history diff
-  .d2h-code-side-linenumber {
-    position: static;
-    display: table-cell;
-  }
+// revision-history diff
+.d2h-wrapper {
+  position: relative;
 }


### PR DESCRIPTION
GW-3843 デザイン修正：ボディ内のスクロールを実装

[ページリスト]と[添付データ]は、ページャーがついており、縦幅が長くなることがないためスクロールはできません。