### PR TITLE
change btn-outline color

### DIFF
--- a/src/client/styles/scss/theme/spring.scss
+++ b/src/client/styles/scss/theme/spring.scss
@@ -96,8 +96,7 @@ html[dark] {
   //Button
   // Outline buttons are applyed the accent color to this spring theme cuz the primary is too light and it looks like unable to click them.
   .btn.btn-outline-primary {
-    color: $accentcolor;
-    border-color: $accentcolor;
+    @include button-outline-variant($accentcolor, $accentcolor, lighten($accentcolor, 20%), $accentcolor);
   }
   .btn-group.grw-three-stranded-button {
     .btn.btn-outline-primary {

--- a/src/client/styles/scss/theme/spring.scss
+++ b/src/client/styles/scss/theme/spring.scss
@@ -94,6 +94,11 @@ html[dark] {
   @import 'apply-colors-light';
 
   //Button
+  // Outline buttons are applyed the accent color to this spring theme cuz the primary is too light and it looks like unable to click them.
+  .btn.btn-outline-primary {
+    color: $accentcolor;
+    border-color: $accentcolor;
+  }
   .btn-group.grw-three-stranded-button {
     .btn.btn-outline-primary {
       @include three-stranded-button(darken($primary, 50%), lighten($primary, 5%), lighten($primary, 10%));


### PR DESCRIPTION
GW-4398 【spring theme】ボタンの文字色が薄いのを修正

spring themeなんかコードが微妙なので(自分が書いたのですが....)時間があるときに大幅改修しようと思います

<img width="822" alt="Screen Shot 2020-11-10 at 12 20 42" src="https://user-images.githubusercontent.com/59536731/98623504-2f6d1a80-234f-11eb-90fa-504d52170037.png">


<img width="838" alt="Screen Shot 2020-11-10 at 12 05 32" src="https://user-images.githubusercontent.com/59536731/98623348-d43b2800-234e-11eb-9525-4c89fe03267e.png">
