### PR TITLE
Imprv/gw3891 my drafts redesign

### DIFF
--- a/src/client/js/components/MyDraftList/Draft.jsx
+++ b/src/client/js/components/MyDraftList/Draft.jsx
@@ -87,7 +87,7 @@ class Draft extends React.Component {
 
     return (
       <span>
-        <i className={` icon icon-arrow-up ${iconClass}`}></i>
+        <i className={`icon icon-arrow-up ${iconClass}`}></i>
         <span className="mx-2" onClick={() => this.setState({ isPanelExpanded: !isPanelExpanded })}>
           {this.props.path}
         </span>

--- a/src/client/js/components/MyDraftList/Draft.jsx
+++ b/src/client/js/components/MyDraftList/Draft.jsx
@@ -83,18 +83,19 @@ class Draft extends React.Component {
   renderAccordionTitle(isExist) {
     const { isPanelExpanded } = this.state;
     const { t } = this.props;
-    const iconClass = isPanelExpanded ? 'caret-opened' : '';
+    const iconClass = isPanelExpanded ? 'fa-rotate-90' : '';
 
     return (
       <span>
-        <i className={`icon icon-arrow-up ${iconClass}`}></i>
-        <span className="mx-2" onClick={() => this.setState({ isPanelExpanded: !isPanelExpanded })}>
+
+        <span className="mr-2 draft-path" onClick={() => this.setState({ isPanelExpanded: !isPanelExpanded })}>
+          <i className={`fa fa-fw fa-angle-right mr-5 ${iconClass}`}></i>
           {this.props.path}
         </span>
-        { !isExist && (
+        { isExist && (
           <span className="badge badge-warning">{t('page exists')}</span>
         ) }
-        { isExist && (
+        { !isExist && (
           <span className="badge badge-info">draft</span>
         ) }
 

--- a/src/client/js/components/MyDraftList/Draft.jsx
+++ b/src/client/js/components/MyDraftList/Draft.jsx
@@ -89,7 +89,7 @@ class Draft extends React.Component {
       <span>
 
         <span className="mr-2 draft-path" onClick={() => this.setState({ isPanelExpanded: !isPanelExpanded })}>
-          <i className={`fa fa-fw fa-angle-right mr-5 ${iconClass}`}></i>
+          <i className={`fa fa-fw fa-angle-right mr-2 ${iconClass}`}></i>
           {this.props.path}
         </span>
         { isExist && (

--- a/src/client/js/components/MyDraftList/Draft.jsx
+++ b/src/client/js/components/MyDraftList/Draft.jsx
@@ -82,20 +82,20 @@ class Draft extends React.Component {
 
   renderAccordionTitle(isExist) {
     const { isPanelExpanded } = this.state;
-
+    const { t } = this.props;
     const iconClass = isPanelExpanded ? 'caret-opened' : '';
 
     return (
       <span>
-        <i className={`caret ${iconClass}`}></i>
+        <i className={` icon icon-arrow-up ${iconClass}`}></i>
         <span className="mx-2" onClick={() => this.setState({ isPanelExpanded: !isPanelExpanded })}>
           {this.props.path}
         </span>
-        { isExist && (
-          <span>({this.props.t('page exists')})</span>
-        ) }
         { !isExist && (
-          <span className="badge badge-secondary">draft</span>
+          <span className="badge badge-warning">{t('page exists')}</span>
+        ) }
+        { isExist && (
+          <span className="badge badge-info">draft</span>
         ) }
 
         <a className="ml-2" href={this.props.path}><i className="icon icon-login"></i></a>

--- a/src/client/js/components/MyDraftList/MyDraftList.jsx
+++ b/src/client/js/components/MyDraftList/MyDraftList.jsx
@@ -134,15 +134,16 @@ class MyDraftList extends React.Component {
     const totalCount = this.state.totalDrafts;
 
     return (
-      <div className="page-list-container-create">
-
+      <div className="page-list-container-create ">
+        <h2>My Drafts</h2>
+        <hr />
         { totalCount === 0
-          && <span>No drafts yet.</span>
+          && <span className="mt-2">No drafts yet.</span>
         }
 
         { totalCount > 0 && (
           <React.Fragment>
-            <div className="d-flex justify-content-between">
+            <div className="d-flex justify-content-between mt-2">
               <h4>Total: {totalCount} drafts</h4>
               <div className="align-self-center">
                 <button type="button" className="btn btn-sm btn-outline-danger" onClick={this.clearAllDrafts}>
@@ -152,7 +153,7 @@ class MyDraftList extends React.Component {
               </div>
             </div>
 
-            <div className="tab-pane mt-5 accordion" id="draft-list">
+            <div className="tab-pane mt-2 accordion" id="draft-list">
               {draftList}
             </div>
             <PaginationWrapper

--- a/src/client/styles/scss/_draft.scss
+++ b/src/client/styles/scss/_draft.scss
@@ -1,14 +1,13 @@
 .draft-list-item {
-  .panel-heading {
-    .caret {
-      transition: 0.4s;
-      transform: rotate(-90deg);
+  .icon-arrow-up {
+    transition: 0.4s;
+    transform: rotate(-90deg);
 
-      &.caret-opened {
-        transform: rotate(0deg);
-      }
+    &.caret-opened {
+      transform: rotate(30deg);
     }
-
+  }
+  .panel-heading {
     .icon-container {
       a:hover {
         text-decoration: unset;

--- a/src/client/styles/scss/_draft.scss
+++ b/src/client/styles/scss/_draft.scss
@@ -1,12 +1,4 @@
 .draft-list-item {
-  // .icon-arrow-up {
-  //   transition: 0.4s;
-  //   transform: rotate(-90deg);
-
-  //   &.caret-opened {
-  //     transform: rotate(30deg);
-  //   }
-  // }
   .panel-heading {
     .icon-container {
       a:hover {

--- a/src/client/styles/scss/_draft.scss
+++ b/src/client/styles/scss/_draft.scss
@@ -1,12 +1,12 @@
 .draft-list-item {
-  .icon-arrow-up {
-    transition: 0.4s;
-    transform: rotate(-90deg);
+  // .icon-arrow-up {
+  //   transition: 0.4s;
+  //   transform: rotate(-90deg);
 
-    &.caret-opened {
-      transform: rotate(30deg);
-    }
-  }
+  //   &.caret-opened {
+  //     transform: rotate(30deg);
+  //   }
+  // }
   .panel-heading {
     .icon-container {
       a:hover {
@@ -27,6 +27,9 @@
   }
 
   .draft-copy {
+    cursor: pointer;
+  }
+  .draft-path {
     cursor: pointer;
   }
 }


### PR DESCRIPTION
# GW-3891 my draftsタブのデザイン修正
- 既存の内容との相違点
  - `draft`バッジをinfoカラーに。
  - `this page already exists`をバッジ化し、warningカラーに。
  - ページ名の左にシェブロンを追加、開閉に合わせ向きが変わる。
シェブロンは実装の都合上、デザインスペックと見た目が違っています。
単独ページ化は別タスクにて進行→"GW-3850 my draftsタブをページとして独立させる"
### ページが`draft`の時
![image](https://user-images.githubusercontent.com/65531771/93597538-2b2f1b80-f9f6-11ea-8d1f-f5e3c8d41532.png)
### ページがが既に存在する時
![image](https://user-images.githubusercontent.com/65531771/93597247-b3f98780-f9f5-11ea-9194-1b0906bfeba0.png)
### カードが開いている時
![image](https://user-images.githubusercontent.com/65531771/93597675-6893a900-f9f6-11ea-88c3-b8d0ec4ef589.png)

### デザイン
![image](https://user-images.githubusercontent.com/65531771/93597861-b4dee900-f9f6-11ea-9a6c-35b937b38654.png)
