### PR TITLE
change pagenation size by adding proptype

### DIFF
--- a/src/client/js/components/Admin/ManageExternalAccount.jsx
+++ b/src/client/js/components/Admin/ManageExternalAccount.jsx
@@ -43,6 +43,7 @@ class ManageExternalAccount extends React.Component {
         totalItemsCount={adminExternalAccountsContainer.state.totalAccounts}
         pagingLimit={adminExternalAccountsContainer.state.pagingLimit}
         align="right"
+        size="sm"
       />
 
     );

--- a/src/client/js/components/Admin/Security/ShareLinkSetting.jsx
+++ b/src/client/js/components/Admin/Security/ShareLinkSetting.jsx
@@ -98,6 +98,7 @@ class ShareLinkSetting extends React.Component {
           totalItemsCount={totalshareLinks}
           pagingLimit={shareLinksPagingLimit}
           align="right"
+          size="sm"
         />
       );
     }

--- a/src/client/js/components/Admin/UserGroup/UserGroupPage.jsx
+++ b/src/client/js/components/Admin/UserGroup/UserGroupPage.jsx
@@ -157,6 +157,7 @@ class UserGroupPage extends React.Component {
           changePage={this.handlePage}
           totalItemsCount={this.state.totalUserGroups}
           pagingLimit={this.state.pagingLimit}
+          size="sm"
         />
         <UserGroupDeleteModal
           userGroups={this.state.userGroups}

--- a/src/client/js/components/Admin/UserGroupDetail/UserGroupPageList.jsx
+++ b/src/client/js/components/Admin/UserGroupDetail/UserGroupPageList.jsx
@@ -64,6 +64,7 @@ class UserGroupPageList extends React.Component {
           changePage={this.handlePageChange}
           totalItemsCount={this.state.total}
           pagingLimit={this.state.pagingLimit}
+          size="sm"
         />
       </Fragment>
     );

--- a/src/client/js/components/Admin/UserManagement.jsx
+++ b/src/client/js/components/Admin/UserManagement.jsx
@@ -121,6 +121,7 @@ class UserManagement extends React.Component {
           totalItemsCount={adminUsersContainer.state.totalUsers}
           pagingLimit={adminUsersContainer.state.pagingLimit}
           align="right"
+          size="sm"
         />
       </div>
     );

--- a/src/client/js/components/MyDraftList/MyDraftList.jsx
+++ b/src/client/js/components/MyDraftList/MyDraftList.jsx
@@ -160,6 +160,7 @@ class MyDraftList extends React.Component {
               changePage={this.handlePage}
               totalItemsCount={this.state.totalDrafts}
               pagingLimit={this.state.pagingLimit}
+              size="sm"
             />
           </React.Fragment>
         ) }

--- a/src/client/js/components/PaginationWrapper.jsx
+++ b/src/client/js/components/PaginationWrapper.jsx
@@ -173,7 +173,7 @@ class PaginationWrapper extends React.Component {
 
     return (
       <React.Fragment>
-        <Pagination size="sm" listClassName={this.getListClassName()}>{paginationItems}</Pagination>
+        <Pagination size={this.props.size} listClassName={this.getListClassName()}>{paginationItems}</Pagination>
       </React.Fragment>
     );
   }
@@ -191,9 +191,11 @@ PaginationWrapper.propTypes = {
   totalItemsCount: PropTypes.number.isRequired,
   pagingLimit: PropTypes.number.isRequired,
   align: PropTypes.string,
+  size: PropTypes.string,
 };
 PaginationWrapper.defaultProps = {
   align: 'left',
+  size: 'md',
 };
 
 export default withTranslation()(PaginationWrappered);

--- a/src/client/js/components/RecentCreated/RecentCreated.jsx
+++ b/src/client/js/components/RecentCreated/RecentCreated.jsx
@@ -78,6 +78,7 @@ class RecentCreated extends React.Component {
           changePage={this.handlePage}
           totalItemsCount={this.state.totalPages}
           pagingLimit={this.state.pagingLimit}
+          size="sm"
         />
       </div>
     );

--- a/src/client/js/components/TagsList.jsx
+++ b/src/client/js/components/TagsList.jsx
@@ -80,6 +80,7 @@ class TagsList extends React.Component {
             changePage={this.handlePage}
             totalItemsCount={this.state.totalTags}
             pagingLimit={this.state.pagingLimit}
+            size="sm"
           />
         </div>
       </div>


### PR DESCRIPTION
GW-4021 pagination-wrapper を拡張してサイズを変更できる
元々どのページネーションにも`sm`が指定されるようになっていましたが、標準でmdサイズにし、smやlgにする時はpropsで渡すしように変更しました。

[変更前 smサイズ]
<img width="1152" alt="Screen Shot 2020-10-05 at 13 58 37" src="https://user-images.githubusercontent.com/59536731/95041881-e9e77d00-0712-11eb-96c3-e5c6fbb2cbf2.png">

[変更後 普通サイズ]
<img width="1172" alt="Screen Shot 2020-10-05 at 13 57 10" src="https://user-images.githubusercontent.com/59536731/95041807-bdcbfc00-0712-11eb-8a90-6d31ca9b9eca.png">
