### PR TITLE
fix xss for presentation mode

### DIFF
--- a/src/lib/service/xss/xssOption.js
+++ b/src/lib/service/xss/xssOption.js
@@ -1,23 +1,10 @@
 class XssOption {
 
-  // constructor(config) {
-  //   const recommendedWhitelist = require('./recommended-whitelist');
-  //   const initializedConfig = (config != null) ? config : {};
-
-  //   this.isEnabledXssPrevention = initializedConfig.isEnabledXssPrevention || true;
-  //   this.tagWhiteList = initializedConfig.tagWhiteList || recommendedWhitelist.tags;
-  //   this.attrWhiteList = initializedConfig.attrWhiteList || recommendedWhitelist.attrs;
-  // }
-
   constructor(config, crowi) {
     const recommendedWhitelist = require('./recommended-whitelist');
     const initializedConfig = (config != null) ? config : {};
 
     this.isEnabledXssPrevention = initializedConfig.isEnabledXssPrevention || true;
-    // if (!crowi.configManager.getConfig('markdown', 'markdown:xss:isEnabledPrevention')) {
-    //   this.isEnabledXssPrevention = false;
-    // }
-
     this.tagWhiteList = initializedConfig.tagWhiteList || crowi.xssService.getTagWhiteList() || recommendedWhitelist.tags;
     this.attrWhiteList = initializedConfig.attrWhiteList || crowi.xssService.getAttrWhiteList() || recommendedWhitelist.attrs;
 

--- a/src/lib/service/xss/xssOption.js
+++ b/src/lib/service/xss/xssOption.js
@@ -1,12 +1,12 @@
 class XssOption {
 
-  constructor(config, crowi) {
+  constructor(config) {
     const recommendedWhitelist = require('./recommended-whitelist');
     const initializedConfig = (config != null) ? config : {};
 
     this.isEnabledXssPrevention = initializedConfig.isEnabledXssPrevention || true;
-    this.tagWhiteList = initializedConfig.tagWhiteList || crowi.xssService.getTagWhiteList() || recommendedWhitelist.tags;
-    this.attrWhiteList = initializedConfig.attrWhiteList || crowi.xssService.getAttrWhiteList() || recommendedWhitelist.attrs;
+    this.tagWhiteList = initializedConfig.tagWhiteList || recommendedWhitelist.tags;
+    this.attrWhiteList = initializedConfig.attrWhiteList || recommendedWhitelist.attrs;
 
   }
 

--- a/src/lib/service/xss/xssOption.js
+++ b/src/lib/service/xss/xssOption.js
@@ -1,12 +1,26 @@
 class XssOption {
 
-  constructor(config) {
+  // constructor(config) {
+  //   const recommendedWhitelist = require('./recommended-whitelist');
+  //   const initializedConfig = (config != null) ? config : {};
+
+  //   this.isEnabledXssPrevention = initializedConfig.isEnabledXssPrevention || true;
+  //   this.tagWhiteList = initializedConfig.tagWhiteList || recommendedWhitelist.tags;
+  //   this.attrWhiteList = initializedConfig.attrWhiteList || recommendedWhitelist.attrs;
+  // }
+
+  constructor(config, crowi) {
     const recommendedWhitelist = require('./recommended-whitelist');
     const initializedConfig = (config != null) ? config : {};
 
     this.isEnabledXssPrevention = initializedConfig.isEnabledXssPrevention || true;
-    this.tagWhiteList = initializedConfig.tagWhiteList || recommendedWhitelist.tags;
-    this.attrWhiteList = initializedConfig.attrWhiteList || recommendedWhitelist.attrs;
+    // if (!crowi.configManager.getConfig('markdown', 'markdown:xss:isEnabledPrevention')) {
+    //   this.isEnabledXssPrevention = false;
+    // }
+
+    this.tagWhiteList = initializedConfig.tagWhiteList || crowi.xssService.getTagWhiteList() || recommendedWhitelist.tags;
+    this.attrWhiteList = initializedConfig.attrWhiteList || crowi.xssService.getAttrWhiteList() || recommendedWhitelist.attrs;
+
   }
 
 }

--- a/src/server/crowi/index.js
+++ b/src/server/crowi/index.js
@@ -132,7 +132,7 @@ Crowi.prototype.initForTest = async function() {
   // // slack depends on setUpSlacklNotification
   await Promise.all([
     this.setUpApp(),
-    // this.setUpXss(),
+    this.setUpXss(),
     // this.setUpSlacklNotification(),
     // this.setUpGrowiBridge(),
   ]);

--- a/src/server/routes/page.js
+++ b/src/server/routes/page.js
@@ -231,18 +231,21 @@ module.exports = function(crowi, app) {
 
   function addRenderVarsForPresentation(renderVars, page) {
     // sanitize page.revision.body
-    const Xss = require('../../lib/service/xss/index');
-    const XssOption = require('../../lib/service/xss/xssOption');
-
-    const initializedConfig =  {
-        tagWhiteList:    crowi.xssService.getTagWhiteList()
-        attrWhiteList:  crowi.xssService.getAttrWhiteList() 
-    }
-    
-    // crowi.config is empty.
-    const xssOption = new XssOption(initializedConfig);
 
     if (crowi.configManager.getConfig('markdown', 'markdown:xss:isEnabledPrevention')) {
+
+      const Xss = require('../../lib/service/xss/index');
+      const XssOption = require('../../lib/service/xss/xssOption');
+
+      const initializedConfig = {
+        isEnabledXssPrevention: crowi.configManager.getConfig('markdown', 'markdown:xss:isEnabledPrevention'),
+        tagWhiteList: crowi.xssService.getTagWhiteList(),
+        attrWhiteList: crowi.xssService.getAttrWhiteList(),
+      };
+
+      const xssOption = new XssOption(initializedConfig);
+      console.log(xssOption);
+
       const xss = new Xss(xssOption);
       const preventXssRevision = xss.process(page.revision.body);
       page.revision.body = preventXssRevision;

--- a/src/server/routes/page.js
+++ b/src/server/routes/page.js
@@ -231,20 +231,23 @@ module.exports = function(crowi, app) {
 
   function addRenderVarsForPresentation(renderVars, page) {
     // sanitize page.revision.body
+    const Xss = require('../../lib/service/xss/index');
+    const XssOption = require('../../lib/service/xss/xssOption');
 
-    // const Xss = require('../../lib/service/xss/index');
-    // const XssOption = require('../../lib/service/xss/xssOption');
+    // crowi.config is empty.
+    const xssOption = new XssOption(crowi.config, crowi);
 
-    // const xssOption = new XssOption(crowi.config, crowi); // {}
-
-    // console.log(xssOption);
-    // const xss = new Xss(xssOption);
-    // console.log(xss);
-    // const preventXssRevision = xss.process(page.revision.body);
-    // page.revision.body = preventXssRevision;
-
-    renderVars.page = page;
-    renderVars.revision = page.revision;
+    if (crowi.configManager.getConfig('markdown', 'markdown:xss:isEnabledPrevention')) {
+      const xss = new Xss(xssOption);
+      const preventXssRevision = xss.process(page.revision.body);
+      page.revision.body = preventXssRevision;
+      renderVars.page = page;
+      renderVars.revision = page.revision;
+    }
+    else {
+      renderVars.page = page;
+      renderVars.revision = page.revision;
+    }
   }
 
   async function addRenderVarsForUserPage(renderVars, page, requestUser) {

--- a/src/server/routes/page.js
+++ b/src/server/routes/page.js
@@ -231,7 +231,7 @@ module.exports = function(crowi, app) {
 
   function addRenderVarsForPresentation(renderVars, page) {
     // sanitize revision.body
-    const preventXssRevision = crowi.xss.process(page.revision.body);
+    const preventXssRevision = crowi.xssService.process(page.revision.body);
     page.revision.body = preventXssRevision;
 
     renderVars.page = page;

--- a/src/server/routes/page.js
+++ b/src/server/routes/page.js
@@ -234,8 +234,13 @@ module.exports = function(crowi, app) {
     const Xss = require('../../lib/service/xss/index');
     const XssOption = require('../../lib/service/xss/xssOption');
 
+    const initializedConfig =  {
+        tagWhiteList:    crowi.xssService.getTagWhiteList()
+        attrWhiteList:  crowi.xssService.getAttrWhiteList() 
+    }
+    
     // crowi.config is empty.
-    const xssOption = new XssOption(crowi.config, crowi);
+    const xssOption = new XssOption(initializedConfig);
 
     if (crowi.configManager.getConfig('markdown', 'markdown:xss:isEnabledPrevention')) {
       const xss = new Xss(xssOption);

--- a/src/server/routes/page.js
+++ b/src/server/routes/page.js
@@ -230,7 +230,14 @@ module.exports = function(crowi, app) {
   }
 
   function addRenderVarsForPresentation(renderVars, page) {
-    // sanitize revision.body
+    // sanitize page.revision.body
+
+    // const Xss = require('../../lib/service/xss/index');
+    // const XssOption = require('../../lib/service/xss/xssOption');
+    // const option = new XssOption(crowi.config); // {}
+    // const xss = new Xss(option);
+    // const preventXssRevision = xss.process(page.revision.body);
+    // page.revision.body = preventXssRevision;
     const preventXssRevision = crowi.xssService.process(page.revision.body);
     page.revision.body = preventXssRevision;
 

--- a/src/server/routes/page.js
+++ b/src/server/routes/page.js
@@ -234,12 +234,14 @@ module.exports = function(crowi, app) {
 
     // const Xss = require('../../lib/service/xss/index');
     // const XssOption = require('../../lib/service/xss/xssOption');
-    // const option = new XssOption(crowi.config); // {}
-    // const xss = new Xss(option);
+
+    // const xssOption = new XssOption(crowi.config, crowi); // {}
+
+    // console.log(xssOption);
+    // const xss = new Xss(xssOption);
+    // console.log(xss);
     // const preventXssRevision = xss.process(page.revision.body);
     // page.revision.body = preventXssRevision;
-    const preventXssRevision = crowi.xssService.process(page.revision.body);
-    page.revision.body = preventXssRevision;
 
     renderVars.page = page;
     renderVars.revision = page.revision;

--- a/src/server/routes/page.js
+++ b/src/server/routes/page.js
@@ -230,6 +230,10 @@ module.exports = function(crowi, app) {
   }
 
   function addRenderVarsForPresentation(renderVars, page) {
+
+    const preventXssRevision = page.revision.body.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    page.revision.body = preventXssRevision;
+
     renderVars.page = page;
     renderVars.revision = page.revision;
   }

--- a/src/server/routes/page.js
+++ b/src/server/routes/page.js
@@ -230,8 +230,14 @@ module.exports = function(crowi, app) {
   }
 
   function addRenderVarsForPresentation(renderVars, page) {
+    // const XssService = require('../service/xss');
+    // const preventXssRevision = new XssService();
+    // const hoge = preventXssRevision.process(page.revision.body);
+    // console.log(hoge);
+    // page.revision.body = hoge;
 
-    const preventXssRevision = page.revision.body.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    // sanitize revision.body
+    const preventXssRevision = crowi.xss.process(page.revision.body);
     page.revision.body = preventXssRevision;
 
     renderVars.page = page;

--- a/src/server/routes/page.js
+++ b/src/server/routes/page.js
@@ -231,21 +231,15 @@ module.exports = function(crowi, app) {
 
   function addRenderVarsForPresentation(renderVars, page) {
     // sanitize page.revision.body
-
     if (crowi.configManager.getConfig('markdown', 'markdown:xss:isEnabledPrevention')) {
-
       const Xss = require('../../lib/service/xss/index');
       const XssOption = require('../../lib/service/xss/xssOption');
-
       const initializedConfig = {
         isEnabledXssPrevention: crowi.configManager.getConfig('markdown', 'markdown:xss:isEnabledPrevention'),
         tagWhiteList: crowi.xssService.getTagWhiteList(),
         attrWhiteList: crowi.xssService.getAttrWhiteList(),
       };
-
       const xssOption = new XssOption(initializedConfig);
-      console.log(xssOption);
-
       const xss = new Xss(xssOption);
       const preventXssRevision = xss.process(page.revision.body);
       page.revision.body = preventXssRevision;

--- a/src/server/routes/page.js
+++ b/src/server/routes/page.js
@@ -154,8 +154,6 @@ module.exports = function(crowi, app) {
     tagWhiteList: crowi.xssService.getTagWhiteList(),
     attrWhiteList: crowi.xssService.getAttrWhiteList(),
   };
-  console.log(initializedConfig.tagWhiteList);
-  console.log('----------------------------------------------');
   const xssOption = new XssOption(initializedConfig);
   const xss = new Xss(xssOption);
 

--- a/src/server/routes/page.js
+++ b/src/server/routes/page.js
@@ -147,6 +147,17 @@ module.exports = function(crowi, app) {
   const interceptorManager = crowi.getInterceptorManager();
   const globalNotificationService = crowi.getGlobalNotificationService();
 
+  const XssOption = require('../../lib/service/xss/xssOption');
+  const Xss = require('../../lib/service/xss/index');
+  const initializedConfig = {
+    isEnabledXssPrevention: crowi.configManager.getConfig('markdown', 'markdown:xss:isEnabledPrevention'),
+    tagWhiteList: crowi.xssService.getTagWhiteList(),
+    attrWhiteList: crowi.xssService.getAttrWhiteList(),
+  };
+  this.xssOption = new XssOption(initializedConfig);
+  this.xss = new Xss(this.xssOption);
+
+
   const actions = {};
 
   function getPathFromRequest(req) {
@@ -232,19 +243,9 @@ module.exports = function(crowi, app) {
   function addRenderVarsForPresentation(renderVars, page) {
     // sanitize page.revision.body
     if (crowi.configManager.getConfig('markdown', 'markdown:xss:isEnabledPrevention')) {
-      const Xss = require('../../lib/service/xss/index');
-      const XssOption = require('../../lib/service/xss/xssOption');
-      const initializedConfig = {
-        isEnabledXssPrevention: crowi.configManager.getConfig('markdown', 'markdown:xss:isEnabledPrevention'),
-        tagWhiteList: crowi.xssService.getTagWhiteList(),
-        attrWhiteList: crowi.xssService.getAttrWhiteList(),
-      };
-      const xssOption = new XssOption(initializedConfig);
-      const xss = new Xss(xssOption);
-      const preventXssRevision = xss.process(page.revision.body);
+      const preventXssRevision = this.xss.process(page.revision.body);
       page.revision.body = preventXssRevision;
     }
-
     renderVars.page = page;
     renderVars.revision = page.revision;
   }

--- a/src/server/routes/page.js
+++ b/src/server/routes/page.js
@@ -241,13 +241,10 @@ module.exports = function(crowi, app) {
       const xss = new Xss(xssOption);
       const preventXssRevision = xss.process(page.revision.body);
       page.revision.body = preventXssRevision;
-      renderVars.page = page;
-      renderVars.revision = page.revision;
     }
-    else {
-      renderVars.page = page;
-      renderVars.revision = page.revision;
-    }
+
+    renderVars.page = page;
+    renderVars.revision = page.revision;
   }
 
   async function addRenderVarsForUserPage(renderVars, page, requestUser) {

--- a/src/server/routes/page.js
+++ b/src/server/routes/page.js
@@ -154,8 +154,10 @@ module.exports = function(crowi, app) {
     tagWhiteList: crowi.xssService.getTagWhiteList(),
     attrWhiteList: crowi.xssService.getAttrWhiteList(),
   };
-  this.xssOption = new XssOption(initializedConfig);
-  this.xss = new Xss(this.xssOption);
+  console.log(initializedConfig.tagWhiteList);
+  console.log('----------------------------------------------');
+  const xssOption = new XssOption(initializedConfig);
+  const xss = new Xss(xssOption);
 
 
   const actions = {};
@@ -243,7 +245,7 @@ module.exports = function(crowi, app) {
   function addRenderVarsForPresentation(renderVars, page) {
     // sanitize page.revision.body
     if (crowi.configManager.getConfig('markdown', 'markdown:xss:isEnabledPrevention')) {
-      const preventXssRevision = this.xss.process(page.revision.body);
+      const preventXssRevision = xss.process(page.revision.body);
       page.revision.body = preventXssRevision;
     }
     renderVars.page = page;

--- a/src/server/routes/page.js
+++ b/src/server/routes/page.js
@@ -230,12 +230,6 @@ module.exports = function(crowi, app) {
   }
 
   function addRenderVarsForPresentation(renderVars, page) {
-    // const XssService = require('../service/xss');
-    // const preventXssRevision = new XssService();
-    // const hoge = preventXssRevision.process(page.revision.body);
-    // console.log(hoge);
-    // page.revision.body = hoge;
-
     // sanitize revision.body
     const preventXssRevision = crowi.xss.process(page.revision.body);
     page.revision.body = preventXssRevision;


### PR DESCRIPTION
[概要]
presentation mode のときに alert が出る問題を修正しました。

当初 xss を導入しました。
しかし、xss に引っかかってしまうと、`</script><script></script>` が文字として表示されなくなるので replace する方法に変更しました。
replace した結果 < と > が内在するものは html において　`'&lt;/script&gt;` のように置換され、アラートも発生せず、presentation mode でも文字として表示させることが可能になりました。

[実際の挙動]
alert が出現しなくなった。
<img width="2032" alt="スクリーンショット 2020-12-02 15 48 36" src="https://user-images.githubusercontent.com/57100766/100840859-d3169a00-34b9-11eb-8153-4e0c47628cb4.png">

[server log]
<img width="527" alt="スクリーンショット 2020-12-02 15 49 09" src="https://user-images.githubusercontent.com/57100766/100840872-d6aa2100-34b9-11eb-99a2-02ac6f2345ab.png">
