### PR TITLE
Imprv/modify layout of easy grid

### DIFF
--- a/resource/locales/en_US/translation.json
+++ b/resource/locales/en_US/translation.json
@@ -792,10 +792,11 @@
   },
   "grid_edit":{
     "create_bootstrap_4_grid":"Create Bootstrap 4 Grid",
-    "grid_pattern":"Grid Pattern:",
+    "grid_settings": "Grid Settings",
+    "grid_pattern":"Grid Pattern",
     "division":"Divisions",
     "smart_no":"Smartphone / No Break",
-    "break_point":"Break point by display size:"
+    "break_point":"Break point by display size"
   },
   "validation":{
     "aws_region": "For the region, enter the AWS region name. ex):us-east-1",

--- a/resource/locales/ja_JP/translation.json
+++ b/resource/locales/ja_JP/translation.json
@@ -785,10 +785,11 @@
   },
   "grid_edit":{
     "create_bootstrap_4_grid":"Bootstrap 4 グリッドを作成",
-    "grid_pattern":"グリッド　パターン：",
+    "grid_settings": "グリッド設定",
+    "grid_pattern":"グリッド　パターン",
     "division":"分割",
     "smart_no":"スマホ / 分割なし",
-    "break_point":"画面サイズより分割："
+    "break_point":"画面サイズより分割"
   },
   "validation":{
     "aws_region": "リージョンには、AWSリージョン名を入力してください。例: ap-northeast-1",

--- a/resource/locales/zh_CN/translation.json
+++ b/resource/locales/zh_CN/translation.json
@@ -797,10 +797,11 @@
 	},
   "grid_edit":{
     "create_bootstrap_4_grid":"创建Bootstrap 4网格",
-    "grid_pattern":"网格样式：",
+    "grid_settings": "网格设置",
+    "grid_pattern": "网格样式",
     "division":"分割",
     "smart_no":"手机/不分割",
-    "break_point":"按画面大小分割："
+    "break_point":"按画面大小分割"
   },
   "validation":{
     "aws_region": "关于地区，请输入AWS地区名，例如：ap-east-1",

--- a/src/client/js/components/PageEditor/GridEditModal.jsx
+++ b/src/client/js/components/PageEditor/GridEditModal.jsx
@@ -33,7 +33,7 @@ class GridEditModal extends React.Component {
     this.cancel = this.cancel.bind(this);
     this.pasteCodedGrid = this.pasteCodedGrid.bind(this);
     this.renderSelectedGridPattern = this.renderSelectedGridPattern.bind(this);
-    this.renderSelectedBreakPoint = this.renderSelectedBreakPoint.bind(this);
+    this.renderBreakPointSetting = this.renderBreakPointSetting.bind(this);
   }
 
   async checkResposiveSize(rs) {
@@ -83,15 +83,24 @@ class GridEditModal extends React.Component {
     return colsRatios.join(' - ');
   }
 
-  renderSelectedBreakPoint() {
+  renderBreakPointSetting() {
     const { t } = this.props;
     const output = Object.entries(resSizeObj).map((responsiveSizeForMap) => {
-      return (this.state.responsiveSize === responsiveSizeForMap[0]
-        && (
-        <span>
-          <i className={`pr-1 ${responsiveSizeForMap[1].iconClass}`}> {t(responsiveSizeForMap[1].displayText)}</i>
-        </span>
-        )
+      return (
+        <div className="custom-control custom-radio custom-control-inline">
+          <input
+            type="radio"
+            className="custom-control-input"
+            id={responsiveSizeForMap[1].displayText}
+            value={responsiveSizeForMap[1].displayText}
+            checked={this.state.responsiveSize === responsiveSizeForMap[0]}
+            onChange={e => this.checkResposiveSize(responsiveSizeForMap[0])}
+          />
+          <label className="custom-control-label" htmlFor={responsiveSizeForMap[1].displayText}>
+            <i className={`pr-1 ${responsiveSizeForMap[1].iconClass}`} />
+            {t(responsiveSizeForMap[1].displayText)}
+          </label>
+        </div>
       );
     });
     return output;
@@ -125,18 +134,6 @@ class GridEditModal extends React.Component {
         </div>
       </div>
     );
-  }
-
-  renderBreakPointMenu() {
-    const { t } = this.props;
-    const output = Object.entries(resSizeObj).map((responsiveSizeForMap) => {
-      return (
-        <button className="dropdown-item" type="button" onClick={() => { this.checkResposiveSize(responsiveSizeForMap[0]) }}>
-          <i className={`${responsiveSizeForMap[1].iconClass}`}></i> {t(responsiveSizeForMap[1].displayText)}
-        </button>
-      );
-    });
-    return output;
   }
 
   renderPreview() {
@@ -182,7 +179,6 @@ class GridEditModal extends React.Component {
     if (this.state.responsiveSize === BootstrapGrid.ResponsiveSize.MD_SIZE) {
       return (
         <div className="row">
-          <h3 className="grw-modal-preview">{t('preview')}</h3>
           <div className="col-lg-6">
             <label className="d-block mt-2"><i className="pr-2 icon-screen-desktop"></i>{t('desktop')}</label>
             <div className="desktop-preview d-block">
@@ -207,7 +203,6 @@ class GridEditModal extends React.Component {
     if (this.state.responsiveSize === BootstrapGrid.ResponsiveSize.SM_SIZE) {
       return (
         <div className="row">
-          <h3 className="grw-modal-preview">{t('preview')}</h3>
           <div className="col-lg-6">
             <label className="d-block mt-2"><i className="pr-2 icon-screen-desktop"></i>{t('desktop')}</label>
             <div className="desktop-preview d-block">
@@ -232,7 +227,6 @@ class GridEditModal extends React.Component {
     if (this.state.responsiveSize === BootstrapGrid.ResponsiveSize.XS_SIZE) {
       return (
         <div className="row">
-          <h3 className="grw-modal-preview">{t('preview')}</h3>
           <div className="col-lg-6">
             <label className="d-block mt-2"><i className="pr-2 icon-screen-desktop"></i>{t('desktop')}</label>
             <div className="desktop-preview d-block">
@@ -294,9 +288,9 @@ class GridEditModal extends React.Component {
             <div className="col-12">
               <h3 className="grw-modal-head">{t('grid_edit.grid_settings')}</h3>
               <form className="form-group mb-0">
-                <div className="form-group row">
-                  <label className="col-sm-3 text-md-right" htmlFor="gridPattern">
-                    {t('grid_edit.grid_pattern')}:
+                <div className="form-group row my-3">
+                  <label className="col-sm-3" htmlFor="gridPattern">
+                    {t('grid_edit.grid_pattern')}
                   </label>
                   <div className="col-sm-9">
                     <button
@@ -315,28 +309,17 @@ class GridEditModal extends React.Component {
                   </div>
                 </div>
                 <div className="form-group row">
-                  <label className="col-sm-3 text-md-right" htmlFor="breakPoint">
-                    {t('grid_edit.break_point')}:
+                  <label className="col-sm-3" htmlFor="breakPoint">
+                    {t('grid_edit.break_point')}
                   </label>
                   <div className="col-sm-9">
-                    <div
-                      className="btn btn-outline-secondary dropdown-toggle"
-                      type="button"
-                      id="dropdownMenuButton"
-                      data-toggle="dropdown"
-                      aria-haspopup="true"
-                      aria-expanded="false"
-                    >
-                      {this.renderSelectedBreakPoint()}
-                    </div>
-                    <div className="dropdown-menu break-point-menu" aria-labelledby="dropdownMenuButton">
-                      {this.renderBreakPointMenu()}
-                    </div>
+                    {this.renderBreakPointSetting()}
                   </div>
                 </div>
               </form>
             </div>
           </div>
+          <h3 className="grw-modal-head">{t('preview')}</h3>
           {this.renderPreview()}
         </ModalBody>
         <ModalFooter className="grw-modal-footer">

--- a/src/client/js/components/PageEditor/GridEditModal.jsx
+++ b/src/client/js/components/PageEditor/GridEditModal.jsx
@@ -28,7 +28,8 @@ class GridEditModal extends React.Component {
 
     this.checkResposiveSize = this.checkResposiveSize.bind(this);
     this.checkColsRatios = this.checkColsRatios.bind(this);
-    this.init = this.init.bind(this);
+    // use when re-edit grid
+    // this.init = this.init.bind(this);
     this.show = this.show.bind(this);
     this.hide = this.hide.bind(this);
     this.cancel = this.cancel.bind(this);
@@ -52,7 +53,8 @@ class GridEditModal extends React.Component {
   // }
 
   show(gridHtml) {
-    this.init(gridHtml);
+    // use when re-edit grid
+    // this.init(gridHtml);
     this.setState({ show: true });
   }
 

--- a/src/client/js/components/PageEditor/GridEditModal.jsx
+++ b/src/client/js/components/PageEditor/GridEditModal.jsx
@@ -181,7 +181,8 @@ class GridEditModal extends React.Component {
     const { t } = this.props;
     if (this.state.responsiveSize === BootstrapGrid.ResponsiveSize.MD_SIZE) {
       return (
-        <>
+        <div className="row">
+          <h3 className="grw-modal-preview">{t('preview')}</h3>
           <div className="col-lg-6">
             <label className="d-block mt-2"><i className="pr-2 icon-screen-desktop"></i>{t('desktop')}</label>
             <div className="desktop-preview d-block">
@@ -200,12 +201,13 @@ class GridEditModal extends React.Component {
               {this.renderBreakPreview()}
             </div>
           </div>
-        </>
+        </div>
       );
     }
     if (this.state.responsiveSize === BootstrapGrid.ResponsiveSize.SM_SIZE) {
       return (
-        <>
+        <div className="row">
+          <h3 className="grw-modal-preview">{t('preview')}</h3>
           <div className="col-lg-6">
             <label className="d-block mt-2"><i className="pr-2 icon-screen-desktop"></i>{t('desktop')}</label>
             <div className="desktop-preview d-block">
@@ -224,12 +226,13 @@ class GridEditModal extends React.Component {
               {this.renderBreakPreview()}
             </div>
           </div>
-        </>
+        </div>
       );
     }
     if (this.state.responsiveSize === BootstrapGrid.ResponsiveSize.XS_SIZE) {
       return (
-        <>
+        <div className="row">
+          <h3 className="grw-modal-preview">{t('preview')}</h3>
           <div className="col-lg-6">
             <label className="d-block mt-2"><i className="pr-2 icon-screen-desktop"></i>{t('desktop')}</label>
             <div className="desktop-preview d-block">
@@ -248,7 +251,7 @@ class GridEditModal extends React.Component {
               {this.renderNoBreakPreview()}
             </div>
           </div>
-        </>
+        </div>
       );
     }
   }
@@ -286,49 +289,55 @@ class GridEditModal extends React.Component {
         <ModalHeader tag="h4" toggle={this.cancel} className="bg-primary text-light">
           {t('grid_edit.create_bootstrap_4_grid')}
         </ModalHeader>
-        <ModalBody>
-          <div className="container">
-            <div className="row">
-              <div className="col-lg-6 mb-3">
-                <label htmlFor="gridPattern">{t('grid_edit.grid_pattern')}</label>
-                <button
-                  className="btn btn-outline-secondary dropdown-toggle btn-block"
-                  type="button"
-                  id="dropdownMenuButton"
-                  data-toggle="dropdown"
-                  aria-haspopup="true"
-                  aria-expanded="false"
-                >
-                  {this.renderSelectedGridPattern()}
-                </button>
-                <div className="dropdown-menu grid-division-menu" aria-labelledby="dropdownMenuButton">
-                  {this.renderGridDivisionMenu()}
+        <ModalBody className="container">
+          <div className="row">
+            <div className="col-12">
+              <h3 className="grw-modal-head">{t('grid_edit.grid_settings')}</h3>
+              <form className="form-group mb-0">
+                <div className="form-group row">
+                  <label className="col-sm-3 text-md-right" htmlFor="gridPattern">
+                    {t('grid_edit.grid_pattern')}:
+                  </label>
+                  <div className="col-sm-9">
+                    <button
+                      className="btn btn-outline-secondary dropdown-toggle"
+                      type="button"
+                      id="dropdownMenuButton"
+                      data-toggle="dropdown"
+                      aria-haspopup="true"
+                      aria-expanded="false"
+                    >
+                      {this.renderSelectedGridPattern()}
+                    </button>
+                    <div className="dropdown-menu grid-division-menu" aria-labelledby="dropdownMenuButton">
+                      {this.renderGridDivisionMenu()}
+                    </div>
+                  </div>
                 </div>
-              </div>
-              <div className="col-lg-6">
-                <div className="mr-3 d-inline">
-                  <label htmlFor="breakPoint">{t('grid_edit.break_point')}</label>
+                <div className="form-group row">
+                  <label className="col-sm-3 text-md-right" htmlFor="breakPoint">
+                    {t('grid_edit.break_point')}:
+                  </label>
+                  <div className="col-sm-9">
+                    <div
+                      className="btn btn-outline-secondary dropdown-toggle"
+                      type="button"
+                      id="dropdownMenuButton"
+                      data-toggle="dropdown"
+                      aria-haspopup="true"
+                      aria-expanded="false"
+                    >
+                      {this.renderSelectedBreakPoint()}
+                    </div>
+                    <div className="dropdown-menu break-point-menu" aria-labelledby="dropdownMenuButton">
+                      {this.renderBreakPointMenu()}
+                    </div>
+                  </div>
                 </div>
-                <div
-                  className="btn btn-outline-secondary btn-block dropdown-toggle"
-                  type="button"
-                  id="dropdownMenuButton"
-                  data-toggle="dropdown"
-                  aria-haspopup="true"
-                  aria-expanded="false"
-                >
-                  {this.renderSelectedBreakPoint()}
-                </div>
-                <div className="dropdown-menu break-point-menu" aria-labelledby="dropdownMenuButton">
-                  {this.renderBreakPointMenu()}
-                </div>
-              </div>
-            </div>
-            <div className="row">
-              <h1 className="pl-3 w-100">{t('preview')}</h1>
-              {this.renderPreview()}
+              </form>
             </div>
           </div>
+          {this.renderPreview()}
         </ModalBody>
         <ModalFooter className="grw-modal-footer">
           <div className="ml-auto">

--- a/src/client/js/components/PageEditor/GridEditModal.jsx
+++ b/src/client/js/components/PageEditor/GridEditModal.jsx
@@ -22,7 +22,8 @@ class GridEditModal extends React.Component {
       colsRatios: [6, 6],
       responsiveSize: BootstrapGrid.ResponsiveSize.XS_SIZE,
       show: false,
-      gridHtml: '',
+      // use when re-edit grid
+      // gridHtml: '',
     };
 
     this.checkResposiveSize = this.checkResposiveSize.bind(this);
@@ -44,13 +45,11 @@ class GridEditModal extends React.Component {
     await this.setState({ colsRatios: cr });
   }
 
-  init(gridHtml) {
-    const initGridHtml = gridHtml;
-    this.setState({ gridHtml: initGridHtml }, function() {
-      // display gridHtml for re-editing
-      console.log(this.state.gridHtml);
-    });
-  }
+  // use when re-edit grid
+  // init(gridHtml) {
+  //   const initGridHtml = gridHtml;
+  //   this.setState({ gridHtml: initGridHtml });
+  // }
 
   show(gridHtml) {
     this.init(gridHtml);
@@ -68,9 +67,7 @@ class GridEditModal extends React.Component {
   pasteCodedGrid() {
     const { colsRatios, responsiveSize } = this.state;
     const convertedHTML = geu.convertRatiosAndSizeToHTML(colsRatios, responsiveSize);
-    const pastedGridData = `::: editable-row\n<div class="container">\n\t<div class="row">\n${convertedHTML}\n\t</div>\n</div>\n:::`;
-    // display converted html on console
-    console.log(convertedHTML);
+    const pastedGridData = `::: editable-row\n<div class="container">\n <div class="row">\n${convertedHTML}\n\t</div>\n</div>\n:::`;
 
     if (this.props.onSave != null) {
       this.props.onSave(pastedGridData);

--- a/src/client/styles/scss/_on-edit.scss
+++ b/src/client/styles/scss/_on-edit.scss
@@ -337,12 +337,11 @@ body.on-edit {
   .tablet-preview,
   .mobile-preview {
     .row {
-      height: 100%;
+      height: 140px;
       margin: 0px;
     }
   }
   .desktop-preview {
-    height: 400px;
     .row {
       div {
         padding: 0px;
@@ -352,7 +351,6 @@ body.on-edit {
   }
 
   .tablet-preview {
-    height: 380px;
     .row {
       div {
         padding: 0px;
@@ -363,7 +361,6 @@ body.on-edit {
 
   .mobile-preview {
     width: 75%;
-    height: 280px;
     .row {
       div {
         padding: 0px;

--- a/src/client/styles/scss/_on-edit.scss
+++ b/src/client/styles/scss/_on-edit.scss
@@ -338,13 +338,14 @@ body.on-edit {
   .mobile-preview {
     .row {
       height: 100%;
-      padding: 5px;
+      margin: 0px;
     }
   }
   .desktop-preview {
     height: 400px;
     .row {
       div {
+        padding: 0px;
         background-color: $info;
       }
     }
@@ -354,6 +355,7 @@ body.on-edit {
     height: 380px;
     .row {
       div {
+        padding: 0px;
         background-color: $purple;
       }
     }
@@ -364,6 +366,7 @@ body.on-edit {
     height: 280px;
     .row {
       div {
+        padding: 0px;
         background-color: $pink;
       }
     }


### PR DESCRIPTION
- タイトルのデザイン統一
- コンテンツのはみ出し修正
- ブレークポイント設定をラジオボタンに変更
- Preview の縦幅調整

Preview 部分は [GW-4750](https://youtrack.weseek.co.jp/issue/GW-4750) で再作成予定
<img width="1214" alt="Screen Shot 2020-12-17 at 16 41 08" src="https://user-images.githubusercontent.com/38426468/102457848-be73fd80-4086-11eb-9024-a00258ca8827.png">
