### PR TITLE
ページパスとページタイトルが長い場合のEditモードのサブナビバーの表示

### DIFF
--- a/src/client/js/components/Navbar/GrowiSubNavigation.jsx
+++ b/src/client/js/components/Navbar/GrowiSubNavigation.jsx
@@ -53,11 +53,13 @@ const PagePathNav = ({ pageId, pagePath, isPageForbidden }) => {
       {formerLink}
       <span className="d-flex align-items-center">
         <h1 className="m-0">{latterLink}</h1>
-        <RevisionPathControls
-          pageId={pageId}
-          pagePath={pagePath}
-          isPageForbidden={isPageForbidden}
-        />
+        <div className="mx-2">
+          <RevisionPathControls
+            pageId={pageId}
+            pagePath={pagePath}
+            isPageForbidden={isPageForbidden}
+          />
+        </div>
       </span>
     </div>
   );
@@ -72,10 +74,12 @@ const UserPagePathNav = ({ pageId, pagePath }) => {
     <div className="grw-page-path-nav">
       <span className="d-flex align-items-center flex-wrap">
         <h4 className="grw-user-page-path">{latterLink}</h4>
-        <RevisionPathControls
-          pageId={pageId}
-          pagePath={pagePath}
-        />
+        <div className="mx-2">
+          <RevisionPathControls
+            pageId={pageId}
+            pagePath={pagePath}
+          />
+        </div>
       </span>
     </div>
   );
