### PR TITLE
Imprv/correct wording in admin customize by changed paging size in mydrafts

### DIFF
--- a/resource/locales/en_US/admin/admin.json
+++ b/resource/locales/en_US/admin/admin.json
@@ -112,10 +112,10 @@
       "list_num_desc_s": "Set number of list per page such as 'Pagelist', 'Timeline', 'Page History' and 'Share Link' pages",
 
       "list_num_m": "Number of list displayed on article pages included other contents",
-      "list_num_desc_m": "Set number of list per page such as 'Bookmarks', 'Recently created' and 'Drafts'",
+      "list_num_desc_m": "Set number of list per page such as 'Bookmarks', 'Recently created'",
 
-      "list_num_l": "Number of list displayed on 'Search' and 'Draft' pages",
-      "list_num_desc_l": "Set number of list per page such as 'Search' and 'Draft' pages",
+      "list_num_l": "Number of list displayed on 'Search' pages",
+      "list_num_desc_l": "Set number of list per page such as 'Search' pages",
 
       "list_num_xl": "Number of list displayed on article pages",
       "list_num_desc_xl": "Set number of list per page such as 'Not found' and 'Trash' pages",

--- a/resource/locales/en_US/admin/admin.json
+++ b/resource/locales/en_US/admin/admin.json
@@ -112,7 +112,7 @@
       "list_num_desc_s": "Set number of list per page such as 'Pagelist', 'Timeline', 'Page History' and 'Share Link' pages",
 
       "list_num_m": "Number of list displayed on article pages included other contents",
-      "list_num_desc_m": "Set number of list per page such as 'Bookmarks', 'Recently created'",
+      "list_num_desc_m": "Set number of list per page such as 'Bookmarks' and 'Recently created'",
 
       "list_num_l": "Number of list displayed on 'Search' pages",
       "list_num_desc_l": "Set number of list per page such as 'Search' pages",

--- a/resource/locales/en_US/admin/admin.json
+++ b/resource/locales/en_US/admin/admin.json
@@ -112,7 +112,7 @@
       "list_num_desc_s": "Set number of list per page such as 'Pagelist', 'Timeline', 'Page History' and 'Share Link' pages",
 
       "list_num_m": "Number of list displayed on article pages included other contents",
-      "list_num_desc_m": "Set number of list per page such as 'Bookmarks' and 'Recently created'",
+      "list_num_desc_m": "Set number of list per page such as 'Bookmarks' and 'Recently created' pages",
 
       "list_num_l": "Number of list displayed on 'Search' pages",
       "list_num_desc_l": "Set number of list per page such as 'Search' pages",

--- a/resource/locales/ja_JP/admin/admin.json
+++ b/resource/locales/ja_JP/admin/admin.json
@@ -115,7 +115,7 @@
       "list_num_desc_m": "ユーザーページにおける <Bookmarks> <Recently Created>での、1ページあたりの表示数を設定します。",
 
       "list_num_l": "検索ページやDraftページに表示されるリスト数",
-      "list_num_desc_l": "<Search> <My Drafts> での、1ページあたりの表示数を設定します。",
+      "list_num_desc_l": "<Search>での、1ページあたりの表示数を設定します。",
 
       "list_num_xl": "Not FoundページやTrashページに表示されるリスト数",
       "list_num_desc_xl": "記事エリアにおける<Not Found> <Trash>での、1ページあたりの表示数を設定します。",

--- a/resource/locales/ja_JP/admin/admin.json
+++ b/resource/locales/ja_JP/admin/admin.json
@@ -114,7 +114,7 @@
       "list_num_m": "ユーザーページに表示されるリスト数",
       "list_num_desc_m": "ユーザーページにおける <Bookmarks> <Recently Created>での、1ページあたりの表示数を設定します。",
 
-      "list_num_l": "検索ページやDraftページに表示されるリスト数",
+      "list_num_l": "検索ページに表示されるリスト数",
       "list_num_desc_l": "<Search>での、1ページあたりの表示数を設定します。",
 
       "list_num_xl": "Not FoundページやTrashページに表示されるリスト数",

