### PR TITLE
Imprv/gw4213 design fix for comment area new

### DIFF
--- a/src/client/js/components/PageComments.jsx
+++ b/src/client/js/components/PageComments.jsx
@@ -170,7 +170,7 @@ class PageComments extends React.Component {
               className="btn-comment-reply"
               onClick={() => { return this.replyButtonClickedHandler(commentId) }}
             >
-              <i className="icon-fw icon-action-redo"></i> Reply
+              <i className="icon-fw icon-action-undo"></i> Reply
             </Button>
           </div>
         )}

--- a/src/client/styles/scss/_comment_growi.scss
+++ b/src/client/styles/scss/_comment_growi.scss
@@ -100,11 +100,7 @@
   .btn.btn-comment-reply {
     width: 120px;
     margin-top: 0.5em;
-    margin-right: 15px;
-
-    border-top: none;
-    border-right: none;
-    border-left: none;
+    border: none;
   }
 
   // display cheatsheet for comment form only

--- a/src/client/styles/scss/_comment_growi.scss
+++ b/src/client/styles/scss/_comment_growi.scss
@@ -34,7 +34,6 @@
 
   .page-comments-row {
     margin: 30px 0px;
-    border-top: 5px solid;
   }
 
   .page-comments {

--- a/src/client/styles/scss/_comment_growi.scss
+++ b/src/client/styles/scss/_comment_growi.scss
@@ -98,7 +98,6 @@
   }
   // reply button
   .btn.btn-comment-reply {
-    width: 120px;
     margin-top: 0.5em;
     border: none;
   }

--- a/src/client/styles/scss/_comment_growi.scss
+++ b/src/client/styles/scss/_comment_growi.scss
@@ -33,7 +33,8 @@
   }
 
   .page-comments-row {
-    margin: 30px 0px;
+    // offset margin left to apply bg-color
+    margin: 30px 0px 30px -15px;
   }
 
   .page-comments {

--- a/src/client/styles/scss/theme/_apply-colors-dark.scss
+++ b/src/client/styles/scss/theme/_apply-colors-dark.scss
@@ -343,6 +343,12 @@ body.on-edit {
   }
 }
 
+.growi .main {
+  .page-comments-row {
+    background: $bgcolor-subnav;
+  }
+}
+
 /*
  * GROWI tags
  */
@@ -361,14 +367,5 @@ body.on-edit {
     svg {
       fill: $color-global;
     }
-  }
-}
-
-/*
- * GROWI comment form
- */
-.growi .main {
-  .page-comments-row {
-    background: darken($gray-900, 5%);
   }
 }

--- a/src/client/styles/scss/theme/_apply-colors-dark.scss
+++ b/src/client/styles/scss/theme/_apply-colors-dark.scss
@@ -363,3 +363,12 @@ body.on-edit {
     }
   }
 }
+
+/*
+ * GROWI comment form
+ */
+.growi .main {
+  .page-comments-row {
+    background: $gray-900;
+  }
+}

--- a/src/client/styles/scss/theme/_apply-colors-dark.scss
+++ b/src/client/styles/scss/theme/_apply-colors-dark.scss
@@ -369,6 +369,6 @@ body.on-edit {
  */
 .growi .main {
   .page-comments-row {
-    background: $gray-900;
+    background: darken($gray-900, 5%);
   }
 }

--- a/src/client/styles/scss/theme/_apply-colors-light.scss
+++ b/src/client/styles/scss/theme/_apply-colors-light.scss
@@ -299,6 +299,6 @@ $table-hover-bg: $bgcolor-table-hover;
  */
 .growi .main {
   .page-comments-row {
-    background: $gray-100;
+    background: lighten($gray-100, 3%);
   }
 }

--- a/src/client/styles/scss/theme/_apply-colors-light.scss
+++ b/src/client/styles/scss/theme/_apply-colors-light.scss
@@ -293,3 +293,12 @@ $table-hover-bg: $bgcolor-table-hover;
     }
   }
 }
