### PR TITLE
Imprv/gw3399 form adjustment

### DIFF
--- a/resource/locales/en_US/admin/admin.json
+++ b/resource/locales/en_US/admin/admin.json
@@ -122,11 +122,11 @@
       "list_num_desc_in_notfound_and_trash_pages": "Number of 'Not found' and 'Trash' pages displayed",
       "all_list_num_desc_in_notfound_and_trash_pages": "Number of 'Not found' and 'Trash' pages displayed on article page",
 
-      "list_num_desc_in_page_contents_modal": "Number of page contents modal displayedページコンテンツモーダルに表示されるリスト数",
-      "all_list_num_desc_in_page_contents_modal": "Number of 'Pagelist', 'Timeline', 'Page History' and 'Share Link' pages displayed on page contents modal",
-
       "list_num_desc_in_draft_and_search_pages": "Number of 'Search' and 'Draft' pages displayed",
       "all_list_num_desc_in_draft_and_search_pages": "Number of 'Search' and 'Draft' pages displayed",
+
+      "list_num_desc_in_page_contents_modal": "Number of page contents modal displayed",
+      "all_list_num_desc_in_page_contents_modal": "Number of 'Pagelist', 'Timeline', 'Page History' and 'Share Link' pages displayed on page contents modal",
 
       "stale_notification": "Display notification on stale pages",
       "stale_notification_desc": "Displays the notification to pages more than 1 year since the last update.",

--- a/resource/locales/en_US/admin/admin.json
+++ b/resource/locales/en_US/admin/admin.json
@@ -115,8 +115,19 @@
       "tab_switch_desc2": "By invalidating, you can make page transition as the only object for forward/back command of the browser.",
       "attach_title_header": "Add h1 section when create new page automatically",
       "attach_title_header_desc": "Add page path to the first line as h1 section when create new page",
+
       "list_num_desc_in_user_page": "Number of user page displayed",
       "all_list_num_desc_in_user_page": "Number of Bookmarks, recently created pages and drafts displayed on user page",
+
+      "list_num_desc_in_notfound_and_trash_pages": "Number of 'Not found' and 'Trash' pages displayed",
+      "all_list_num_desc_in_notfound_and_trash_pages": "Number of 'Not found' and 'Trash' pages displayed on article page",
+
+      "list_num_desc_in_page_contents_modal": "Number of page contents modal displayedページコンテンツモーダルに表示されるリスト数",
+      "all_list_num_desc_in_page_contents_modal": "Number of 'Pagelist', 'Timeline', 'Page History' and 'Share Link' pages displayed on page contents modal",
+
+      "list_num_desc_in_draft_and_search_pages": "Number of 'Search' and 'Draft' pages displayed",
+      "all_list_num_desc_in_draft_and_search_pages": "Number of 'Search' and 'Draft' pages displayed",
+
       "stale_notification": "Display notification on stale pages",
       "stale_notification_desc": "Displays the notification to pages more than 1 year since the last update.",
       "show_all_reply_comments": "Show all reply comments",

--- a/resource/locales/en_US/admin/admin.json
+++ b/resource/locales/en_US/admin/admin.json
@@ -116,17 +116,19 @@
       "attach_title_header": "Add h1 section when create new page automatically",
       "attach_title_header_desc": "Add page path to the first line as h1 section when create new page",
 
-      "list_num_desc_in_user_page": "Number of user page displayed",
-      "all_list_num_desc_in_user_page": "Number of Bookmarks, recently created pages and drafts displayed on user page",
+      "list_num_s": "Number of list displayed on modals",
+      "list_num_desc_s": "Set number of list per page such as 'Pagelist', 'Timeline', 'Page History' and 'Share Link' pages",
 
-      "list_num_desc_in_notfound_and_trash_pages": "Number of 'Not found' and 'Trash' pages displayed",
-      "all_list_num_desc_in_notfound_and_trash_pages": "Number of 'Not found' and 'Trash' pages displayed on article page",
+      "list_num_m": "Number of list displayed on article pages included other contents",
+      "list_num_desc_m": "Set number of list per page such as 'Bookmarks', 'Recently created' and 'Drafts'",
 
-      "list_num_desc_in_draft_and_search_pages": "Number of 'Search' and 'Draft' pages displayed",
-      "all_list_num_desc_in_draft_and_search_pages": "Number of 'Search' and 'Draft' pages displayed",
+      "list_num_l": "Number of list displayed on 'Search' and 'Draft' pages",
+      "list_num_desc_l": "Set number of list per page such as 'Search' and 'Draft' pages",
 
-      "list_num_desc_in_page_contents_modal": "Number of page contents modal displayed",
-      "all_list_num_desc_in_page_contents_modal": "Number of 'Pagelist', 'Timeline', 'Page History' and 'Share Link' pages displayed on page contents modal",
+      "list_num_xl": "Number of list displayed on article pages",
+      "list_num_desc_xl": "Set number of list per page such as 'Not found' and 'Trash' pages",
+
+
 
       "stale_notification": "Display notification on stale pages",
       "stale_notification_desc": "Displays the notification to pages more than 1 year since the last update.",

--- a/resource/locales/ja_JP/admin/admin.json
+++ b/resource/locales/ja_JP/admin/admin.json
@@ -122,11 +122,11 @@
       "list_num_desc_in_notfound_and_trash_pages": "Not FoundページやTrashページに表示されるリスト数",
       "all_list_num_desc_in_notfound_and_trash_pages": "記事エリアにおける<Not Found> <Trash>での、1ページの表示数を設定します。",
 
-      "list_num_desc_in_page_contents_modal": "ページコンテンツモーダルに表示されるリスト数",
-      "all_list_num_desc_in_page_contents_modal": "ページコンテンツモーダルにおける <Pagelist> <Timeline> <Page History> <Share Link>での、1ページの表示数を設定します。",
-
       "list_num_desc_in_draft_and_search_pages": "検索ページやDraftページに表示されるリスト数",
       "all_list_num_desc_in_draft_and_search_pages": "<Search> <My Drafts> での、1ページの表示数を設定します。",
+
+      "list_num_desc_in_page_contents_modal": "ページコンテンツモーダルに表示されるリスト数",
+      "all_list_num_desc_in_page_contents_modal": "ページコンテンツモーダルにおける <Pagelist> <Timeline> <Page History> <Share Link>での、1ページの表示数を設定します。",
 
       "stale_notification": "古いページに通知を表示する",
       "stale_notification_desc": "最後の更新から1年を超えるページへの通知を表示します。",

--- a/resource/locales/ja_JP/admin/admin.json
+++ b/resource/locales/ja_JP/admin/admin.json
@@ -115,8 +115,19 @@
       "tab_switch_desc2": "無効化することで、ページ遷移のみを戻る/進む操作の対象にすることができます。",
       "attach_title_header": "新規ページ作成時の h1 セクション自動挿入",
       "attach_title_header_desc": "新規作成したページの1行目に、ページのパスを h1 セクションとして挿入します。",
+
       "list_num_desc_in_user_page": "ユーザーページに表示されるリスト数",
-      "all_list_num_desc_in_user_page": "ユーザーページにおける <Bookmarks> <Recently Created> <My Drafts> での、1ページの表示数を設定します。",
+      "all_list_num_desc_in_user_page": "ユーザーページにおける <Bookmarks> <Recently Created>での、1ページの表示数を設定します。",
+
+      "list_num_desc_in_notfound_and_trash_pages": "Not FoundページやTrashページに表示されるリスト数",
+      "all_list_num_desc_in_notfound_and_trash_pages": "記事エリアにおける<Not Found> <Trash>での、1ページの表示数を設定します。",
+
+      "list_num_desc_in_page_contents_modal": "ページコンテンツモーダルに表示されるリスト数",
+      "all_list_num_desc_in_page_contents_modal": "ページコンテンツモーダルにおける <Pagelist> <Timeline> <Page History> <Share Link>での、1ページの表示数を設定します。",
+
+      "list_num_desc_in_draft_and_search_pages": "検索ページやDraftページに表示されるリスト数",
+      "all_list_num_desc_in_draft_and_search_pages": "<Search> <My Drafts> での、1ページの表示数を設定します。",
+
       "stale_notification": "古いページに通知を表示する",
       "stale_notification_desc": "最後の更新から1年を超えるページへの通知を表示します。",
       "show_all_reply_comments": "返信コメントを全て表示する",

