### PR TITLE
Fix/push create btn in case of guest user

### DIFF
--- a/src/client/js/app.jsx
+++ b/src/client/js/app.jsx
@@ -89,7 +89,7 @@ Object.assign(componentMappings, {
 
   'not-found-alert': <NotFoundAlert
     onPageCreateClicked={navigationContainer.setEditorMode}
-    isUser={appContainer.currentUser}
+    isGuestUserMode={appContainer.currentUser == null}
     isHidden={pageContainer.state.isForbidden || pageContainer.state.isNotCreatable || pageContainer.state.isTrashPage}
   />,
 

--- a/src/client/js/app.jsx
+++ b/src/client/js/app.jsx
@@ -89,6 +89,7 @@ Object.assign(componentMappings, {
 
   'not-found-alert': <NotFoundAlert
     onPageCreateClicked={navigationContainer.setEditorMode}
+    isUser={appContainer.currentUser}
     isHidden={pageContainer.state.isForbidden || pageContainer.state.isNotCreatable || pageContainer.state.isTrashPage}
   />,
 

--- a/src/client/js/components/Page/NotFoundAlert.jsx
+++ b/src/client/js/components/Page/NotFoundAlert.jsx
@@ -5,7 +5,7 @@ import { UncontrolledTooltip } from 'reactstrap';
 
 
 const NotFoundAlert = (props) => {
-  const { t, isHidden, isUser } = props;
+  const { t, isHidden, isGuestUserMode } = props;
   function clickHandler(viewType) {
     if (props.onPageCreateClicked === null) {
       return;
@@ -30,14 +30,14 @@ const NotFoundAlert = (props) => {
         </h2>
         <button
           type="button"
-          className={`m-1 pl-3 pr-3 btn bg-info text-white ${!isUser && 'disabled'}`}
+          className={`m-1 pl-3 pr-3 btn bg-info text-white ${isGuestUserMode && 'disabled'}`}
           onClick={() => { clickHandler('edit') }}
         >
           <i className="icon-note icon-fw" />
           {t('not_found_page.Create Page')}
         </button>
 
-        {!isUser && (
+        {isGuestUserMode && (
         <UncontrolledTooltip placement="top" target="create-page-btn-wrapper-for-tooltip" fade={false}>
           {t('Not available for guest')}
         </UncontrolledTooltip>
@@ -52,7 +52,7 @@ NotFoundAlert.propTypes = {
   t: PropTypes.func.isRequired, // i18next
   onPageCreateClicked: PropTypes.func,
   isHidden: PropTypes.bool.isRequired,
-  isUser: PropTypes.bool.isRequired,
+  isGuestUserMode: PropTypes.bool.isRequired,
 };
 
 export default withTranslation()(NotFoundAlert);

--- a/src/client/js/components/Page/NotFoundAlert.jsx
+++ b/src/client/js/components/Page/NotFoundAlert.jsx
@@ -22,7 +22,7 @@ const NotFoundAlert = (props) => {
     <div className="border border-info p-3">
       <div
         className="col-md-12 p-0"
-        id="hoge"
+        id="create-page-btn-wrapper-for-tooltip"
       >
         <h2 className="text-info lead">
           <i className="icon-info pr-2 font-weight-bold" aria-hidden="true"></i>
@@ -38,7 +38,7 @@ const NotFoundAlert = (props) => {
         </button>
 
         {!isUser && (
-        <UncontrolledTooltip placement="top" target="hoge" fade={false}>
+        <UncontrolledTooltip placement="top" target="create-page-btn-wrapper-for-tooltip" fade={false}>
           {t('Not available for guest')}
         </UncontrolledTooltip>
       )}

--- a/src/client/js/components/Page/NotFoundAlert.jsx
+++ b/src/client/js/components/Page/NotFoundAlert.jsx
@@ -22,13 +22,13 @@ const NotFoundAlert = (props) => {
     <div className="border border-info p-3">
       <div
         className="col-md-12 p-0"
-        id="create-page-btn-wrapper-for-tooltip"
       >
         <h2 className="text-info lead">
           <i className="icon-info pr-2 font-weight-bold" aria-hidden="true"></i>
           {t('not_found_page.page_not_exist_alert')}
         </h2>
         <button
+          id="create-page-btn-wrapper-for-tooltip"
           type="button"
           className={`m-1 pl-3 pr-3 btn bg-info text-white ${isGuestUserMode && 'disabled'}`}
           onClick={() => { clickHandler('edit') }}

--- a/src/client/js/components/Page/NotFoundAlert.jsx
+++ b/src/client/js/components/Page/NotFoundAlert.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { withTranslation } from 'react-i18next';
+import { UncontrolledTooltip } from 'reactstrap';
+
 
 const NotFoundAlert = (props) => {
-  const { t, isHidden } = props;
+  const { t, isHidden, isUser } = props;
   function clickHandler(viewType) {
     if (props.onPageCreateClicked === null) {
       return;
@@ -15,21 +17,31 @@ const NotFoundAlert = (props) => {
     return null;
   }
 
+
   return (
     <div className="border border-info p-3">
-      <div className="col-md-12 p-0">
+      <div
+        className="col-md-12 p-0"
+        id="hoge"
+      >
         <h2 className="text-info lead">
           <i className="icon-info pr-2 font-weight-bold" aria-hidden="true"></i>
           {t('not_found_page.page_not_exist_alert')}
         </h2>
         <button
           type="button"
-          className="m-1 pl-3 pr-3 btn bg-info text-white"
+          className={`m-1 pl-3 pr-3 btn bg-info text-white ${!isUser && 'disabled'}`}
           onClick={() => { clickHandler('edit') }}
         >
           <i className="icon-note icon-fw" />
           {t('not_found_page.Create Page')}
         </button>
+
+        {!isUser && (
+        <UncontrolledTooltip placement="top" target="hoge" fade={false}>
+          {t('Not available for guest')}
+        </UncontrolledTooltip>
+      )}
       </div>
     </div>
   );
@@ -40,6 +52,7 @@ NotFoundAlert.propTypes = {
   t: PropTypes.func.isRequired, // i18next
   onPageCreateClicked: PropTypes.func,
   isHidden: PropTypes.bool.isRequired,
+  isUser: PropTypes.bool.isRequired,
 };
 
 export default withTranslation()(NotFoundAlert);

--- a/src/client/js/components/Page/NotFoundAlert.jsx
+++ b/src/client/js/components/Page/NotFoundAlert.jsx
@@ -38,7 +38,7 @@ const NotFoundAlert = (props) => {
         </button>
 
         {isGuestUserMode && (
-        <UncontrolledTooltip placement="top" target="create-page-btn-wrapper-for-tooltip" fade={false}>
+        <UncontrolledTooltip placement="bottom" target="create-page-btn-wrapper-for-tooltip" fade={false}>
           {t('Not available for guest')}
         </UncontrolledTooltip>
       )}


### PR DESCRIPTION
guest user のときに、url に直接打ち込んでページを作成しようとすると、not-found のページに遷移します。
そこまでは良いのですが、 create btn を クリックできることがよくない(ページは作成できない)ので、disabled にしました。
また tooltip も追加しています。
<img width="1627" alt="スクリーンショット 2020-11-11 16 13 15" src="https://user-images.githubusercontent.com/57100766/98780868-d2e62a00-2438-11eb-8afc-4efb9519ae17.png">

スクリーンショットなので禁止マークが消えていますが、実際はあります。