### PR TITLE
Slackボタンのデザインの当て（デザインチェックFB対応）

### DIFF
--- a/src/client/js/components/SlackNotification.jsx
+++ b/src/client/js/components/SlackNotification.jsx
@@ -54,7 +54,7 @@ class SlackNotification extends React.Component {
             </div>
           </label>
           <input
-            className="grw-form-control-slack-notification form-control align-top ml-n2"
+            className="grw-form-control-slack-notification form-control align-top"
             type="text"
             value={this.props.slackChannels}
             placeholder="Input channels"

--- a/src/client/js/components/SlackNotification.jsx
+++ b/src/client/js/components/SlackNotification.jsx
@@ -49,7 +49,7 @@ class SlackNotification extends React.Component {
                 checked={this.props.isSlackEnabled}
                 onChange={this.updateCheckboxHandler}
               />
-              <label className={`custom-control-label align-center ${this.props.popUp ? 'mt-1' : ''}`} htmlFor={this.props.id}>
+              <label className="custom-control-label align-center" htmlFor={this.props.id}>
               </label>
             </div>
           </label>

--- a/src/client/js/components/SlackNotification.jsx
+++ b/src/client/js/components/SlackNotification.jsx
@@ -54,7 +54,7 @@ class SlackNotification extends React.Component {
             </div>
           </label>
           <input
-            className="grw-form-control-slack-notification form-control align-top"
+            className="grw-form-control-slack-notification form-control align-top pl-0"
             type="text"
             value={this.props.slackChannels}
             placeholder="Input channels"

--- a/src/client/js/components/SlackNotification.jsx
+++ b/src/client/js/components/SlackNotification.jsx
@@ -54,7 +54,7 @@ class SlackNotification extends React.Component {
             </div>
           </label>
           <input
-            className="grw-form-control-slack-notification form-control align-top"
+            className="grw-form-control-slack-notification form-control align-top ml-n2"
             type="text"
             value={this.props.slackChannels}
             placeholder="Input channels"

--- a/src/client/styles/scss/molecules/slack-notification.scss
+++ b/src/client/styles/scss/molecules/slack-notification.scss
@@ -23,6 +23,12 @@
   }
   .grw-input-group-slack-notification {
     height: $input-height-slack;
+    label {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      margin-bottom: 0;
+    }
   }
 
   .custom-control-label {

--- a/src/client/styles/scss/molecules/slack-notification.scss
+++ b/src/client/styles/scss/molecules/slack-notification.scss
@@ -1,5 +1,5 @@
 .grw-slack-notification {
-  $input-height-slack: 24px;
+  $input-height-slack: $custom-control-indicator-size * 1.5;
   border-color: $gray-200;
 
   border-style: solid;
@@ -23,6 +23,12 @@
   }
   .grw-input-group-slack-notification {
     height: $input-height-slack;
+  }
+
+  .custom-control-label {
+    &::before {
+      border: transparent;
+    }
   }
 }
 //　TODO デザインの使用が確定して実装、本タスクのスコープ外

--- a/src/client/styles/scss/theme/_apply-colors-light.scss
+++ b/src/client/styles/scss/theme/_apply-colors-light.scss
@@ -36,6 +36,10 @@ $table-hover-bg: $bgcolor-table-hover;
   background-color: $bgcolor-global;
 }
 
+.form-control::placeholder {
+  color: darken($bgcolor-global, 20%);
+}
+
 .form-control[disabled],
 .form-control[readonly] {
   color: lighten($color-global, 10%);


### PR DESCRIPTION

## やったこと
### デザインのスタイル修正
- custom switchとフォームの幅を詰めた
- placeholderの色が濃いので別のgrayを入れて薄くした（その他のText-Inputにも反映させた）
- Switchの丸い部分が縦にやや長いので、真円にした
- スマホ版のスタイルが崩れていたので修正


## スクショ
- PC
  - ![image](https://user-images.githubusercontent.com/20252919/95846185-19872c80-0d86-11eb-9326-675840435956.png)
- SP
  - ![image](https://user-images.githubusercontent.com/20252919/95846235-2ad03900-0d86-11eb-8d22-1df72a24a684.png)