--- a/resource/locales/ja_JP/admin/admin.json
+++ b/resource/locales/ja_JP/admin/admin.json
@@ -116,17 +116,17 @@
       "attach_title_header": "新規ページ作成時の h1 セクション自動挿入",
       "attach_title_header_desc": "新規作成したページの1行目に、ページのパスを h1 セクションとして挿入します。",
 
-      "list_num_desc_in_user_page": "ユーザーページに表示されるリスト数",
-      "all_list_num_desc_in_user_page": "ユーザーページにおける <Bookmarks> <Recently Created>での、1ページの表示数を設定します。",
+      "list_num_s": "モーダルに表示されるリスト数",
+      "list_num_desc_s": "モーダルにおける <Pagelist> <Timeline> <Page History> <Share Link>での、1ページあたりの表示数を設定します。",
 
-      "list_num_desc_in_notfound_and_trash_pages": "Not FoundページやTrashページに表示されるリスト数",
-      "all_list_num_desc_in_notfound_and_trash_pages": "記事エリアにおける<Not Found> <Trash>での、1ページの表示数を設定します。",
+      "list_num_m": "ユーザーページに表示されるリスト数",
+      "list_num_desc_m": "ユーザーページにおける <Bookmarks> <Recently Created>での、1ページあたりの表示数を設定します。",
 
-      "list_num_desc_in_draft_and_search_pages": "検索ページやDraftページに表示されるリスト数",
-      "all_list_num_desc_in_draft_and_search_pages": "<Search> <My Drafts> での、1ページの表示数を設定します。",
+      "list_num_l": "検索ページやDraftページに表示されるリスト数",
+      "list_num_desc_l": "<Search> <My Drafts> での、1ページあたりの表示数を設定します。",
 
-      "list_num_desc_in_page_contents_modal": "ページコンテンツモーダルに表示されるリスト数",
-      "all_list_num_desc_in_page_contents_modal": "ページコンテンツモーダルにおける <Pagelist> <Timeline> <Page History> <Share Link>での、1ページの表示数を設定します。",
+      "list_num_xl": "Not FoundページやTrashページに表示されるリスト数",
+      "list_num_desc_xl": "記事エリアにおける<Not Found> <Trash>での、1ページあたりの表示数を設定します。",
 
       "stale_notification": "古いページに通知を表示する",
       "stale_notification_desc": "最後の更新から1年を超えるページへの通知を表示します。",

--- a/resource/locales/zh_CN/admin/admin.json
+++ b/resource/locales/zh_CN/admin/admin.json
@@ -130,8 +130,19 @@
 			"tab_switch_desc2": "通过失效，您可以将页面转换作为浏览器的前向/后向命令的唯一对象。",
 			"attach_title_header": "自动创建新页面时添加h1节",
       "attach_title_header_desc": "创建新页面时，将页面路径作为h1节添加到第一行",
+
 	  	"list_num_desc_in_user_page": "Number of user page displayed",
       "all_list_num_desc_in_user_page": "Number of Bookmarks, recently created pages and drafts displayed on user page",
+
+      "list_num_desc_in_notfound_and_trash_pages": "Number of 'Not found' and 'Trash' pages displayed",
+      "all_list_num_desc_in_notfound_and_trash_pages": "Number of 'Not found' and 'Trash' pages displayed on article page",
+
+      "list_num_desc_in_page_contents_modal": "Number of page contents modal displayedページコンテンツモーダルに表示されるリスト数",
+      "all_list_num_desc_in_page_contents_modal": "Number of 'Pagelist', 'Timeline', 'Page History' and 'Share Link' pages displayed on page contents modal",
+
+      "list_num_desc_in_draft_and_search_pages": "Number of 'Search' and 'Draft' pages displayed",
+      "all_list_num_desc_in_draft_and_search_pages": "Number of 'Search' and 'Draft' pages displayed",
+
 			"stale_notification": "在过期页上显示通知",
 			"stale_notification_desc": "显示自上次更新以来超过1年的页面通知。",
 			"show_all_reply_comments": "显示所有回复评论",

--- a/resource/locales/zh_CN/admin/admin.json
+++ b/resource/locales/zh_CN/admin/admin.json
@@ -137,11 +137,11 @@
       "list_num_desc_in_notfound_and_trash_pages": "Number of 'Not found' and 'Trash' pages displayed",
       "all_list_num_desc_in_notfound_and_trash_pages": "Number of 'Not found' and 'Trash' pages displayed on article page",
 
-      "list_num_desc_in_page_contents_modal": "Number of page contents modal displayedページコンテンツモーダルに表示されるリスト数",
-      "all_list_num_desc_in_page_contents_modal": "Number of 'Pagelist', 'Timeline', 'Page History' and 'Share Link' pages displayed on page contents modal",
-
       "list_num_desc_in_draft_and_search_pages": "Number of 'Search' and 'Draft' pages displayed",
       "all_list_num_desc_in_draft_and_search_pages": "Number of 'Search' and 'Draft' pages displayed",
+
+      "list_num_desc_in_page_contents_modal": "Number of page contents modal displayed",
+      "all_list_num_desc_in_page_contents_modal": "Number of 'Pagelist', 'Timeline', 'Page History' and 'Share Link' pages displayed on page contents modal",
 
 			"stale_notification": "在过期页上显示通知",
 			"stale_notification_desc": "显示自上次更新以来超过1年的页面通知。",

--- a/resource/locales/zh_CN/admin/admin.json
+++ b/resource/locales/zh_CN/admin/admin.json
@@ -131,17 +131,17 @@
 			"attach_title_header": "自动创建新页面时添加h1节",
       "attach_title_header_desc": "创建新页面时，将页面路径作为h1节添加到第一行",
 
-	  	"list_num_desc_in_user_page": "Number of user page displayed",
-      "all_list_num_desc_in_user_page": "Number of Bookmarks, recently created pages and drafts displayed on user page",
+      "list_num_s": "Number of list displayed on modals",
+      "list_num_desc_s": "Set number of list per page such as 'Pagelist', 'Timeline', 'Page History' and 'Share Link' pages",
 
-      "list_num_desc_in_notfound_and_trash_pages": "Number of 'Not found' and 'Trash' pages displayed",
-      "all_list_num_desc_in_notfound_and_trash_pages": "Number of 'Not found' and 'Trash' pages displayed on article page",
+      "list_num_m": "Number of list displayed on article pages included other contents",
+      "list_num_desc_m": "Set number of list per page such as 'Bookmarks', 'Recently created' and 'Drafts'",
 
-      "list_num_desc_in_draft_and_search_pages": "Number of 'Search' and 'Draft' pages displayed",
-      "all_list_num_desc_in_draft_and_search_pages": "Number of 'Search' and 'Draft' pages displayed",
+      "list_num_l": "Number of list displayed on 'Search' and 'Draft' pages",
+      "list_num_desc_l": "Set number of list per page such as 'Search' and 'Draft' pages",
 
-      "list_num_desc_in_page_contents_modal": "Number of page contents modal displayed",
-      "all_list_num_desc_in_page_contents_modal": "Number of 'Pagelist', 'Timeline', 'Page History' and 'Share Link' pages displayed on page contents modal",
+      "list_num_xl": "Number of list displayed on article pages",
+      "list_num_desc_xl": "Set number of list per page such as 'Not found' and 'Trash' pages",
 
 			"stale_notification": "在过期页上显示通知",
 			"stale_notification_desc": "显示自上次更新以来超过1年的页面通知。",

