### PR TITLE
Imprv/gw4751 add gidelines

### DIFF
--- a/src/client/js/components/PageEditor/GridEditorUtil.js
+++ b/src/client/js/components/PageEditor/GridEditorUtil.js
@@ -132,7 +132,7 @@ class GridEditorUtil {
     const cols = ratioNumbers.map((ratioNumber, i) => {
       const spaceTab = '    ';
       const className = `col${responsiveSize !== 'xs' ? `-${responsiveSize}` : ''}-${ratioNumber} bsGrid${i + 1}`;
-      return `${spaceTab}${spaceTab}<div class="${className}">ここにコンテンツを追加</div>`;
+      return `${spaceTab}${spaceTab}<div class="${className}">Content</div>`;
     });
     return cols.join('\n');
   }

--- a/src/client/js/components/PageEditor/GridEditorUtil.js
+++ b/src/client/js/components/PageEditor/GridEditorUtil.js
@@ -132,7 +132,7 @@ class GridEditorUtil {
     const cols = ratioNumbers.map((ratioNumber, i) => {
       const spaceTab = '    ';
       const className = `col${responsiveSize !== 'xs' ? `-${responsiveSize}` : ''}-${ratioNumber} bsGrid${i + 1}`;
-      return `${spaceTab}${spaceTab}<div class="${className}"></div>`;
+      return `${spaceTab}${spaceTab}<div class="${className}">ここにコンテンツを追加</div>`;
     });
     return cols.join('\n');
   }


### PR DESCRIPTION
## 該当タスク

GW-4751 編集ガイドの追加

<img width="1648" alt="Screen Shot 2020-12-18 at 17 19 28" src="https://user-images.githubusercontent.com/59536731/102591515-7bcd2680-4155-11eb-8f5e-43b5f35776dc.png">


初めはtranslation.jsonで言語が切り替わるようにしようと思っていましたが、該当コードがutil fileで
propsとして{ t }を取得できないので、言語設定にかかわらず単純に`Content`と表示されるようにしました。