--- a/resource/locales/zh_CN/admin/admin.json
+++ b/resource/locales/zh_CN/admin/admin.json
@@ -124,7 +124,7 @@
       "list_num_desc_s": "Set number of list per page such as 'Pagelist', 'Timeline', 'Page History' and 'Share Link' pages",
 
       "list_num_m": "Number of list displayed on article pages included other contents",
-      "list_num_desc_m": "Set number of list per page such as 'Bookmarks' and 'Recently created'",
+      "list_num_desc_m": "Set number of list per page such as 'Bookmarks' and 'Recently created' pages",
 
       "list_num_l": "Number of list displayed on 'Search' pages",
       "list_num_desc_l": "Set number of list per page such as 'Search' pages",

--- a/resource/locales/zh_CN/admin/admin.json
+++ b/resource/locales/zh_CN/admin/admin.json
@@ -124,7 +124,7 @@
       "list_num_desc_s": "Set number of list per page such as 'Pagelist', 'Timeline', 'Page History' and 'Share Link' pages",
 
       "list_num_m": "Number of list displayed on article pages included other contents",
-      "list_num_desc_m": "Set number of list per page such as 'Bookmarks', 'Recently created'",
+      "list_num_desc_m": "Set number of list per page such as 'Bookmarks' and 'Recently created'",
 
       "list_num_l": "Number of list displayed on 'Search' pages",
       "list_num_desc_l": "Set number of list per page such as 'Search' pages",

--- a/resource/locales/zh_CN/admin/admin.json
+++ b/resource/locales/zh_CN/admin/admin.json
@@ -126,8 +126,8 @@
       "list_num_m": "Number of list displayed on article pages included other contents",
       "list_num_desc_m": "Set number of list per page such as 'Bookmarks', 'Recently created'",
 
-      "list_num_l": "Number of list displayed on 'Search' and 'Draft' pages",
-      "list_num_desc_l": "Set number of list per page such as 'Search' and pages",
+      "list_num_l": "Number of list displayed on 'Search' pages",
+      "list_num_desc_l": "Set number of list per page such as 'Search' pages",
 
       "list_num_xl": "Number of list displayed on article pages",
       "list_num_desc_xl": "Set number of list per page such as 'Not found' and 'Trash' pages",

--- a/resource/locales/zh_CN/admin/admin.json
+++ b/resource/locales/zh_CN/admin/admin.json
@@ -124,10 +124,10 @@
       "list_num_desc_s": "Set number of list per page such as 'Pagelist', 'Timeline', 'Page History' and 'Share Link' pages",
 
       "list_num_m": "Number of list displayed on article pages included other contents",
-      "list_num_desc_m": "Set number of list per page such as 'Bookmarks', 'Recently created' and 'Drafts'",
+      "list_num_desc_m": "Set number of list per page such as 'Bookmarks', 'Recently created'",
 
       "list_num_l": "Number of list displayed on 'Search' and 'Draft' pages",
-      "list_num_desc_l": "Set number of list per page such as 'Search' and 'Draft' pages",
+      "list_num_desc_l": "Set number of list per page such as 'Search' and pages",
 
       "list_num_xl": "Number of list displayed on article pages",
       "list_num_desc_xl": "Set number of list per page such as 'Not found' and 'Trash' pages",


### PR DESCRIPTION
MyDrafts でページングサイズを固定値に設定したので、
管理画面での表記を訂正しました。

[paging 設定画面 削除前]
<img width="971" alt="スクリーンショット 2020-10-15 17 21 47" src="https://user-images.githubusercontent.com/57100766/96096585-f5a12380-0f0a-11eb-982e-5a72782f7c41.png">

[paging 設定画面 削除後]
<img width="1920" alt="スクリーンショット 2020-10-15 12 25 37（2）" src="https://user-images.githubusercontent.com/57100766/96073781-1e60f300-0ee2-11eb-801a-67b93c8a7dd0.png">

[中, 英 version 削除前]
<img width="409" alt="スクリーンショット 2020-10-15 17 21 03" src="https://user-images.githubusercontent.com/57100766/96096736-1ec1b400-0f0b-11eb-8587-8f364ccf2eb6.png">

[中, 英 version 削除後]
<img width="400" alt="スクリーンショット 2020-10-15 17 18 08" src="https://user-images.githubusercontent.com/57100766/96096126-74e22780-0f0a-11eb-8246-61a7a3f68a9f.png">