### PR TITLE
Imprv/gw3920 rename dropdown button of user page appropriately

### DIFF
--- a/src/client/js/components/Admin/Customize/CustomizeFunctionSetting.jsx
+++ b/src/client/js/components/Admin/Customize/CustomizeFunctionSetting.jsx
@@ -144,8 +144,7 @@ class CustomizeFunctionSetting extends React.Component {
                 </div>
                 <Dropdown isOpen={this.state.isDropdownOpenM} toggle={this.onToggleDropdownM}>
                   <DropdownToggle className="text-right col-6" caret>
-                    {/* [TODO: rename pageListLimitForUserPage to pageLimitationM by gw3920] */}
-                    <span className="float-left">{adminCustomizeContainer.state.pageListLimitForUserPage}</span>
+                    <span className="float-left">{adminCustomizeContainer.state.pageLimitationM}</span>
                   </DropdownToggle>
                   <DropdownMenu className="dropdown-menu" role="menu">
                     <DropdownItem key={10} role="presentation" onClick={() => { adminCustomizeContainer.switchPageListLimitationM(10) }}>

--- a/src/client/js/components/Admin/Customize/CustomizeFunctionSetting.jsx
+++ b/src/client/js/components/Admin/Customize/CustomizeFunctionSetting.jsx
@@ -22,8 +22,7 @@ class CustomizeFunctionSetting extends React.Component {
 
     this.state = {
       isDropdownOpenS: false, // S
-      // [TODO: rename isDropdownOpen to isDropdownOpenM by gw3920]
-      isDropdownOpen: false, // M
+      isDropdownOpenM: false, // M
       isDropdownOpenL: false, // L
       isDropdownOpenXL: false, // XL
     };
@@ -41,7 +40,7 @@ class CustomizeFunctionSetting extends React.Component {
 
   // [TODO: rename onToggleDropdown to onToggleDropdownM by gw3920]
   onToggleDropdown() {
-    this.setState({ isDropdownOpen: !this.state.isDropdownOpen });
+    this.setState({ isDropdownOpenM: !this.state.isDropdownOpenM });
   }
 
   onToggleDropdownL() {
@@ -144,7 +143,7 @@ class CustomizeFunctionSetting extends React.Component {
                 <div className="my-0 w-100">
                   <label>{t('admin:customize_setting.function_options.list_num_m')}</label>
                 </div>
-                <Dropdown isOpen={this.state.isDropdownOpen} toggle={this.onToggleDropdown}>
+                <Dropdown isOpen={this.state.isDropdownOpenM} toggle={this.onToggleDropdown}>
                   <DropdownToggle className="text-right col-6" caret>
                     {/* [TODO: rename pageListLimitForUserPage to pageLimitationM by gw3920] */}
                     <span className="float-left">{adminCustomizeContainer.state.pageListLimitForUserPage}</span>

--- a/src/client/js/components/Admin/Customize/CustomizeFunctionSetting.jsx
+++ b/src/client/js/components/Admin/Customize/CustomizeFunctionSetting.jsx
@@ -28,7 +28,7 @@ class CustomizeFunctionSetting extends React.Component {
     };
 
     this.onToggleDropdownS = this.onToggleDropdownS.bind(this); // S
-    this.onToggleDropdown = this.onToggleDropdown.bind(this); // M
+    this.onToggleDropdownM = this.onToggleDropdownM.bind(this); // M
     this.onToggleDropdownL = this.onToggleDropdownL.bind(this); // L
     this.onToggleDropdownXL = this.onToggleDropdownXL.bind(this); // XL
     this.onClickSubmit = this.onClickSubmit.bind(this);
@@ -38,8 +38,7 @@ class CustomizeFunctionSetting extends React.Component {
     this.setState({ isDropdownOpenS: !this.state.isDropdownOpenS });
   }
 
-  // [TODO: rename onToggleDropdown to onToggleDropdownM by gw3920]
-  onToggleDropdown() {
+  onToggleDropdownM() {
     this.setState({ isDropdownOpenM: !this.state.isDropdownOpenM });
   }
 
@@ -143,7 +142,7 @@ class CustomizeFunctionSetting extends React.Component {
                 <div className="my-0 w-100">
                   <label>{t('admin:customize_setting.function_options.list_num_m')}</label>
                 </div>
-                <Dropdown isOpen={this.state.isDropdownOpenM} toggle={this.onToggleDropdown}>
+                <Dropdown isOpen={this.state.isDropdownOpenM} toggle={this.onToggleDropdownM}>
                   <DropdownToggle className="text-right col-6" caret>
                     {/* [TODO: rename pageListLimitForUserPage to pageLimitationM by gw3920] */}
                     <span className="float-left">{adminCustomizeContainer.state.pageListLimitForUserPage}</span>

--- a/src/client/js/components/MyBookmarkList/MyBookmarkList.jsx
+++ b/src/client/js/components/MyBookmarkList/MyBookmarkList.jsx
@@ -43,7 +43,7 @@ class MyBookmarkList extends React.Component {
     const userId = appContainer.currentUserId;
     /* TODO #2 change variable name in database keys */
     /* TODO #3 write migration */
-    const limit = appContainer.getConfig().pageListLimitForUserPage;
+    const limit = appContainer.getConfig().pageLimitationM;
     const page = selectPageNumber;
     const params = { page, limit };
 

--- a/src/client/js/components/MyDraftList/MyDraftList.jsx
+++ b/src/client/js/components/MyDraftList/MyDraftList.jsx
@@ -68,8 +68,8 @@ class MyDraftList extends React.Component {
 
   getCurrentDrafts(selectPageNumber) {
     const { appContainer } = this.props;
-
-    const limit = appContainer.getConfig().pageListLimitForUserPage;
+    // [TODO: rename pageLimitationM to pageLimitationL]
+    const limit = appContainer.getConfig().pageLimitationM;
 
     const totalDrafts = this.state.drafts.length;
     const activePage = selectPageNumber;

--- a/src/client/js/components/RecentCreated/RecentCreated.jsx
+++ b/src/client/js/components/RecentCreated/RecentCreated.jsx
@@ -36,7 +36,7 @@ class RecentCreated extends React.Component {
     const { appContainer, userId } = this.props;
 
     // const userId = appContainer.currentUserId;
-    const limit = appContainer.getConfig().pageListLimitForUserPage;
+    const limit = appContainer.getConfig().pageLimitationM;
     const offset = (selectPageNumber - 1) * limit;
 
     // pagesList get and pagination calculate

--- a/src/client/js/services/AdminCustomizeContainer.js
+++ b/src/client/js/services/AdminCustomizeContainer.js
@@ -29,8 +29,7 @@ export default class AdminCustomizeContainer extends Container {
       isEnabledAttachTitleHeader: false,
 
       pageLimitationS: 10,
-      // [TODO: rename pageListLimitForUserPage to pageLimitationM by gw3920]
-      pageListLimitForUserPage: 10,
+      pageLimitationM: 10,
       pageLimitationL: 10,
       pageLimitationXL: 10,
 
@@ -80,7 +79,7 @@ export default class AdminCustomizeContainer extends Container {
         isEnabledTimeline: customizeParams.isEnabledTimeline,
         isSavedStatesOfTabChanges: customizeParams.isSavedStatesOfTabChanges,
         isEnabledAttachTitleHeader: customizeParams.isEnabledAttachTitleHeader,
-        pageListLimitForUserPage: customizeParams.pageListLimitForUserPage,
+        pageLimitationM: customizeParams.pageLimitationM,
         // TODO implement for pageListLimitForModal
         isEnabledStaleNotification: customizeParams.isEnabledStaleNotification,
         isAllReplyShown: customizeParams.isAllReplyShown,
@@ -146,9 +145,8 @@ export default class AdminCustomizeContainer extends Container {
   /**
    * M: Switch pageListLimitationM
    */
-  // [TODO: rename pageListLimitForUserPage to pageLimitationM by gw3920]
   switchPageListLimitationM(value) {
-    this.setState({ pageListLimitForUserPage: value });
+    this.setState({ pageLimitationM: value });
   }
 
   /**
@@ -285,7 +283,7 @@ export default class AdminCustomizeContainer extends Container {
         isEnabledTimeline: this.state.isEnabledTimeline,
         isSavedStatesOfTabChanges: this.state.isSavedStatesOfTabChanges,
         isEnabledAttachTitleHeader: this.state.isEnabledAttachTitleHeader,
-        pageListLimitForUserPage: this.state.pageListLimitForUserPage,
+        pageLimitationM: this.state.pageLimitationM,
         // TODO implement for pageListLimitForModal
         isEnabledStaleNotification: this.state.isEnabledStaleNotification,
         isAllReplyShown: this.state.isAllReplyShown,
@@ -295,7 +293,7 @@ export default class AdminCustomizeContainer extends Container {
         isEnabledTimeline: customizedParams.isEnabledTimeline,
         isSavedStatesOfTabChanges: customizedParams.isSavedStatesOfTabChanges,
         isEnabledAttachTitleHeader: customizedParams.isEnabledAttachTitleHeader,
-        pageListLimitForUserPage: customizedParams.pageListLimitForUserPage,
+        pageLimitationM: customizedParams.pageLimitationM,
         // TODO implement for pageListLimitForModal
         isEnabledStaleNotification: customizedParams.isEnabledStaleNotification,
         isAllReplyShown: customizedParams.isAllReplyShown,

--- a/src/server/models/config.js
+++ b/src/server/models/config.js
@@ -111,7 +111,7 @@ module.exports = function(crowi) {
       'customize:isEnabledTimeline' : true,
       'customize:isSavedStatesOfTabChanges' : true,
       'customize:isEnabledAttachTitleHeader' : false,
-      'customize:showPageListLimitNumberForUserPage' : 10,
+      'customize:showPageLimitationM' : 10,
       'customize:isEnabledStaleNotification': false,
       'customize:isAllReplyShown': false,
 
@@ -218,7 +218,7 @@ module.exports = function(crowi) {
         MATHJAX: env.MATHJAX || null,
         NO_CDN: env.NO_CDN || null,
       },
-      pageListLimitForUserPage: crowi.configManager.getConfig('crowi', 'customize:showPageListLimitNumberForUserPage'),
+      pageLimitationM: crowi.configManager.getConfig('crowi', 'customize:showPageLimitationM'),
       // TODO implement for pageListLimitForModal
       isEnabledStaleNotification: crowi.configManager.getConfig('crowi', 'customize:isEnabledStaleNotification'),
       isAclEnabled: crowi.aclService.isAclEnabled(),

--- a/src/server/routes/apiv3/customize-setting.js
+++ b/src/server/routes/apiv3/customize-setting.js
@@ -37,7 +37,7 @@ const ErrorV3 = require('../../models/vo/error-apiv3');
  *            type: boolean
  *          isEnabledAttachTitleHeader:
  *            type: boolean
- *          pageListLimitForUserPage:
+ *          pageLimitationM:
  *            type: number
  *          isEnabledStaleNotification:
  *            type: boolean
@@ -100,7 +100,7 @@ module.exports = (crowi) => {
       body('isSavedStatesOfTabChanges').isBoolean(),
       body('isEnabledAttachTitleHeader').isBoolean(),
       // TODO implement for pageListLimitForModal
-      body('pageListLimitForUserPage').isInt().isInt({ min: 1, max: 1000 }),
+      body('pageLimitationM').isInt().isInt({ min: 1, max: 1000 }),
       body('isEnabledStaleNotification').isBoolean(),
       body('isAllReplyShown').isBoolean(),
     ],
@@ -152,7 +152,7 @@ module.exports = (crowi) => {
       isEnabledTimeline: await crowi.configManager.getConfig('crowi', 'customize:isEnabledTimeline'),
       isSavedStatesOfTabChanges: await crowi.configManager.getConfig('crowi', 'customize:isSavedStatesOfTabChanges'),
       isEnabledAttachTitleHeader: await crowi.configManager.getConfig('crowi', 'customize:isEnabledAttachTitleHeader'),
-      pageListLimitForUserPage: await crowi.configManager.getConfig('crowi', 'customize:showPageListLimitNumberForUserPage'),
+      pageLimitationM: await crowi.configManager.getConfig('crowi', 'customize:showPageLimitationM'),
       // TODO implement for pageListLimitForModal
       isEnabledStaleNotification: await crowi.configManager.getConfig('crowi', 'customize:isEnabledStaleNotification'),
       isAllReplyShown: await crowi.configManager.getConfig('crowi', 'customize:isAllReplyShown'),
@@ -276,7 +276,7 @@ module.exports = (crowi) => {
       'customize:isSavedStatesOfTabChanges': req.body.isSavedStatesOfTabChanges,
       'customize:isEnabledAttachTitleHeader': req.body.isEnabledAttachTitleHeader,
       // TODO implement for pageListLimitForModal
-      'customize:showPageListLimitForUserPage': req.body.pageListLimitForUserPage,
+      'customize:showPageLimitationM': req.body.pageLimitationM,
       'customize:isEnabledStaleNotification': req.body.isEnabledStaleNotification,
       'customize:isAllReplyShown': req.body.isAllReplyShown,
     };
@@ -288,7 +288,7 @@ module.exports = (crowi) => {
         isSavedStatesOfTabChanges: await crowi.configManager.getConfig('crowi', 'customize:isSavedStatesOfTabChanges'),
         isEnabledAttachTitleHeader: await crowi.configManager.getConfig('crowi', 'customize:isEnabledAttachTitleHeader'),
         // TODO implement for pageListLimitForModal
-        pageListLimitForUserPage: await crowi.configManager.getConfig('crowi', 'customize:showPageListLimitNumberForUserPage'),
+        pageLimitationM: await crowi.configManager.getConfig('crowi', 'customize:showPageLimitationM'),
         isEnabledStaleNotification: await crowi.configManager.getConfig('crowi', 'customize:isEnabledStaleNotification'),
         isAllReplyShown: await crowi.configManager.getConfig('crowi', 'customize:isAllReplyShown'),
       };


### PR DESCRIPTION
GW-3920 ページのグルーピング化に伴いユーザーページドロップダウン関連の名称を変更する

<img width="1208" alt="スクリーンショット 0002-09-27 15 09 51" src="https://user-images.githubusercontent.com/59536731/94357391-91413000-00d3-11eb-8f3d-f3f69f0a59c1.png">

今回変更したのは、
1. onToggleDropdown ➡︎　onToggleDropdownM
2. pageListLimitForUserPage　➡︎　pageLimitationM
3. showPageListLimitNumberForUserPage  ➡︎ showPageLimitationM
の3つです。