### PR TITLE
translate last section of presentation

### DIFF
--- a/resource/locales/en_US/translation.json
+++ b/resource/locales/en_US/translation.json
@@ -50,6 +50,7 @@
   "attachment_data": "Attachment Data",
   "No_attachments_yet": "No attachments yet.",
   "Presentation Mode": "Presentation",
+  "The end": "The end",
   "Not available for guest": "Not available for guest",
   "Create Archive Page": "Create Archive Page",
   "File type": "File type",

--- a/resource/locales/ja_JP/translation.json
+++ b/resource/locales/ja_JP/translation.json
@@ -51,6 +51,7 @@
   "attachment_data": "添付データ",
   "No_attachments_yet": "No attachments yet.",
   "Presentation Mode": "プレゼンテーション",
+  "The end": "おしまい",
   "Not available for guest": "ゲストユーザーは利用できません",
   "Create Archive Page": "アーカイブページの作成",
   "Target page": "対象ページ",

--- a/resource/locales/zh_CN/translation.json
+++ b/resource/locales/zh_CN/translation.json
@@ -52,6 +52,7 @@
   "attachment_data": "Attachment Data",
   "No_attachments_yet": "暂无附件",
 	"Presentation Mode": "演示文稿",
+  "The end": "结束",
   "Not available for guest": "Not available for guest",
   "Create Archive Page": "创建归档页",
   "File type": "文件类型",

--- a/src/server/views/page_presentation.html
+++ b/src/server/views/page_presentation.html
@@ -56,7 +56,7 @@
 {{ revision.body|presentation|safe }}
           </script>
         </section>
-        <section  data-markdown># おしまい</section>
+        <section  data-markdown># {{ t('The end') }}</section>
       </div>
     </div>
 


### PR DESCRIPTION
fix #3007 

- 英語
<img width="1221" alt="Screen Shot 2020-11-04 at 22 32 28" src="https://user-images.githubusercontent.com/38426468/98118068-fca9c900-1eed-11eb-9fa1-03d1617d0de8.png">

- 中国語

<img width="1221" alt="Screen Shot 2020-11-04 at 22 33 06" src="https://user-images.githubusercontent.com/38426468/98118074-ff0c2300-1eed-11eb-8ad2-32e26b0847fb.png">
