### PR TITLE
Imprv/7423 create validation for each request user

### DIFF
--- a/src/server/routes/apiv3/users.js
+++ b/src/server/routes/apiv3/users.js
@@ -89,32 +89,16 @@ module.exports = (crowi) => {
   };
 
   validator.statusList = [
-    // validate status list status array match to statusNo
-
-    // query('selectedStatusList').custom((value, { req }) => {
-    //   const error = [];
-    //   value.forEach((status) => {
-    //     if (!Object.keys(statusNo)) {
-    //       error.push(status);
-    //     }
-    //   });
-    //   return (error.length === 0);
-    // }),
-
-    // これ
     query('selectedStatusList').customSanitizer((value, { req }) => {
       const { user } = req;
       const isAdmin = user.admin;
-      console.log(`isAdmin = ${isAdmin}`);
 
-      if (!isAdmin) {
+      if (isAdmin) {
         return value;
       }
 
       const getActiveStatusForNotAdmin = ['active'];
-      console.log(typeof getActiveStatusForNotAdmin);
       return getActiveStatusForNotAdmin;
-
     }),
 
     // validate sortOrder : asc or desc

--- a/src/server/routes/apiv3/users.js
+++ b/src/server/routes/apiv3/users.js
@@ -89,7 +89,13 @@ module.exports = (crowi) => {
 
   validator.statusList = [
     // validate status list status array match to statusNo
-    query('selectedStatusList').custom((value) => {
+    query('selectedStatusList').custom((value, { req }) => {
+      const { user } = req;
+      const isAdmin = user.admin;
+
+      console.log(`user = ${user}`);
+      console.log(`isAdmin = ${isAdmin}`);
+
       const error = [];
       value.forEach((status) => {
         if (!Object.keys(statusNo)) {

--- a/src/server/routes/apiv3/users.js
+++ b/src/server/routes/apiv3/users.js
@@ -100,7 +100,6 @@ module.exports = (crowi) => {
       const getActiveStatusForNotAdmin = ['active'];
       return getActiveStatusForNotAdmin;
     }),
-
     // validate sortOrder : asc or desc
     query('sortOrder').isIn(['asc', 'desc']),
     // validate sort : what column you will sort

--- a/src/server/routes/apiv3/users.js
+++ b/src/server/routes/apiv3/users.js
@@ -113,25 +113,12 @@ module.exports = (crowi) => {
       const isAdmin = user.admin;
       console.log(`isAdmin = ${isAdmin}`);
 
-      // console.log(`{Object.keys(statusNo) = ${Object.keys(statusNo)}`);
-      // console.log(`{Object.keys(statusNo)[1] = ${Object.keys(statusNo)[1]}`);
-      console.log(`{Object.values(statusNo) = ${Object.values(statusNo)}`);
-      console.log(`{Object.values(statusNo)[1] = ${Object.values(statusNo)[1]}`);
-      // console.log(`statusNo = ${statusNo}`);
-      // console.log(`statusNo.active = ${statusNo.active}`);
-
-      // return isAdmin ? Object.keys(statusNo) : Object.keys(statusNo)[1];
-      // return isAdmin ? Object.values(statusNo) : Object.values(statusNo.active);
-      // return isAdmin ? statusNo : statusNo.active;
-      console.log(`vallue = ${value}`);
-
       if (isAdmin) {
         return value;
       }
 
-      return statusNo.active;
-
-      // return !isAdmin;
+      const getActiveStatusForNotAdmin = 'active';
+      return getActiveStatusForNotAdmin;
 
     }),
 

--- a/src/server/routes/apiv3/users.js
+++ b/src/server/routes/apiv3/users.js
@@ -92,12 +92,6 @@ module.exports = (crowi) => {
     // validate status list status array match to statusNo
 
     // query('selectedStatusList').custom((value, { req }) => {
-    //   const { user } = req;
-    //   const isAdmin = user.admin;
-
-    //   console.log(`user = ${user}`);
-    //   console.log(`isAdmin = ${isAdmin}`);
-
     //   const error = [];
     //   value.forEach((status) => {
     //     if (!Object.keys(statusNo)) {
@@ -113,11 +107,12 @@ module.exports = (crowi) => {
       const isAdmin = user.admin;
       console.log(`isAdmin = ${isAdmin}`);
 
-      if (isAdmin) {
+      if (!isAdmin) {
         return value;
       }
 
-      const getActiveStatusForNotAdmin = 'active';
+      const getActiveStatusForNotAdmin = ['active'];
+      console.log(typeof getActiveStatusForNotAdmin);
       return getActiveStatusForNotAdmin;
 
     }),
@@ -192,7 +187,7 @@ module.exports = (crowi) => {
     const page = parseInt(req.query.page) || 1;
     // status
     const { selectedStatusList, forceIncludeAttributes } = req.query;
-    console.log(`selectedStatusList = ${selectedStatusList}`);
+    console.log(`selectedStatusList = ${typeof selectedStatusList}`);
     const statusNoList = (selectedStatusList.includes('all')) ? Object.values(statusNo) : selectedStatusList.map(element => statusNo[element]);
     // const statusNoList = (selectedStatusList.includes('all')) ? Object.values(statusNo) : selectedStatusList;
     console.log(`statusNoList = ${statusNoList}`);

--- a/src/server/routes/apiv3/users.js
+++ b/src/server/routes/apiv3/users.js
@@ -90,21 +90,35 @@ module.exports = (crowi) => {
 
   validator.statusList = [
     // validate status list status array match to statusNo
-    query('selectedStatusList').custom((value, { req }) => {
+
+    // query('selectedStatusList').custom((value, { req }) => {
+    //   const { user } = req;
+    //   const isAdmin = user.admin;
+
+    //   console.log(`user = ${user}`);
+    //   console.log(`isAdmin = ${isAdmin}`);
+
+    //   const error = [];
+    //   value.forEach((status) => {
+    //     if (!Object.keys(statusNo)) {
+    //       error.push(status);
+    //     }
+    //   });
+    //   return (error.length === 0);
+    // }),
+
+    // これ
+    query('selectedStatusList').customSanitizer((value, { req }) => {
       const { user } = req;
       const isAdmin = user.admin;
+      console.log(`statusNo = ${statusNo}`);
+      console.log(`statusNo.active = ${statusNo.active}`);
+      console.log(`{Object.keys(statusNo) = ${Object.keys(statusNo)}`);
+      console.log(`{Object.keys(statusNo.active) = ${Object.keys(statusNo.active)}`);
 
-      console.log(`user = ${user}`);
-      console.log(`isAdmin = ${isAdmin}`);
-
-      const error = [];
-      value.forEach((status) => {
-        if (!Object.keys(statusNo)) {
-          error.push(status);
-        }
-      });
-      return (error.length === 0);
+      return isAdmin ? Object.keys(statusNo) : Object.keys(statusNo.active);
     }),
+
     // validate sortOrder : asc or desc
     query('sortOrder').isIn(['asc', 'desc']),
     // validate sort : what column you will sort

--- a/src/server/routes/apiv3/users.js
+++ b/src/server/routes/apiv3/users.js
@@ -95,12 +95,12 @@ module.exports = (crowi) => {
 
       const { user } = req;
 
-      if (user == null || !user.admin) {
-        throw new Error(errorStr);
+      if (user !== null && user.admin) {
+        return value;
       }
-      return value;
-
+      throw new Error(errorStr);
     }),
+
     // validate sortOrder : asc or desc
     query('sortOrder').isIn(['asc', 'desc']),
     // validate sort : what column you will sort

--- a/src/server/routes/apiv3/users.js
+++ b/src/server/routes/apiv3/users.js
@@ -91,16 +91,13 @@ module.exports = (crowi) => {
   validator.statusList = [
     query('selectedStatusList').if(value => value != null).custom((value, { req }) => {
 
-      const errorStr = 'the param \'selectedStatusList\' is not allowed to use by the user not logged in';
-
       const { user } = req;
 
       if (user !== null && user.admin) {
         return value;
       }
-      throw new Error(errorStr);
+      throw new Error('the param \'selectedStatusList\' is not allowed to use by the users except administrators');
     }),
-
     // validate sortOrder : asc or desc
     query('sortOrder').isIn(['asc', 'desc']),
     // validate sort : what column you will sort

--- a/src/server/routes/apiv3/users.js
+++ b/src/server/routes/apiv3/users.js
@@ -111,12 +111,28 @@ module.exports = (crowi) => {
     query('selectedStatusList').customSanitizer((value, { req }) => {
       const { user } = req;
       const isAdmin = user.admin;
-      console.log(`statusNo = ${statusNo}`);
-      console.log(`statusNo.active = ${statusNo.active}`);
-      console.log(`{Object.keys(statusNo) = ${Object.keys(statusNo)}`);
-      console.log(`{Object.keys(statusNo.active) = ${Object.keys(statusNo.active)}`);
+      console.log(`isAdmin = ${isAdmin}`);
 
-      return isAdmin ? Object.keys(statusNo) : Object.keys(statusNo.active);
+      // console.log(`{Object.keys(statusNo) = ${Object.keys(statusNo)}`);
+      // console.log(`{Object.keys(statusNo)[1] = ${Object.keys(statusNo)[1]}`);
+      console.log(`{Object.values(statusNo) = ${Object.values(statusNo)}`);
+      console.log(`{Object.values(statusNo)[1] = ${Object.values(statusNo)[1]}`);
+      // console.log(`statusNo = ${statusNo}`);
+      // console.log(`statusNo.active = ${statusNo.active}`);
+
+      // return isAdmin ? Object.keys(statusNo) : Object.keys(statusNo)[1];
+      // return isAdmin ? Object.values(statusNo) : Object.values(statusNo.active);
+      // return isAdmin ? statusNo : statusNo.active;
+      console.log(`vallue = ${value}`);
+
+      if (isAdmin) {
+        return value;
+      }
+
+      return statusNo.active;
+
+      // return !isAdmin;
+
     }),
 
     // validate sortOrder : asc or desc
@@ -189,7 +205,10 @@ module.exports = (crowi) => {
     const page = parseInt(req.query.page) || 1;
     // status
     const { selectedStatusList, forceIncludeAttributes } = req.query;
+    console.log(`selectedStatusList = ${selectedStatusList}`);
     const statusNoList = (selectedStatusList.includes('all')) ? Object.values(statusNo) : selectedStatusList.map(element => statusNo[element]);
+    // const statusNoList = (selectedStatusList.includes('all')) ? Object.values(statusNo) : selectedStatusList;
+    console.log(`statusNoList = ${statusNoList}`);
 
     // Search from input
     const searchText = req.query.searchText || '';

--- a/src/server/routes/apiv3/users.js
+++ b/src/server/routes/apiv3/users.js
@@ -171,10 +171,7 @@ module.exports = (crowi) => {
     const page = parseInt(req.query.page) || 1;
     // status
     const { selectedStatusList, forceIncludeAttributes } = req.query;
-    console.log(`selectedStatusList = ${typeof selectedStatusList}`);
     const statusNoList = (selectedStatusList.includes('all')) ? Object.values(statusNo) : selectedStatusList.map(element => statusNo[element]);
-    // const statusNoList = (selectedStatusList.includes('all')) ? Object.values(statusNo) : selectedStatusList;
-    console.log(`statusNoList = ${statusNoList}`);
 
     // Search from input
     const searchText = req.query.searchText || '';


### PR DESCRIPTION
## 該当タスク
- GC-7423 request user ごとのvalidatorを作成する

管理者には、valueに入ってくる全ての値をそのまま返す。
管理者以外には、active user のみを渡す。
という仕様にしました。


## 動作確認方法
### userがadminの場合
- ユーザー管理ページでstatusのチェックボックスをそれぞれクリックしてみて、ちゃんとuserlistに反映されているかを確認しました。
<img width="1264" alt="Screen Shot 2020-12-09 at 19 35 58" src="https://user-images.githubusercontent.com/59536731/101618841-d976ba00-3a55-11eb-9fe8-6f57c52d959a.png">
<img width="1255" alt="Screen Shot 2020-12-09 at 19 36 09" src="https://user-images.githubusercontent.com/59536731/101618844-daa7e700-3a55-11eb-9e0f-0f87559cd90c.png">

### userが!adminの場合
```
      if (!isAdmin) {
        return value;
      }
```
↑上記のように仮で`!isAdmin`と入力
として、ユーザー管理ページで、どのチェックボックスにチェックを入れてもactive userの値しか表示されないことを確認。
<img width="1279" alt="Screen Shot 2020-12-09 at 19 37 09" src="https://user-images.githubusercontent.com/59536731/101618979-fd3a0000-3a55-11eb-9fe8-6636358be9c2.png">

## 参考
- [/Web会議室/20201203_UserApiの整理#検索に引っかかるユーザーのstatus](
https://dev.growi.org/5fc8aa3fe692e7004836b97f#検索に引っかかるユーザーのstatus)