--- a/src/client/js/components/Admin/Customize/CustomizeFunctionSetting.jsx
+++ b/src/client/js/components/Admin/Customize/CustomizeFunctionSetting.jsx
@@ -124,92 +124,7 @@ class CustomizeFunctionSetting extends React.Component {
               </div>
             </div>
 
-            {/* User Page */}
-            <div className="form-group row">
-              <div className="offset-md-3 col-md-6 text-left">
-                <div className="my-0 w-100">
-                  <label>{t('admin:customize_setting.function_options.list_num_desc_in_user_page')}</label>
-                </div>
-                <Dropdown isOpen={this.state.isDropdownOpen} toggle={this.onToggleDropdown}>
-                  <DropdownToggle className="text-right col-6" caret>
-                    <span className="float-left">{adminCustomizeContainer.state.pageListLimitForUserPage}</span>
-                  </DropdownToggle>
-                  <DropdownMenu className="dropdown-menu" role="menu">
-                    <DropdownItem key={10} role="presentation" onClick={() => { adminCustomizeContainer.switchPageListLimitForUserPage(10) }}>
-                      <a role="menuitem">10</a>
-                    </DropdownItem>
-                    <DropdownItem key={30} role="presentation" onClick={() => { adminCustomizeContainer.switchPageListLimitForUserPage(30) }}>
-                      <a role="menuitem">30</a>
-                    </DropdownItem>
-                    <DropdownItem key={50} role="presentation" onClick={() => { adminCustomizeContainer.switchPageListLimitForUserPage(50) }}>
-                      <a role="menuitem">50</a>
-                    </DropdownItem>
-                  </DropdownMenu>
-                </Dropdown>
-                <p className="form-text text-muted">
-                  {t('admin:customize_setting.function_options.all_list_num_desc_in_user_page')}
-                </p>
-              </div>
-            </div>
-
-            {/* TODO Implemetn dropdown toggle for pageListLimitForModal (pageList pageTimelin pageHistory, pageAttachment, shareLink) */}
-            {/* NotFound / Trash Page */}
-            <div className="form-group row">
-              <div className="offset-md-3 col-md-6 text-left">
-                <div className="my-0 w-100">
-                  <label>{t('admin:customize_setting.function_options.list_num_desc_in_notfound_and_trash_pages')}</label>
-                </div>
-                <Dropdown isOpen={this.state.isDropdownOpen2} toggle={this.onToggleDropdown2}>
-                  <DropdownToggle className="text-right col-6" caret>
-                    <span className="float-left">{adminCustomizeContainer.state.pageListLimitForUserPage}</span>
-                  </DropdownToggle>
-                  <DropdownMenu className="dropdown-menu" role="menu">
-                    <DropdownItem key={10} role="presentation" onClick={() => { adminCustomizeContainer.switchPageListLimitForUserPage(10) }}>
-                      <a role="menuitem">10</a>
-                    </DropdownItem>
-                    <DropdownItem key={30} role="presentation" onClick={() => { adminCustomizeContainer.switchPageListLimitForUserPage(30) }}>
-                      <a role="menuitem">30</a>
-                    </DropdownItem>
-                    <DropdownItem key={50} role="presentation" onClick={() => { adminCustomizeContainer.switchPageListLimitForUserPage(50) }}>
-                      <a role="menuitem">50</a>
-                    </DropdownItem>
-                  </DropdownMenu>
-                </Dropdown>
-                <p className="form-text text-muted">
-                  {t('admin:customize_setting.function_options.all_list_num_desc_in_notfound_and_trash_pages')}
-                </p>
-              </div>
-            </div>
-
-            {/* Search / Draft Page */}
-            <div className="form-group row">
-              <div className="offset-md-3 col-md-6 text-left">
-                <div className="my-0 w-100">
-                  <label>{t('admin:customize_setting.function_options.list_num_desc_in_draft_and_search_pages')}</label>
-                </div>
-                <Dropdown isOpen={this.state.isDropdownOpen3} toggle={this.onToggleDropdown3}>
-                  <DropdownToggle className="text-right col-6" caret>
-                    <span className="float-left">{adminCustomizeContainer.state.pageListLimitForUserPage}</span>
-                  </DropdownToggle>
-                  <DropdownMenu className="dropdown-menu" role="menu">
-                    <DropdownItem key={10} role="presentation" onClick={() => { adminCustomizeContainer.switchPageListLimitForUserPage(10) }}>
-                      <a role="menuitem">10</a>
-                    </DropdownItem>
-                    <DropdownItem key={30} role="presentation" onClick={() => { adminCustomizeContainer.switchPageListLimitForUserPage(30) }}>
-                      <a role="menuitem">30</a>
-                    </DropdownItem>
-                    <DropdownItem key={50} role="presentation" onClick={() => { adminCustomizeContainer.switchPageListLimitForUserPage(50) }}>
-                      <a role="menuitem">50</a>
-                    </DropdownItem>
-                  </DropdownMenu>
-                </Dropdown>
-                <p className="form-text text-muted">
-                  {t('admin:customize_setting.function_options.all_list_num_desc_in_draft_and_search_pages')}
-                </p>
-              </div>
-            </div>
-
-            {/* Modal */}
+            {/* S: Modal */}
             <div className="form-group row">
               <div className="offset-md-3 col-md-6 text-left">
                 <div className="my-0 w-100">
@@ -220,19 +135,103 @@ class CustomizeFunctionSetting extends React.Component {
                     <span className="float-left">{adminCustomizeContainer.state.pageListLimitForUserPage}</span>
                   </DropdownToggle>
                   <DropdownMenu className="dropdown-menu" role="menu">
-                    <DropdownItem key={10} role="presentation" onClick={() => { adminCustomizeContainer.switchPageListLimitForUserPage(10) }}>
+                    <DropdownItem key={10} role="presentation" onClick={() => { adminCustomizeContainer.switchGroupSPageListLimitation(10) }}>
                       <a role="menuitem">10</a>
                     </DropdownItem>
-                    <DropdownItem key={30} role="presentation" onClick={() => { adminCustomizeContainer.switchPageListLimitForUserPage(30) }}>
+                    <DropdownItem key={30} role="presentation" onClick={() => { adminCustomizeContainer.switchGroupSPageListLimitation(30) }}>
                       <a role="menuitem">30</a>
                     </DropdownItem>
-                    <DropdownItem key={50} role="presentation" onClick={() => { adminCustomizeContainer.switchPageListLimitForUserPage(50) }}>
+                    <DropdownItem key={50} role="presentation" onClick={() => { adminCustomizeContainer.switchGroupSPageListLimitation(50) }}>
                       <a role="menuitem">50</a>
                     </DropdownItem>
                   </DropdownMenu>
                 </Dropdown>
                 <p className="form-text text-muted">
                   {t('admin:customize_setting.function_options.all_list_num_desc_in_page_contents_modal')}
+                </p>
+              </div>
+            </div>
+
+            {/* M: User Page */}
+            <div className="form-group row">
+              <div className="offset-md-3 col-md-6 text-left">
+                <div className="my-0 w-100">
+                  <label>{t('admin:customize_setting.function_options.list_num_desc_in_user_page')}</label>
+                </div>
+                <Dropdown isOpen={this.state.isDropdownOpen} toggle={this.onToggleDropdown}>
+                  <DropdownToggle className="text-right col-6" caret>
+                    <span className="float-left">{adminCustomizeContainer.state.pageListLimitForUserPage}</span>
+                  </DropdownToggle>
+                  <DropdownMenu className="dropdown-menu" role="menu">
+                    <DropdownItem key={10} role="presentation" onClick={() => { adminCustomizeContainer.switchGroupMPageListLimitation(10) }}>
+                      <a role="menuitem">10</a>
+                    </DropdownItem>
+                    <DropdownItem key={30} role="presentation" onClick={() => { adminCustomizeContainer.switchGroupMPageListLimitation(30) }}>
+                      <a role="menuitem">30</a>
+                    </DropdownItem>
+                    <DropdownItem key={50} role="presentation" onClick={() => { adminCustomizeContainer.switchGroupMPageListLimitation(50) }}>
+                      <a role="menuitem">50</a>
+                    </DropdownItem>
+                  </DropdownMenu>
+                </Dropdown>
+                <p className="form-text text-muted">
+                  {t('admin:customize_setting.function_options.all_list_num_desc_in_user_page')}
+                </p>
+              </div>
+            </div>
+
+            {/* L: Search / Draft Pages */}
+            <div className="form-group row">
+              <div className="offset-md-3 col-md-6 text-left">
+                <div className="my-0 w-100">
+                  <label>{t('admin:customize_setting.function_options.list_num_desc_in_draft_and_search_pages')}</label>
+                </div>
+                <Dropdown isOpen={this.state.isDropdownOpen3} toggle={this.onToggleDropdown3}>
+                  <DropdownToggle className="text-right col-6" caret>
+                    <span className="float-left">{adminCustomizeContainer.state.pageListLimitForUserPage}</span>
+                  </DropdownToggle>
+                  <DropdownMenu className="dropdown-menu" role="menu">
+                    <DropdownItem key={10} role="presentation" onClick={() => { adminCustomizeContainer.switchGroupLPageListLimitation(10) }}>
+                      <a role="menuitem">10</a>
+                    </DropdownItem>
+                    <DropdownItem key={30} role="presentation" onClick={() => { adminCustomizeContainer.switchGroupLPageListLimitation(30) }}>
+                      <a role="menuitem">30</a>
+                    </DropdownItem>
+                    <DropdownItem key={50} role="presentation" onClick={() => { adminCustomizeContainer.switchGroupLPageListLimitation(50) }}>
+                      <a role="menuitem">50</a>
+                    </DropdownItem>
+                  </DropdownMenu>
+                </Dropdown>
+                <p className="form-text text-muted">
+                  {t('admin:customize_setting.function_options.all_list_num_desc_in_draft_and_search_pages')}
+                </p>
+              </div>
+            </div>
+
+            {/* XL: NotFound / Trash Pages */}
+            <div className="form-group row">
+              <div className="offset-md-3 col-md-6 text-left">
+                <div className="my-0 w-100">
+                  <label>{t('admin:customize_setting.function_options.list_num_desc_in_notfound_and_trash_pages')}</label>
+                </div>
+                <Dropdown isOpen={this.state.isDropdownOpen2} toggle={this.onToggleDropdown2}>
+                  <DropdownToggle className="text-right col-6" caret>
+                    <span className="float-left">{adminCustomizeContainer.state.pageListLimitForNotFoundAndTrashPage}</span>
+                  </DropdownToggle>
+                  <DropdownMenu className="dropdown-menu" role="menu">
+                    <DropdownItem key={10} role="presentation" onClick={() => { adminCustomizeContainer.switchGroupXLPageListLimitation(10) }}>
+                      <a role="menuitem">10</a>
+                    </DropdownItem>
+                    <DropdownItem key={30} role="presentation" onClick={() => { adminCustomizeContainer.switchGroupXLPageListLimitation(30) }}>
+                      <a role="menuitem">30</a>
+                    </DropdownItem>
+                    <DropdownItem key={50} role="presentation" onClick={() => { adminCustomizeContainer.switchGroupXLPageListLimitation(50) }}>
+                      <a role="menuitem">50</a>
+                    </DropdownItem>
+                  </DropdownMenu>
+                </Dropdown>
+                <p className="form-text text-muted">
+                  {t('admin:customize_setting.function_options.all_list_num_desc_in_notfound_and_trash_pages')}
                 </p>
               </div>
             </div>

--- a/src/client/js/components/Admin/Customize/CustomizeFunctionSetting.jsx
+++ b/src/client/js/components/Admin/Customize/CustomizeFunctionSetting.jsx
@@ -91,7 +91,6 @@ class CustomizeFunctionSetting extends React.Component {
                 </CustomizeFunctionOption>
               </div>
             </div>
-
             <div className="form-group row">
               <div className="offset-md-3 col-md-6 text-left">
                 <CustomizeFunctionOption
@@ -107,6 +106,7 @@ class CustomizeFunctionSetting extends React.Component {
               </div>
             </div>
 
+            {/* ユーザーページ */}
             <div className="form-group row">
               <div className="offset-md-3 col-md-6 text-left">
                 <div className="my-0 w-100">
@@ -135,6 +135,33 @@ class CustomizeFunctionSetting extends React.Component {
             </div>
 
             {/* TODO Implemetn dropdown toggle for pageListLimitForModal (pageList pageTimelin pageHistory, pageAttachment, shareLink) */}
+            {/* NotFound / Trash ページ */}
+            <div className="form-group row">
+              <div className="offset-md-3 col-md-6 text-left">
+                <div className="my-0 w-100">
+                  <label>{t('admin:customize_setting.function_options.list_num_desc_in_notfound_and_trash_pages')}</label>
+                </div>
+                <Dropdown isOpen={this.state.isDropdownOpen} toggle={this.onToggleDropdown}>
+                  <DropdownToggle className="text-right col-6" caret>
+                    <span className="float-left">{adminCustomizeContainer.state.pageListLimitForUserPage}</span>
+                  </DropdownToggle>
+                  <DropdownMenu className="dropdown-menu" role="menu">
+                    <DropdownItem key={10} role="presentation" onClick={() => { adminCustomizeContainer.switchPageListLimitForUserPage(10) }}>
+                      <a role="menuitem">10</a>
+                    </DropdownItem>
+                    <DropdownItem key={30} role="presentation" onClick={() => { adminCustomizeContainer.switchPageListLimitForUserPage(30) }}>
+                      <a role="menuitem">30</a>
+                    </DropdownItem>
+                    <DropdownItem key={50} role="presentation" onClick={() => { adminCustomizeContainer.switchPageListLimitForUserPage(50) }}>
+                      <a role="menuitem">50</a>
+                    </DropdownItem>
+                  </DropdownMenu>
+                </Dropdown>
+                <p className="form-text text-muted">
+                  {t('admin:customize_setting.function_options.all_list_num_desc_in_notfound_and_trash_pages')}
+                </p>
+              </div>
+            </div>
 
             <div className="form-group row">
               <div className="offset-md-3 col-md-6 text-left">

--- a/src/client/js/components/Admin/Customize/CustomizeFunctionSetting.jsx
+++ b/src/client/js/components/Admin/Customize/CustomizeFunctionSetting.jsx
@@ -22,14 +22,32 @@ class CustomizeFunctionSetting extends React.Component {
 
     this.state = {
       isDropdownOpen: false,
+      isDropdownOpen2: false,
+      isDropdownOpen3: false,
+      isDropdownOpen4: false,
     };
 
     this.onToggleDropdown = this.onToggleDropdown.bind(this);
+    this.onToggleDropdown2 = this.onToggleDropdown2.bind(this);
+    this.onToggleDropdown3 = this.onToggleDropdown3.bind(this);
+    this.onToggleDropdown4 = this.onToggleDropdown4.bind(this);
     this.onClickSubmit = this.onClickSubmit.bind(this);
   }
 
   onToggleDropdown() {
     this.setState({ isDropdownOpen: !this.state.isDropdownOpen });
+  }
+
+  onToggleDropdown2() {
+    this.setState({ isDropdownOpen2: !this.state.isDropdownOpen2 });
+  }
+
+  onToggleDropdown3() {
+    this.setState({ isDropdownOpen3: !this.state.isDropdownOpen3 });
+  }
+
+  onToggleDropdown4() {
+    this.setState({ isDropdownOpen4: !this.state.isDropdownOpen4 });
   }
 
   async onClickSubmit() {
@@ -141,7 +159,7 @@ class CustomizeFunctionSetting extends React.Component {
                 <div className="my-0 w-100">
                   <label>{t('admin:customize_setting.function_options.list_num_desc_in_notfound_and_trash_pages')}</label>
                 </div>
-                <Dropdown isOpen={this.state.isDropdownOpen} toggle={this.onToggleDropdown}>
+                <Dropdown isOpen={this.state.isDropdownOpen2} toggle={this.onToggleDropdown2}>
                   <DropdownToggle className="text-right col-6" caret>
                     <span className="float-left">{adminCustomizeContainer.state.pageListLimitForUserPage}</span>
                   </DropdownToggle>
@@ -169,7 +187,7 @@ class CustomizeFunctionSetting extends React.Component {
                 <div className="my-0 w-100">
                   <label>{t('admin:customize_setting.function_options.list_num_desc_in_draft_and_search_pages')}</label>
                 </div>
-                <Dropdown isOpen={this.state.isDropdownOpen} toggle={this.onToggleDropdown}>
+                <Dropdown isOpen={this.state.isDropdownOpen3} toggle={this.onToggleDropdown3}>
                   <DropdownToggle className="text-right col-6" caret>
                     <span className="float-left">{adminCustomizeContainer.state.pageListLimitForUserPage}</span>
                   </DropdownToggle>
@@ -197,7 +215,7 @@ class CustomizeFunctionSetting extends React.Component {
                 <div className="my-0 w-100">
                   <label>{t('admin:customize_setting.function_options.list_num_desc_in_page_contents_modal')}</label>
                 </div>
-                <Dropdown isOpen={this.state.isDropdownOpen} toggle={this.onToggleDropdown}>
+                <Dropdown isOpen={this.state.isDropdownOpen4} toggle={this.onToggleDropdown4}>
                   <DropdownToggle className="text-right col-6" caret>
                     <span className="float-left">{adminCustomizeContainer.state.pageListLimitForUserPage}</span>
                   </DropdownToggle>

--- a/src/client/js/components/Admin/Customize/CustomizeFunctionSetting.jsx
+++ b/src/client/js/components/Admin/Customize/CustomizeFunctionSetting.jsx
@@ -136,13 +136,13 @@ class CustomizeFunctionSetting extends React.Component {
                     <span className="float-left">{adminCustomizeContainer.state.pageLimitationS}</span>
                   </DropdownToggle>
                   <DropdownMenu className="dropdown-menu" role="menu">
-                    <DropdownItem key={10} role="presentation" onClick={() => { adminCustomizeContainer.switchGroupSPageListLimitation(10) }}>
+                    <DropdownItem key={10} role="presentation" onClick={() => { adminCustomizeContainer.switchPageListLimitationS(10) }}>
                       <a role="menuitem">10</a>
                     </DropdownItem>
-                    <DropdownItem key={30} role="presentation" onClick={() => { adminCustomizeContainer.switchGroupSPageListLimitation(30) }}>
+                    <DropdownItem key={30} role="presentation" onClick={() => { adminCustomizeContainer.switchPageListLimitationS(30) }}>
                       <a role="menuitem">30</a>
                     </DropdownItem>
-                    <DropdownItem key={50} role="presentation" onClick={() => { adminCustomizeContainer.switchGroupSPageListLimitation(50) }}>
+                    <DropdownItem key={50} role="presentation" onClick={() => { adminCustomizeContainer.switchPageListLimitationS(50) }}>
                       <a role="menuitem">50</a>
                     </DropdownItem>
                   </DropdownMenu>
@@ -161,16 +161,17 @@ class CustomizeFunctionSetting extends React.Component {
                 </div>
                 <Dropdown isOpen={this.state.isDropdownOpen} toggle={this.onToggleDropdown}>
                   <DropdownToggle className="text-right col-6" caret>
+                    {/* [TODO: rename pageListLimitForUserPage to pageLimitationM by gw3920] */}
                     <span className="float-left">{adminCustomizeContainer.state.pageListLimitForUserPage}</span>
                   </DropdownToggle>
                   <DropdownMenu className="dropdown-menu" role="menu">
-                    <DropdownItem key={10} role="presentation" onClick={() => { adminCustomizeContainer.switchGroupMPageListLimitation(10) }}>
+                    <DropdownItem key={10} role="presentation" onClick={() => { adminCustomizeContainer.switchPageListLimitationM(10) }}>
                       <a role="menuitem">10</a>
                     </DropdownItem>
-                    <DropdownItem key={30} role="presentation" onClick={() => { adminCustomizeContainer.switchGroupMPageListLimitation(30) }}>
+                    <DropdownItem key={30} role="presentation" onClick={() => { adminCustomizeContainer.switchPageListLimitationM(30) }}>
                       <a role="menuitem">30</a>
                     </DropdownItem>
-                    <DropdownItem key={50} role="presentation" onClick={() => { adminCustomizeContainer.switchGroupMPageListLimitation(50) }}>
+                    <DropdownItem key={50} role="presentation" onClick={() => { adminCustomizeContainer.switchPageListLimitationM(50) }}>
                       <a role="menuitem">50</a>
                     </DropdownItem>
                   </DropdownMenu>
@@ -192,13 +193,13 @@ class CustomizeFunctionSetting extends React.Component {
                     <span className="float-left">{adminCustomizeContainer.state.pageLimitationL}</span>
                   </DropdownToggle>
                   <DropdownMenu className="dropdown-menu" role="menu">
-                    <DropdownItem key={10} role="presentation" onClick={() => { adminCustomizeContainer.switchGroupLPageListLimitation(10) }}>
+                    <DropdownItem key={10} role="presentation" onClick={() => { adminCustomizeContainer.switchPageListLimitationL(10) }}>
                       <a role="menuitem">10</a>
                     </DropdownItem>
-                    <DropdownItem key={30} role="presentation" onClick={() => { adminCustomizeContainer.switchGroupLPageListLimitation(30) }}>
+                    <DropdownItem key={30} role="presentation" onClick={() => { adminCustomizeContainer.switchPageListLimitationL(30) }}>
                       <a role="menuitem">30</a>
                     </DropdownItem>
-                    <DropdownItem key={50} role="presentation" onClick={() => { adminCustomizeContainer.switchGroupLPageListLimitation(50) }}>
+                    <DropdownItem key={50} role="presentation" onClick={() => { adminCustomizeContainer.switchPageListLimitationL(50) }}>
                       <a role="menuitem">50</a>
                     </DropdownItem>
                   </DropdownMenu>
@@ -220,13 +221,13 @@ class CustomizeFunctionSetting extends React.Component {
                     <span className="float-left">{adminCustomizeContainer.state.pageLimitationXL}</span>
                   </DropdownToggle>
                   <DropdownMenu className="dropdown-menu" role="menu">
-                    <DropdownItem key={10} role="presentation" onClick={() => { adminCustomizeContainer.switchGroupXLPageListLimitation(10) }}>
+                    <DropdownItem key={10} role="presentation" onClick={() => { adminCustomizeContainer.switchPageListLimitationXL(10) }}>
                       <a role="menuitem">10</a>
                     </DropdownItem>
-                    <DropdownItem key={30} role="presentation" onClick={() => { adminCustomizeContainer.switchGroupXLPageListLimitation(30) }}>
+                    <DropdownItem key={30} role="presentation" onClick={() => { adminCustomizeContainer.switchPageListLimitationXL(30) }}>
                       <a role="menuitem">30</a>
                     </DropdownItem>
-                    <DropdownItem key={50} role="presentation" onClick={() => { adminCustomizeContainer.switchGroupXLPageListLimitation(50) }}>
+                    <DropdownItem key={50} role="presentation" onClick={() => { adminCustomizeContainer.switchPageListLimitationXL(50) }}>
                       <a role="menuitem">50</a>
                     </DropdownItem>
                   </DropdownMenu>

--- a/src/client/js/components/Admin/Customize/CustomizeFunctionSetting.jsx
+++ b/src/client/js/components/Admin/Customize/CustomizeFunctionSetting.jsx
@@ -106,7 +106,7 @@ class CustomizeFunctionSetting extends React.Component {
               </div>
             </div>
 
-            {/* ユーザーページ */}
+            {/* User Page */}
             <div className="form-group row">
               <div className="offset-md-3 col-md-6 text-left">
                 <div className="my-0 w-100">
@@ -135,7 +135,7 @@ class CustomizeFunctionSetting extends React.Component {
             </div>
 
             {/* TODO Implemetn dropdown toggle for pageListLimitForModal (pageList pageTimelin pageHistory, pageAttachment, shareLink) */}
-            {/* NotFound / Trash ページ */}
+            {/* NotFound / Trash Page */}
             <div className="form-group row">
               <div className="offset-md-3 col-md-6 text-left">
                 <div className="my-0 w-100">
@@ -163,7 +163,7 @@ class CustomizeFunctionSetting extends React.Component {
               </div>
             </div>
 
-            {/* 検索ページ / Draftページ */}
+            {/* Search / Draft Page */}
             <div className="form-group row">
               <div className="offset-md-3 col-md-6 text-left">
                 <div className="my-0 w-100">
@@ -191,7 +191,7 @@ class CustomizeFunctionSetting extends React.Component {
               </div>
             </div>
 
-            {/* モーダル */}
+            {/* Modal */}
             <div className="form-group row">
               <div className="offset-md-3 col-md-6 text-left">
                 <div className="my-0 w-100">

--- a/src/client/js/components/Admin/Customize/CustomizeFunctionSetting.jsx
+++ b/src/client/js/components/Admin/Customize/CustomizeFunctionSetting.jsx
@@ -163,6 +163,62 @@ class CustomizeFunctionSetting extends React.Component {
               </div>
             </div>
 
+            {/* 検索ページ / Draftページ */}
+            <div className="form-group row">
+              <div className="offset-md-3 col-md-6 text-left">
+                <div className="my-0 w-100">
+                  <label>{t('admin:customize_setting.function_options.list_num_desc_in_draft_and_search_pages')}</label>
+                </div>
+                <Dropdown isOpen={this.state.isDropdownOpen} toggle={this.onToggleDropdown}>
+                  <DropdownToggle className="text-right col-6" caret>
+                    <span className="float-left">{adminCustomizeContainer.state.pageListLimitForUserPage}</span>
+                  </DropdownToggle>
+                  <DropdownMenu className="dropdown-menu" role="menu">
+                    <DropdownItem key={10} role="presentation" onClick={() => { adminCustomizeContainer.switchPageListLimitForUserPage(10) }}>
+                      <a role="menuitem">10</a>
+                    </DropdownItem>
+                    <DropdownItem key={30} role="presentation" onClick={() => { adminCustomizeContainer.switchPageListLimitForUserPage(30) }}>
+                      <a role="menuitem">30</a>
+                    </DropdownItem>
+                    <DropdownItem key={50} role="presentation" onClick={() => { adminCustomizeContainer.switchPageListLimitForUserPage(50) }}>
+                      <a role="menuitem">50</a>
+                    </DropdownItem>
+                  </DropdownMenu>
+                </Dropdown>
+                <p className="form-text text-muted">
+                  {t('admin:customize_setting.function_options.all_list_num_desc_in_draft_and_search_pages')}
+                </p>
+              </div>
+            </div>
+
+            {/* モーダル */}
+            <div className="form-group row">
+              <div className="offset-md-3 col-md-6 text-left">
+                <div className="my-0 w-100">
+                  <label>{t('admin:customize_setting.function_options.list_num_desc_in_page_contents_modal')}</label>
+                </div>
+                <Dropdown isOpen={this.state.isDropdownOpen} toggle={this.onToggleDropdown}>
+                  <DropdownToggle className="text-right col-6" caret>
+                    <span className="float-left">{adminCustomizeContainer.state.pageListLimitForUserPage}</span>
+                  </DropdownToggle>
+                  <DropdownMenu className="dropdown-menu" role="menu">
+                    <DropdownItem key={10} role="presentation" onClick={() => { adminCustomizeContainer.switchPageListLimitForUserPage(10) }}>
+                      <a role="menuitem">10</a>
+                    </DropdownItem>
+                    <DropdownItem key={30} role="presentation" onClick={() => { adminCustomizeContainer.switchPageListLimitForUserPage(30) }}>
+                      <a role="menuitem">30</a>
+                    </DropdownItem>
+                    <DropdownItem key={50} role="presentation" onClick={() => { adminCustomizeContainer.switchPageListLimitForUserPage(50) }}>
+                      <a role="menuitem">50</a>
+                    </DropdownItem>
+                  </DropdownMenu>
+                </Dropdown>
+                <p className="form-text text-muted">
+                  {t('admin:customize_setting.function_options.all_list_num_desc_in_page_contents_modal')}
+                </p>
+              </div>
+            </div>
+
             <div className="form-group row">
               <div className="offset-md-3 col-md-6 text-left">
                 <CustomizeFunctionOption

--- a/src/client/js/components/Admin/Customize/CustomizeFunctionSetting.jsx
+++ b/src/client/js/components/Admin/Customize/CustomizeFunctionSetting.jsx
@@ -21,34 +21,35 @@ class CustomizeFunctionSetting extends React.Component {
     super(props);
 
     this.state = {
-      isDropdownOpen: false,
-      isDropdownOpen2: false,
-      isDropdownOpen3: false,
-      isDropdownOpen4: false,
+      isDropdownOpenS: false, // S
+      isDropdownOpen: false, // M
+      isDropdownOpenL: false, // L
+      isDropdownOpenXL: false, // XL
     };
 
-    this.onToggleDropdown = this.onToggleDropdown.bind(this);
-    this.onToggleDropdown2 = this.onToggleDropdown2.bind(this);
-    this.onToggleDropdown3 = this.onToggleDropdown3.bind(this);
-    this.onToggleDropdown4 = this.onToggleDropdown4.bind(this);
+    this.onToggleDropdownS = this.onToggleDropdownS.bind(this); // S
+    this.onToggleDropdown = this.onToggleDropdown.bind(this); // M
+    this.onToggleDropdownL = this.onToggleDropdownL.bind(this); // L
+    this.onToggleDropdownXL = this.onToggleDropdownXL.bind(this); // XL
     this.onClickSubmit = this.onClickSubmit.bind(this);
+  }
+
+  onToggleDropdownS() {
+    this.setState({ isDropdownOpenS: !this.state.isDropdownOpenS });
   }
 
   onToggleDropdown() {
     this.setState({ isDropdownOpen: !this.state.isDropdownOpen });
   }
 
-  onToggleDropdown2() {
-    this.setState({ isDropdownOpen2: !this.state.isDropdownOpen2 });
+  onToggleDropdownL() {
+    this.setState({ isDropdownOpenL: !this.state.isDropdownOpenL });
   }
 
-  onToggleDropdown3() {
-    this.setState({ isDropdownOpen3: !this.state.isDropdownOpen3 });
+  onToggleDropdownXL() {
+    this.setState({ isDropdownOpenXL: !this.state.isDropdownOpenXL });
   }
 
-  onToggleDropdown4() {
-    this.setState({ isDropdownOpen4: !this.state.isDropdownOpen4 });
-  }
 
   async onClickSubmit() {
     const { t, adminCustomizeContainer } = this.props;
@@ -130,7 +131,7 @@ class CustomizeFunctionSetting extends React.Component {
                 <div className="my-0 w-100">
                   <label>{t('admin:customize_setting.function_options.list_num_desc_in_page_contents_modal')}</label>
                 </div>
-                <Dropdown isOpen={this.state.isDropdownOpen4} toggle={this.onToggleDropdown4}>
+                <Dropdown isOpen={this.state.isDropdownOpenS} toggle={this.onToggleDropdownS}>
                   <DropdownToggle className="text-right col-6" caret>
                     <span className="float-left">{adminCustomizeContainer.state.pageListLimitForUserPage}</span>
                   </DropdownToggle>
@@ -186,7 +187,7 @@ class CustomizeFunctionSetting extends React.Component {
                 <div className="my-0 w-100">
                   <label>{t('admin:customize_setting.function_options.list_num_desc_in_draft_and_search_pages')}</label>
                 </div>
-                <Dropdown isOpen={this.state.isDropdownOpen3} toggle={this.onToggleDropdown3}>
+                <Dropdown isOpen={this.state.isDropdownOpenL} toggle={this.onToggleDropdownL}>
                   <DropdownToggle className="text-right col-6" caret>
                     <span className="float-left">{adminCustomizeContainer.state.pageListLimitForUserPage}</span>
                   </DropdownToggle>
@@ -214,7 +215,7 @@ class CustomizeFunctionSetting extends React.Component {
                 <div className="my-0 w-100">
                   <label>{t('admin:customize_setting.function_options.list_num_desc_in_notfound_and_trash_pages')}</label>
                 </div>
-                <Dropdown isOpen={this.state.isDropdownOpen2} toggle={this.onToggleDropdown2}>
+                <Dropdown isOpen={this.state.isDropdownOpenXL} toggle={this.onToggleDropdownXL}>
                   <DropdownToggle className="text-right col-6" caret>
                     <span className="float-left">{adminCustomizeContainer.state.pageListLimitForNotFoundAndTrashPage}</span>
                   </DropdownToggle>

--- a/src/client/js/components/Admin/Customize/CustomizeFunctionSetting.jsx
+++ b/src/client/js/components/Admin/Customize/CustomizeFunctionSetting.jsx
@@ -133,7 +133,7 @@ class CustomizeFunctionSetting extends React.Component {
                 </div>
                 <Dropdown isOpen={this.state.isDropdownOpenS} toggle={this.onToggleDropdownS}>
                   <DropdownToggle className="text-right col-6" caret>
-                    <span className="float-left">{adminCustomizeContainer.state.pageListLimitForUserPage}</span>
+                    <span className="float-left">{adminCustomizeContainer.state.pageLimitationS}</span>
                   </DropdownToggle>
                   <DropdownMenu className="dropdown-menu" role="menu">
                     <DropdownItem key={10} role="presentation" onClick={() => { adminCustomizeContainer.switchGroupSPageListLimitation(10) }}>
@@ -189,7 +189,7 @@ class CustomizeFunctionSetting extends React.Component {
                 </div>
                 <Dropdown isOpen={this.state.isDropdownOpenL} toggle={this.onToggleDropdownL}>
                   <DropdownToggle className="text-right col-6" caret>
-                    <span className="float-left">{adminCustomizeContainer.state.pageListLimitForUserPage}</span>
+                    <span className="float-left">{adminCustomizeContainer.state.pageLimitationL}</span>
                   </DropdownToggle>
                   <DropdownMenu className="dropdown-menu" role="menu">
                     <DropdownItem key={10} role="presentation" onClick={() => { adminCustomizeContainer.switchGroupLPageListLimitation(10) }}>
@@ -217,7 +217,7 @@ class CustomizeFunctionSetting extends React.Component {
                 </div>
                 <Dropdown isOpen={this.state.isDropdownOpenXL} toggle={this.onToggleDropdownXL}>
                   <DropdownToggle className="text-right col-6" caret>
-                    <span className="float-left">{adminCustomizeContainer.state.pageListLimitForNotFoundAndTrashPage}</span>
+                    <span className="float-left">{adminCustomizeContainer.state.pageLimitationXL}</span>
                   </DropdownToggle>
                   <DropdownMenu className="dropdown-menu" role="menu">
                     <DropdownItem key={10} role="presentation" onClick={() => { adminCustomizeContainer.switchGroupXLPageListLimitation(10) }}>

--- a/src/client/js/components/Admin/Customize/CustomizeFunctionSetting.jsx
+++ b/src/client/js/components/Admin/Customize/CustomizeFunctionSetting.jsx
@@ -22,6 +22,7 @@ class CustomizeFunctionSetting extends React.Component {
 
     this.state = {
       isDropdownOpenS: false, // S
+      // [TODO: rename isDropdownOpen to isDropdownOpenM by gw3920]
       isDropdownOpen: false, // M
       isDropdownOpenL: false, // L
       isDropdownOpenXL: false, // XL
@@ -38,6 +39,7 @@ class CustomizeFunctionSetting extends React.Component {
     this.setState({ isDropdownOpenS: !this.state.isDropdownOpenS });
   }
 
+  // [TODO: rename onToggleDropdown to onToggleDropdownM by gw3920]
   onToggleDropdown() {
     this.setState({ isDropdownOpen: !this.state.isDropdownOpen });
   }

--- a/src/client/js/components/Admin/Customize/CustomizeFunctionSetting.jsx
+++ b/src/client/js/components/Admin/Customize/CustomizeFunctionSetting.jsx
@@ -131,7 +131,7 @@ class CustomizeFunctionSetting extends React.Component {
             <div className="form-group row">
               <div className="offset-md-3 col-md-6 text-left">
                 <div className="my-0 w-100">
-                  <label>{t('admin:customize_setting.function_options.list_num_desc_in_page_contents_modal')}</label>
+                  <label>{t('admin:customize_setting.function_options.list_num_s')}</label>
                 </div>
                 <Dropdown isOpen={this.state.isDropdownOpenS} toggle={this.onToggleDropdownS}>
                   <DropdownToggle className="text-right col-6" caret>
@@ -150,7 +150,7 @@ class CustomizeFunctionSetting extends React.Component {
                   </DropdownMenu>
                 </Dropdown>
                 <p className="form-text text-muted">
-                  {t('admin:customize_setting.function_options.all_list_num_desc_in_page_contents_modal')}
+                  {t('admin:customize_setting.function_options.list_num_desc_s')}
                 </p>
               </div>
             </div>
@@ -159,7 +159,7 @@ class CustomizeFunctionSetting extends React.Component {
             <div className="form-group row">
               <div className="offset-md-3 col-md-6 text-left">
                 <div className="my-0 w-100">
-                  <label>{t('admin:customize_setting.function_options.list_num_desc_in_user_page')}</label>
+                  <label>{t('admin:customize_setting.function_options.list_num_m')}</label>
                 </div>
                 <Dropdown isOpen={this.state.isDropdownOpen} toggle={this.onToggleDropdown}>
                   <DropdownToggle className="text-right col-6" caret>
@@ -179,7 +179,7 @@ class CustomizeFunctionSetting extends React.Component {
                   </DropdownMenu>
                 </Dropdown>
                 <p className="form-text text-muted">
-                  {t('admin:customize_setting.function_options.all_list_num_desc_in_user_page')}
+                  {t('admin:customize_setting.function_options.list_num_desc_m')}
                 </p>
               </div>
             </div>
@@ -188,7 +188,7 @@ class CustomizeFunctionSetting extends React.Component {
             <div className="form-group row">
               <div className="offset-md-3 col-md-6 text-left">
                 <div className="my-0 w-100">
-                  <label>{t('admin:customize_setting.function_options.list_num_desc_in_draft_and_search_pages')}</label>
+                  <label>{t('admin:customize_setting.function_options.list_num_l')}</label>
                 </div>
                 <Dropdown isOpen={this.state.isDropdownOpenL} toggle={this.onToggleDropdownL}>
                   <DropdownToggle className="text-right col-6" caret>
@@ -207,7 +207,7 @@ class CustomizeFunctionSetting extends React.Component {
                   </DropdownMenu>
                 </Dropdown>
                 <p className="form-text text-muted">
-                  {t('admin:customize_setting.function_options.all_list_num_desc_in_draft_and_search_pages')}
+                  {t('admin:customize_setting.function_options.list_num_desc_l')}
                 </p>
               </div>
             </div>
@@ -216,7 +216,7 @@ class CustomizeFunctionSetting extends React.Component {
             <div className="form-group row">
               <div className="offset-md-3 col-md-6 text-left">
                 <div className="my-0 w-100">
-                  <label>{t('admin:customize_setting.function_options.list_num_desc_in_notfound_and_trash_pages')}</label>
+                  <label>{t('admin:customize_setting.function_options.list_num_xl')}</label>
                 </div>
                 <Dropdown isOpen={this.state.isDropdownOpenXL} toggle={this.onToggleDropdownXL}>
                   <DropdownToggle className="text-right col-6" caret>
@@ -235,7 +235,7 @@ class CustomizeFunctionSetting extends React.Component {
                   </DropdownMenu>
                 </Dropdown>
                 <p className="form-text text-muted">
-                  {t('admin:customize_setting.function_options.all_list_num_desc_in_notfound_and_trash_pages')}
+                  {t('admin:customize_setting.function_options.list_num_desc_xl')}
                 </p>
               </div>
             </div>

--- a/src/client/js/services/AdminCustomizeContainer.js
+++ b/src/client/js/services/AdminCustomizeContainer.js
@@ -140,16 +140,34 @@ export default class AdminCustomizeContainer extends Container {
     this.setState({ isEnabledAttachTitleHeader:  !this.state.isEnabledAttachTitleHeader });
   }
 
+
   /**
-   * Switch pageListdLimitForUserPage
+   * S: Switch pageListdLimitForPageContentsModal
    */
-  switchPageListLimitForUserPage(value) {
+  switchGroupSPageListLimitation(value) {
     this.setState({ pageListLimitForUserPage: value });
   }
 
   /**
-   * Switch pageListdLimitForModal
+   * M: Switch pageListdLimitForUserPage
    */
+  switchGroupMPageListLimitation(value) {
+    this.setState({ pageListLimitForUserPage: value });
+  }
+
+  /**
+   * L: Switch pageListdLimitForSearchAndDraftPages
+   */
+  switchGroupLPageListLimitation(value) {
+    this.setState({ pageListLimitForUserPage: value });
+  }
+
+  /**
+   * XL: Switch pageListdLimitForNotFoundAndTrashPages
+   */
+  switchGroupXLPageListLimitation(value) {
+    this.setState({ pageListLimitForNotFoundAndTrashPage: value });
+  }
 
   /**
    * Switch enabledStaleNotification

--- a/src/client/js/services/AdminCustomizeContainer.js
+++ b/src/client/js/services/AdminCustomizeContainer.js
@@ -80,13 +80,7 @@ export default class AdminCustomizeContainer extends Container {
         isSavedStatesOfTabChanges: customizeParams.isSavedStatesOfTabChanges,
         isEnabledAttachTitleHeader: customizeParams.isEnabledAttachTitleHeader,
         pageListLimitForUserPage: customizeParams.pageListLimitForUserPage,
-
         // TODO implement for pageListLimitForModal
-        pageLimitationS: customizeParams.pageLimitationS,
-        // pageLimitationM: customizeParams.pageLimitationM,
-        pageLimitationL: customizeParams.pageLimitationL,
-        pageLimitationXL: customizeParams.pageLimitationXL,
-
         isEnabledStaleNotification: customizeParams.isEnabledStaleNotification,
         isAllReplyShown: customizeParams.isAllReplyShown,
         currentHighlightJsStyleId: customizeParams.styleName,
@@ -316,8 +310,6 @@ export default class AdminCustomizeContainer extends Container {
         isEnabledAttachTitleHeader: customizedParams.isEnabledAttachTitleHeader,
         pageListLimitForUserPage: customizedParams.pageListLimitForUserPage,
         // TODO implement for pageListLimitForModal
-        switchPageListLimitForNotFoundAndTrashPages: customizedParams.switchPageListLimitForNotFoundAndTrashPages,
-
         isEnabledStaleNotification: customizedParams.isEnabledStaleNotification,
         isAllReplyShown: customizedParams.isAllReplyShown,
       });

--- a/src/client/js/services/AdminCustomizeContainer.js
+++ b/src/client/js/services/AdminCustomizeContainer.js
@@ -27,6 +27,11 @@ export default class AdminCustomizeContainer extends Container {
       isEnabledAttachTitleHeader: false,
       pageListLimitForUserPage: 10,
       // TODO implement for pageListLimitForModal
+      pageLimitationS: 10,
+      pageLimitationM: 10,
+      pageLimitationL: 10,
+      pageLimitationXL: 10,
+
       isEnabledStaleNotification: false,
       isAllReplyShown: false,
       currentHighlightJsStyleId: '',
@@ -75,7 +80,13 @@ export default class AdminCustomizeContainer extends Container {
         isSavedStatesOfTabChanges: customizeParams.isSavedStatesOfTabChanges,
         isEnabledAttachTitleHeader: customizeParams.isEnabledAttachTitleHeader,
         pageListLimitForUserPage: customizeParams.pageListLimitForUserPage,
+
         // TODO implement for pageListLimitForModal
+        pageLimitationS: customizeParams.pageLimitationS,
+        // pageLimitationM: customizeParams.pageLimitationM,
+        pageLimitationL: customizeParams.pageLimitationL,
+        pageLimitationXL: customizeParams.pageLimitationXL,
+
         isEnabledStaleNotification: customizeParams.isEnabledStaleNotification,
         isAllReplyShown: customizeParams.isAllReplyShown,
         currentHighlightJsStyleId: customizeParams.styleName,
@@ -145,13 +156,14 @@ export default class AdminCustomizeContainer extends Container {
    * S: Switch pageListdLimitForPageContentsModal
    */
   switchGroupSPageListLimitation(value) {
-    this.setState({ pageListLimitForUserPage: value });
+    this.setState({ pageLimitationS: value });
   }
 
   /**
    * M: Switch pageListdLimitForUserPage
    */
   switchGroupMPageListLimitation(value) {
+    // this.setState({ pageListLimitForUserPage: value });
     this.setState({ pageListLimitForUserPage: value });
   }
 
@@ -159,14 +171,14 @@ export default class AdminCustomizeContainer extends Container {
    * L: Switch pageListdLimitForSearchAndDraftPages
    */
   switchGroupLPageListLimitation(value) {
-    this.setState({ pageListLimitForUserPage: value });
+    this.setState({ pageLimitationL: value });
   }
 
   /**
    * XL: Switch pageListdLimitForNotFoundAndTrashPages
    */
   switchGroupXLPageListLimitation(value) {
-    this.setState({ pageListLimitForNotFoundAndTrashPage: value });
+    this.setState({ pageLimitationXL: value });
   }
 
   /**
@@ -293,6 +305,8 @@ export default class AdminCustomizeContainer extends Container {
         isEnabledAttachTitleHeader: this.state.isEnabledAttachTitleHeader,
         pageListLimitForUserPage: this.state.pageListLimitForUserPage,
         // TODO implement for pageListLimitForModal
+        switchPageListLimitForNotFoundAndTrashPages: this.state.switchPageListLimitForNotFoundAndTrashPages,
+
         isEnabledStaleNotification: this.state.isEnabledStaleNotification,
         isAllReplyShown: this.state.isAllReplyShown,
       });
@@ -303,6 +317,8 @@ export default class AdminCustomizeContainer extends Container {
         isEnabledAttachTitleHeader: customizedParams.isEnabledAttachTitleHeader,
         pageListLimitForUserPage: customizedParams.pageListLimitForUserPage,
         // TODO implement for pageListLimitForModal
+        switchPageListLimitForNotFoundAndTrashPages: customizedParams.switchPageListLimitForNotFoundAndTrashPages,
+
         isEnabledStaleNotification: customizedParams.isEnabledStaleNotification,
         isAllReplyShown: customizedParams.isAllReplyShown,
       });

--- a/src/client/js/services/AdminCustomizeContainer.js
+++ b/src/client/js/services/AdminCustomizeContainer.js
@@ -153,31 +153,31 @@ export default class AdminCustomizeContainer extends Container {
 
 
   /**
-   * S: Switch pageListdLimitForPageContentsModal
+   * S: Switch pageListLimitationS
    */
-  switchGroupSPageListLimitation(value) {
+  switchPageListLimitationS(value) {
     this.setState({ pageLimitationS: value });
   }
 
   /**
-   * M: Switch pageListdLimitForUserPage
+   * M: Switch pageListLimitationM
    */
-  switchGroupMPageListLimitation(value) {
-    // this.setState({ pageListLimitForUserPage: value });
+  // [TODO: rename pageListLimitForUserPage to pageLimitationM by gw3920]
+  switchPageListLimitationM(value) {
     this.setState({ pageListLimitForUserPage: value });
   }
 
   /**
-   * L: Switch pageListdLimitForSearchAndDraftPages
+   * L: Switch pageListLimitationL
    */
-  switchGroupLPageListLimitation(value) {
+  switchPageListLimitationL(value) {
     this.setState({ pageLimitationL: value });
   }
 
   /**
-   * XL: Switch pageListdLimitForNotFoundAndTrashPages
+   * XL: Switch pageListLimitationXL
    */
-  switchGroupXLPageListLimitation(value) {
+  switchPageListLimitationXL(value) {
     this.setState({ pageLimitationXL: value });
   }
 
@@ -303,10 +303,9 @@ export default class AdminCustomizeContainer extends Container {
         isEnabledTimeline: this.state.isEnabledTimeline,
         isSavedStatesOfTabChanges: this.state.isSavedStatesOfTabChanges,
         isEnabledAttachTitleHeader: this.state.isEnabledAttachTitleHeader,
+
         pageListLimitForUserPage: this.state.pageListLimitForUserPage,
         // TODO implement for pageListLimitForModal
-        switchPageListLimitForNotFoundAndTrashPages: this.state.switchPageListLimitForNotFoundAndTrashPages,
-
         isEnabledStaleNotification: this.state.isEnabledStaleNotification,
         isAllReplyShown: this.state.isAllReplyShown,
       });

--- a/src/client/js/services/AdminCustomizeContainer.js
+++ b/src/client/js/services/AdminCustomizeContainer.js
@@ -25,10 +25,10 @@ export default class AdminCustomizeContainer extends Container {
       isEnabledTimeline: false,
       isSavedStatesOfTabChanges: false,
       isEnabledAttachTitleHeader: false,
-      pageListLimitForUserPage: 10,
-      // TODO implement for pageListLimitForModal
+
       pageLimitationS: 10,
-      pageLimitationM: 10,
+      // [TODO: rename pageListLimitForUserPage to pageLimitationM by gw3920]
+      pageListLimitForUserPage: 10,
       pageLimitationL: 10,
       pageLimitationXL: 10,
 

--- a/src/client/js/services/AdminCustomizeContainer.js
+++ b/src/client/js/services/AdminCustomizeContainer.js
@@ -297,7 +297,6 @@ export default class AdminCustomizeContainer extends Container {
         isEnabledTimeline: this.state.isEnabledTimeline,
         isSavedStatesOfTabChanges: this.state.isSavedStatesOfTabChanges,
         isEnabledAttachTitleHeader: this.state.isEnabledAttachTitleHeader,
-
         pageListLimitForUserPage: this.state.pageListLimitForUserPage,
         // TODO implement for pageListLimitForModal
         isEnabledStaleNotification: this.state.isEnabledStaleNotification,


### PR DESCRIPTION
GW-3887 フォームの修正
ドロップダウンボタンを3つ追加しました。
また、元々実装済みのドロップダウンを含めた4つを順序をページの小さい順に並べ替えました
このタスクでは、フロント側(見た目の部分)のみの実装となっています。

[ページリストの洗い出し](https://dev.growi.org/5f64878ad2483d00480ed118)