### PR TITLE
Imprv/add contents in dot drop down other than delete

### DIFF
--- a/src/client/js/components/Page/PageManagement.jsx
+++ b/src/client/js/components/Page/PageManagement.jsx
@@ -100,6 +100,23 @@ const PageManagement = (props) => {
   //   setIsArchiveCreateModalShown(false);
   // }
 
+  function renderDropdownItemForTopPage() {
+    return (
+      <>
+        <button className="dropdown-item" type="button" onClick={openPageDuplicateModalHandler}>
+          <i className="icon-fw icon-docs"></i> { t('Duplicate') }
+        </button>
+        <button className="dropdown-item" type="button" onClick={openPagePresentationModalHandler}>
+          <i className="icon-fw"><PresentationIcon /></i><span className="d-none d-sm-inline"> { t('Presentation Mode') }</span>
+        </button>
+        <button type="button" className="dropdown-item" onClick={() => { exportPageHandler('md') }}>
+          <i className="icon-fw icon-cloud-download"></i>{t('export_bulk.export_page_markdown')}
+        </button>
+        <div className="dropdown-divider"></div>
+      </>
+    );
+  }
+
   function renderDropdownItemForNotTopPage() {
     return (
       <>
@@ -206,7 +223,7 @@ const PageManagement = (props) => {
     <>
       {currentUser == null ? renderDotsIconForGuestUser() : renderDotsIconForCurrentUser()}
       <div className="dropdown-menu dropdown-menu-right">
-        {!isTopPagePath && renderDropdownItemForNotTopPage()}
+        {isTopPagePath ? renderDropdownItemForTopPage() : renderDropdownItemForNotTopPage()}
         <button className="dropdown-item" type="button" onClick={openPageTemplateModalHandler}>
           <i className="icon-fw icon-magic-wand"></i> { t('template.option_label.create/edit') }
         </button>

--- a/src/client/js/components/Page/PageManagement.jsx
+++ b/src/client/js/components/Page/PageManagement.jsx
@@ -106,9 +106,10 @@ const PageManagement = (props) => {
         <button className="dropdown-item" type="button" onClick={openPageDuplicateModalHandler}>
           <i className="icon-fw icon-docs"></i> { t('Duplicate') }
         </button>
-        <button className="dropdown-item" type="button" onClick={openPagePresentationModalHandler}>
+        {/* TODO Presentation Mode is not function. So if it is really necessary, survey this cause and implement Presentation Mode in top page */}
+        {/* <button className="dropdown-item" type="button" onClick={openPagePresentationModalHandler}>
           <i className="icon-fw"><PresentationIcon /></i><span className="d-none d-sm-inline"> { t('Presentation Mode') }</span>
-        </button>
+        </button> */}
         <button type="button" className="dropdown-item" onClick={() => { exportPageHandler('md') }}>
           <i className="icon-fw icon-cloud-download"></i>{t('export_bulk.export_page_markdown')}
         </button>


### PR DESCRIPTION
[概要]
トップページの dot ドロップダウンに 以下を追加しました。
- 複製
- マークダウン形式でページをエクスポート

ここにプレゼンテーションを追加していたのですが、挙動がおかしかったので一旦外しております。
本当に必要であれば、改善タスクを作成します。
なければ、この部分は削除します。

[完成図]
<img width="292" alt="スクリーンショット 2020-10-26 13 56 01" src="https://user-images.githubusercontent.com/57100766/97135554-e4baa280-1793-11eb-8a00-1477083160e8.png">
