### PR TITLE
move buttons to footer

### DIFF
--- a/src/client/js/components/PageEditor/LinkEditModal.jsx
+++ b/src/client/js/components/PageEditor/LinkEditModal.jsx
@@ -5,6 +5,7 @@ import {
   Modal,
   ModalHeader,
   ModalBody,
+  ModalFooter,
   Popover,
   PopoverBody,
 } from 'reactstrap';
@@ -445,17 +446,15 @@ class LinkEditModal extends React.PureComponent {
               {this.renderLinkPreview()}
             </div>
           </div>
-          <div className="row">
-            <div className="col-12 text-center">
-              <button type="button" className="btn btn-sm btn-outline-secondary mx-1" onClick={this.hide}>
-                {t('Cancel')}
-              </button>
-              <button type="submit" className="btn btn-sm btn-primary mx-1" onClick={this.save}>
-                {t('Done')}
-              </button>
-            </div>
-          </div>
         </ModalBody>
+        <ModalFooter>
+          <button type="button" className="btn btn-sm btn-outline-secondary mx-1" onClick={this.hide}>
+            {t('Cancel')}
+          </button>
+          <button type="submit" className="btn btn-sm btn-primary mx-1" onClick={this.save}>
+            {t('Done')}
+          </button>
+        </ModalFooter>
       </Modal>
     );
   }


### PR DESCRIPTION
リンク編集モーダルの下部のボタンを他のモーダルのレイアウトに合わせフッターに移動（デザインチームに相談済み）

- before
<img width="807" alt="Screen Shot 2020-12-22 at 9 23 48" src="https://user-images.githubusercontent.com/38426468/102960027-5c9f1200-4524-11eb-8580-98f5e6730e8b.png">

- after
<img width="807" alt="Screen Shot 2020-12-22 at 9 24 34" src="https://user-images.githubusercontent.com/38426468/102960028-5dd03f00-4524-11eb-8284-771e527420ca.png">
