### PR TITLE
Fix/gw 4460 enable view only attachment for shared user

### DIFF
--- a/src/client/js/components/Page/NotFoundAlert.jsx
+++ b/src/client/js/components/Page/NotFoundAlert.jsx
@@ -5,7 +5,7 @@ import { UncontrolledTooltip } from 'reactstrap';
 
 
 const NotFoundAlert = (props) => {
-  const { t, isHidden, isGuestUser } = props;
+  const { t, isHidden, isGuestUserMode } = props;
   function clickHandler(viewType) {
     if (props.onPageCreateClicked === null) {
       return;
@@ -55,7 +55,7 @@ NotFoundAlert.propTypes = {
   t: PropTypes.func.isRequired, // i18next
   onPageCreateClicked: PropTypes.func,
   isHidden: PropTypes.bool.isRequired,
-  isGuestUser: PropTypes.bool.isRequired,
+  isGuestUserMode: PropTypes.bool.isRequired,
 };
 
 export default withTranslation()(NotFoundAlert);

--- a/src/client/js/components/Page/NotFoundAlert.jsx
+++ b/src/client/js/components/Page/NotFoundAlert.jsx
@@ -5,7 +5,7 @@ import { UncontrolledTooltip } from 'reactstrap';
 
 
 const NotFoundAlert = (props) => {
-  const { t, isHidden, isGuestUserMode } = props;
+  const { t, isHidden, isGuestUser } = props;
   function clickHandler(viewType) {
     if (props.onPageCreateClicked === null) {
       return;
@@ -30,14 +30,14 @@ const NotFoundAlert = (props) => {
         <button
           id="create-page-btn-wrapper-for-tooltip"
           type="button"
-          className={`m-1 pl-3 pr-3 btn bg-info text-white ${isGuestUserMode && 'disabled'}`}
+          className={`m-1 pl-3 pr-3 btn bg-info text-white ${isGuestUser && 'disabled'}`}
           onClick={() => { clickHandler('edit') }}
         >
           <i className="icon-note icon-fw" />
           {t('not_found_page.Create Page')}
         </button>
 
-        {isGuestUserMode && (
+        {isGuestUser && (
         <UncontrolledTooltip placement="bottom" target="create-page-btn-wrapper-for-tooltip" fade={false}>
           {t('Not available for guest')}
         </UncontrolledTooltip>
@@ -52,7 +52,7 @@ NotFoundAlert.propTypes = {
   t: PropTypes.func.isRequired, // i18next
   onPageCreateClicked: PropTypes.func,
   isHidden: PropTypes.bool.isRequired,
-  isGuestUserMode: PropTypes.bool.isRequired,
+  isGuestUser: PropTypes.bool.isRequired,
 };
 
 export default withTranslation()(NotFoundAlert);

--- a/src/client/js/components/PageAccessories.jsx
+++ b/src/client/js/components/PageAccessories.jsx
@@ -11,17 +11,14 @@ import PageAccessoriesContainer from '../services/PageAccessoriesContainer';
 const PageAccessories = (props) => {
   const { appContainer, pageAccessoriesContainer } = props;
   const isGuestUserMode = appContainer.currentUser == null;
-
-  // not render only when this page is shared and user is not login.
-  if (appContainer.isSharedUser && isGuestUserMode) {
-    return null;
-  }
+  const isSharedUserMode = appContainer.isSharedUser;
 
   return (
     <>
-      <PageAccessoriesModalControl isGuestUserMode={isGuestUserMode} />
+      <PageAccessoriesModalControl isGuestUserMode={isGuestUserMode} isSharedUserMode={isSharedUserMode} />
       <PageAccessoriesModal
         isGuestUserMode={isGuestUserMode}
+        isSharedUserMode={isSharedUserMode}
         isOpen={pageAccessoriesContainer.state.isPageAccessoriesModalShown}
         onClose={pageAccessoriesContainer.closePageAccessoriesModal}
       />

--- a/src/client/js/components/PageAccessories.jsx
+++ b/src/client/js/components/PageAccessories.jsx
@@ -10,15 +10,15 @@ import PageAccessoriesContainer from '../services/PageAccessoriesContainer';
 
 const PageAccessories = (props) => {
   const { appContainer, pageAccessoriesContainer } = props;
-  const isGuestUserMode = appContainer.currentUser == null;
-  const isSharedUserMode = appContainer.isSharedUser;
+  const isGuestUser = appContainer.currentUser == null;
+  const isSharedUser = appContainer.isSharedUser;
 
   return (
     <>
-      <PageAccessoriesModalControl isGuestUserMode={isGuestUserMode} isSharedUserMode={isSharedUserMode} />
+      <PageAccessoriesModalControl isGuestUser={isGuestUser} isSharedUser={isSharedUser} />
       <PageAccessoriesModal
-        isGuestUserMode={isGuestUserMode}
-        isSharedUserMode={isSharedUserMode}
+        isGuestUser={isGuestUser}
+        isSharedUser={isSharedUser}
         isOpen={pageAccessoriesContainer.state.isPageAccessoriesModalShown}
         onClose={pageAccessoriesContainer.closePageAccessoriesModal}
       />

--- a/src/client/js/components/PageAccessoriesModal.jsx
+++ b/src/client/js/components/PageAccessoriesModal.jsx
@@ -24,7 +24,7 @@ import ExpandOrContractButton from './ExpandOrContractButton';
 
 const PageAccessoriesModal = (props) => {
   const {
-    t, pageAccessoriesContainer, onClose, isGuestUserMode, isSharedUserMode,
+    t, pageAccessoriesContainer, onClose, isGuestUser, isSharedUser,
   } = props;
   const { switchActiveTab } = pageAccessoriesContainer;
   const { activeTab, activeComponents } = pageAccessoriesContainer.state;
@@ -36,19 +36,19 @@ const PageAccessoriesModal = (props) => {
         Icon: PageListIcon,
         i18n: t('page_list'),
         index: 0,
-        isLinkEnabled: v => !isSharedUserMode,
+        isLinkEnabled: v => !isSharedUser,
       },
       timeline: {
         Icon: TimeLineIcon,
         i18n: t('Timeline View'),
         index: 1,
-        isLinkEnabled: v => !isSharedUserMode,
+        isLinkEnabled: v => !isSharedUser,
       },
       pageHistory: {
         Icon: HistoryIcon,
         i18n: t('History'),
         index: 2,
-        isLinkEnabled: v => !isSharedUserMode,
+        isLinkEnabled: v => !isSharedUser,
       },
       attachment: {
         Icon: AttachmentIcon,
@@ -59,10 +59,10 @@ const PageAccessoriesModal = (props) => {
         Icon: ShareLinkIcon,
         i18n: t('share_links.share_link_management'),
         index: 4,
-        isLinkEnabled: v => !isGuestUserMode || !isSharedUserMode,
+        isLinkEnabled: v => !isGuestUser || !isSharedUser,
       },
     };
-  }, [t, isGuestUserMode, isSharedUserMode]);
+  }, [t, isGuestUser, isSharedUser]);
 
   const closeModalHandler = useCallback(() => {
     if (onClose == null) {
@@ -117,7 +117,7 @@ const PageAccessoriesModal = (props) => {
             <TabPane tabId="attachment">
               {activeComponents.has('attachment') && <PageAttachment />}
             </TabPane>
-            {!isGuestUserMode && (
+            {!isGuestUser && (
               <TabPane tabId="shareLink">
                 {activeComponents.has('shareLink') && <ShareLink />}
               </TabPane>
@@ -137,8 +137,8 @@ const PageAccessoriesModalWrapper = withUnstatedContainers(PageAccessoriesModal,
 PageAccessoriesModal.propTypes = {
   t: PropTypes.func.isRequired, //  i18next
   pageAccessoriesContainer: PropTypes.instanceOf(PageAccessoriesContainer).isRequired,
-  isGuestUserMode: PropTypes.bool.isRequired,
-  isSharedUserMode: PropTypes.bool.isRequired,
+  isGuestUser: PropTypes.bool.isRequired,
+  isSharedUser: PropTypes.bool.isRequired,
   isOpen: PropTypes.bool.isRequired,
   onClose: PropTypes.func,
 };

--- a/src/client/js/components/PageAccessoriesModal.jsx
+++ b/src/client/js/components/PageAccessoriesModal.jsx
@@ -24,7 +24,7 @@ import ExpandOrContractButton from './ExpandOrContractButton';
 
 const PageAccessoriesModal = (props) => {
   const {
-    t, pageAccessoriesContainer, onClose, isGuestUserMode,
+    t, pageAccessoriesContainer, onClose, isGuestUserMode, isSharedUserMode,
   } = props;
   const { switchActiveTab } = pageAccessoriesContainer;
   const { activeTab, activeComponents } = pageAccessoriesContainer.state;
@@ -36,16 +36,19 @@ const PageAccessoriesModal = (props) => {
         Icon: PageListIcon,
         i18n: t('page_list'),
         index: 0,
+        isLinkEnabled: v => !isSharedUserMode,
       },
-      timeline:  {
+      timeline: {
         Icon: TimeLineIcon,
         i18n: t('Timeline View'),
         index: 1,
+        isLinkEnabled: v => !isSharedUserMode,
       },
       pageHistory: {
         Icon: HistoryIcon,
         i18n: t('History'),
         index: 2,
+        isLinkEnabled: v => !isSharedUserMode,
       },
       attachment: {
         Icon: AttachmentIcon,
@@ -56,10 +59,10 @@ const PageAccessoriesModal = (props) => {
         Icon: ShareLinkIcon,
         i18n: t('share_links.share_link_management'),
         index: 4,
-        isLinkEnabled: v => !isGuestUserMode,
+        isLinkEnabled: v => !isGuestUserMode || !isSharedUserMode,
       },
     };
-  }, [t, isGuestUserMode]);
+  }, [t, isGuestUserMode, isSharedUserMode]);
 
   const closeModalHandler = useCallback(() => {
     if (onClose == null) {
@@ -135,6 +138,7 @@ PageAccessoriesModal.propTypes = {
   t: PropTypes.func.isRequired, //  i18next
   pageAccessoriesContainer: PropTypes.instanceOf(PageAccessoriesContainer).isRequired,
   isGuestUserMode: PropTypes.bool.isRequired,
+  isSharedUserMode: PropTypes.bool.isRequired,
   isOpen: PropTypes.bool.isRequired,
   onClose: PropTypes.func,
 };

--- a/src/client/js/components/PageAccessoriesModalControl.jsx
+++ b/src/client/js/components/PageAccessoriesModalControl.jsx
@@ -17,7 +17,7 @@ import { withUnstatedContainers } from './UnstatedUtils';
 
 const PageAccessoriesModalControl = (props) => {
   const {
-    t, pageAccessoriesContainer, isGuestUserMode, isSharedUserMode,
+    t, pageAccessoriesContainer, isGuestUser, isSharedUser,
   } = props;
 
   const accessoriesBtnList = useMemo(() => {
@@ -25,17 +25,17 @@ const PageAccessoriesModalControl = (props) => {
       {
         name: 'pagelist',
         Icon: <PageListIcon />,
-        disabled: isSharedUserMode,
+        disabled: isSharedUser,
       },
       {
         name: 'timeline',
         Icon: <TimeLineIcon />,
-        disabled: isSharedUserMode,
+        disabled: isSharedUser,
       },
       {
         name: 'pageHistory',
         Icon: <HistoryIcon />,
-        disabled: isSharedUserMode,
+        disabled: isSharedUser,
       },
       {
         name: 'attachment',
@@ -45,10 +45,10 @@ const PageAccessoriesModalControl = (props) => {
       {
         name: 'shareLink',
         Icon: <ShareLinkIcon />,
-        disabled: isGuestUserMode || isSharedUserMode,
+        disabled: isGuestUser || isSharedUser,
       },
     ];
-  }, [isGuestUserMode, isSharedUserMode]);
+  }, [isGuestUser, isSharedUser]);
 
   return (
     <div className="grw-page-accessories-control d-flex align-items-center justify-content-between pb-1">
@@ -74,7 +74,7 @@ const PageAccessoriesModalControl = (props) => {
       })}
       <div className="d-flex align-items-center">
         <span className="border-left grw-border-vr">&nbsp;</span>
-        <SeenUserInfo disabled={isSharedUserMode} />
+        <SeenUserInfo disabled={isSharedUser} />
       </div>
     </div>
   );
@@ -89,8 +89,8 @@ PageAccessoriesModalControl.propTypes = {
 
   pageAccessoriesContainer: PropTypes.instanceOf(PageAccessoriesContainer).isRequired,
 
-  isGuestUserMode: PropTypes.bool.isRequired,
-  isSharedUserMode: PropTypes.bool.isRequired,
+  isGuestUser: PropTypes.bool.isRequired,
+  isSharedUser: PropTypes.bool.isRequired,
 };
 
 export default withTranslation()(PageAccessoriesModalControlWrapper);

--- a/src/client/js/components/PageAccessoriesModalControl.jsx
+++ b/src/client/js/components/PageAccessoriesModalControl.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 
 import { withTranslation } from 'react-i18next';
@@ -16,58 +16,62 @@ import SeenUserInfo from './User/SeenUserInfo';
 import { withUnstatedContainers } from './UnstatedUtils';
 
 const PageAccessoriesModalControl = (props) => {
-  const { t, pageAccessoriesContainer, isGuestUserMode } = props;
+  const {
+    t, pageAccessoriesContainer, isGuestUserMode, isSharedUserMode,
+  } = props;
+
+  const accessoriesBtnList = useMemo(() => {
+    return [
+      {
+        name: 'pagelist',
+        Icon: <PageListIcon />,
+        disabled: isSharedUserMode,
+      },
+      {
+        name: 'timeline',
+        Icon: <TimeLineIcon />,
+        disabled: isSharedUserMode,
+      },
+      {
+        name: 'pageHistory',
+        Icon: <HistoryIcon />,
+        disabled: isSharedUserMode,
+      },
+      {
+        name: 'attachment',
+        Icon: <AttachmentIcon />,
+        disabled: false,
+      },
+      {
+        name: 'shareLink',
+        Icon: <ShareLinkIcon />,
+        disabled: isGuestUserMode || isSharedUserMode,
+      },
+    ];
+  }, [t, isGuestUserMode, isSharedUserMode]);
 
   return (
     <div className="grw-page-accessories-control d-flex align-items-center justify-content-between pb-1">
-
-      <button
-        type="button"
-        className="btn btn-link grw-btn-page-accessories"
-        onClick={() => pageAccessoriesContainer.openPageAccessoriesModal('pagelist')}
-      >
-        <PageListIcon />
-      </button>
-
-      <button
-        type="button"
-        className="btn btn-link grw-btn-page-accessories"
-        onClick={() => pageAccessoriesContainer.openPageAccessoriesModal('timeline')}
-      >
-        <TimeLineIcon />
-      </button>
-
-      <button
-        type="button"
-        className="btn btn-link grw-btn-page-accessories"
-        onClick={() => pageAccessoriesContainer.openPageAccessoriesModal('pageHistory')}
-      >
-        <HistoryIcon />
-      </button>
-
-      <button
-        type="button"
-        className="btn btn-link grw-btn-page-accessories"
-        onClick={() => pageAccessoriesContainer.openPageAccessoriesModal('attachment')}
-      >
-        <AttachmentIcon />
-      </button>
-
-      <div id="shareLink-btn-wrapper-for-tooltip">
-        <button
-          type="button"
-          className={`btn btn-link grw-btn-page-accessories ${isGuestUserMode && 'disabled'}`}
-          onClick={() => pageAccessoriesContainer.openPageAccessoriesModal('shareLink')}
-        >
-          <ShareLinkIcon />
-        </button>
-      </div>
-      {isGuestUserMode && (
-        <UncontrolledTooltip placement="top" target="shareLink-btn-wrapper-for-tooltip" fade={false}>
-          {t('Not available for guest')}
-        </UncontrolledTooltip>
-      )}
-
+      {accessoriesBtnList.map((accessory) => {
+        return (
+          <>
+            <div id={`shareLink-btn-wrapper-for-tooltip-for-${accessory.name}`}>
+              <button
+                type="button"
+                className={`btn btn-link grw-btn-page-accessories ${accessory.disabled && 'disabled'}`}
+                onClick={() => pageAccessoriesContainer.openPageAccessoriesModal(accessory.name)}
+              >
+                {accessory.Icon}
+              </button>
+            </div>
+            {accessory.disabled && (
+              <UncontrolledTooltip placement="top" target={`shareLink-btn-wrapper-for-tooltip-for-${accessory.name}`} fade={false}>
+                {t('Not available for guest')}
+              </UncontrolledTooltip>
+            )}
+          </>
+        );
+      })}
       <div className="d-flex align-items-center">
         <span className="border-left grw-border-vr">&nbsp;</span>
         <SeenUserInfo />
@@ -86,6 +90,7 @@ PageAccessoriesModalControl.propTypes = {
   pageAccessoriesContainer: PropTypes.instanceOf(PageAccessoriesContainer).isRequired,
 
   isGuestUserMode: PropTypes.bool.isRequired,
+  isSharedUserMode: PropTypes.bool.isRequired,
 };
 
 export default withTranslation()(PageAccessoriesModalControlWrapper);

--- a/src/client/js/components/PageAccessoriesModalControl.jsx
+++ b/src/client/js/components/PageAccessoriesModalControl.jsx
@@ -48,7 +48,7 @@ const PageAccessoriesModalControl = (props) => {
         disabled: isGuestUserMode || isSharedUserMode,
       },
     ];
-  }, [t, isGuestUserMode, isSharedUserMode]);
+  }, [isGuestUserMode, isSharedUserMode]);
 
   return (
     <div className="grw-page-accessories-control d-flex align-items-center justify-content-between pb-1">

--- a/src/client/js/components/PageAccessoriesModalControl.jsx
+++ b/src/client/js/components/PageAccessoriesModalControl.jsx
@@ -74,7 +74,7 @@ const PageAccessoriesModalControl = (props) => {
       })}
       <div className="d-flex align-items-center">
         <span className="border-left grw-border-vr">&nbsp;</span>
-        <SeenUserInfo />
+        <SeenUserInfo disabled={isSharedUserMode} />
       </div>
     </div>
   );

--- a/src/client/js/components/User/SeenUserInfo.jsx
+++ b/src/client/js/components/User/SeenUserInfo.jsx
@@ -18,14 +18,14 @@ import FootstampIcon from '../FootstampIcon';
 const SeenUserInfo = (props) => {
   const [popoverOpen, setPopoverOpen] = useState(false);
   const toggle = () => setPopoverOpen(!popoverOpen);
-  const { pageContainer } = props;
+  const { pageContainer, disabled } = props;
   return (
     <div className="grw-seen-user-info">
       <Button id="po-seen-user" color="link" className="px-2">
         <span className="mr-1 footstamp-icon"><FootstampIcon /></span>
         <span className="seen-user-count">{pageContainer.state.countOfSeenUsers}</span>
       </Button>
-      <Popover placement="bottom" isOpen={popoverOpen} target="po-seen-user" toggle={toggle} trigger="legacy">
+      <Popover placement="bottom" isOpen={popoverOpen} target="po-seen-user" toggle={toggle} trigger="legacy" disabled={disabled}>
         <PopoverBody className="seen-user-popover">
           <div className="px-2 text-right user-list-content text-truncate text-muted">
             <UserPictureList users={pageContainer.state.seenUsers} />
@@ -38,6 +38,7 @@ const SeenUserInfo = (props) => {
 
 SeenUserInfo.propTypes = {
   pageContainer: PropTypes.instanceOf(PageContainer).isRequired,
+  disabled: PropTypes.bool,
 };
 
 /**

--- a/src/client/js/services/AppContainer.js
+++ b/src/client/js/services/AppContainer.js
@@ -39,9 +39,6 @@ export default class AppContainer extends Container {
 
     this.config = JSON.parse(document.getElementById('growi-context-hydrate').textContent || '{}');
 
-    const isSharedPageElem = document.getElementById('is-shared-page');
-    this.isSharedUser = (isSharedPageElem != null);
-
     const userAgent = window.navigator.userAgent.toLowerCase();
     this.isMobile = /iphone|ipad|android/.test(userAgent);
 
@@ -49,6 +46,9 @@ export default class AppContainer extends Container {
     if (currentUserElem != null) {
       this.currentUser = JSON.parse(currentUserElem.textContent);
     }
+
+    const isSharedPageElem = document.getElementById('is-shared-page');
+    this.isSharedUser = this.currentUser == null && isSharedPageElem != null;
 
     const userLocaleId = this.currentUser?.lang;
     this.i18n = i18nFactory(userLocaleId);


### PR DESCRIPTION
shared page にてログインしていない場合 pageAccessories の中の attachment のみ見れるように変更しました
「Attachment だけを表示する」の実装ですが、以前はレンダー自体しないようにしてましたが、レンダーはするようにし、他のコンテンツは disabled にするようにしています。
<img width="1118" alt="Screen Shot 2020-11-12 at 17 39 32" src="https://user-images.githubusercontent.com/38426468/98916344-676e8c00-250e-11eb-88b2-3641b0d1e832.png">

また、足跡ユーザーに関しては、ログインしていない場合はseenUserList の tooltip がでないようにしました。（人数は表示しています。）