### PR TITLE
Fix/do not let guest user edit mode in top page content edit button

### DIFF
--- a/src/client/js/legacy/crowi.js
+++ b/src/client/js/legacy/crowi.js
@@ -202,11 +202,6 @@ $(() => {
 window.addEventListener('load', (e) => {
   const { appContainer } = window;
 
-  // do nothing if user is guest
-  if (appContainer.currentUser == null) {
-    return;
-  }
-
   // hash on page
   if (window.location.hash) {
     const navigationContainer = appContainer.getContainer('NavigationContainer');

--- a/src/client/js/services/NavigationContainer.js
+++ b/src/client/js/services/NavigationContainer.js
@@ -91,7 +91,7 @@ export default class NavigationContainer extends Container {
   setEditorMode(editorMode) {
 
     if (this.appContainer.currentUser == null) {
-      logger.warn('Please login or signup.');
+      logger.warn('Please login or signup to edit the page or use hackmd.');
       return;
     }
 

--- a/src/client/js/services/NavigationContainer.js
+++ b/src/client/js/services/NavigationContainer.js
@@ -1,4 +1,7 @@
 import { Container } from 'unstated';
+import loggerFactory from '@alias/logger';
+
+const logger = loggerFactory('growi:services:NavigationContainer');
 
 /**
  * Service container related to options for Application
@@ -88,6 +91,7 @@ export default class NavigationContainer extends Container {
   setEditorMode(editorMode) {
 
     if (this.appContainer.currentUser == null) {
+      logger.warn('Please login or signup.');
       return;
     }
 

--- a/src/client/js/services/NavigationContainer.js
+++ b/src/client/js/services/NavigationContainer.js
@@ -86,6 +86,11 @@ export default class NavigationContainer extends Container {
   }
 
   setEditorMode(editorMode) {
+
+    if (this.appContainer.currentUser == null) {
+      return;
+    }
+
     this.setState({ editorMode });
     if (editorMode === 'view') {
       $('body').removeClass('on-edit');


### PR DESCRIPTION
[概要]
page_content  内にある編集ボタンを押すとページ遷移していました。
これは不適切な挙動なので、それを修正しています。

- 当初 crowi.js に記述しようと考えましたが、navigationContainer.js で制御することにしました。

<img width="1053" alt="スクリーンショット 2020-10-23 19 33 24" src="https://user-images.githubusercontent.com/57100766/96994820-2f57d700-1568-11eb-8c61-f8a26347c9dc.png">
