### PR TITLE
Imprv/hide three stranded button in couldnt create page 2

### DIFF
--- a/src/client/js/components/Navbar/GrowiSubNavigation.jsx
+++ b/src/client/js/components/Navbar/GrowiSubNavigation.jsx
@@ -142,7 +142,7 @@ const GrowiSubNavigation = (props) => {
   const { isDrawerMode } = navigationContainer.state;
   const {
     pageId, path, createdAt, creator, updatedAt, revisionAuthor,
-    isForbidden: isPageForbidden, pageUser, isCreatablePage,
+    isForbidden: isPageForbidden, pageUser, isNotCreatablePage,
   } = pageContainer.state;
 
   const isPageNotFound = pageId == null;
@@ -195,7 +195,7 @@ const GrowiSubNavigation = (props) => {
             { !isPageNotFound && !isPageForbidden && <PageManagement /> }
           </div>
           <div className="mt-2">
-            { !isCreatablePage && <ThreeStrandedButton onThreeStrandedButtonClicked={onThreeStrandedButtonClicked} />}
+            { !isNotCreatablePage && <ThreeStrandedButton onThreeStrandedButtonClicked={onThreeStrandedButtonClicked} />}
           </div>
         </div>
 

--- a/src/client/js/components/Navbar/GrowiSubNavigation.jsx
+++ b/src/client/js/components/Navbar/GrowiSubNavigation.jsx
@@ -142,7 +142,7 @@ const GrowiSubNavigation = (props) => {
   const { isDrawerMode } = navigationContainer.state;
   const {
     pageId, path, createdAt, creator, updatedAt, revisionAuthor,
-    isForbidden: isPageForbidden, pageUser,
+    isForbidden: isPageForbidden, pageUser, isCreatablePage,
   } = pageContainer.state;
 
   const isPageNotFound = pageId == null;
@@ -195,7 +195,7 @@ const GrowiSubNavigation = (props) => {
             { !isPageNotFound && !isPageForbidden && <PageManagement /> }
           </div>
           <div className="mt-2">
-            <ThreeStrandedButton onThreeStrandedButtonClicked={onThreeStrandedButtonClicked} />
+            { !isCreatablePage && <ThreeStrandedButton onThreeStrandedButtonClicked={onThreeStrandedButtonClicked} />}
           </div>
         </div>
 

--- a/src/client/js/components/Navbar/GrowiSubNavigation.jsx
+++ b/src/client/js/components/Navbar/GrowiSubNavigation.jsx
@@ -142,7 +142,7 @@ const GrowiSubNavigation = (props) => {
   const { isDrawerMode } = navigationContainer.state;
   const {
     pageId, path, createdAt, creator, updatedAt, revisionAuthor,
-    isForbidden: isPageForbidden, pageUser, isDisableToCreatePage,
+    isForbidden: isPageForbidden, pageUser, isCreatable,
   } = pageContainer.state;
 
   const isPageNotFound = pageId == null;
@@ -195,7 +195,7 @@ const GrowiSubNavigation = (props) => {
             { !isPageNotFound && !isPageForbidden && <PageManagement /> }
           </div>
           <div className="mt-2">
-            { !isDisableToCreatePage && <ThreeStrandedButton onThreeStrandedButtonClicked={onThreeStrandedButtonClicked} />}
+            { !isCreatable && <ThreeStrandedButton onThreeStrandedButtonClicked={onThreeStrandedButtonClicked} />}
           </div>
         </div>
 

--- a/src/client/js/components/Navbar/GrowiSubNavigation.jsx
+++ b/src/client/js/components/Navbar/GrowiSubNavigation.jsx
@@ -142,7 +142,7 @@ const GrowiSubNavigation = (props) => {
   const { isDrawerMode } = navigationContainer.state;
   const {
     pageId, path, createdAt, creator, updatedAt, revisionAuthor,
-    isForbidden: isPageForbidden, pageUser, isNotCreatablePage,
+    isForbidden: isPageForbidden, pageUser, isDisableToCreatePage,
   } = pageContainer.state;
 
   const isPageNotFound = pageId == null;
@@ -195,7 +195,7 @@ const GrowiSubNavigation = (props) => {
             { !isPageNotFound && !isPageForbidden && <PageManagement /> }
           </div>
           <div className="mt-2">
-            { !isNotCreatablePage && <ThreeStrandedButton onThreeStrandedButtonClicked={onThreeStrandedButtonClicked} />}
+            { !isDisableToCreatePage && <ThreeStrandedButton onThreeStrandedButtonClicked={onThreeStrandedButtonClicked} />}
           </div>
         </div>
 

--- a/src/client/js/services/PageContainer.js
+++ b/src/client/js/services/PageContainer.js
@@ -62,7 +62,7 @@ export default class PageContainer extends Container {
       isForbidden:  JSON.parse(mainContent.getAttribute('data-page-is-forbidden')),
       isDeleted:  JSON.parse(mainContent.getAttribute('data-page-is-deleted')),
       isDeletable:  JSON.parse(mainContent.getAttribute('data-page-is-deletable')),
-      isNotCreatablePage: mainContent.getAttribute('data-page-is-not-able-to-create'),
+      isNotCreatablePage: JSON.parse(mainContent.getAttribute('data-page-disable-to-create')),
       isAbleToDeleteCompletely:  JSON.parse(mainContent.getAttribute('data-page-is-able-to-delete-completely')),
       pageUser: JSON.parse(mainContent.getAttribute('data-page-user')),
       tags: null,

--- a/src/client/js/services/PageContainer.js
+++ b/src/client/js/services/PageContainer.js
@@ -62,7 +62,7 @@ export default class PageContainer extends Container {
       isForbidden:  JSON.parse(mainContent.getAttribute('data-page-is-forbidden')),
       isDeleted:  JSON.parse(mainContent.getAttribute('data-page-is-deleted')),
       isDeletable:  JSON.parse(mainContent.getAttribute('data-page-is-deletable')),
-      isNotCreatablePage: JSON.parse(mainContent.getAttribute('data-page-disable-to-create')),
+      isDisableToCreatePage: JSON.parse(mainContent.getAttribute('data-page-disable-to-create')),
       isAbleToDeleteCompletely:  JSON.parse(mainContent.getAttribute('data-page-is-able-to-delete-completely')),
       pageUser: JSON.parse(mainContent.getAttribute('data-page-user')),
       tags: null,

--- a/src/client/js/services/PageContainer.js
+++ b/src/client/js/services/PageContainer.js
@@ -39,6 +39,7 @@ export default class PageContainer extends Container {
 
     const revisionId = mainContent.getAttribute('data-page-revision-id');
     const path = decodeURI(mainContent.getAttribute('data-path'));
+
     this.state = {
       // local page data
       markdown: null, // will be initialized after initStateMarkdown()
@@ -61,6 +62,7 @@ export default class PageContainer extends Container {
       isForbidden:  JSON.parse(mainContent.getAttribute('data-page-is-forbidden')),
       isDeleted:  JSON.parse(mainContent.getAttribute('data-page-is-deleted')),
       isDeletable:  JSON.parse(mainContent.getAttribute('data-page-is-deletable')),
+      isCreatablePage: mainContent.getAttribute('data-page-is-able-to-create'),
       isAbleToDeleteCompletely:  JSON.parse(mainContent.getAttribute('data-page-is-able-to-delete-completely')),
       pageUser: JSON.parse(mainContent.getAttribute('data-page-user')),
       tags: null,
@@ -68,6 +70,7 @@ export default class PageContainer extends Container {
       templateTagData: mainContent.getAttribute('data-template-tags') || null,
       shareLinksNumber:  mainContent.getAttribute('data-share-links-number'),
       shareLinkId: JSON.parse(mainContent.getAttribute('data-share-link-id') || null),
+      threeStrandedButton: mainContent.getAttribute('three-stranded-button'),
 
       // latest(on remote) information
       remoteRevisionId: revisionId,

--- a/src/client/js/services/PageContainer.js
+++ b/src/client/js/services/PageContainer.js
@@ -70,7 +70,6 @@ export default class PageContainer extends Container {
       templateTagData: mainContent.getAttribute('data-template-tags') || null,
       shareLinksNumber:  mainContent.getAttribute('data-share-links-number'),
       shareLinkId: JSON.parse(mainContent.getAttribute('data-share-link-id') || null),
-      threeStrandedButton: mainContent.getAttribute('three-stranded-button'),
 
       // latest(on remote) information
       remoteRevisionId: revisionId,

--- a/src/client/js/services/PageContainer.js
+++ b/src/client/js/services/PageContainer.js
@@ -62,7 +62,7 @@ export default class PageContainer extends Container {
       isForbidden:  JSON.parse(mainContent.getAttribute('data-page-is-forbidden')),
       isDeleted:  JSON.parse(mainContent.getAttribute('data-page-is-deleted')),
       isDeletable:  JSON.parse(mainContent.getAttribute('data-page-is-deletable')),
-      isCreatablePage: mainContent.getAttribute('data-page-is-able-to-create'),
+      isNotCreatablePage: mainContent.getAttribute('data-page-is-not-able-to-create'),
       isAbleToDeleteCompletely:  JSON.parse(mainContent.getAttribute('data-page-is-able-to-delete-completely')),
       pageUser: JSON.parse(mainContent.getAttribute('data-page-user')),
       tags: null,

--- a/src/client/js/services/PageContainer.js
+++ b/src/client/js/services/PageContainer.js
@@ -62,7 +62,7 @@ export default class PageContainer extends Container {
       isForbidden:  JSON.parse(mainContent.getAttribute('data-page-is-forbidden')),
       isDeleted:  JSON.parse(mainContent.getAttribute('data-page-is-deleted')),
       isDeletable:  JSON.parse(mainContent.getAttribute('data-page-is-deletable')),
-      isDisableToCreatePage: JSON.parse(mainContent.getAttribute('data-page-disable-to-create')),
+      isCreatable: JSON.parse(mainContent.getAttribute('data-page-is-creatable')),
       isAbleToDeleteCompletely:  JSON.parse(mainContent.getAttribute('data-page-is-able-to-delete-completely')),
       pageUser: JSON.parse(mainContent.getAttribute('data-page-user')),
       tags: null,

--- a/src/server/views/widget/not_creatable_content.html
+++ b/src/server/views/widget/not_creatable_content.html
@@ -10,7 +10,7 @@
 <div id="content-main" class="content-main page-list"
   data-path="{{ encodeURI(path) }}"
   data-current-user="{% if user %}{{ user._id.toString() }}{% endif %}"
-  data-page-is-not-able-to-create="{}"
+  data-page-is-not-able-to-create="{{}}"
   ></div>
 
 </div>

--- a/src/server/views/widget/not_creatable_content.html
+++ b/src/server/views/widget/not_creatable_content.html
@@ -10,6 +10,7 @@
 <div id="content-main" class="content-main page-list"
   data-path="{{ encodeURI(path) }}"
   data-current-user="{% if user %}{{ user._id.toString() }}{% endif %}"
+  data-page-is-able-to-create="{}"
   ></div>
 
 </div>

--- a/src/server/views/widget/not_creatable_content.html
+++ b/src/server/views/widget/not_creatable_content.html
@@ -10,7 +10,7 @@
 <div id="content-main" class="content-main page-list"
   data-path="{{ encodeURI(path) }}"
   data-current-user="{% if user %}{{ user._id.toString() }}{% endif %}"
-  data-page-is-able-to-create="{}"
+  data-page-is-not-able-to-create="{}"
   ></div>
 
 </div>

--- a/src/server/views/widget/not_creatable_content.html
+++ b/src/server/views/widget/not_creatable_content.html
@@ -10,7 +10,7 @@
 <div id="content-main" class="content-main page-list"
   data-path="{{ encodeURI(path) }}"
   data-current-user="{% if user %}{{ user._id.toString() }}{% endif %}"
-  data-page-is-not-able-to-create="{{}}"
+  data-page-disable-to-create="true"
   ></div>
 
 </div>

--- a/src/server/views/widget/not_creatable_content.html
+++ b/src/server/views/widget/not_creatable_content.html
@@ -10,7 +10,7 @@
 <div id="content-main" class="content-main page-list"
   data-path="{{ encodeURI(path) }}"
   data-current-user="{% if user %}{{ user._id.toString() }}{% endif %}"
-  data-page-disable-to-create="true"
+  data-page-is-creatable="true"
   ></div>
 
 </div>

--- a/src/server/views/widget/page_content.html
+++ b/src/server/views/widget/page_content.html
@@ -17,7 +17,7 @@
   data-page-is-forbidden="{% if forbidden %}true{% else %}false{% endif %}"
   data-page-is-deleted="{% if page.isDeleted() %}true{% else %}false{% endif %}"
   data-page-is-deletable="{% if isDeletablePage() %}true{% else %}false{% endif %}"
-  data-page-disable-to-create="false"
+  data-page-is-creatable="false"
   data-page-is-able-to-delete-completely="{% if user.canDeleteCompletely(page.creator._id) %}true{% else %}false{% endif %}"
   data-slack-channels="{{ slack|default('') }}"
   data-page-created-at="{% if page %}{{ page.createdAt|datetz('Y/m/d H:i:s') }}{% endif %}"

--- a/src/server/views/widget/page_content.html
+++ b/src/server/views/widget/page_content.html
@@ -17,6 +17,7 @@
   data-page-is-forbidden="{% if forbidden %}true{% else %}false{% endif %}"
   data-page-is-deleted="{% if page.isDeleted() %}true{% else %}false{% endif %}"
   data-page-is-deletable="{% if isDeletablePage() %}true{% else %}false{% endif %}"
+  data-page-disable-to-create="false"
   data-page-is-able-to-delete-completely="{% if user.canDeleteCompletely(page.creator._id) %}true{% else %}false{% endif %}"
   data-slack-channels="{{ slack|default('') }}"
   data-page-created-at="{% if page %}{{ page.createdAt|datetz('Y/m/d H:i:s') }}{% endif %}"


### PR DESCRIPTION
[概要]
couldn't create ページにおいて、三連ボタンを非表示にしました。
今回は、service 層の PageContainer.js の state 内に isDisableToCreatePage を作成し、
 true / flase で判断するように実装しました。
not_creatable_content.html では true になるように、
page_content.html では false になるように実装しています。

[実装前]
<img width="1326" alt="スクリーンショット 2020-10-14 21 54 41" src="https://user-images.githubusercontent.com/57100766/95991583-e5843800-0e67-11eb-8415-eae2ae6d1870.png">

[実装後]
<img width="886" alt="スクリーンショット 2020-10-14 20 46 15" src="https://user-images.githubusercontent.com/57100766/95991403-afdf4f00-0e67-11eb-8637-d89d7acee494.png">