@@ -162,14 +166,14 @@ const GrowiSubNavigation = (props) => {
     <div className={`grw-subnav d-flex align-items-center justify-content-between ${isCompactMode ? 'grw-subnav-compact d-print-none' : ''}`}>
 
       {/* Left side */}
-      <div className="d-flex overflow-hidden">
+      <div className="d-flex grw-subnav-left-side">
         { isDrawerMode && (
           <div className="d-none d-md-flex align-items-center border-right mr-3 pr-3">
             <DrawerToggler />
           </div>
         ) }
 
-        <div className="overflow-hidden">
+        <div className="grw-path-nav-container">
           { !isCompactMode && !isPageNotFound && !isPageForbidden && !isUserPage && (
             <div className="mb-2">
               <TagLabels />

--- a/src/client/js/components/Navbar/GrowiSubNavigation.jsx
+++ b/src/client/js/components/Navbar/GrowiSubNavigation.jsx
@@ -51,7 +51,7 @@ const PagePathNav = ({ pageId, pagePath, isPageForbidden }) => {
   return (
     <div className="grw-page-path-nav">
       {formerLink}
-      <span className="d-flex align-items-center flex-wrap">
+      <span className="d-flex align-items-center">
         <h1 className="m-0">{latterLink}</h1>
         <RevisionPathControls
           pageId={pageId}
@@ -162,14 +162,14 @@ const GrowiSubNavigation = (props) => {
     <div className={`grw-subnav d-flex align-items-center justify-content-between ${isCompactMode ? 'grw-subnav-compact d-print-none' : ''}`}>
 
       {/* Left side */}
-      <div className="d-flex">
+      <div className="d-flex overflow-hidden">
         { isDrawerMode && (
           <div className="d-none d-md-flex align-items-center border-right mr-3 pr-3">
             <DrawerToggler />
           </div>
         ) }
 
-        <div>
+        <div className="overflow-hidden">
           { !isCompactMode && !isPageNotFound && !isPageForbidden && !isUserPage && (
             <div className="mb-2">
               <TagLabels />

--- a/src/client/js/components/Page/RevisionPathControls.jsx
+++ b/src/client/js/components/Page/RevisionPathControls.jsx
@@ -21,14 +21,14 @@ const RevisionPathControls = (props) => {
   const isPageInTrash = isTrashPage(pagePath);
 
   return (
-    <div className="mx-2">
+    <>
       <CopyDropdown pagePath={pagePath} pageId={pageId} buttonStyle={buttonStyle} />
       { !isPageInTrash && !isPageForbidden && (
         <a href="#edit" className="d-edit-none text-muted btn btn-secondary bg-transparent btn-edit border-0" style={buttonStyle}>
           <i className="icon-note" />
         </a>
       ) }
-    </div>
+    </>
   );
 };
 

--- a/src/client/js/components/Page/RevisionPathControls.jsx
+++ b/src/client/js/components/Page/RevisionPathControls.jsx
@@ -21,14 +21,14 @@ const RevisionPathControls = (props) => {
   const isPageInTrash = isTrashPage(pagePath);
 
   return (
-    <>
+    <div className="mx-2">
       <CopyDropdown pagePath={pagePath} pageId={pageId} buttonStyle={buttonStyle} />
       { !isPageInTrash && !isPageForbidden && (
         <a href="#edit" className="d-edit-none text-muted btn btn-secondary bg-transparent btn-edit border-0" style={buttonStyle}>
           <i className="icon-note" />
         </a>
       ) }
-    </>
+    </div>
   );
 };
 

--- a/src/client/styles/scss/_on-edit.scss
+++ b/src/client/styles/scss/_on-edit.scss
@@ -29,18 +29,24 @@ body.on-edit {
     }
   }
 
-  .grw-page-path-nav {
-    white-space: nowrap;
-
-    .grw-page-path-hierarchical-link {
-      display: inline-block;
-      width: 100%;
+  .grw-subnav-left-side {
+    overflow: hidden;
+    .grw-path-nav-container {
       overflow: hidden;
-      text-overflow: ellipsis;
-    }
+      .grw-page-path-nav {
+        white-space: nowrap;
 
-    h1 {
-      overflow: hidden;
+        .grw-page-path-hierarchical-link {
+          display: inline-block;
+          width: 100%;
+          overflow: hidden;
+          text-overflow: ellipsis;
+        }
+
+        h1 {
+          overflow: hidden;
+        }
+      }
     }
   }
 

--- a/src/client/styles/scss/_on-edit.scss
+++ b/src/client/styles/scss/_on-edit.scss
@@ -29,27 +29,6 @@ body.on-edit {
     }
   }
 
-  .grw-subnav-left-side {
-    overflow: hidden;
-    .grw-path-nav-container {
-      overflow: hidden;
-      .grw-page-path-nav {
-        white-space: nowrap;
-
-        .grw-page-path-hierarchical-link {
-          display: inline-block;
-          width: 100%;
-          overflow: hidden;
-          text-overflow: ellipsis;
-        }
-
-        h1 {
-          overflow: hidden;
-        }
-      }
-    }
-  }
-
   .page-wrapper {
     position: relative;
     top: $grw-navbar-border-width;
@@ -179,6 +158,27 @@ body.on-edit {
   /*********************
    * Navigation styles
    */
+  // ellipsis .grw-page-path-hierarchical-link
+  .grw-subnav-left-side {
+    overflow: hidden;
+    .grw-path-nav-container {
+      overflow: hidden;
+      .grw-page-path-nav {
+        white-space: nowrap;
+
+        .grw-page-path-hierarchical-link {
+          width: 100%;
+          overflow: hidden;
+          text-overflow: ellipsis;
+        }
+
+        h1 {
+          overflow: hidden;
+        }
+      }
+    }
+  }
+
   .nav:hover {
     .btn-copy,
     .btn-edit,

--- a/src/client/styles/scss/_on-edit.scss
+++ b/src/client/styles/scss/_on-edit.scss
@@ -29,19 +29,18 @@ body.on-edit {
     }
   }
 
-  .grw-page-path-nav,
-  .grw-page-path-nav h1 {
-    width: calc(100vw - 300px);
-    overflow: hidden;
-    text-overflow: ellipsis;
+  .grw-page-path-nav {
     white-space: nowrap;
 
-    @include media-breakpoint-up(md) {
-      width: calc(100vw - 350px);
+    .grw-page-path-hierarchical-link {
+      display: inline-block;
+      width: 100%;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
 
-    @include media-breakpoint-up(lg) {
-      width: calc(100vw - 560px);
+    h1 {
+      overflow: hidden;
     }
   }
 

--- a/src/lib/components/PagePathHierarchicalLink.jsx
+++ b/src/lib/components/PagePathHierarchicalLink.jsx
@@ -46,7 +46,7 @@ const PagePathHierarchicalLink = (props) => {
   const RootElm = ({ children }) => {
     return props.isInnerElem
       ? <>{children}</>
-      : <span className="grw-page-path-hierarchical-link text-break">{children}</span>;
+      : <span className="grw-page-path-hierarchical-link d-inline-block text-break">{children}</span>;
   };
 
   return (


### PR DESCRIPTION
## スクショ
- ![image](https://user-images.githubusercontent.com/20252919/95542414-aa7da100-0a30-11eb-9ee0-a1cd71409116.png)

## やったこと
- calcを使って横幅を決定していた書き方から、自然に横幅が決定するような書き方に変更
- ついでにやったこと
  - タイトルの横の[copyPagePathDropdown]ボタンは単体で改行してしまっていた(flex-wrapがついていた)
  - ページタイトルの右横に位置しているほうが、デザイン的に美しいのでそのようにした