### PR TITLE
Fix/confidential in case of mobile

### DIFF
--- a/src/client/js/components/Navbar/GrowiNavbar.jsx
+++ b/src/client/js/components/Navbar/GrowiNavbar.jsx
@@ -53,7 +53,6 @@ class GrowiNavbar extends React.Component {
         </span>
         <UncontrolledTooltip
           placement="bottom"
-          trigger="click"
           target="confidentialTooltip"
           className="d-md-none"
         >

--- a/src/client/js/components/Page/TagLabels.jsx
+++ b/src/client/js/components/Page/TagLabels.jsx
@@ -78,6 +78,7 @@ class TagLabels extends React.Component {
 
     return (
       <>
+        
         <form className="grw-tag-labels form-inline">
           <i className="tag-icon icon-tag mr-2"></i>
           <Suspense fallback={<span className="grw-tag-label badge badge-secondary">―</span>}>
@@ -96,6 +97,7 @@ class TagLabels extends React.Component {
           appContainer={this.props.appContainer}
           onTagsUpdated={this.tagsUpdatedHandler}
         />
+        
       </>
     );
   }

--- a/src/client/js/components/Page/TagLabels.jsx
+++ b/src/client/js/components/Page/TagLabels.jsx
@@ -78,7 +78,7 @@ class TagLabels extends React.Component {
 
     return (
       <>
-        
+
         <form className="grw-tag-labels form-inline">
           <i className="tag-icon icon-tag mr-2"></i>
           <Suspense fallback={<span className="grw-tag-label badge badge-secondary">―</span>}>
@@ -97,7 +97,7 @@ class TagLabels extends React.Component {
           appContainer={this.props.appContainer}
           onTagsUpdated={this.tagsUpdatedHandler}
         />
-        
+
       </>
     );
   }

--- a/src/client/js/components/Page/TagLabels.jsx
+++ b/src/client/js/components/Page/TagLabels.jsx
@@ -78,7 +78,6 @@ class TagLabels extends React.Component {
 
     return (
       <>
-
         <form className="grw-tag-labels form-inline">
           <i className="tag-icon icon-tag mr-2"></i>
           <Suspense fallback={<span className="grw-tag-label badge badge-secondary">―</span>}>
@@ -97,7 +96,6 @@ class TagLabels extends React.Component {
           appContainer={this.props.appContainer}
           onTagsUpdated={this.tagsUpdatedHandler}
         />
-
       </>
     );
   }


### PR DESCRIPTION
mobile 版で confidential を表示したとき、再度 confidential をクリックしないと消せない仕様になっていたので修正しました。
<img width="428" alt="スクリーンショット 2020-12-10 13 54 24" src="https://user-images.githubusercontent.com/57100766/101728486-d33a1980-3af9-11eb-8261-d75ffd9c7423.png">
