### PR TITLE
Imprv/4660 darkmode for slack notification

### DIFF
--- a/src/client/styles/scss/theme/_apply-colors-dark.scss
+++ b/src/client/styles/scss/theme/_apply-colors-dark.scss
@@ -47,12 +47,6 @@ textarea.form-control {
   // border: 1px solid darken($border, 30%);
 }
 
-.grw-slack-notification {
-  .form-control {
-    background: $bgcolor-global;
-  }
-}
-
 .form-control[disabled],
 .form-control[readonly] {
   color: lighten($color-global, 10%);
@@ -316,6 +310,10 @@ ul.pagination {
 .grw-slack-notification {
   background-color: transparent;
   $color-slack: #4b144c;
+
+  .form-control {
+    background: $bgcolor-global;
+  }
 
   .custom-control-label {
     &::before {

--- a/src/client/styles/scss/theme/_apply-colors-light.scss
+++ b/src/client/styles/scss/theme/_apply-colors-light.scss
@@ -38,12 +38,6 @@ $border-color: $border-color-global;
   background-color: $bgcolor-global;
 }
 
-.grw-slack-notification {
-  .form-control {
-    background: white;
-  }
-}
-
 .form-control::placeholder {
   color: darken($bgcolor-global, 20%);
 }
@@ -221,6 +215,10 @@ $border-color: $border-color-global;
 .grw-slack-notification {
   background-color: white;
   $color-slack: #4b144c;
+
+  .form-control {
+    background: white;
+  }
 
   .custom-control-label {
     &::before {

--- a/src/client/styles/scss/theme/_apply-colors-light.scss
+++ b/src/client/styles/scss/theme/_apply-colors-light.scss
@@ -185,6 +185,8 @@ $border-color: $border-color-global;
  * GROWI on-edit
  */
 .grw-editor-navbar-bottom {
+  background-color: $gray-50;
+
   #slack-mark-white {
     display: none;
   }

--- a/src/client/styles/scss/theme/_apply-colors.scss
+++ b/src/client/styles/scss/theme/_apply-colors.scss
@@ -433,10 +433,6 @@ body.on-edit {
       border-top-color: $border-color-theme;
     }
   }
-
-  .grw-editor-navbar-bottom {
-    background-color: $gray-50;
-  }
 }
 
 /*


### PR DESCRIPTION
GW-4660 slack フォームのダークモード対応

## 変更前
- ナビバーボトムの背景色が白い
- slack notificationの色がおかしい

<img width="234" alt="Screen Shot 2020-12-07 at 14 29 26" src="https://user-images.githubusercontent.com/59536731/101313422-73453800-3899-11eb-91a1-c05f87bf9a95.png">

<img width="1184" alt="Screen Shot 2020-12-07 at 13 21 34" src="https://user-images.githubusercontent.com/59536731/101312399-02048580-3897-11eb-893f-815e71028f5e.png">

## 変更後
[dark mode]
<img width="592" alt="Screen Shot 2020-12-07 at 14 12 06" src="https://user-images.githubusercontent.com/59536731/101312419-0a5cc080-3897-11eb-871f-6c3643b991cb.png">

<img width="1179" alt="Screen Shot 2020-12-07 at 14 37 47" src="https://user-images.githubusercontent.com/59536731/101313609-cf0fc100-3899-11eb-828f-d1165b83e7ac.png">

[light mode]
<img width="1179" alt="Screen Shot 2020-12-07 at 14 04 29" src="https://user-images.githubusercontent.com/59536731/101313539-aee00200-3899-11eb-8c82-6749554b6994.png">

