### PR TITLE
changed gray-50 to bgcolor-global cus the background colors of the cards were too bright

### DIFF
--- a/src/client/styles/scss/theme/halloween.scss
+++ b/src/client/styles/scss/theme/halloween.scss
@@ -38,7 +38,7 @@ html[dark] {
   // Background colors
   $bgcolor-global: #050000;
   $bgcolor-inline-code: #1f1f22; //optional
-  $bgcolor-card: $gray-50;
+  $bgcolor-card: $bgcolor-global;
 
   // Font colors
   $color-global: #e9af2b;


### PR DESCRIPTION
GW-4372 テーマハロウィンの時、背景が白いと文字が見えづらい
[変更前]
<img width="555" alt="Screen Shot 2020-11-10 at 8 03 11" src="https://user-images.githubusercontent.com/59536731/98608807-57e51c80-232f-11eb-98eb-d237f0b567ce.png">

[変更後]
<img width="1043" alt="Screen Shot 2020-11-10 at 8 33 13" src="https://user-images.githubusercontent.com/59536731/98608850-6fbca080-232f-11eb-99de-089e42ab79ac.png">
