### PR TITLE
fix state in revision loader

### DIFF
--- a/src/client/js/components/Page/RevisionLoader.jsx
+++ b/src/client/js/components/Page/RevisionLoader.jsx
@@ -57,9 +57,7 @@ class RevisionLoader extends React.Component {
       }
     }
     catch (errors) {
-      errors.map((error) => {
-        return this.setState({ markdown: error.message });
-      });
+      errors.forEach((error) => { this.setState({ markdown: error.message }) });
     }
     finally {
       this.setState({ isLoaded: true, isLoading: false });

--- a/src/client/js/components/Page/RevisionLoader.jsx
+++ b/src/client/js/components/Page/RevisionLoader.jsx
@@ -22,7 +22,7 @@ class RevisionLoader extends React.Component {
       markdown: '',
       isLoading: false,
       isLoaded: false,
-      error: null,
+      errors: null,
     };
 
     this.loadData = this.loadData.bind(this);
@@ -49,18 +49,15 @@ class RevisionLoader extends React.Component {
 
       this.setState({
         markdown: res.data.revision.body,
-        error: null,
+        errors: null,
       });
 
       if (this.props.onRevisionLoaded != null) {
         this.props.onRevisionLoaded(res.data.revision);
       }
     }
-    catch (error) {
-      console.log(error);
-      // errors.forEach((error) => { this.setState({ markdown: error.message }) });
-      // this.setState({ error });
-      this.setState({ error: error[0].message });
+    catch (errors) {
+      this.setState({ errors });
     }
     finally {
       this.setState({ isLoaded: true, isLoading: false });
@@ -97,8 +94,11 @@ class RevisionLoader extends React.Component {
 
     // ----- after load -----
     let markdown = this.state.markdown;
-    if (this.state.error != null) {
-      markdown = `<span class="text-muted"><em>${this.state.error}</em></span>`;
+    if (this.state.errors != null) {
+      const errorMessages = this.state.errors.map((error) => {
+        return `<span class="text-muted"><em>${error.message}</em></span>`;
+      });
+      markdown = errorMessages.join('');
     }
 
     return (

--- a/src/client/js/components/Page/RevisionLoader.jsx
+++ b/src/client/js/components/Page/RevisionLoader.jsx
@@ -52,7 +52,6 @@ class RevisionLoader extends React.Component {
         error: null,
       });
 
-
       if (this.props.onRevisionLoaded != null) {
         this.props.onRevisionLoaded(res.data.revision);
       }

--- a/src/client/js/components/Page/RevisionLoader.jsx
+++ b/src/client/js/components/Page/RevisionLoader.jsx
@@ -56,8 +56,10 @@ class RevisionLoader extends React.Component {
         this.props.onRevisionLoaded(res.data.revision);
       }
     }
-    catch (error) {
-      this.setState({ markdown: error[0].message });
+    catch (errors) {
+      errors.map((error) => {
+        return this.setState({ markdown: error.message });
+      });
     }
     finally {
       this.setState({ isLoaded: true, isLoading: false });

--- a/src/client/js/components/Page/RevisionLoader.jsx
+++ b/src/client/js/components/Page/RevisionLoader.jsx
@@ -52,12 +52,13 @@ class RevisionLoader extends React.Component {
         error: null,
       });
 
+
       if (this.props.onRevisionLoaded != null) {
         this.props.onRevisionLoaded(res.data.revision);
       }
     }
     catch (error) {
-      this.setState({ error });
+      this.setState({ markdown: error[0].message });
     }
     finally {
       this.setState({ isLoaded: true, isLoading: false });

--- a/src/client/js/components/Page/RevisionLoader.jsx
+++ b/src/client/js/components/Page/RevisionLoader.jsx
@@ -56,8 +56,11 @@ class RevisionLoader extends React.Component {
         this.props.onRevisionLoaded(res.data.revision);
       }
     }
-    catch (errors) {
-      errors.forEach((error) => { this.setState({ markdown: error.message }) });
+    catch (error) {
+      console.log(error);
+      // errors.forEach((error) => { this.setState({ markdown: error.message }) });
+      // this.setState({ error });
+      this.setState({ error: error[0].message });
     }
     finally {
       this.setState({ isLoaded: true, isLoading: false });


### PR DESCRIPTION
制限ページにおいて,
[Object, object] の表示問題を修正しました。

修正前
<img width="2032" alt="スクリーンショット 2020-12-07 19 12 37" src="https://user-images.githubusercontent.com/57100766/101338348-317bb800-38c0-11eb-90d0-77a734dd204b.png">

修正後 / アクセス権限ない user
<img width="2032" alt="スクリーンショット 2020-12-07 19 11 46" src="https://user-images.githubusercontent.com/57100766/101338467-5b34df00-38c0-11eb-8706-5af4920ab839.png">

修正後 / アクセス権限ある user
<img width="2032" alt="スクリーンショット 2020-12-07 19 11 17" src="https://user-images.githubusercontent.com/57100766/101338515-6daf1880-38c0-11eb-84de-9357c1125573.png">