+
+/*
+ * GROWI comment form
+ */
+.growi .main {
+  .page-comments-row {
+    background: $gray-100;
+  }
+}

--- a/src/client/styles/scss/theme/_apply-colors-light.scss
+++ b/src/client/styles/scss/theme/_apply-colors-light.scss
@@ -273,6 +273,12 @@ $table-hover-bg: $bgcolor-table-hover;
   }
 }
 
+.growi .main {
+  .page-comments-row {
+    background: $bgcolor-subnav;
+  }
+}
+
 /*
  * GROWI tags
  */
@@ -291,14 +297,5 @@ $table-hover-bg: $bgcolor-table-hover;
     svg {
       fill: $color-global;
     }
-  }
-}
-
-/*
- * GROWI comment form
- */
-.growi .main {
-  .page-comments-row {
-    background: lighten($gray-100, 3%);
   }
 }

--- a/src/client/styles/scss/theme/_apply-colors.scss
+++ b/src/client/styles/scss/theme/_apply-colors.scss
@@ -452,16 +452,12 @@ body.on-edit {
  * GROWI comment form
  */
 .growi .main {
-  .page-comments-row {
-    border-top-color: $border-color-theme;
-  }
-
   .page-comment .page-comment-main,
   .page-comment-form .comment-form-main {
-    background-color: darken($bgcolor-global, 4%);
+    background-color: $bgcolor-global;
 
     &:before {
-      border-right-color: darken($bgcolor-global, 4%);
+      border-right-color: $bgcolor-global;
     }
 
     .nav.nav-tabs {

--- a/src/server/views/layout-growi/widget/comments.html
+++ b/src/server/views/layout-growi/widget/comments.html
@@ -1,8 +1,8 @@
 <div class="page-comments-row row d-edit-none d-print-none">
 
-  <div class="page-comments col-xl-7 col-lg-9">
+  <div class="page-comments col-xl-7 col-lg-9 my-5">
 
-    <h4 class="my-2"><i class="icon-fw icon-bubbles"></i> Comments</h4>
+    <h1 class="border-bottom pb-2 mb-3"><i class="icon-fw icon-bubbles"></i> Comments</h1>
 
     <div class="page-comments-list" id="page-comments-list"></div>
 

--- a/src/server/views/layout-growi/widget/comments.html
+++ b/src/server/views/layout-growi/widget/comments.html
@@ -1,6 +1,6 @@
 <div class="page-comments-row row d-edit-none d-print-none">
 
-  <div class="page-comments col-xl-7 col-lg-9 my-5">
+  <div class="page-comments col-lg-12 my-5">
 
     <h1 class="border-bottom pb-2 mb-3"><i class="icon-fw icon-bubbles"></i> Comments</h1>
 

--- a/src/server/views/layout-growi/widget/comments.html
+++ b/src/server/views/layout-growi/widget/comments.html
@@ -1,6 +1,6 @@
 <div class="page-comments-row row d-edit-none d-print-none">
 
-  <div class="page-comments col-lg-12 my-5">
+  <div class="page-comments col-lg-10 my-5">
 
     <h1 class="border-bottom pb-2 mb-3"><i class="icon-fw icon-bubbles"></i> Comments</h1>
 


### PR DESCRIPTION
GW-4213 コメントエリアの見出しとデザイン修正
[XD]
<img width="671" alt="Screen Shot 2020-10-29 at 20 49 59" src="https://user-images.githubusercontent.com/59536731/97564737-60cd1880-1a28-11eb-8658-0678a8803e97.png">

[変更後]
<img width="1338" alt="Screen Shot 2020-10-29 at 20 54 09" src="https://user-images.githubusercontent.com/59536731/97565081-f49ee480-1a28-11eb-9be6-4f189f72b7d0.png">


<img width="854" alt="Screen Shot 2020-10-29 at 20 53 36" src="https://user-images.githubusercontent.com/59536731/97565005-d5a05280-1a28-11eb-8424-e9d69358cbad.png">

