### PR TITLE
Imprv/focus link input when open link edit modal

### DIFF
--- a/src/client/js/components/PageEditor/LinkEditModal.jsx
+++ b/src/client/js/components/PageEditor/LinkEditModal.jsx
@@ -299,6 +299,7 @@ class LinkEditModal extends React.PureComponent {
                 placeholder="Input page path or URL"
                 keywordOnInit={this.state.linkInputValue}
                 behaviorOfResetBtn="clear"
+                autoFocus
               />
               <div className="d-none d-sm-block input-group-append">
                 <button type="button" id="preview-btn" className="btn btn-info btn-page-preview">
@@ -421,7 +422,7 @@ class LinkEditModal extends React.PureComponent {
 
   render() {
     return (
-      <Modal className="link-edit-modal" isOpen={this.state.show} toggle={this.cancel} size="lg">
+      <Modal className="link-edit-modal" isOpen={this.state.show} toggle={this.cancel} size="lg" autoFocus={false}>
         <ModalHeader tag="h4" toggle={this.cancel} className="bg-primary text-light">
           Edit Links
         </ModalHeader>

--- a/src/client/js/components/SearchTypeahead.jsx
+++ b/src/client/js/components/SearchTypeahead.jsx
@@ -44,9 +44,6 @@ class SearchTypeahead extends React.Component {
   }
 
   componentDidMount() {
-    // **MEMO** This doesn't work at this time -- 2019.05.13 Yuki Takei
-    // It is needed to use Modal component of react-bootstrap when showing Move/Duplicate/CreateNewPage modals
-    // this.typeahead.getInstance().focus();
   }
 
   componentWillUnmount() {
@@ -222,6 +219,7 @@ class SearchTypeahead extends React.Component {
           renderMenuItemChildren={this.renderMenuItemChildren}
           caseSensitive={false}
           defaultSelected={defaultSelected}
+          autoFocus={this.props.autoFocus}
         />
         {resetFormButton}
       </div>
@@ -252,6 +250,7 @@ SearchTypeahead.propTypes = {
   placeholder:     PropTypes.string,
   keywordOnInit:   PropTypes.string,
   helpElement:     PropTypes.object,
+  autoFocus:       PropTypes.bool,
   behaviorOfResetBtn: PropTypes.oneOf(['restore', 'clear']),
 };
 
@@ -265,6 +264,7 @@ SearchTypeahead.defaultProps = {
   placeholder:     '',
   keywordOnInit:   '',
   behaviorOfResetBtn: 'restore',
+  autoFocus:       false,
   onInputChange: () => {},
 };
 


### PR DESCRIPTION
- SearchTypeAhead に autoFocus props を追加、このコンポーネント内部の AsyncTypeAhead の props にそのまま引き継がれるようにした
- Modal の props に autoFocus={false} を追加することで input (AsyncTypeAhead) の autoFocus がうまく動かない問題を解消
   - https://github.com/reactstrap/reactstrap/issues/335#issuecomment-317812602