### PR TITLE
Imprv/omit if page path is too long on edit mode

### DIFF
--- a/src/client/styles/scss/_on-edit.scss
+++ b/src/client/styles/scss/_on-edit.scss
@@ -31,13 +31,10 @@ body.on-edit {
 
   .grw-page-path-nav,
   .grw-page-path-nav h1 {
+    width: calc(100vw - 300px);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-
-    @include media-breakpoint-up(xs) {
-      width: calc(100vw - 300px);
-    }
 
     @include media-breakpoint-up(md) {
       width: calc(100vw - 350px);

--- a/src/client/styles/scss/_on-edit.scss
+++ b/src/client/styles/scss/_on-edit.scss
@@ -51,6 +51,28 @@ body.on-edit {
       width: 800px;
     }
   }
+  .grw-page-path-nav h1 {
+    width: 800px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
+    @include media-breakpoint-only(xs) {
+      width: 100px;
+    }
+    @include media-breakpoint-only(sm) {
+      width: 300px;
+    }
+    @include media-breakpoint-only(md) {
+      width: 420px;
+    }
+    @include media-breakpoint-only(lg) {
+      width: 500px;
+    }
+    @include media-breakpoint-only(xl) {
+      width: 800px;
+    }
+  }
 
   .page-wrapper {
     position: relative;

--- a/src/client/styles/scss/_on-edit.scss
+++ b/src/client/styles/scss/_on-edit.scss
@@ -30,8 +30,8 @@ body.on-edit {
   }
 
   //temp data
-  .grw-page-path-nav {
-    display: flex;
+  .grw-page-path-nav h1 {
+    // display: flex;
     width: 700px;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/src/client/styles/scss/_on-edit.scss
+++ b/src/client/styles/scss/_on-edit.scss
@@ -31,10 +31,21 @@ body.on-edit {
 
   .grw-page-path-nav,
   .grw-page-path-nav h1 {
-    width: calc(100vw - 460px);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+
+    @include media-breakpoint-up(xs) {
+      width: calc(100vw - 300px);
+    }
+
+    @include media-breakpoint-up(md) {
+      width: calc(100vw - 350px);
+    }
+
+    @include media-breakpoint-up(lg) {
+      width: calc(100vw - 560px);
+    }
   }
 
   .page-wrapper {

--- a/src/client/styles/scss/_on-edit.scss
+++ b/src/client/styles/scss/_on-edit.scss
@@ -29,10 +29,8 @@ body.on-edit {
     }
   }
 
-  //temp data
-  .grw-page-path-nav h1 {
-    // display: flex;
-    width: 700px;
+  .grw-page-path-nav {
+    width: 800px;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -47,10 +45,10 @@ body.on-edit {
       width: 420px;
     }
     @include media-breakpoint-only(lg) {
-      width: 490px;
+      width: 500px;
     }
     @include media-breakpoint-only(xl) {
-      width: 700px;
+      width: 800px;
     }
   }
 

--- a/src/client/styles/scss/_on-edit.scss
+++ b/src/client/styles/scss/_on-edit.scss
@@ -34,21 +34,22 @@ body.on-edit {
     display: flex;
     width: 700px;
     overflow: hidden;
+    text-overflow: ellipsis;
     white-space: nowrap;
 
-    @include media-breakpoint-down(xs) {
-      width: 10px;
-    }
-    @include media-breakpoint-down(sm) {
-      width: 30px;
-    }
-    @include media-breakpoint-down(md) {
+    @include media-breakpoint-only(xs) {
       width: 100px;
     }
-    @include media-breakpoint-down(lg) {
-      width: 200px;
+    @include media-breakpoint-only(sm) {
+      width: 300px;
     }
-    @include media-breakpoint-down(xl) {
+    @include media-breakpoint-only(md) {
+      width: 420px;
+    }
+    @include media-breakpoint-only(lg) {
+      width: 490px;
+    }
+    @include media-breakpoint-only(xl) {
       width: 700px;
     }
   }

--- a/src/client/styles/scss/_on-edit.scss
+++ b/src/client/styles/scss/_on-edit.scss
@@ -31,26 +31,10 @@ body.on-edit {
 
   .grw-page-path-nav,
   .grw-page-path-nav h1 {
-    width: 800px;
+    width: calc(100vw - 460px);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-
-    @include media-breakpoint-only(xs) {
-      width: 100px;
-    }
-    @include media-breakpoint-only(sm) {
-      width: 300px;
-    }
-    @include media-breakpoint-only(md) {
-      width: 420px;
-    }
-    @include media-breakpoint-only(lg) {
-      width: 500px;
-    }
-    @include media-breakpoint-only(xl) {
-      width: 800px;
-    }
   }
 
   .page-wrapper {

--- a/src/client/styles/scss/_on-edit.scss
+++ b/src/client/styles/scss/_on-edit.scss
@@ -29,28 +29,7 @@ body.on-edit {
     }
   }
 
-  .grw-page-path-nav {
-    width: 800px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-
-    @include media-breakpoint-only(xs) {
-      width: 100px;
-    }
-    @include media-breakpoint-only(sm) {
-      width: 300px;
-    }
-    @include media-breakpoint-only(md) {
-      width: 420px;
-    }
-    @include media-breakpoint-only(lg) {
-      width: 500px;
-    }
-    @include media-breakpoint-only(xl) {
-      width: 800px;
-    }
-  }
+  .grw-page-path-nav,
   .grw-page-path-nav h1 {
     width: 800px;
     overflow: hidden;

--- a/src/client/styles/scss/_on-edit.scss
+++ b/src/client/styles/scss/_on-edit.scss
@@ -31,7 +31,7 @@ body.on-edit {
 
   //temp data
   .grw-page-path-nav {
-    width: 200px;
+    display: flex;
     overflow: hidden;
     white-space: nowrap;
   }

--- a/src/client/styles/scss/_on-edit.scss
+++ b/src/client/styles/scss/_on-edit.scss
@@ -35,8 +35,12 @@ body.on-edit {
     width: 700px;
     overflow: hidden;
     white-space: nowrap;
+
+    @include media-breakpoint-down(xs) {
+      width: 10px;
+    }
     @include media-breakpoint-down(sm) {
-      // width: 10px;
+      width: 30px;
     }
     @include media-breakpoint-down(md) {
       width: 100px;

--- a/src/client/styles/scss/_on-edit.scss
+++ b/src/client/styles/scss/_on-edit.scss
@@ -32,8 +32,21 @@ body.on-edit {
   //temp data
   .grw-page-path-nav {
     display: flex;
+    width: 700px;
     overflow: hidden;
     white-space: nowrap;
+    @include media-breakpoint-down(sm) {
+      // width: 10px;
+    }
+    @include media-breakpoint-down(md) {
+      width: 100px;
+    }
+    @include media-breakpoint-down(lg) {
+      width: 200px;
+    }
+    @include media-breakpoint-down(xl) {
+      width: 700px;
+    }
   }
 
   .page-wrapper {

--- a/src/client/styles/scss/_on-edit.scss
+++ b/src/client/styles/scss/_on-edit.scss
@@ -29,6 +29,13 @@ body.on-edit {
     }
   }
 
+  //temp data
+  .grw-page-path-nav {
+    width: 200px;
+    overflow: hidden;
+    white-space: nowrap;
+  }
+
   .page-wrapper {
     position: relative;
     top: $grw-navbar-border-width;


### PR DESCRIPTION
各デバイスのサイズ感は以下のようになります。
path 最も長そうなものを採用しています。

surface duo のみイマイチな感じになります。
これを調整しようとしたのですが、その場合、他の サイズが崩れてしまうので、
surface duo のみ少し余白が多くなってしまいました。

<img width="366" alt="スクリーンショット 2020-10-06 15 44 12" src="https://user-images.githubusercontent.com/57100766/95168259-02779600-07ec-11eb-9af9-8dd4d28974cf.png">
<img width="359" alt="スクリーンショット 2020-10-06 15 45 05" src="https://user-images.githubusercontent.com/57100766/95168113-c7756280-07eb-11eb-8c1d-e3e9f7305235.png">
<img width="359" alt="スクリーンショット 2020-10-06 15 44 50" src="https://user-images.githubusercontent.com/57100766/95168131-cd6b4380-07eb-11eb-955b-1150535b9cd8.png">
<img width="374" alt="スクリーンショット 2020-10-06 15 45 14" src="https://user-images.githubusercontent.com/57100766/95168110-c5ab9f00-07eb-11eb-8738-20340af1721f.png">
<img width="374" alt="スクリーンショット 2020-10-06 15 44 41" src="https://user-images.githubusercontent.com/57100766/95168143-d22ff780-07eb-11eb-9a4c-2cd50398c145.png">
<img width="396" alt="スクリーンショット 2020-10-06 15 44 58" src="https://user-images.githubusercontent.com/57100766/95168122-c93f2600-07eb-11eb-90f7-39d0ea22e906.png">
<img width="394" alt="スクリーンショット 2020-10-06 15 44 31" src="https://user-images.githubusercontent.com/57100766/95168239-fbe91e80-07eb-11eb-986e-9ee07069234c.png">
<img width="393" alt="スクリーンショット 2020-10-06 15 44 21" src="https://user-images.githubusercontent.com/57100766/95168250-ff7ca580-07eb-11eb-9063-65796c6a4e65.png">
<img width="440" alt="スクリーンショット 2020-10-06 15 45 27" src="https://user-images.githubusercontent.com/57100766/95168183-e542c780-07eb-11eb-9c85-4e37c1f857e4.png">
<img width="446" alt="スクリーンショット 2020-10-06 15 43 53" src="https://user-images.githubusercontent.com/57100766/95168286-0b686780-07ec-11eb-9479-03eedb7c94ac.png">
<img width="549" alt="スクリーンショット 2020-10-06 15 44 02" src="https://user-images.githubusercontent.com/57100766/95168276-07d4e080-07ec-11eb-897d-bd9cb704efdb.png">
<img width="1920" alt="スクリーンショット 2020-10-06 15 58 00" src="https://user-images.githubusercontent.com/57100766/95168770-c1cc4c80-07ec-11eb-8508-c0ceb0725d39.png">

