### PR TITLE
Support/gc 6972 modify workflow yml to push image to ghcr

### DIFF
--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -52,13 +52,13 @@ jobs:
         username: wsmoogle
         password: ${{ secrets.DOCKER_REGISTRY_ON_GITHUB_PASSWORD }}
 
-    - name: Build and push to ghcr
-      uses: docker/build-push-action@v2
+    - name: Docker Tags by SemVer in Github Container Registry
+      uses: weseek/ghaction-docker-tags-by-semver@v1.0.3
       with:
-        context: .
-        file: ./docker/Dockerfile
-        push: true
-        tags: ghcr.io/weseek/growi:${{ env.SEMVER }}
+        source: growi
+        target: ghcr.io/weseek/growi
+        semver: ${{ env.SEMVER }}
+        publish: true
 
     - name: Check whether workspace is clean
       run: |

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -45,6 +45,21 @@ jobs:
         semver: ${{ env.SEMVER }}
         publish: true
 
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: wsmoogle
+        password: ${{ secrets.DOCKER_REGISTRY_ON_GITHUB_PASSWORD }}
+
+    - name: Build and push
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: ./docker/Dockerfile
+        push: true
+        tags: ghcr.io/weseek/growi:${{ env.SEMVER }}
+
     - name: Check whether workspace is clean
       run: |
         STATUS=`git status --porcelain`

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -52,7 +52,7 @@ jobs:
         username: wsmoogle
         password: ${{ secrets.DOCKER_REGISTRY_ON_GITHUB_PASSWORD }}
 
-    - name: Build and push
+    - name: Build and push to ghcr
       uses: docker/build-push-action@v2
       with:
         context: .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,13 +97,6 @@ jobs:
         additional-tags: 'latest'
         publish: true
 
-    - name: Slack Notification
-      uses: weseek/ghaction-release-slack-notification@master
-      with:
-        channel: '#general'
-        url: ${{ secrets.SLACK_WEBHOOK_URL }}
-        created_tag: 'v${{ needs.github-release.outputs.RELEASE_VERSION }}${{ env.SUFFIX }}'
-
     - name: Update Docker Hub Description
       uses: peter-evans/dockerhub-description@v2
       with:
@@ -111,6 +104,28 @@ jobs:
         password: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
         repository: weseek/growi
         readme-filepath: ./docker/README.md
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: wsmoogle
+        password: ${{ secrets.DOCKER_REGISTRY_ON_GITHUB_PASSWORD }}
+
+    - name: Build and push to ghcr
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: ./docker/Dockerfile
+        push: true
+        tags: ghcr.io/weseek/growi:${{ needs.github-release.outputs.RELEASE_VERSION }}${{ env.SUFFIX }}
+
+    - name: Slack Notification
+      uses: weseek/ghaction-release-slack-notification@master
+      with:
+        channel: '#general'
+        url: ${{ secrets.SLACK_WEBHOOK_URL }}
+        created_tag: 'v${{ needs.github-release.outputs.RELEASE_VERSION }}${{ env.SUFFIX }}'
 
     - name: Check whether workspace is clean
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,13 +112,15 @@ jobs:
         username: wsmoogle
         password: ${{ secrets.DOCKER_REGISTRY_ON_GITHUB_PASSWORD }}
 
-    - name: Build and push to ghcr
-      uses: docker/build-push-action@v2
+    - name: Docker Tags by SemVer in Github Container Registry
+      uses: weseek/ghaction-docker-tags-by-semver@v1.0.3
       with:
-        context: .
-        file: ./docker/Dockerfile
-        push: true
-        tags: ghcr.io/weseek/growi:${{ needs.github-release.outputs.RELEASE_VERSION }}${{ env.SUFFIX }}
+        source: growi${{ env.SUFFIX }}
+        target: ghcr.io/weseek/growi
+        semver: ${{ needs.github-release.outputs.RELEASE_VERSION }}
+        suffix: ${{ env.SUFFIX }}
+        additional-tags: 'latest'
+        publish: true
 
     - name: Slack Notification
       uses: weseek/ghaction-release-slack-notification@master


### PR DESCRIPTION
release の際に、 Github Container Registry に image  を push するよう改修しました

追加した"Login to GitHub Container Registry"と"Build and push to ghcr"が正常に動くことは確認済みです

Dockerhub と Github Container Registry の両方への push が終わってから Slack通知が来るよう、 release.yml の "Slack Notification" は順番を入れ替えています

### 追記
FB対応しました
正常に動作することは確認しました