### PR TITLE
fixed update password message

### DIFF
--- a/src/client/js/components/Me/PasswordSettings.jsx
+++ b/src/client/js/components/Me/PasswordSettings.jsx
@@ -55,7 +55,7 @@ class PasswordSettings extends React.Component {
       });
       this.setState({ oldPassword: '', newPassword: '', newPasswordConfirm: '' });
       await personalContainer.retrievePersonalData();
-      toastSuccess(t('toaster.update_successed', { target: t('personal_settings.update_password') }));
+      toastSuccess(t('toaster.update_successed', { target: t('Password') }));
     }
     catch (err) {
       toastError(err);


### PR DESCRIPTION
パスワードの更新時に誤ったメッセージが表示されていたのを修正しました

修正前
![スクリーンショット 2020-11-01 105310](https://user-images.githubusercontent.com/19851537/98101742-ff98bf80-1ed5-11eb-96fe-99a52a77eb16.png)

修正後
![スクリーンショット 2020-11-01 110345](https://user-images.githubusercontent.com/19851537/98101757-032c4680-1ed6-11eb-9d6b-62c0aabab641.png)
