### PR TITLE
change hover color of the like button

### DIFF
--- a/src/client/styles/scss/atoms/_buttons.scss
+++ b/src/client/styles/scss/atoms/_buttons.scss
@@ -1,5 +1,5 @@
 .btn.btn-like {
-  @include button-outline-variant($secondary, lighten($info, 15%), rgba(lighten($info, 10%), 0.5), rgba(lighten($info, 10%), 0.5));
+  @include button-outline-variant($secondary, lighten($info, 15%), rgba(lighten($info, 10%), 0.15), rgba(lighten($info, 10%), 0.5));
   &:not(:disabled):not(.disabled):active,
   &:not(:disabled):not(.disabled).active {
     color: lighten($info, 15%);


### PR DESCRIPTION
GW-4369 Likeボタンのhover時のBGカラーをXDどおりに変更

[デザインスペック]
<img width="613" alt="Screen Shot 2020-11-06 at 21 36 26" src="https://user-images.githubusercontent.com/59536731/98367714-73270200-2079-11eb-93fd-f1c434901136.png">

[変更前]
<img width="113" alt="Screen Shot 2020-11-06 at 21 47 05" src="https://user-images.githubusercontent.com/59536731/98367830-a5386400-2079-11eb-97e2-17ed99aea53f.png">

[変更後]
<img width="112" alt="Screen Shot 2020-11-06 at 21 34 35" src="https://user-images.githubusercontent.com/59536731/98367882-b97c6100-2079-11eb-9af1-5d35dbd4b741.png">

青いカラーはデザインスペックと若干違いますが、一旦このままで良いそうです。