### PR TITLE
change to 24 hour fomat

### DIFF
--- a/src/client/js/components/ShareLink/ShareLinkForm.jsx
+++ b/src/client/js/components/ShareLink/ShareLinkForm.jsx
@@ -22,7 +22,7 @@ class ShareLinkForm extends React.Component {
       numberOfDays: '7',
       description: '',
       customExpirationDate: dateFnsFormat(new Date(), 'yyyy-MM-dd'),
-      customExpirationTime: dateFnsFormat(new Date(), 'hh:mm'),
+      customExpirationTime: dateFnsFormat(new Date(), 'HH:mm'),
     };
 
     this.handleChangeExpirationType = this.handleChangeExpirationType.bind(this);


### PR DESCRIPTION
## docs
GW-4410 Share settingsモーダル、custom入力時のデフォルトの時間が12時間ずれているので修正
元々、defalultの値(現在時刻)は12時間表記になっており、
リンクを発行しようとすると
<img width="331" alt="Screen Shot 2020-11-10 at 15 59 55" src="https://user-images.githubusercontent.com/59536731/98640681-cd6fdd80-236d-11eb-8d18-cf1120d64d23.png">
「それは過去の時間だよ」というエラーが出てしまっていました。

これは、ドロップダウン内部の選択できる値が24時間表記になっていたことが原因であると判明したため、defaultで表示される値も24時間表記に統一しました。
<img width="152" alt="Screen Shot 2020-11-10 at 15 57 03" src="https://user-images.githubusercontent.com/59536731/98640812-0c9e2e80-236e-11eb-947b-73f12b65e3e0.png">



### 変更前
<img width="734" alt="Screen Shot 2020-11-10 at 15 43 15" src="https://user-images.githubusercontent.com/59536731/98637336-a57f7a80-236b-11eb-8269-c0726957d973.png">

### 変更後

<img width="748" alt="Screen Shot 2020-11-10 at 15 42 50" src="https://user-images.githubusercontent.com/59536731/98637332-a4e6e400-236b-11eb-9f4d-d994c64202fe.png">

## docs
https://date-fns.org/v1.28.5/docs/format
