### PR TITLE
add mb-3 in recentCreated.jsx

### DIFF
--- a/src/client/js/components/RecentCreated/RecentCreated.jsx
+++ b/src/client/js/components/RecentCreated/RecentCreated.jsx
@@ -67,7 +67,7 @@ class RecentCreated extends React.Component {
 
     return (
       <div className="page-list-container-create">
-        <ul className="page-list-ul page-list-ul-flat">
+        <ul className="page-list-ul page-list-ul-flat mb-3">
           {pageList}
         </ul>
         <PaginationWrapper


### PR DESCRIPTION
recentCreated において margin が適用されていなかったので修正しています。

修正前
<img width="968" alt="スクリーンショット 2020-11-12 19 37 04" src="https://user-images.githubusercontent.com/57100766/98930342-daccc980-251f-11eb-8bbd-77fbcd0689a9.png">

修正後
<img width="831" alt="スクリーンショット 2020-11-12 19 33 55" src="https://user-images.githubusercontent.com/57100766/98930328-d7d1d900-251f-11eb-98c4-71979cdd8390.png">

