### PR TITLE
fix typo

### DIFF
--- a/src/client/js/components/PageList.jsx
+++ b/src/client/js/components/PageList.jsx
@@ -43,7 +43,7 @@ const PageList = (props) => {
   if (isLoading) {
     return (
       <div className="wiki">
-        <div className="text-muted test-center">
+        <div className="text-muted text-center">
           <i className="fa fa-2x fa-spinner fa-pulse mr-1"></i>
         </div>
       </div>


### PR DESCRIPTION
中央になっていなかったのは、単純な typo でした。
![スクリーンショット 2020-11-16 23 08 44](https://user-images.githubusercontent.com/57100766/99262533-76807180-2861-11eb-928b-948191b53bb7.png)
![スクリーンショット 2020-11-16 23 10 52](https://user-images.githubusercontent.com/57100766/99262542-78e2cb80-2861-11eb-9ff8-79df9cbe0947.png)
