### PR TITLE
Fix/layout trash page btn

### DIFF
--- a/src/client/js/components/Page/TrashPageAlert.jsx
+++ b/src/client/js/components/Page/TrashPageAlert.jsx
@@ -107,13 +107,15 @@ const TrashPageAlert = (props) => {
 
   return (
     <>
-      <div className="alert alert-warning py-3 px-4 d-flex align-items-center">
-        <div>
+      <div className="alert alert-warning py-3 px-4 d-flex flex-column flex-lg-row ">
+        <div className="py-1 flex-grow-1">
           This page is in the trash <i className="icon-trash" aria-hidden="true"></i>.
           {isDeleted && <span><br /><UserPicture user={{ username: lastUpdateUsername }} /> Deleted by {lastUpdateUsername} at {updatedAt}</span>}
         </div>
-        { pageContainer.isAbleToShowEmptyTrashButton && renderEmptyButton()}
-        { pageContainer.isAbleToShowTrashPageManagementButtons && renderTrashPageManagementButtons()}
+        <div className="pt-2 justifi-content-right">
+          <span>{ pageContainer.isAbleToShowEmptyTrashButton && renderEmptyButton()}</span>
+          { pageContainer.isAbleToShowTrashPageManagementButtons && renderTrashPageManagementButtons()}
+        </div>
       </div>
       {renderModals()}
     </>

--- a/src/client/js/components/Page/TrashPageAlert.jsx
+++ b/src/client/js/components/Page/TrashPageAlert.jsx
@@ -107,12 +107,12 @@ const TrashPageAlert = (props) => {
 
   return (
     <>
-      <div className="alert alert-warning py-3 px-4 d-flex flex-column flex-lg-row ">
-        <div className="py-1 flex-grow-1">
+      <div className="alert alert-warning pt-3 pl-4 pb-2 pr-0 d-flex flex-column flex-lg-row ">
+        <div className="flex-grow-1">
           This page is in the trash <i className="icon-trash" aria-hidden="true"></i>.
           {isDeleted && <span><br /><UserPicture user={{ username: lastUpdateUsername }} /> Deleted by {lastUpdateUsername} at {updatedAt}</span>}
         </div>
-        <div className="pt-2 d-flex justify-content-end">
+        <div className="pt-2 d-flex align-items-end">
           <span>{ pageContainer.isAbleToShowEmptyTrashButton && renderEmptyButton()}</span>
           { pageContainer.isAbleToShowTrashPageManagementButtons && renderTrashPageManagementButtons()}
         </div>

--- a/src/client/js/components/Page/TrashPageAlert.jsx
+++ b/src/client/js/components/Page/TrashPageAlert.jsx
@@ -112,7 +112,7 @@ const TrashPageAlert = (props) => {
           This page is in the trash <i className="icon-trash" aria-hidden="true"></i>.
           {isDeleted && <span><br /><UserPicture user={{ username: lastUpdateUsername }} /> Deleted by {lastUpdateUsername} at {updatedAt}</span>}
         </div>
-        <div className="pt-2 justifi-content-right">
+        <div className="pt-2 d-flex justify-content-end">
           <span>{ pageContainer.isAbleToShowEmptyTrashButton && renderEmptyButton()}</span>
           { pageContainer.isAbleToShowTrashPageManagementButtons && renderTrashPageManagementButtons()}
         </div>

--- a/src/client/js/components/Page/TrashPageAlert.jsx
+++ b/src/client/js/components/Page/TrashPageAlert.jsx
@@ -72,7 +72,7 @@ const TrashPageAlert = (props) => {
         </button>
         <button
           type="button"
-          className="btn btn-danger rounded-pill btn-sm mr-2"
+          className="btn btn-danger rounded-pill btn-sm"
           disabled={!isAbleToDeleteCompletely}
           onClick={openPageDeleteModalHandler}
         >
@@ -107,7 +107,7 @@ const TrashPageAlert = (props) => {
 
   return (
     <>
-      <div className="alert alert-warning py-3 pl-4 pr-0 d-flex flex-column flex-lg-row">
+      <div className="alert alert-warning py-3 pl-4 d-flex flex-column flex-lg-row">
         <div className="flex-grow-1">
           This page is in the trash <i className="icon-trash" aria-hidden="true"></i>.
           {isDeleted && <span><br /><UserPicture user={{ username: lastUpdateUsername }} /> Deleted by {lastUpdateUsername} at {updatedAt}</span>}

--- a/src/client/js/components/Page/TrashPageAlert.jsx
+++ b/src/client/js/components/Page/TrashPageAlert.jsx
@@ -107,12 +107,12 @@ const TrashPageAlert = (props) => {
 
   return (
     <>
-      <div className="alert alert-warning pt-3 pl-4 pb-2 pr-0 d-flex flex-column flex-lg-row ">
+      <div className="alert alert-warning py-3 pl-4 pr-0 d-flex flex-column flex-lg-row">
         <div className="flex-grow-1">
           This page is in the trash <i className="icon-trash" aria-hidden="true"></i>.
           {isDeleted && <span><br /><UserPicture user={{ username: lastUpdateUsername }} /> Deleted by {lastUpdateUsername} at {updatedAt}</span>}
         </div>
-        <div className="pt-2 d-flex align-items-end">
+        <div className="pt-1 d-flex align-items-end align-items-lg-center">
           <span>{ pageContainer.isAbleToShowEmptyTrashButton && renderEmptyButton()}</span>
           { pageContainer.isAbleToShowTrashPageManagementButtons && renderTrashPageManagementButtons()}
         </div>


### PR DESCRIPTION
trash page の btn の配置を調整しました。

[side bar あるとき]
<img width="2032" alt="スクリーンショット 2020-12-10 13 15 17" src="https://user-images.githubusercontent.com/57100766/101722001-a2071c80-3aec-11eb-924b-30337ab48125.png">
<img width="1100" alt="スクリーンショット 2020-12-10 13 15 29" src="https://user-images.githubusercontent.com/57100766/101722008-a6333a00-3aec-11eb-8c4a-bf1afa1e8eeb.png">
<img width="891" alt="スクリーンショット 2020-12-10 13 15 36" src="https://user-images.githubusercontent.com/57100766/101722011-a8959400-3aec-11eb-905c-2e35a6a34509.png">

[通常時]
<img width="2016" alt="スクリーンショット 2020-12-10 13 16 19" src="https://user-images.githubusercontent.com/57100766/101722090-d4187e80-3aec-11eb-907f-45f57c0b3f79.png">
<img width="1239" alt="スクリーンショット 2020-12-10 13 16 11" src="https://user-images.githubusercontent.com/57100766/101722095-d67ad880-3aec-11eb-97de-a869acc13dac.png">
<img width="864" alt="スクリーンショット 2020-12-10 13 15 58" src="https://user-images.githubusercontent.com/57100766/101722102-d8449c00-3aec-11eb-8a5d-8c1cc8c7184c.png">
<img width="612" alt="スクリーンショット 2020-12-10 13 15 49" src="https://user-images.githubusercontent.com/57100766/101722107-daa6f600-3aec-11eb-8da5-df78b1d838a5.png">

[mobile 実寸 iPhone SE]
![IMG_1709](https://user-images.githubusercontent.com/57100766/101722192-09bd6780-3aed-11eb-9b26-7ab07ff51a28.PNG)

