### PR TITLE
enhance security policy about getting attachment

### DIFF
--- a/src/server/routes/attachment.js
+++ b/src/server/routes/attachment.js
@@ -239,7 +239,7 @@ module.exports = function(crowi, app) {
     else {
       res.set({
         'Content-Type': attachment.fileFormat,
-        'Content-Security-Policy': "script-src 'unsafe-hashes'",
+        'Content-Security-Policy': "script-src 'unsafe-hashes'; object-src 'none'; require-trusted-types-for 'script'; default-src 'none';",
       });
     }
   }


### PR DESCRIPTION
対応している脆弱性の内容はレビュー用タスクに記載しています。
アタッチメントアップロード時にファイルのmimetypeによりフィルタリングする方法も提案されていましたが、アタッチメント表示時のサーバーからのレスポンスでのセキュリティポリシーを追加することで対応しています。