### PR TITLE
Imprv/re gw3897 bordercolor redesign

### DIFF
--- a/src/client/styles/scss/_admin.scss
+++ b/src/client/styles/scss/_admin.scss
@@ -39,7 +39,7 @@
   }
 
   .admin-setting-header {
-    border-bottom: 1px solid #dee2e6;
+    border-bottom: 1px solid $border-color;
   }
 
   .admin-security {
@@ -141,7 +141,7 @@
     // style
     .theme-option-container a {
       background-color: $gray-50;
-      border: 1px solid $gray-300;
+      border: 1px solid $border-color;
     }
     .theme-option-name {
       opacity: 0.3;

--- a/src/client/styles/scss/_layout.scss
+++ b/src/client/styles/scss/_layout.scss
@@ -16,7 +16,7 @@ body {
 
 .grw-modal-head {
   font-size: 1em;
-  border-bottom: 1px solid $gray-500;
+  border-bottom: 1px solid yellow;
 }
 
 // padding settings for GrowiNavbarBottom

--- a/src/client/styles/scss/_layout.scss
+++ b/src/client/styles/scss/_layout.scss
@@ -16,7 +16,7 @@ body {
 
 .grw-modal-head {
   font-size: 1em;
-  border-bottom: 1px solid yellow;
+  border-bottom: 1px solid $border-color;
 }
 
 // padding settings for GrowiNavbarBottom

--- a/src/client/styles/scss/_override-bootstrap-variables.scss
+++ b/src/client/styles/scss/_override-bootstrap-variables.scss
@@ -25,7 +25,6 @@ $gray-900: darken($dark, 5%) !default;
 $grays: ("50": $gray-50) !default;
 $red: #ff0a54 !default;
 
-$border-color: $gray-300 !default;
 
 //== Typography
 //

--- a/src/client/styles/scss/_override-bootstrap-variables.scss
+++ b/src/client/styles/scss/_override-bootstrap-variables.scss
@@ -56,7 +56,7 @@ $btn-link-disabled-color: $gray-500;
 
 //== Forms
 //
-$input-border-color: border-color;
+$input-border-color: $border-color;
 
 $input-border-radius: $border-radius-sm;
 $input-border-radius-sm: $border-radius-sm;
@@ -64,7 +64,7 @@ $input-border-radius-lg: $border-radius;
 
 $input-placeholder-color: $gray-500;
 
-$custom-control-indicator-border-color: border-color;
+$custom-control-indicator-border-color: $border-color;
 $custom-control-label-disabled-color: $gray-500;
 $custom-select-disabled-color: $gray-500;
 $custom-range-thumb-disabled-bg: $gray-400;

--- a/src/client/styles/scss/_override-bootstrap-variables.scss
+++ b/src/client/styles/scss/_override-bootstrap-variables.scss
@@ -25,6 +25,7 @@ $gray-900: darken($dark, 5%) !default;
 $grays: ("50": $gray-50) !default;
 $red: #ff0a54 !default;
 
+$border-color: $gray-300 !default;
 
 //== Typography
 //

--- a/src/client/styles/scss/_override-bootstrap-variables.scss
+++ b/src/client/styles/scss/_override-bootstrap-variables.scss
@@ -25,7 +25,7 @@ $gray-900: darken($dark, 5%) !default;
 $grays: ("50": $gray-50) !default;
 $red: #ff0a54 !default;
 
-$border-color: red; //glay-200 test
+$border-color: $gray-300 !default;
 
 //== Typography
 //

--- a/src/client/styles/scss/_override-bootstrap-variables.scss
+++ b/src/client/styles/scss/_override-bootstrap-variables.scss
@@ -25,6 +25,8 @@ $gray-900: darken($dark, 5%) !default;
 $grays: ("50": $gray-50) !default;
 $red: #ff0a54 !default;
 
+$border-color: red; //glay-200 test
+
 //== Typography
 //
 //## Font, line-height, and color for body text, headings, and more.
@@ -54,7 +56,7 @@ $btn-link-disabled-color: $gray-500;
 
 //== Forms
 //
-$input-border-color: $gray-300;
+$input-border-color: border-color;
 
 $input-border-radius: $border-radius-sm;
 $input-border-radius-sm: $border-radius-sm;
@@ -62,7 +64,7 @@ $input-border-radius-lg: $border-radius;
 
 $input-placeholder-color: $gray-500;
 
-$custom-control-indicator-border-color: $gray-400;
+$custom-control-indicator-border-color: border-color;
 $custom-control-label-disabled-color: $gray-500;
 $custom-select-disabled-color: $gray-500;
 $custom-range-thumb-disabled-bg: $gray-400;

--- a/src/client/styles/scss/_override-bootstrap-variables.scss
+++ b/src/client/styles/scss/_override-bootstrap-variables.scss
@@ -64,7 +64,7 @@ $input-border-radius-lg: $border-radius;
 
 $input-placeholder-color: $gray-500;
 
-$custom-control-indicator-border-color: $border-color;
+$custom-control-indicator-border-color: $gray-400;
 $custom-control-label-disabled-color: $gray-500;
 $custom-select-disabled-color: $gray-500;
 $custom-range-thumb-disabled-bg: $gray-400;

--- a/src/client/styles/scss/theme/_apply-colors-light.scss
+++ b/src/client/styles/scss/theme/_apply-colors-light.scss
@@ -293,12 +293,3 @@ $table-hover-bg: $bgcolor-table-hover;
     }
   }
 }
-
-// override-codemirror day-theme
-
-.CodeMirror {
-  .CodeMirror-gutters {
-    background-color: $gray-50;
-    border-right-color: $border-color;
-  }
-}

--- a/src/client/styles/scss/theme/_apply-colors-light.scss
+++ b/src/client/styles/scss/theme/_apply-colors-light.scss
@@ -50,7 +50,7 @@ $table-hover-bg: $bgcolor-table-hover;
  */
 .card.card-disabled {
   background-color: darken($bgcolor-card, 5%);
-  border-color: $gray-200;
+  border-color: $border-color;
 }
 
 /*
@@ -282,11 +282,15 @@ $table-hover-bg: $bgcolor-table-hover;
   }
 }
 
-.top-of-table-contents {
-  border-color: $border-color;
-
-  .grw-seen-user-list {
+.revision-toc {
+  .top-of-table-contents {
     border-color: $border-color;
+
+    .grw-seen-user-list {
+      &:before {
+        border-color: $border-color;
+      }
+    }
   }
 }
 

--- a/src/client/styles/scss/theme/_apply-colors-light.scss
+++ b/src/client/styles/scss/theme/_apply-colors-light.scss
@@ -16,7 +16,6 @@ $color-tags: $gray-500 !default;
 $bgcolor-tags: $gray-200 !default;
 
 // override bootstrap variables
-$border-color: $gray-200;
 $table-color: $color-table;
 $table-bg: $bgcolor-table;
 $table-border-color: $border-color-table;
@@ -280,5 +279,22 @@ $table-hover-bg: $bgcolor-table-hover;
   .grw-tag-label {
     color: $color-tags;
     background-color: $bgcolor-tags;
+  }
+}
+
+.top-of-table-contents {
+  border-color: $border-color;
+
+  .grw-seen-user-list {
+    border-color: $border-color;
+  }
+}
+
+// override-codemirror day-theme
+
+.CodeMirror {
+  .CodeMirror-gutters {
+    background-color: $gray-50;
+    border-right-color: $border-color;
   }
 }

--- a/src/client/styles/scss/theme/_apply-colors.scss
+++ b/src/client/styles/scss/theme/_apply-colors.scss
@@ -524,3 +524,12 @@ mark.rbt-highlight-text {
 .grw-btn-page-management:focus {
   background-color: rgba($color-link, 0.15);
 }
+
+// override-codemirror elegant-theme
+
+.CodeMirror.cm-s-elegant {
+  .CodeMirror-gutters {
+    background-color: $gray-50;
+    border-right-color: $border-color;
+  }
+}

--- a/src/client/styles/scss/theme/_apply-colors.scss
+++ b/src/client/styles/scss/theme/_apply-colors.scss
@@ -396,11 +396,11 @@ body.on-edit {
     background-color: darken($bgcolor-global, 2%);
 
     .page-editor-editor-container {
-      border-right-color: $border-color-theme;
+      border-right-color: $border-color;
 
       .navbar-editor {
         background-color: $bgcolor-global; // same color with active tab
-        border-bottom-color: $border-color-theme;
+        border-bottom-color: $border-color;
       }
     }
 
@@ -409,7 +409,7 @@ body.on-edit {
     }
 
     .page-editor-footer {
-      border-top-color: $border-color-theme;
+      border-top-color: $border-color;
     }
   }
 

--- a/src/client/styles/scss/theme/_apply-colors.scss
+++ b/src/client/styles/scss/theme/_apply-colors.scss
@@ -524,12 +524,3 @@ mark.rbt-highlight-text {
 .grw-btn-page-management:focus {
   background-color: rgba($color-link, 0.15);
 }
-
-// override-codemirror elegant-theme
-
-.CodeMirror.cm-s-elegant {
-  .CodeMirror-gutters {
-    background-color: $gray-50;
-    border-right-color: $border-color;
-  }
-}

--- a/src/client/styles/scss/theme/default.scss
+++ b/src/client/styles/scss/theme/default.scss
@@ -90,7 +90,7 @@ html[light] {
   $color-editor-icons: $color-global;
 
   // Border colors
-  $border-color-theme: $gray-400;
+  $border-color-theme: blue;
   $bordercolor-inline-code: $gray-400; // optional
 
   // Dropdown colors

--- a/src/client/styles/scss/theme/default.scss
+++ b/src/client/styles/scss/theme/default.scss
@@ -90,7 +90,7 @@ html[light] {
   $color-editor-icons: $color-global;
 
   // Border colors
-  $border-color-theme: blue;
+  $border-color-theme: $gray-400;
   $bordercolor-inline-code: $gray-400; // optional
 
   // Dropdown colors

--- a/src/client/styles/scss/theme/mixins/_list-group.scss
+++ b/src/client/styles/scss/theme/mixins/_list-group.scss
@@ -3,6 +3,7 @@
     .list-group-item {
       color: $color;
       background-color: $bgcolor;
+      border-color: $border-color;
 
       &.list-group-item-action {
         &:hover {


### PR DESCRIPTION
# ライトテーマ全ページにおいて、規定した3種類以外のボーダー色変数をなくす

## 作業タスク
- GW-3897 記事エリアの主要なボーダー色の統一
- GW-4138 tableに当たっている変数の正体を突き止め、gray-200系ボーダーに統一する。
- GW-4139 ライトテーマ全ページにおいて、規定した3種類以外のボーダー色変数をなくす
- ※ダークモードと他のテーマは後続タスクにて対応。

## 作業内容
### ボーダーカラーを下記の３種類に統一。
- $border-color (Bootstrap4純正のボーダー色。$gray-300)
- $border-color-theme(デフォルトライトでは$gray-400)
- $table-border-color(table意外に使わない。$gray-200)
### 実装後の見た目
- 内部のリファクタがメインなので、既存画面からほぼ変更なし。
![image](https://user-images.githubusercontent.com/65531771/97139933-f2c1f080-179e-11eb-90d6-9e3af8a05eb8.png)
