### PR TITLE
Imprv/gw4256 slack notification color

### DIFF
--- a/src/client/styles/scss/theme/_apply-colors-dark.scss
+++ b/src/client/styles/scss/theme/_apply-colors-dark.scss
@@ -44,6 +44,12 @@ textarea.form-control {
   // border: 1px solid darken($border, 30%);
 }
 
+.grw-slack-notification {
+  .form-control {
+    background: $bgcolor-global;
+  }
+}
+
 .form-control[disabled],
 .form-control[readonly] {
   color: lighten($color-global, 10%);

--- a/src/client/styles/scss/theme/_apply-colors-light.scss
+++ b/src/client/styles/scss/theme/_apply-colors-light.scss
@@ -36,6 +36,12 @@ $table-hover-bg: $bgcolor-table-hover;
   background-color: $bgcolor-global;
 }
 
+.grw-slack-notification {
+  .form-control {
+    background: white;
+  }
+}
+
 .form-control::placeholder {
   color: darken($bgcolor-global, 20%);
 }

--- a/src/client/styles/scss/theme/mono-blue.scss
+++ b/src/client/styles/scss/theme/mono-blue.scss
@@ -202,9 +202,4 @@ html[dark] {
       @include three-stranded-button(lighten($primary, 30%), $primary, darken($primary, 10%), darken($primary, 20%));
     }
   }
-  .grw-slack-notification {
-    .form-control {
-      background: $themedark;
-    }
-  }
 }

--- a/src/client/styles/scss/theme/mono-blue.scss
+++ b/src/client/styles/scss/theme/mono-blue.scss
@@ -202,4 +202,9 @@ html[dark] {
       @include three-stranded-button(lighten($primary, 30%), $primary, darken($primary, 10%), darken($primary, 20%));
     }
   }
+  .grw-slack-notification {
+    .form-control {
+      background: $themedark;
+    }
+  }
 }


### PR DESCRIPTION
GW-4256 【slack notificationのinput color】wood, monoblue light & dark, island
GW-4257 【slack notificationのinput color】future, kibela, antarctic

[default:  dark]
<img width="236" alt="Screen Shot 2020-10-30 at 12 29 38" src="https://user-images.githubusercontent.com/59536731/97656855-d1694900-1aab-11eb-898e-fd4c8500b324.png">

[monoblue: dark]
<img width="233" alt="Screen Shot 2020-10-30 at 12 30 12" src="https://user-images.githubusercontent.com/59536731/97656857-d201df80-1aab-11eb-8e90-b1807866984f.png">

[future]
<img width="238" alt="Screen Shot 2020-10-30 at 12 35 50" src="https://user-images.githubusercontent.com/59536731/97657144-7b48d580-1aac-11eb-9cd7-5543e47983a9.png">

[halloween]
<img width="247" alt="Screen Shot 2020-10-30 at 12 36 58" src="https://user-images.githubusercontent.com/59536731/97657218-a7645680-1aac-11eb-8a84-9e2178d2de33.png">

[それ以外の全てのテーマ]
<img width="226" alt="Screen Shot 2020-10-30 at 12 33 39" src="https://user-images.githubusercontent.com/59536731/97657269-cd89f680-1aac-11eb-8664-4efa38cdde2d.png">
