### PR TITLE
Fix unclosed conditional tag in user page

### DIFF
--- a/src/server/views/widget/user_page_content.html
+++ b/src/server/views/widget/user_page_content.html
@@ -32,7 +32,7 @@
         <div class="page-list-container">
           {# {% include 'page_list.html' with { pages: bookmarkList, pagePropertyName: 'page' } %} #}
         </div>
-        {# {% endif %} #}
+      {% endif %}
     </div>
 
     <div class="tab-pane user-created-list page-list" id="user-created-list">


### PR DESCRIPTION
This unclosed tag breaks _Bookmarks_ and _Recently Created_ lists in user page, when `bookmarkList.length == 0`. 