### PR TITLE
use Dropdown of reactstrap

### DIFF
--- a/src/client/js/components/Admin/Users/UserMenu.jsx
+++ b/src/client/js/components/Admin/Users/UserMenu.jsx
@@ -1,6 +1,9 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { withTranslation } from 'react-i18next';
+import {
+  UncontrolledDropdown, DropdownToggle, DropdownMenu,
+} from 'reactstrap';
 
 import StatusActivateButton from './StatusActivateButton';
 import StatusSuspendedButton from './StatusSuspendedButton';
@@ -80,16 +83,16 @@ class UserMenu extends React.Component {
 
     return (
       <Fragment>
-        <div className="btn-group admin-user-menu position-absolute" role="group">
-          <button id="userMenu" type="button" className="btn btn-outline-secondary btn-sm dropdown-toggle" data-toggle="dropdown">
+        <UncontrolledDropdown id="userMenu" size="sm">
+          <DropdownToggle caret color="secondary" outline>
             <i className="icon-settings"></i>
-          </button>
-          <div className="dropdown-menu" aria-labelledby="userMenu">
+          </DropdownToggle>
+          <DropdownMenu positionFixed>
             {this.renderEditMenu()}
             {user.status !== 4 && this.renderStatusMenu()}
             {user.status === 2 && this.renderAdminMenu()}
-          </div>
-        </div>
+          </DropdownMenu>
+        </UncontrolledDropdown>
       </Fragment>
     );
   }


### PR DESCRIPTION
userテーブル内のドロップダウンボタンのpositionがabsolute だったため横幅が小さい時に以下のようにレイアウトが崩れる ([#3091](https://github.com/weseek/growi/pull/3091) での変更)

<img width="1055" alt="Screen Shot 2020-11-20 at 15 58 02" src="https://user-images.githubusercontent.com/38426468/99769124-319e5880-2b49-11eb-9ed9-1804cc52063c.png">


なのでCopyDropdown を真似て reactstrap の Dropdown (with positionFixeD) を使って修正

修正後↓
![fix-user-table-layout](https://user-images.githubusercontent.com/38426468/99769093-25b29680-2b49-11eb-8219-448736c324a1.gif)
