### PR TITLE
improve could'nt create page

### DIFF
--- a/src/client/js/legacy/crowi.js
+++ b/src/client/js/legacy/crowi.js
@@ -201,13 +201,13 @@ $(() => {
 
 window.addEventListener('load', (e) => {
   const { appContainer, pageContainer } = window;
-  const editablePages = pageContainer;
+  const isEditable = pageContainer;
 
   // hash on page
   if (window.location.hash) {
     const navigationContainer = appContainer.getContainer('NavigationContainer');
 
-    if (window.location.hash === '#edit' && editablePages) {
+    if (window.location.hash === '#edit' && isEditable) {
       navigationContainer.setEditorMode('edit');
 
       // focus

--- a/src/client/js/legacy/crowi.js
+++ b/src/client/js/legacy/crowi.js
@@ -201,16 +201,13 @@ $(() => {
 
 window.addEventListener('load', (e) => {
   const { appContainer, pageContainer } = window;
-  const { currentUser } = appContainer;
-  const {
-    isPageExist, isPageForbidden, isNotCreatable, isTrashPage,
-  } = pageContainer.state;
+  const isEditableMode = pageContainer;
 
   // hash on page
   if (window.location.hash) {
     const navigationContainer = appContainer.getContainer('NavigationContainer');
 
-    if (window.location.hash === '#edit' && isPageExist && (currentUser != null) && !isPageForbidden && !isNotCreatable && !isTrashPage) {
+    if (window.location.hash === '#edit' && isEditableMode) {
       navigationContainer.setEditorMode('edit');
 
       // focus

--- a/src/client/js/legacy/crowi.js
+++ b/src/client/js/legacy/crowi.js
@@ -201,6 +201,7 @@ $(() => {
 
 window.addEventListener('load', (e) => {
   const { appContainer, pageContainer } = window;
+  const { currentUser } = appContainer;
   const {
     isPageExist, isPageForbidden, isNotCreatable, isTrashPage,
   } = pageContainer.state;
@@ -209,7 +210,7 @@ window.addEventListener('load', (e) => {
   if (window.location.hash) {
     const navigationContainer = appContainer.getContainer('NavigationContainer');
 
-    if (window.location.hash === '#edit' && isPageExist && !isPageForbidden && !isNotCreatable && !isTrashPage) {
+    if (window.location.hash === '#edit' && isPageExist && (currentUser != null) && !isPageForbidden && !isNotCreatable && !isTrashPage) {
       navigationContainer.setEditorMode('edit');
 
       // focus

--- a/src/client/js/legacy/crowi.js
+++ b/src/client/js/legacy/crowi.js
@@ -201,13 +201,13 @@ $(() => {
 
 window.addEventListener('load', (e) => {
   const { appContainer, pageContainer } = window;
-  const isEditableMode = pageContainer;
+  const editablePages = pageContainer;
 
   // hash on page
   if (window.location.hash) {
     const navigationContainer = appContainer.getContainer('NavigationContainer');
 
-    if (window.location.hash === '#edit' && isEditableMode) {
+    if (window.location.hash === '#edit' && editablePages) {
       navigationContainer.setEditorMode('edit');
 
       // focus

--- a/src/client/js/legacy/crowi.js
+++ b/src/client/js/legacy/crowi.js
@@ -200,8 +200,9 @@ $(() => {
 });
 
 window.addEventListener('load', (e) => {
-  const { appContainer, pageContainer } = window;
-  const isEditable = pageContainer;
+  const { appContainer } = window;
+  const pageContainer = appContainer.getContainer('PageContainer');
+  const { isEditable } = pageContainer;
 
   // hash on page
   if (window.location.hash) {

--- a/src/client/js/legacy/crowi.js
+++ b/src/client/js/legacy/crowi.js
@@ -200,13 +200,16 @@ $(() => {
 });
 
 window.addEventListener('load', (e) => {
-  const { appContainer } = window;
+  const { appContainer, pageContainer } = window;
+  const {
+    isPageExist, isPageForbidden, isNotCreatable, isTrashPage,
+  } = pageContainer.state;
 
   // hash on page
   if (window.location.hash) {
     const navigationContainer = appContainer.getContainer('NavigationContainer');
 
-    if (window.location.hash === '#edit') {
+    if (window.location.hash === '#edit' && isPageExist && !isPageForbidden && !isNotCreatable && !isTrashPage) {
       navigationContainer.setEditorMode('edit');
 
       // focus

--- a/src/client/js/services/PageContainer.js
+++ b/src/client/js/services/PageContainer.js
@@ -133,7 +133,8 @@ export default class PageContainer extends Container {
     return 'PageContainer';
   }
 
-  isEditableMode() {
+
+  get editablePages() {
     const { appContainer } = window;
     const { currentUser } = appContainer;
     const {
@@ -143,6 +144,7 @@ export default class PageContainer extends Container {
     if (isPageExist && (currentUser != null) && !isPageForbidden && !isNotCreatable && !isTrashPage) {
       return true;
     }
+    return false;
   }
 
   /**

--- a/src/client/js/services/PageContainer.js
+++ b/src/client/js/services/PageContainer.js
@@ -133,6 +133,18 @@ export default class PageContainer extends Container {
     return 'PageContainer';
   }
 
+  isEditableMode() {
+    const { appContainer } = window;
+    const { currentUser } = appContainer;
+    const {
+      isPageExist, isPageForbidden, isNotCreatable, isTrashPage,
+    } = this.state;
+
+    if (isPageExist && (currentUser != null) && !isPageForbidden && !isNotCreatable && !isTrashPage) {
+      return true;
+    }
+  }
+
   /**
    * initialize state for markdown data
    */

--- a/src/client/js/services/PageContainer.js
+++ b/src/client/js/services/PageContainer.js
@@ -135,8 +135,7 @@ export default class PageContainer extends Container {
 
 
   get isEditable() {
-    const { appContainer } = window;
-    const { currentUser } = appContainer;
+    const { currentUser } = this.appContainer;
     const {
       isPageExist, isPageForbidden, isNotCreatable, isTrashPage,
     } = this.state;

--- a/src/client/js/services/PageContainer.js
+++ b/src/client/js/services/PageContainer.js
@@ -134,7 +134,7 @@ export default class PageContainer extends Container {
   }
 
 
-  get editablePages() {
+  get isEditable() {
     const { appContainer } = window;
     const { currentUser } = appContainer;
     const {

--- a/src/server/views/widget/not_creatable_content.html
+++ b/src/server/views/widget/not_creatable_content.html
@@ -1,4 +1,4 @@
-<div class="row not-found-message-row mb-4">
+<div class="row not-found-message-row m-2">
   <div class="col-md-12">
     <h2 class="text-muted">
       <i class="icon-ban" aria-hidden="true"></i>

--- a/src/server/views/widget/not_creatable_content.html
+++ b/src/server/views/widget/not_creatable_content.html
@@ -1,4 +1,4 @@
-<div class="row not-found-message-row m-2">
+<div class="row not-found-message-row">
   <div class="col-md-12">
     <h2 class="text-muted">
       <i class="icon-ban" aria-hidden="true"></i>


### PR DESCRIPTION
GW-4317 could'nt create page作成時のテキストにmarginをつける
could'nt page 作成時(#edit)に、メッセージが端によってしまっていたのでmarginをつけて余白を作りました。

## 元々の見た目
#### ページ作成時(#edit)

<img width="525" alt="Screen Shot 2020-11-05 at 13 44 48" src="https://user-images.githubusercontent.com/59536731/98198775-1b02d980-1f6d-11eb-9df5-c7d1d1caa0b7.png">

### (# view)
<img width="527" alt="Screen Shot 2020-11-05 at 13 44 52" src="https://user-images.githubusercontent.com/59536731/98198777-1b9b7000-1f6d-11eb-877e-54ff7e225214.png">


## 変更後
#### (#edit)
<img width="1210" alt="Screen Shot 2020-11-05 at 13 46 28" src="https://user-images.githubusercontent.com/59536731/98198893-60bfa200-1f6d-11eb-82da-32d83ad42615.png">

### (# view)
<img width="737" alt="Screen Shot 2020-11-05 at 13 46 51" src="https://user-images.githubusercontent.com/59536731/98198896-61f0cf00-1f6d-11eb-9429-9a3963054834.png">
