### PR TITLE
Imprv/old tabs on user page

### DIFF
--- a/src/client/js/components/Icons/LooockIcon.jsx
+++ b/src/client/js/components/Icons/LooockIcon.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const LockIcon = () => <i className="icon-fw icon-lock"></i>;
+
+export default LockIcon;

--- a/src/client/js/components/Icons/PaperPlaneIcon.jsx
+++ b/src/client/js/components/Icons/PaperPlaneIcon.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const PaperPlaneIcon = () => <i className="icon-fw icon-paper-plane"></i>;
+
+export default PaperPlaneIcon;

--- a/src/client/js/components/Icons/ShareAltIcon.jsx
+++ b/src/client/js/components/Icons/ShareAltIcon.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const ShareAltIcon = () => <i className="icon-fw icon-share-alt"></i>;
+
+export default ShareAltIcon;

--- a/src/client/js/components/Icons/UserIcon.jsx
+++ b/src/client/js/components/Icons/UserIcon.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const UserIcon = () => <i className="icon-fw icon-user"></i>;
+
+export default UserIcon;

--- a/src/client/js/components/Me/PersonalSettings.jsx
+++ b/src/client/js/components/Me/PersonalSettings.jsx
@@ -47,9 +47,7 @@ class PersonalSettings extends React.Component {
 
 
     return (
-      <>
-        <CustomNavigation navTabMapping={navTabMapping} />
-      </>
+      <CustomNavigation navTabMapping={navTabMapping} />
     );
   }
 

--- a/src/client/js/components/Me/PersonalSettings.jsx
+++ b/src/client/js/components/Me/PersonalSettings.jsx
@@ -8,26 +8,15 @@ import PasswordSettings from './PasswordSettings';
 import ExternalAccountLinkedMe from './ExternalAccountLinkedMe';
 import ApiSettings from './ApiSettings';
 
