### PR TITLE
Feat/gw 4240 adjust color of icon in dark

### DIFF
--- a/src/client/styles/scss/_comment.scss
+++ b/src/client/styles/scss/_comment.scss
@@ -44,6 +44,7 @@
     .page-comment-revision svg {
       width: 16px;
       height: 16px;
+      fill: $primary;
     }
   }
 

--- a/src/client/styles/scss/_comment.scss
+++ b/src/client/styles/scss/_comment.scss
@@ -44,7 +44,6 @@
     .page-comment-revision svg {
       width: 16px;
       height: 16px;
-      fill: $primary;
     }
   }
 

--- a/src/client/styles/scss/theme/_apply-colors.scss
+++ b/src/client/styles/scss/theme/_apply-colors.scss
@@ -419,6 +419,17 @@ body.on-edit {
 }
 
 /*
+ * GROWI comment
+ */
+.page-comment-meta .page-comment-revision svg {
+  fill: $color-link;
+
+  &:hover() {
+    fill: $color-link-hover;
+  }
+}
+
+/*
  * GROWI comment form
  */
 .growi .main {


### PR DESCRIPTION
light, dark 共に $color-link で統一

<img width="390" alt="Screen Shot 2020-10-29 at 21 52 03" src="https://user-images.githubusercontent.com/38426468/97576396-76930b80-1a31-11eb-850d-082d86e30055.png">
<img width="390" alt="Screen Shot 2020-10-29 at 21 52 20" src="https://user-images.githubusercontent.com/38426468/97576399-772ba200-1a31-11eb-884c-db434af9c1f7.png">
