### PR TITLE
fix text color of modal headers in christmas theme

### DIFF
--- a/src/client/styles/scss/theme/_apply-colors.scss
+++ b/src/client/styles/scss/theme/_apply-colors.scss
@@ -39,7 +39,7 @@ $nav-tabs-link-active-border-color: $bordercolor-nav-tabs-active;
 @import 'reboot-bootstrap-nav';
 @import 'reboot-toastr-colors';
 
-// determine variables with　bootstrap function (These variables can be used after importing bootstrap)
+// determine variables with　bootstrap function (These variables can be used after importing bootstrap above)
 $color-modal-header: color-yiq($primary) !default;
 
 :not(pre) {

--- a/src/client/styles/scss/theme/_apply-colors.scss
+++ b/src/client/styles/scss/theme/_apply-colors.scss
@@ -39,6 +39,9 @@ $nav-tabs-link-active-border-color: $bordercolor-nav-tabs-active;
 @import 'reboot-bootstrap-nav';
 @import 'reboot-toastr-colors';
 
+// determine variables with　bootstrap function (These variables can be used after importing bootstrap)
+$color-modal-header: color-yiq($primary) !default;
+
 :not(pre) {
   > code {
     color: $color-inline-code;
@@ -286,10 +289,10 @@ ul.pagination {
   .modal-header {
     border-bottom-color: $border-color-theme;
     .modal-title {
-      color: color-yiq($primary);
+      color: $color-modal-header;
     }
     .close {
-      color: color-yiq($primary);
+      color: $color-modal-header;
       opacity: 0.5;
       &:hover {
         opacity: 0.9;

--- a/src/client/styles/scss/theme/christmas.scss
+++ b/src/client/styles/scss/theme/christmas.scss
@@ -51,6 +51,7 @@ html[dark] {
   $color-link-hover: lighten($color-link, 10%);
   $color-link-nabvar: $color-reversal;
   $color-inline-code: #c7254e; // optional
+  $color-modal-header: $themelight;
 
   // Table colors
   $border-color-table: $gray-400; // optional

--- a/src/client/styles/scss/theme/christmas.scss
+++ b/src/client/styles/scss/theme/christmas.scss
@@ -162,22 +162,9 @@ html[dark] {
   /*
   * Modal
   */
-  .modal {
-    .modal-dialog .modal-header.bg-primary {
-      background-image: url('/images/themes/christmas/christmas-navbar.jpg');
-      border-bottom: 2px solid $subthemecolor;
-    }
-
-    .modal-dialog:not(.grw-page-accessories-modal) {
-      .modal-header {
-        .modal-title {
-          color: $themelight;
-        }
-        .close {
-          color: $themelight;
-        }
-      }
-    }
+  .modal-dialog .modal-header.bg-primary {
+    background-image: url('/images/themes/christmas/christmas-navbar.jpg');
+    border-bottom: 2px solid $subthemecolor;
   }
 
   /*

--- a/src/client/styles/scss/theme/christmas.scss
+++ b/src/client/styles/scss/theme/christmas.scss
@@ -161,9 +161,22 @@ html[dark] {
   /*
   * Modal
   */
-  .modal-dialog .modal-header.bg-primary {
-    background-image: url('/images/themes/christmas/christmas-navbar.jpg');
-    border-bottom: 2px solid $subthemecolor;
+  .modal {
+    .modal-dialog .modal-header.bg-primary {
+      background-image: url('/images/themes/christmas/christmas-navbar.jpg');
+      border-bottom: 2px solid $subthemecolor;
+    }
+
+    .modal-dialog:not(.grw-page-accessories-modal) {
+      .modal-header {
+        .modal-title {
+          color: $themelight;
+        }
+        .close {
+          color: $themelight;
+        }
+      }
+    }
   }
 
   /*


### PR DESCRIPTION
# GW-4451 クリスマステーマの modal ヘッダーの文字が見にくい

## 変更前
<img width="815" alt="Screen Shot 2020-11-12 at 19 42 35" src="https://user-images.githubusercontent.com/59536731/98929923-3cd8ff00-251f-11eb-888f-3e63ca762471.png">



## 変更後

<img width="814" alt="Screen Shot 2020-11-12 at 19 40 26" src="https://user-images.githubusercontent.com/59536731/98929856-2468e480-251f-11eb-8aa3-1bc3ec23fa67.png">


### [原因]全テーマに共通の指定
```apply.colors.scss
/*
 * Modal
 */
.modal {
  .modal-header {
    border-bottom-color: $border-color-theme;
    .modal-title {
      color: color-yiq($primary);
    }
    .close {
      color: color-yiq($primary);
      opacity: 0.5;
      &:hover {
        opacity: 0.9;
      }
    }
  }
```
` color: color-yiq($primary);`これが指定されていたことによって、modal-headerに柄のあるクリスマスとはうまく共存できていなかった。