### PR TITLE
add z index _apply-colors.scss

### DIFF
--- a/src/client/styles/scss/theme/_apply-colors.scss
+++ b/src/client/styles/scss/theme/_apply-colors.scss
@@ -313,7 +313,7 @@ ul.pagination {
     fill: $color-link;
   }
   .grw-seen-user-list {
-    @include border-vertical('before', $bordercolor-toc, 70%);
+    @include border-vertical('before', $bordercolor-toc, 70%, -1);
 
     .btn {
       color: $color-seen-user;


### PR DESCRIPTION
足跡ボタンの当たり判定を解消しました。
before 要素の z-index を奥に配置することで解消しています。
![iOS の画像](https://user-images.githubusercontent.com/57100766/98081706-efbfb200-1eba-11eb-8c09-7d2217d5a1d7.jpg)
