### PR TITLE
add admin required to api for getting mongo collections

### DIFF
--- a/src/server/routes/apiv3/mongo.js
+++ b/src/server/routes/apiv3/mongo.js
@@ -14,6 +14,9 @@ const router = express.Router();
  */
 
 module.exports = (crowi) => {
+  const loginRequiredStrictly = require('../../middlewares/login-required')(crowi);
+  const adminRequired = require('../../middlewares/admin-required')(crowi);
+
   /**
    * @swagger
    *
@@ -35,7 +38,7 @@ module.exports = (crowi) => {
    *                    items:
    *                      type: string
    */
-  router.get('/collections', async(req, res) => {
+  router.get('/collections', loginRequiredStrictly, adminRequired, async(req, res) => {
     const listCollectionsResult = await mongoose.connection.db.listCollections().toArray();
     const collections = listCollectionsResult.map(collectionObj => collectionObj.name);
 


### PR DESCRIPTION
`GET /_api/v3/mongo/collections` というエンドポイントに対し、セキュリティリスクはないものの認証がないことに関して指摘されたため loginRequiredStrictly, adminRequired を追加しました。