### PR TITLE
add validation to healthcheck

### DIFF
--- a/src/server/routes/apiv3/healthcheck.js
+++ b/src/server/routes/apiv3/healthcheck.js
@@ -91,7 +91,10 @@ module.exports = (crowi) => {
    *                  info:
    *                    $ref: '#/components/schemas/HealthcheckInfo'
    */
-  router.get('/', helmet.noCache(), async(req, res) => {
+  const loginRequiredStrictly = require('../../middlewares/login-required')(crowi);
+  const adminRequired = require('../../middlewares/admin-required')(crowi);
+
+  router.get('/', helmet.noCache(), loginRequiredStrictly, adminRequired, async(req, res) => {
     const connectToMiddlewares = req.query.connectToMiddlewares != null;
     const checkMiddlewaresStrictly = req.query.checkMiddlewaresStrictly != null;
 


### PR DESCRIPTION
## GC-6845 #6 Health Checkの修正

> GET /_api/v3/healthcheck?connectToMiddlewares=1&checkMiddlewaresStrictly=1 というエンドポイントに対し、
>  ロードバランサーやサーバーヘルスチェックのために必要不可欠だが、セキュリティリスクにはならないと思う

との報告に対し、 loginRequiredStrictly, adminRequired を追加することで修正しました。


## 質問
> Health Check に loginRequired をつけたら cloud から叩けなくなる…?

とのPRを出した後に市澤さんからの指摘があったのですがどう思われますか??

