### PR TITLE
Fix/layout tag area in case of mobile

### DIFF
--- a/src/client/styles/scss/_on-edit.scss
+++ b/src/client/styles/scss/_on-edit.scss
@@ -135,6 +135,7 @@ body.on-edit {
     .grw-taglabels-container {
       margin-bottom: 0;
 
+      // To scroll tags horizontally
       .grw-tag-labels.form-inline {
         flex-flow: row nowrap;
         width: 100%;

--- a/src/client/styles/scss/_on-edit.scss
+++ b/src/client/styles/scss/_on-edit.scss
@@ -134,6 +134,12 @@ body.on-edit {
 
     .grw-taglabels-container {
       margin-bottom: 0;
+
+      .grw-tag-labels.form-inline {
+        flex-flow: row nowrap;
+        width: 100%;
+        overflow-x: scroll;
+      }
     }
   }
 
@@ -141,6 +147,7 @@ body.on-edit {
   .grw-subnav-left-side {
     overflow: hidden;
     .grw-path-nav-container {
+      margin-right: 1rem;
       overflow: hidden;
       .grw-page-path-nav {
         white-space: nowrap;


### PR DESCRIPTION
edit や hackmd  で tag が多い場合、題名が切れてしまう問題を修正 しました。

[ブラウザ]
<img width="1508" alt="スクリーンショット 2020-12-14 16 57 32" src="https://user-images.githubusercontent.com/57100766/102054968-80c86800-3e2d-11eb-86f4-5cff8e38ab37.png">
ブラウザの方は 容量オーバーで gif 貼れませんでした。
[mobile 版]
![hoge](https://user-images.githubusercontent.com/57100766/102054083-2ed31280-3e2c-11eb-807c-076255d52488.gif)


