### PR TITLE
Imprv/gw3976 apply colors to three stranded button 2

### DIFF
--- a/src/client/styles/scss/theme/christmas.scss
+++ b/src/client/styles/scss/theme/christmas.scss
@@ -186,7 +186,7 @@ html[dark] {
   // Button
   .grw-three-stranded-button {
     .btn.btn-outline-primary {
-      @include three-stranded-button(darken($subthemecolor, 15%), lighten($subthemecolor, 15%), lighten($subthemecolor, 25%));
+      @include three-stranded-button(darken($subthemecolor, 15%), lighten($subthemecolor, 35%), lighten($subthemecolor, 45%));
     }
   }
 }

--- a/src/client/styles/scss/theme/christmas.scss
+++ b/src/client/styles/scss/theme/christmas.scss
@@ -182,4 +182,11 @@ html[dark] {
   .grw-navbar {
     background-image: url('/images/themes/christmas/christmas-navbar.jpg');
   }
+
+  // Button
+  .grw-three-stranded-button {
+    .btn.btn-outline-primary {
+      @include three-stranded-button(darken($subthemecolor, 15%), lighten($subthemecolor, 15%), lighten($subthemecolor, 25%));
+    }
+  }
 }

--- a/src/client/styles/scss/theme/island.scss
+++ b/src/client/styles/scss/theme/island.scss
@@ -108,4 +108,11 @@ html[dark] {
       }
     }
   }
+
+  // Button
+  .grw-three-stranded-button {
+    .btn.btn-outline-primary {
+      @include three-stranded-button(darken($primary, 50%), lighten($primary, 5%), darken($primary, 5%));
+    }
+  }
 }

--- a/src/client/styles/scss/theme/nature.scss
+++ b/src/client/styles/scss/theme/nature.scss
@@ -110,4 +110,11 @@ html[dark] {
       color: $color-link-hover !important;
     }
   }
+
+  // Button
+  .grw-three-stranded-button {
+    .btn.btn-outline-primary {
+      @include three-stranded-button($bgcolor-navbar, lighten($bgcolor-navbar, 65%), lighten($bgcolor-navbar, 70%));
+    }
+  }
 }

--- a/src/client/styles/scss/theme/wood.scss
+++ b/src/client/styles/scss/theme/wood.scss
@@ -160,4 +160,11 @@ html[dark] {
       border-color: #aaa !important;
     }
   }
+
+  // Button
+  .grw-three-stranded-button {
+    .btn.btn-outline-primary {
+      @include three-stranded-button(darken($primary, 30%), lighten($primary, 15%), lighten($primary, 25%));
+    }
+  }
 }


### PR DESCRIPTION
GW-3976 各テーマ三連ボタンの新デザイン実装2

<img width="874" alt="Screen Shot 2020-10-01 at 13 42 54" src="https://user-images.githubusercontent.com/59536731/94769036-0c645800-03ec-11eb-891c-e7d0f0416814.png">


[nature]
<img width="321" alt="Screen Shot 2020-10-01 at 13 46 38" src="https://user-images.githubusercontent.com/59536731/94769250-90b6db00-03ec-11eb-9e0b-09eea64cca1d.png">

[wood]
<img width="288" alt="Screen Shot 2020-10-01 at 13 47 26" src="https://user-images.githubusercontent.com/59536731/94769299-a926f580-03ec-11eb-861f-f1c21439410c.png">

[island]
<img width="370" alt="Screen Shot 2020-10-01 at 13 17 23" src="https://user-images.githubusercontent.com/59536731/94769059-1dad6480-03ec-11eb-92ef-dc964398b438.png">

[christmas]
<img width="482" alt="Screen Shot 2020-10-01 at 16 23 08" src="https://user-images.githubusercontent.com/59536731/94779998-bb139300-0402-11eb-9a08-83495b1fa68b.png">



