### PR TITLE
fix name

### DIFF
--- a/src/client/js/services/PageContainer.js
+++ b/src/client/js/services/PageContainer.js
@@ -180,10 +180,10 @@ export default class PageContainer extends Container {
    * ex.) duplicate, rename
    */
   get isAbleToShowPageManagement() {
-    const { isPageExist, isPageInTrash } = this.state;
+    const { isPageExist, isTrashPage } = this.state;
     const { isSharedUser } = this.appContainer;
 
-    return (isPageExist && !isPageInTrash && !isSharedUser);
+    return (isPageExist && !isTrashPage && !isSharedUser);
   }
 
   /**
@@ -191,10 +191,10 @@ export default class PageContainer extends Container {
    * ex.) view, edit, hackmd
    */
   get isAbleToShowPageEditorModeManager() {
-    const { isNotCreatable, isPageInTrash } = this.state;
+    const { isNotCreatable, isTrashPage } = this.state;
     const { isSharedUser } = this.appContainer;
 
-    return (!isNotCreatable && !isPageInTrash && !isSharedUser);
+    return (!isNotCreatable && !isTrashPage && !isSharedUser);
   }
 
   /**


### PR DESCRIPTION
変数名が誤っていたため <PageEditorModeManager> (三連ボタン) が表示されていました。

改修後
<img width="2032" alt="スクリーンショット 2020-11-18 14 53 51" src="https://user-images.githubusercontent.com/57100766/99491130-8d80aa00-29ae-11eb-9cb8-08143032c1ea.png">
