### PR TITLE
refs GC-4383: If the figure of drawio is too big, it will be out of view.

### DIFF
--- a/src/client/js/components/Drawio.jsx
+++ b/src/client/js/components/Drawio.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { debounce } from 'throttle-debounce';
+
 import { withTranslation } from 'react-i18next';
 
 import AppContainer from '../services/AppContainer';
@@ -26,6 +28,9 @@ class Drawio extends React.Component {
     this.drawioContent = this.props.drawioContent;
 
     this.onEdit = this.onEdit.bind(this);
+
+    // create debounced method for rendering Drawio
+    this.renderDrawioWithDebounce = debounce(200, this.renderDrawio);
   }
 
   onEdit() {
@@ -35,6 +40,16 @@ class Drawio extends React.Component {
   }
 
   componentDidMount() {
+    const DrawioViewer = window.GraphViewer;
+    if (DrawioViewer != null) {
+      this.renderDrawio();
+    }
+    else {
+      this.renderDrawioWithDebounce();
+    }
+  }
+
+  renderDrawio() {
     const DrawioViewer = window.GraphViewer;
     if (DrawioViewer != null) {
       const mxgraphs = this.drawioContainer.getElementsByClassName('mxgraph');
@@ -47,6 +62,9 @@ class Drawio extends React.Component {
           DrawioViewer.createViewerForElement(div);
         }
       }
+    }
+    else {
+      this.renderDrawioWithDebounce();
     }
   }
 

--- a/src/server/views/widget/headers/drawio.html
+++ b/src/server/views/widget/headers/drawio.html
@@ -24,8 +24,9 @@
       DrawioViewer.useResizeSensor = false;
       DrawioViewer.prototype.checkVisibleState = false;
 
-      // initialize
-      DrawioViewer.processElements();
+      // Set responsive option.
+      // refs: https://github.com/jgraph/drawio/blob/v13.9.1/src/main/webapp/js/diagramly/GraphViewer.js#L89-L95
+      DrawioViewer.prototype.responsive = true;
     }
   };
 </script>


### PR DESCRIPTION
(日本語で)

* `DrawioViewer.prototype.responsive = true;` を設定することでレンダリング時に width の計算をするように修正
* 4.2.0 では親要素が width: 100% とは限らない (`flex-grow-1` を指定しているところ)ので drawio 側が計算できていなかった
* 追加修正として、初期レンダリング時のフローが分かりづらかった点を修正しました
     * `GraphViewer..processElements();` を呼び出すことを止めました
     * その代わりに MathJax と同様に debounce を利用する形に修正しました