### PR TITLE
Add variables `$border-color-global` and and apply.

### DIFF
--- a/src/client/styles/scss/theme/_apply-colors-dark.scss
+++ b/src/client/styles/scss/theme/_apply-colors-dark.scss
@@ -14,15 +14,16 @@ $bgcolor-table-hover: lighten($bgcolor-table, 7.5%) !default;
 $bgcolor-sidebar-list-group: $bgcolor-list !default;
 $color-tags: #949494 !default;
 $bgcolor-tags: $dark !default;
-$border-color-toc: $gray-500 !default;
+$border-color-global: $gray-500 !default;
+$border-color-toc: $border-color-global !default;
 
 // override bootstrap variables
-$border-color: $gray-500;
 $table-dark-color: $color-table;
 $table-dark-bg: $bgcolor-table;
 $table-dark-border-color: $border-color-table;
 $table-dark-hover-color: $color-table-hover;
 $table-dark-hover-bg: $bgcolor-table-hover;
+$border-color: $border-color-global;
 
 @import 'reboot-bootstrap-border-colors';
 @import 'reboot-bootstrap-tables';
@@ -38,6 +39,7 @@ select.form-control,
 textarea.form-control {
   color: lighten($color-global, 30%);
   background-color: darken($bgcolor-global, 5%);
+  border-color: $border-color-global;
   &:focus {
     background-color: $bgcolor-global;
   }
@@ -65,7 +67,7 @@ textarea.form-control {
 }
 
 .input-group input {
-  border-color: $secondary;
+  border-color: $border-color-global;
 }
 
 /*
@@ -355,6 +357,13 @@ ul.pagination {
 }
 
 /*
+ * admin settings
+ */
+.admin-setting-header {
+  border-color: $border-color-global;
+}
+
+/*
 * grw-side-contents
 */
 .grw-side-contents-sticky-container {
@@ -365,6 +374,13 @@ ul.pagination {
   .revision-toc {
     border-color: $border-color-toc;
   }
+}
+
+/*
+ * modal
+ */
+.grw-modal-head {
+  border-color: $border-color-global;
 }
 
 /*

--- a/src/client/styles/scss/theme/_apply-colors-light.scss
+++ b/src/client/styles/scss/theme/_apply-colors-light.scss
@@ -14,7 +14,8 @@ $bgcolor-table-hover: rgba(black, 0.075) !default;
 $bgcolor-sidebar-list-group: $bgcolor-list !default;
 $color-tags: $gray-500 !default;
 $bgcolor-tags: $gray-200 !default;
-$border-color-toc: $gray-300 !default;
+$border-color-global: $gray-300 !default;
+$border-color-toc: $border-color-global !default;
 
 // override bootstrap variables
 $table-color: $color-table;
@@ -22,6 +23,7 @@ $table-bg: $bgcolor-table;
 $table-border-color: $border-color-table;
 $table-hover-color: $color-table-hover;
 $table-hover-bg: $bgcolor-table-hover;
+$border-color: $border-color-global;
 
 @import 'reboot-bootstrap-border-colors';
 @import 'reboot-bootstrap-tables';
@@ -312,6 +314,13 @@ $table-hover-bg: $bgcolor-table-hover;
  */
 .admin-setting-header {
   border-color: $border-color;
+}
+
+/*
+ * modal
+ */
+.grw-modal-head {
+  border-color: $border-color-global;
 }
 
 /*

--- a/src/client/styles/scss/theme/mixins/_list-group.scss
+++ b/src/client/styles/scss/theme/mixins/_list-group.scss
@@ -3,6 +3,7 @@
     .list-group-item {
       color: $color;
       background-color: $bgcolor;
+      border-color: $border-color-global;
 
       &.list-group-item-action {
         &:hover {


### PR DESCRIPTION
# GW-4428 不足箇所の色指定コーディング
## 作業内容
- [前回のプルリク](https://github.com/weseek/growi/pull/3044/files)で`$border-color`を入れていた箇所に、独自の変数`$border-color-global`を挿入。
## 実装後画面
- 色がわかりやすいのでfutureテーマで撮影
- ボーダーがグレーの箇所が`$border-color-global`
![image](https://user-images.githubusercontent.com/65531771/98675552-c234a600-239d-11eb-8c76-878cd8fb566b.png)
![image](https://user-images.githubusercontent.com/65531771/98675691-f1e3ae00-239d-11eb-9cdc-7d4bef14e17c.png)
![image](https://user-images.githubusercontent.com/65531771/98675741-00ca6080-239e-11eb-8f99-e07fdcf1a829.png)
