### PR TITLE
abolish icon

### DIFF
--- a/src/client/js/components/Page/RevisionPathControls.jsx
+++ b/src/client/js/components/Page/RevisionPathControls.jsx
@@ -25,7 +25,6 @@ const RevisionPathControls = (props) => {
       <CopyDropdown pagePath={pagePath} pageId={pageId} buttonStyle={buttonStyle} />
       { !isPageInTrash && !isPageForbidden && (
         <a href="#edit" className="d-edit-none text-muted btn btn-secondary bg-transparent btn-edit border-0" style={buttonStyle}>
-          <i className="icon-note" />
         </a>
       ) }
     </>

--- a/src/client/js/components/Page/RevisionPathControls.jsx
+++ b/src/client/js/components/Page/RevisionPathControls.jsx
@@ -3,8 +3,6 @@ import PropTypes from 'prop-types';
 
 import { withTranslation } from 'react-i18next';
 
-import { isTrashPage } from '@commons/util/path-utils';
-
 import CopyDropdown from './CopyDropdown';
 
 const RevisionPathControls = (props) => {
@@ -15,18 +13,13 @@ const RevisionPathControls = (props) => {
   };
 
   const {
-    pagePath, pageId, isPageForbidden,
+    pagePath, pageId,
   } = props;
 
-  const isPageInTrash = isTrashPage(pagePath);
 
   return (
     <>
       <CopyDropdown pagePath={pagePath} pageId={pageId} buttonStyle={buttonStyle} />
-      { !isPageInTrash && !isPageForbidden && (
-        <a href="#edit" className="d-edit-none text-muted btn btn-secondary bg-transparent btn-edit border-0" style={buttonStyle}>
-        </a>
-      ) }
     </>
   );
 };


### PR DESCRIPTION
ページパス横の icon を廃止しました。

![スクリーンショット 2020-10-15 2 34 06](https://user-images.githubusercontent.com/57100766/96024877-525ef880-0e8f-11eb-805b-3af9a915fd6c.png)
