### PR TITLE
Imprv/gw3969 apply colors to three stranded button 1

### DIFF
--- a/src/client/styles/scss/_mixins.scss
+++ b/src/client/styles/scss/_mixins.scss
@@ -223,3 +223,14 @@
   transition-timing-function: cubic-bezier(0.25, 1, 0.5, 1);
   transition-duration: 300ms;
 }
+
+@mixin three-stranded-button($textColor, $borderColor, $bgHoverColor, $bgColor: white) {
+  color: $textColor;
+  background-color: $bgColor;
+  border-color: $borderColor;
+  &:hover,
+  &:active {
+    background-color: $bgHoverColor;
+    border-color: $borderColor;
+  }
+}

--- a/src/client/styles/scss/_mixins.scss
+++ b/src/client/styles/scss/_mixins.scss
@@ -230,6 +230,7 @@
   border-color: $borderColor;
   &:hover,
   &:active {
+    color: $textColor;
     background-color: $bgHoverColor;
     border-color: $borderColor;
   }

--- a/src/client/styles/scss/_mixins.scss
+++ b/src/client/styles/scss/_mixins.scss
@@ -224,14 +224,14 @@
   transition-duration: 300ms;
 }
 
-@mixin three-stranded-button($textColor, $borderColor, $bgHoverColor, $bgColor: white) {
+@mixin three-stranded-button($textColor, $borderColor, $bgColorHoverAndActive, $bgColor: white) {
   color: $textColor;
   background-color: $bgColor;
   border-color: $borderColor;
   &:hover,
   &:active {
     color: $textColor;
-    background-color: $bgHoverColor;
+    background-color: $bgColorHoverAndActive;
     border-color: $borderColor;
   }
 }

--- a/src/client/styles/scss/theme/default.scss
+++ b/src/client/styles/scss/theme/default.scss
@@ -202,4 +202,7 @@ html[dark] {
 
   @import 'apply-colors';
   @import 'apply-colors-dark';
+
+  // Button
+  // [TODO: appply colors to three stranded button]
 }

--- a/src/client/styles/scss/theme/default.scss
+++ b/src/client/styles/scss/theme/default.scss
@@ -104,6 +104,7 @@ html[light] {
   @import 'apply-colors';
   @import 'apply-colors-light';
 
+  // Button
   .grw-three-stranded-button {
     .btn.btn-outline-primary {
       @include three-stranded-button($primary, lighten($primary, 65%), lighten($primary, 70%));

--- a/src/client/styles/scss/theme/default.scss
+++ b/src/client/styles/scss/theme/default.scss
@@ -103,6 +103,12 @@ html[light] {
 
   @import 'apply-colors';
   @import 'apply-colors-light';
+
+  .grw-three-stranded-button {
+    .btn.btn-outline-primary {
+      @include three-stranded-button($primary, lighten($primary, 65%), lighten($primary, 70%));
+    }
+  }
 }
 
 //== Dark Mode

--- a/src/client/styles/scss/theme/mono-blue.scss
+++ b/src/client/styles/scss/theme/mono-blue.scss
@@ -88,6 +88,12 @@ html[light] {
       }
     }
   }
+  // Button
+  .grw-three-stranded-button {
+    .btn.btn-outline-primary {
+      @include three-stranded-button($primary, lighten($primary, 65%), lighten($primary, 70%));
+    }
+  }
 }
 
 html[dark] {

--- a/src/client/styles/scss/theme/mono-blue.scss
+++ b/src/client/styles/scss/theme/mono-blue.scss
@@ -195,4 +195,11 @@ html[dark] {
   .table {
     color: white;
   }
+
+  // Button
+  .grw-three-stranded-button {
+    .btn.btn-outline-primary {
+      @include three-stranded-button(lighten($primary, 30%), $primary, darken($primary, 10%), darken($primary, 20%));
+    }
+  }
 }


### PR DESCRIPTION
GW-3969 各テーマの三連ボタンの新デザイン実装
このタスクでは
 - default light
- mono-blue light
- mono-blue dark
の色を変更しました。
[理想]
<img width="559" alt="Screen Shot 2020-10-01 at 0 42 51" src="https://user-images.githubusercontent.com/59536731/94708678-d12c3f80-037f-11eb-8eb5-6fec0a10c53e.png">

[default light]
<img width="490" alt="Screen Shot 2020-10-01 at 0 31 47" src="https://user-images.githubusercontent.com/59536731/94707778-cde48400-037e-11eb-8f9d-512c06aec9d2.png">
[mono-blue light]
<img width="466" alt="Screen Shot 2020-10-01 at 0 34 52" src="https://user-images.githubusercontent.com/59536731/94707770-cc1ac080-037e-11eb-924a-6d42ae4aea6d.png">
[mono-blue dark]
<img width="476" alt="Screen Shot 2020-10-01 at 0 34 43" src="https://user-images.githubusercontent.com/59536731/94707774-cd4bed80-037e-11eb-8aa2-82eb697ad9c5.png">

