### PR TITLE
modify layout of linkedit-preview

### DIFF
--- a/src/client/styles/scss/_linkedit-preview.scss
+++ b/src/client/styles/scss/_linkedit-preview.scss
@@ -4,7 +4,9 @@
     padding-top: 0px;
     margin: 0px -10px 0px -10px;
     .wiki {
+      width: 200%;
       overflow-y: scroll;
+      transform: scale(0.5) translate(-50%, -50%);
     }
   }
 }

--- a/src/client/styles/scss/_linkedit-preview.scss
+++ b/src/client/styles/scss/_linkedit-preview.scss
@@ -4,9 +4,8 @@
     padding-top: 0px;
     margin: 0px -10px 0px -10px;
     .wiki {
-      width: 200%;
       overflow-y: scroll;
-      transform: scale(0.5) translate(-50%, -50%);
+      font-size: 0.5rem;
     }
   }
 }


### PR DESCRIPTION
以前のFB: https://github.com/weseek/growi/pull/2764#discussion_r490956433

font-size の変更で縮小するようにしました。画像はpopoverの幅に合わせて縮小するため問題なかったです。ただbootstrap の alert や card のようにmargin, paddingが指定してあるものは大きめに表示されます。あくまでプレビューなので致命的な問題ではないと考えていますが、気になるようであれば transform の scale() を使うよう変更します。

<img width="1055" alt="Screen Shot 2020-12-02 at 19 57 53" src="https://user-images.githubusercontent.com/38426468/100864538-762adc00-34d9-11eb-84d7-7ed65bd7e961.png">
<img width="1055" alt="Screen Shot 2020-12-02 at 19 58 08" src="https://user-images.githubusercontent.com/38426468/100864541-775c0900-34d9-11eb-89a3-aea004436c9d.png">
