### PR TITLE
Imprv/gw4156 layout adjustment for bookmarks and recentchanges

### DIFF
--- a/src/client/js/components/MyBookmarkList/MyBookmarkList.jsx
+++ b/src/client/js/components/MyBookmarkList/MyBookmarkList.jsx
@@ -89,6 +89,7 @@ class MyBookmarkList extends React.Component {
           {this.generatePageList(this.state.pages)}
         </ul>
         <PaginationWrapper
+          align="center"
           activePage={this.state.activePage}
           changePage={this.handlePage}
           totalItemsCount={this.state.totalPages}

--- a/src/client/js/components/MyBookmarkList/MyBookmarkList.jsx
+++ b/src/client/js/components/MyBookmarkList/MyBookmarkList.jsx
@@ -85,7 +85,7 @@ class MyBookmarkList extends React.Component {
   renderBookmarkList() {
     return (
       <>
-        <ul className="page-list-ul page-list-ul-flat mb-3">
+        <ul className="page-list-ul page-list-ul-flat mb-4">
           {this.generatePageList(this.state.pages)}
         </ul>
         <PaginationWrapper

--- a/src/client/js/components/MyBookmarkList/MyBookmarkList.jsx
+++ b/src/client/js/components/MyBookmarkList/MyBookmarkList.jsx
@@ -85,7 +85,7 @@ class MyBookmarkList extends React.Component {
   renderBookmarkList() {
     return (
       <>
-        <ul className="page-list-ul page-list-ul-flat mb-4">
+        <ul className="page-list-ul page-list-ul-flat">
           {this.generatePageList(this.state.pages)}
         </ul>
         <PaginationWrapper

--- a/src/client/js/components/RecentCreated/RecentCreated.jsx
+++ b/src/client/js/components/RecentCreated/RecentCreated.jsx
@@ -73,6 +73,7 @@ class RecentCreated extends React.Component {
           {pageList}
         </ul>
         <PaginationWrapper
+          align="center"
           activePage={this.state.activePage}
           changePage={this.handlePage}
           totalItemsCount={this.state.totalPages}

--- a/src/client/js/components/RecentCreated/RecentCreated.jsx
+++ b/src/client/js/components/RecentCreated/RecentCreated.jsx
@@ -69,7 +69,7 @@ class RecentCreated extends React.Component {
 
     return (
       <div className="page-list-container-create">
-        <ul className="page-list-ul page-list-ul-flat mb-4">
+        <ul className="page-list-ul page-list-ul-flat">
           {pageList}
         </ul>
         <PaginationWrapper

--- a/src/client/js/components/RecentCreated/RecentCreated.jsx
+++ b/src/client/js/components/RecentCreated/RecentCreated.jsx
@@ -69,7 +69,7 @@ class RecentCreated extends React.Component {
 
     return (
       <div className="page-list-container-create">
-        <ul className="page-list-ul page-list-ul-flat mb-3">
+        <ul className="page-list-ul page-list-ul-flat mb-4">
           {pageList}
         </ul>
         <PaginationWrapper

--- a/src/client/styles/scss/_layout_growi.scss
+++ b/src/client/styles/scss/_layout_growi.scss
@@ -35,13 +35,3 @@
     }
   }
 }
-
-.grw-page-list-m {
-  .grw-page-list-title-m {
-    svg {
-      width: 35px;
-      height: 35px;
-      margin-bottom: 6px;
-    }
-  }
-}

--- a/src/client/styles/scss/_layout_growi.scss
+++ b/src/client/styles/scss/_layout_growi.scss
@@ -41,6 +41,7 @@
     svg {
       width: 35px;
       height: 35px;
+      margin-bottom: 6px;
     }
   }
 }

--- a/src/client/styles/scss/_page_list.scss
+++ b/src/client/styles/scss/_page_list.scss
@@ -9,7 +9,7 @@ body .page-list {
     margin: 0;
 
     > li {
-      margin: 0;
+      margin: 10px;
       list-style: none;
 
       > a {

--- a/src/client/styles/scss/_page_list.scss
+++ b/src/client/styles/scss/_page_list.scss
@@ -72,3 +72,13 @@ body .page-list {
     background-color: $gray-300;
   }
 }
+
+.grw-page-list-m {
+  .grw-page-list-title-m {
+    svg {
+      width: 35px;
+      height: 35px;
+      margin-bottom: 6px;
+    }
+  }
+}

--- a/src/client/styles/scss/_page_list.scss
+++ b/src/client/styles/scss/_page_list.scss
@@ -9,7 +9,7 @@ body .page-list {
     margin: 0;
 
     > li {
-      margin: 10px;
+      margin: 0.5rem;
       list-style: none;
 
       > a {

--- a/src/server/views/layout-growi/user_page.html
+++ b/src/server/views/layout-growi/user_page.html
@@ -56,7 +56,7 @@
       <h1 class="grw-page-list-title-m border-bottom pb-2">
         <i id="user-bookmark-icon"></i>
         Bookmarks
-      </h2>
+      </h1>
       <div class="page-list" id="user-bookmark-list">
         <div class="page-list-container">
         </div>

--- a/src/server/views/layout-growi/user_page.html
+++ b/src/server/views/layout-growi/user_page.html
@@ -53,7 +53,7 @@
 
   {% if page %}
     <div class="grw-page-list-m my-5">
-      <h1 class="grw-page-list-title-m border-bottom pb-2">
+      <h1 class="grw-page-list-title-m border-bottom pb-2 mb-3">
         <i id="user-bookmark-icon"></i>
         Bookmarks
       </h1>
@@ -64,7 +64,7 @@
     </div>
 
     <div class="grw-page-list-m my-5">
-      <h1 class="grw-page-list-title-m border-bottom pb-2">
+      <h1 class="grw-page-list-title-m border-bottom pb-2 mb-3">
         <i id="recent-created-icon"></i>
         Recently Created
       </h2>

--- a/src/server/views/layout-growi/user_page.html
+++ b/src/server/views/layout-growi/user_page.html
@@ -52,7 +52,7 @@
   {% include 'widget/comments.html' %}
 
   {% if page %}
-    <div class="grw-page-list-m">
+    <div class="grw-page-list-m my-5">
       <h1 class="grw-page-list-title-m border-bottom pb-2">
         <i id="user-bookmark-icon"></i>
         Bookmarks
@@ -63,7 +63,7 @@
       </div>
     </div>
 
-    <div class="grw-page-list-m">
+    <div class="grw-page-list-m my-5">
       <h1 class="grw-page-list-title-m border-bottom pb-2">
         <i id="recent-created-icon"></i>
         Recently Created


### PR DESCRIPTION
GW-4159 BookmarksとRecentChangesのレイアウト調整

[デザインスペック]
<img width="961" alt="Screen Shot 2020-10-22 at 15 59 49" src="https://user-images.githubusercontent.com/59536731/96836257-abc2bb00-147f-11eb-9900-8d039c5c73fe.png">


[変更前]
<img width="672" alt="Screen Shot 2020-10-22 at 15 54 50" src="https://user-images.githubusercontent.com/59536731/96835774-fee83e00-147e-11eb-978c-c2cbb18a46af.png">


[変更後]
<img width="1256" alt="Screen Shot 2020-10-22 at 15 51 25" src="https://user-images.githubusercontent.com/59536731/96835513-a3b64b80-147e-11eb-8032-51db6a768e6b.png">