### PR TITLE
Imprv/antarctic border adjust

### DIFF
--- a/src/client/styles/scss/theme/antarctic.scss
+++ b/src/client/styles/scss/theme/antarctic.scss
@@ -98,7 +98,7 @@ html[dark] {
   $color-editor-icons: $color-global;
 
   // Border colors
-  $border-color-theme: $gray-400; // former: `$navbar-border: $gray-300;`
+  $border-color-theme: $gray-400;
   $border-color-global: $gray-400;
   $bordercolor-inline-code: #ccc8c8; // optional
 

--- a/src/client/styles/scss/theme/antarctic.scss
+++ b/src/client/styles/scss/theme/antarctic.scss
@@ -98,7 +98,8 @@ html[dark] {
   $color-editor-icons: $color-global;
 
   // Border colors
-  $border-color-theme: $gray-300; // former: `$navbar-border: $gray-300;`
+  $border-color-theme: $gray-400; // former: `$navbar-border: $gray-300;`
+  $border-color-global: $gray-400;
   $bordercolor-inline-code: #ccc8c8; // optional
 
   // Dropdown colors


### PR DESCRIPTION
## 作業内容
- デザインチェックGW-4440のFB対応
  - antarcticテーマにおいて、boeder色がbg色と似通っていて見辛かったため、色を1段階濃く変更

## 画像
- 変更前
![image](https://user-images.githubusercontent.com/65531771/99228412-ed9d1200-282f-11eb-8799-bb04b6cb9611.png)

- 変更後
![image](https://user-images.githubusercontent.com/65531771/99228137-9008c580-282f-11eb-938d-451ed2dd8bf6.png)
