### PR TITLE
fix

### DIFF
--- a/src/client/js/services/NavigationContainer.js
+++ b/src/client/js/services/NavigationContainer.js
@@ -19,7 +19,6 @@ export default class NavigationContainer extends Container {
     this.appContainer = appContainer;
     this.appContainer.registerContainer(this);
 
-
     const { localStorage } = window;
 
     this.state = {

--- a/src/client/js/services/NavigationContainer.js
+++ b/src/client/js/services/NavigationContainer.js
@@ -19,6 +19,7 @@ export default class NavigationContainer extends Container {
     this.appContainer = appContainer;
     this.appContainer.registerContainer(this);
 
+
     const { localStorage } = window;
 
     this.state = {
@@ -52,6 +53,9 @@ export default class NavigationContainer extends Container {
     return 'NavigationContainer';
   }
 
+  getPageContainer() {
+    return this.appContainer.getContainer('PageContainer');
+  }
 
   initDeviceSize() {
     const mdOrAvobeHandler = async(mql) => {
@@ -89,9 +93,15 @@ export default class NavigationContainer extends Container {
   }
 
   setEditorMode(editorMode) {
+    const { isNotCreatable } = this.getPageContainer().state;
 
     if (this.appContainer.currentUser == null) {
       logger.warn('Please login or signup to edit the page or use hackmd.');
+      return;
+    }
+
+    if (isNotCreatable) {
+      logger.warn('This page could not edit.');
       return;
     }
 


### PR DESCRIPTION
couldn't create のページで e ボタンを押すと # edit が url についてしまう状況でした。
編集こそできないもののページ遷移するのは不適切なので、反応しないようにし logger を出すようにしました。

e ボタン押す前
<img width="1072" alt="スクリーンショット 2020-11-20 11 33 41" src="https://user-images.githubusercontent.com/57100766/99750767-4f0cfb80-2b24-11eb-8193-d38010ddb6f9.png">

押した後
<img width="1072" alt="スクリーンショット 2020-11-20 11 33 29" src="https://user-images.githubusercontent.com/57100766/99750755-4ae0de00-2b24-11eb-9ceb-1275b7606a04.png">

↑の押した後の状態になることが望ましくない。