+import LockIcon from '../Icons/LooockIcon';
+import UserIcon from '../Icons/UserIcon';
+import ShareAltIcon from '../Icons/ShareAltIcon';
+
+
 class PersonalSettings extends React.Component {
 
   render() {
     const { t } = this.props;
-
-    const UserIcon = () => {
-      return <i className="icon-fw icon-user"></i>;
-    };
-
-    const shereAltIcon = () => {
-      return <i className="icon-fw icon-share-alt"></i>;
-    };
-
-    const lockIcon = () => {
-      return <i className="icon-fw icon-lock"></i>;
-    };
-
-    const paperPlaneIcon = () => {
-      return <i className="icon-fw icon-paper-plane"></i>;
-    };
 
     const navTabMapping = {
       user_infomation: {
@@ -37,19 +26,19 @@ class PersonalSettings extends React.Component {
         index: 0,
       },
       external_accounts: {
-        Icon: shereAltIcon,
+        Icon: ShareAltIcon,
         Content: ExternalAccountLinkedMe,
         i18n: t('admin:user_management.external_accounts'),
         index: 1,
       },
       password_settings: {
-        Icon: lockIcon,
+        Icon: LockIcon,
         Content: PasswordSettings,
         i18n: t('Password Settings'),
         index: 2,
       },
       api_settings: {
-        Icon: paperPlaneIcon,
+        Icon: LockIcon,
         Content: ApiSettings,
         i18n: t('API Settings'),
         index: 3,

--- a/src/client/js/components/Me/PersonalSettings.jsx
+++ b/src/client/js/components/Me/PersonalSettings.jsx
@@ -10,74 +10,43 @@ import ApiSettings from './ApiSettings';
 
 class PersonalSettings extends React.Component {
 
-
   render() {
     const { t } = this.props;
 
-    // const Icons = [
-    //   <i className="icon-fw icon-user"></i>,
-    //   <i className="icon-fw icon-share-alt"></i>,
-    //   <i className="icon-fw icon-lock"></i>,
-    //   <i className="icon-fw icon-paper-plane"></i>,
-    // ];
-    // console.log(`Icons = ${Icons}`);
-
-    // const setIcons = () => {
-    //   Icons.map((icon) => {
-    //     console.log(icon);
-    //     return (
-    //       <>
-    //         { icon }
-    //       </>
-    //     );
-    //   });
-    // };
-    // const setIcons = () => {
-    //   Icons.map(icon => icon);
-    // };
-
-    const setIcon1 = () => {
-      return (
-        <i className="icon-fw icon-user"></i>
-      );
+    const UserIcon = () => {
+      return <i className="icon-fw icon-user"></i>;
     };
-    const setIcon2 = () => {
-      return (
-        <i className="icon-fw icon-share-alt"></i>
-      );
+    const shereAltIcon = () => {
+      return <i className="icon-fw icon-share-alt"></i>;
     };
-    const setIcon3 = () => {
-      return (
-        <i className="icon-fw icon-lock"></i>
-      );
+    const lockIcon = () => {
+      return <i className="icon-fw icon-lock"></i>;
     };
-    const setIcon4 = () => {
-      return (
-        <i className="icon-fw icon-paper-plan"></i>
-      );
+    const paperPlaneIcon = () => {
+      return <i className="icon-fw icon-paper-plane"></i>;
     };
 
     const navTabMapping = {
       user_infomation: {
-        Icon: setIcon1,
+        Icon: UserIcon,
         Content: UserSettings,
         i18n: t('User Information'),
         index: 0,
       },
       external_accounts: {
-        Icon: setIcon2,
+        Icon: shereAltIcon,
         Content: ExternalAccountLinkedMe,
         i18n: t('admin:user_management.external_accounts'),
         index: 1,
       },
       password_settings: {
-        Icon: setIcon3,
+        Icon: lockIcon,
         Content: PasswordSettings,
         i18n: t('Password Settings'),
         index: 2,
       },
       api_settings: {
-        Icon: setIcon4,
+        Icon: paperPlaneIcon,
         Content: ApiSettings,
         i18n: t('API Settings'),
         index: 3,

--- a/src/client/js/components/Me/PersonalSettings.jsx
+++ b/src/client/js/components/Me/PersonalSettings.jsx
@@ -13,9 +13,17 @@ class PersonalSettings extends React.Component {
 
   render() {
     const { t } = this.props;
+
+
+    const UserSettingsIcon = () => {
+      return (
+        <i className="icon-fw icon-user"></i>
+      );
+    };
+
     const navTabMapping = {
       user_infomation: {
-        Icon: PageListIcon,
+        Icon: UserSettingsIcon,
         Content: UserSettings,
         i18n: t('User Information'),
         index: 0,
@@ -39,6 +47,7 @@ class PersonalSettings extends React.Component {
         index: 3,
       },
     };
+
 
     return (
       <Fragment>

--- a/src/client/js/components/Me/PersonalSettings.jsx
+++ b/src/client/js/components/Me/PersonalSettings.jsx
@@ -2,20 +2,48 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { withTranslation } from 'react-i18next';
-
+import CustomNavigation from '../CustomNavigation';
 import UserSettings from './UserSettings';
 import PasswordSettings from './PasswordSettings';
 import ExternalAccountLinkedMe from './ExternalAccountLinkedMe';
 import ApiSettings from './ApiSettings';
+import PageListIcon from '../Icons/PageListIcon';
 
 class PersonalSettings extends React.Component {
 
   render() {
     const { t } = this.props;
+    const navTabMapping = {
+      user_infomation: {
+        Icon: PageListIcon,
+        Content: UserSettings,
+        i18n: t('User Information'),
+        index: 0,
+      },
+      external_accounts: {
+        Icon: PageListIcon,
+        Content: ExternalAccountLinkedMe,
+        i18n: t('admin:user_management.external_accounts'),
+        index: 1,
+      },
+      password_settings: {
+        Icon: PageListIcon,
+        Content: PasswordSettings,
+        i18n: t('Password Settings'),
+        index: 2,
+      },
+      api_settings: {
+        Icon: PageListIcon,
+        Content: ApiSettings,
+        i18n: t('API Settings'),
+        index: 3,
+      },
+    };
 
     return (
       <Fragment>
-        <div className="personal-settings">
+        <CustomNavigation navTabMapping={navTabMapping} />
+        {/* <div className="personal-settings">
           <ul className="nav nav-tabs" role="tablist">
             <li className="nav-item">
               <a className="nav-link active" href="#user-settings" data-toggle="tab" role="tab">
@@ -52,7 +80,7 @@ class PersonalSettings extends React.Component {
               <ApiSettings />
             </div>
           </div>
-        </div>
+        </div> */}
       </Fragment>
     );
   }

--- a/src/client/js/components/Me/PersonalSettings.jsx
+++ b/src/client/js/components/Me/PersonalSettings.jsx
@@ -11,6 +11,7 @@ import ApiSettings from './ApiSettings';
 import LockIcon from '../Icons/LooockIcon';
 import UserIcon from '../Icons/UserIcon';
 import ShareAltIcon from '../Icons/ShareAltIcon';
+import PaperPlaneIcon from '../Icons/PaperPlaneIcon';
 
 
 class PersonalSettings extends React.Component {
@@ -38,7 +39,7 @@ class PersonalSettings extends React.Component {
         index: 2,
       },
       api_settings: {
-        Icon: LockIcon,
+        Icon: PaperPlaneIcon,
         Content: ApiSettings,
         i18n: t('API Settings'),
         index: 3,

--- a/src/client/js/components/Me/PersonalSettings.jsx
+++ b/src/client/js/components/Me/PersonalSettings.jsx
@@ -16,12 +16,15 @@ class PersonalSettings extends React.Component {
     const UserIcon = () => {
       return <i className="icon-fw icon-user"></i>;
     };
+
     const shereAltIcon = () => {
       return <i className="icon-fw icon-share-alt"></i>;
     };
+
     const lockIcon = () => {
       return <i className="icon-fw icon-lock"></i>;
     };
+
     const paperPlaneIcon = () => {
       return <i className="icon-fw icon-paper-plane"></i>;
     };

--- a/src/client/js/components/Me/PersonalSettings.jsx
+++ b/src/client/js/components/Me/PersonalSettings.jsx
@@ -8,9 +8,9 @@ import PasswordSettings from './PasswordSettings';
 import ExternalAccountLinkedMe from './ExternalAccountLinkedMe';
 import ApiSettings from './ApiSettings';
 
-import LockIcon from '../Icons/LooockIcon';
 import UserIcon from '../Icons/UserIcon';
 import ShareAltIcon from '../Icons/ShareAltIcon';
+import LockIcon from '../Icons/LooockIcon';
 import PaperPlaneIcon from '../Icons/PaperPlaneIcon';
 
 

--- a/src/client/js/components/Me/PersonalSettings.jsx
+++ b/src/client/js/components/Me/PersonalSettings.jsx
@@ -1,5 +1,5 @@
 
-import React, { Fragment } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { withTranslation } from 'react-i18next';
 import CustomNavigation from '../CustomNavigation';
@@ -7,41 +7,77 @@ import UserSettings from './UserSettings';
 import PasswordSettings from './PasswordSettings';
 import ExternalAccountLinkedMe from './ExternalAccountLinkedMe';
 import ApiSettings from './ApiSettings';
-import PageListIcon from '../Icons/PageListIcon';
 
 class PersonalSettings extends React.Component {
+
 
   render() {
     const { t } = this.props;
 
+    // const Icons = [
+    //   <i className="icon-fw icon-user"></i>,
+    //   <i className="icon-fw icon-share-alt"></i>,
+    //   <i className="icon-fw icon-lock"></i>,
+    //   <i className="icon-fw icon-paper-plane"></i>,
+    // ];
+    // console.log(`Icons = ${Icons}`);
 
-    const UserSettingsIcon = () => {
+    // const setIcons = () => {
+    //   Icons.map((icon) => {
+    //     console.log(icon);
+    //     return (
+    //       <>
+    //         { icon }
+    //       </>
+    //     );
+    //   });
+    // };
+    // const setIcons = () => {
+    //   Icons.map(icon => icon);
+    // };
+
+    const setIcon1 = () => {
       return (
         <i className="icon-fw icon-user"></i>
+      );
+    };
+    const setIcon2 = () => {
+      return (
+        <i className="icon-fw icon-share-alt"></i>
+      );
+    };
+    const setIcon3 = () => {
+      return (
+        <i className="icon-fw icon-lock"></i>
+      );
+    };
+    const setIcon4 = () => {
+      return (
+        <i className="icon-fw icon-paper-plan"></i>
       );
     };
 
     const navTabMapping = {
       user_infomation: {
-        Icon: UserSettingsIcon,
+        Icon: setIcon1,
         Content: UserSettings,
         i18n: t('User Information'),
         index: 0,
       },
       external_accounts: {
-        Icon: PageListIcon,
+        Icon: setIcon2,
         Content: ExternalAccountLinkedMe,
         i18n: t('admin:user_management.external_accounts'),
         index: 1,
       },
       password_settings: {
-        Icon: PageListIcon,
+        Icon: setIcon3,
         Content: PasswordSettings,
         i18n: t('Password Settings'),
         index: 2,
       },
       api_settings: {
-        Icon: PageListIcon,
+        Icon: setIcon4,
         Content: ApiSettings,
         i18n: t('API Settings'),
         index: 3,
@@ -50,47 +86,9 @@ class PersonalSettings extends React.Component {
 
 
     return (
-      <Fragment>
+      <>
         <CustomNavigation navTabMapping={navTabMapping} />
-        {/* <div className="personal-settings">
-          <ul className="nav nav-tabs" role="tablist">
-            <li className="nav-item">
-              <a className="nav-link active" href="#user-settings" data-toggle="tab" role="tab">
-                <i className="icon-fw icon-user"></i>{ t('User Information') }
-              </a>
-            </li>
-            <li className="nav-item">
-              <a className="nav-link" href="#external-accounts" data-toggle="tab" role="tab">
-                <i className="icon-fw icon-share-alt"></i>{ t('admin:user_management.external_accounts') }
-              </a>
-            </li>
-            <li className="nav-item">
-              <a className="nav-link" href="#password-settings" data-toggle="tab" role="tab">
-                <i className="icon-fw icon-lock"></i>{ t('Password Settings') }
-              </a>
-            </li>
-            <li className="nav-item">
-              <a className="nav-link" href="#apiToken" data-toggle="tab" role="tab">
-                <i className="icon-fw icon-paper-plane"></i>{ t('API Settings') }
-              </a>
-            </li>
-          </ul>
-          <div className="tab-content p-t-10">
-            <div id="user-settings" className="tab-pane active" role="tabpanel">
-              <UserSettings />
-            </div>
-            <div id="external-accounts" className="tab-pane" role="tabpanel">
-              <ExternalAccountLinkedMe />
-            </div>
-            <div id="password-settings" className="tab-pane" role="tabpanel">
-              <PasswordSettings />
-            </div>
-            <div id="apiToken" className="tab-pane" role="tabpanel">
-              <ApiSettings />
-            </div>
-          </div>
-        </div> */}
-      </Fragment>
+      </>
     );
   }
 

--- a/src/client/js/components/Me/PersonalSettings.jsx
+++ b/src/client/js/components/Me/PersonalSettings.jsx
@@ -13,7 +13,6 @@ import ShareAltIcon from '../Icons/ShareAltIcon';
 import LockIcon from '../Icons/LooockIcon';
 import PaperPlaneIcon from '../Icons/PaperPlaneIcon';
 
-
 class PersonalSettings extends React.Component {
 
   render() {


### PR DESCRIPTION
# GW-4335 `/me` のタブに CustomNav を適用する
- コンテンツが左端に寄っているのは「GW-4302 レイアウト刷新の影響による不具合を見つけて修正する」ストーリーで修正予定です

<img width="1046" alt="Screen Shot 2020-11-06 at 14 40 16" src="https://user-images.githubusercontent.com/59536731/98330596-1bb77080-203e-11eb-8741-ea139d1e5a2c.png">

<img width="1215" alt="Screen Shot 2020-11-06 at 14 40 20" src="https://user-images.githubusercontent.com/59536731/98330604-1d813400-203e-11eb-8ab5-cf4fed37a46e.png">
<img width="970" alt="Screen Shot 2020-11-06 at 14 40 23" src="https://user-images.githubusercontent.com/59536731/98330605-1d813400-203e-11eb-9b53-835de4810aa1.png">
<img width="1138" alt="Screen Shot 2020-11-06 at 14 40 50" src="https://user-images.githubusercontent.com/59536731/98330606-1e19ca80-203e-11eb-9847-84ea6cf05799.png">
