### PR TITLE
Imprv/focus input when open modal

### DIFF
--- a/src/client/js/components/Page/TagEditModal.jsx
+++ b/src/client/js/components/Page/TagEditModal.jsx
@@ -35,12 +35,12 @@ function TagEditModal(props) {
   }
 
   return (
-    <Modal isOpen={props.isOpen} toggle={closeModalHandler} id="edit-tag-modal">
+    <Modal isOpen={props.isOpen} toggle={closeModalHandler} id="edit-tag-modal" autoFocus={false}>
       <ModalHeader tag="h4" toggle={closeModalHandler} className="bg-primary text-light">
         Edit Tags
       </ModalHeader>
       <ModalBody>
-        <TagsInput tags={tags} onTagsUpdated={onTagsUpdatedByTagsInput} />
+        <TagsInput tags={tags} onTagsUpdated={onTagsUpdatedByTagsInput} autoFocus />
       </ModalBody>
       <ModalFooter>
         <button type="button" className="btn btn-primary" onClick={handleSubmit}>

--- a/src/client/js/components/Page/TagsInput.jsx
+++ b/src/client/js/components/Page/TagsInput.jsx
@@ -82,6 +82,7 @@ class TagsInput extends React.Component {
           options={this.state.resultTags} // Search result (Some tag names)
           placeholder="tag name"
           selectHintOnEnter
+          autoFocus={this.props.autoFocus}
         />
       </div>
     );
@@ -95,13 +96,15 @@ class TagsInput extends React.Component {
 const TagsInputWrapper = withUnstatedContainers(TagsInput, [AppContainer]);
 
 TagsInput.propTypes = {
-  appContainer: PropTypes.instanceOf(AppContainer).isRequired,
+  appContainer:  PropTypes.instanceOf(AppContainer).isRequired,
 
-  tags: PropTypes.array.isRequired,
+  tags:          PropTypes.array.isRequired,
   onTagsUpdated: PropTypes.func.isRequired,
+  autoFocus:     PropTypes.bool,
 };
 
 TagsInput.defaultProps = {
+  autoFocus:     false,
 };
 
 export default TagsInputWrapper;

--- a/src/client/js/components/PageCreateModal.jsx
+++ b/src/client/js/components/PageCreateModal.jsx
@@ -166,6 +166,7 @@ const PageCreateModal = (props) => {
                     addTrailingSlash
                     onSubmit={ppacSubmitHandler}
                     onInputChange={ppacInputChangeHandler}
+                    autoFocus
                   />
                 )
                 : (
@@ -243,7 +244,13 @@ const PageCreateModal = (props) => {
   }
 
   return (
-    <Modal size="lg" isOpen={navigationContainer.state.isPageCreateModalShown} toggle={navigationContainer.closePageCreateModal} className="grw-create-page">
+    <Modal
+      size="lg"
+      isOpen={navigationContainer.state.isPageCreateModalShown}
+      toggle={navigationContainer.closePageCreateModal}
+      className="grw-create-page"
+      autoFocus={false}
+    >
       <ModalHeader tag="h4" toggle={navigationContainer.closePageCreateModal} className="bg-primary text-light">
         { t('New Page') }
       </ModalHeader>

--- a/src/client/js/components/PageDuplicateModal.jsx
+++ b/src/client/js/components/PageDuplicateModal.jsx
@@ -120,7 +120,7 @@ const PageDuplicateModal = (props) => {
   }
 
   return (
-    <Modal size="lg" isOpen={props.isOpen} toggle={props.onClose} className="grw-duplicate-page">
+    <Modal size="lg" isOpen={props.isOpen} toggle={props.onClose} className="grw-duplicate-page" autoFocus={false}>
       <ModalHeader tag="h4" toggle={props.onClose} className="bg-primary text-light">
         { t('modal_duplicate.label.Duplicate page') }
       </ModalHeader>
@@ -141,6 +141,7 @@ const PageDuplicateModal = (props) => {
                   initializedPath={path}
                   onSubmit={ppacSubmitHandler}
                   onInputChange={ppacInputChangeHandler}
+                  autoFocus
                 />
               )
               : (

--- a/src/client/js/components/PagePathAutoComplete.jsx
+++ b/src/client/js/components/PagePathAutoComplete.jsx
@@ -44,6 +44,7 @@ const PagePathAutoComplete = (props) => {
       emptyLabelExceptError={null}
       placeholder="Input page path"
       keywordOnInit={getKeywordOnInit(initializedPath)}
+      autoFocus={props.autoFocus}
     />
   );
 
@@ -55,10 +56,12 @@ PagePathAutoComplete.propTypes = {
 
   onSubmit:         PropTypes.func,
   onInputChange:    PropTypes.func,
+  autoFocus:        PropTypes.bool,
 };
 
 PagePathAutoComplete.defaultProps = {
-  initializedPath: '/',
+  initializedPath:  '/',
+  autoFocus:        false,
 };
 
 export default PagePathAutoComplete;

--- a/src/client/js/components/PageRenameModal.jsx
+++ b/src/client/js/components/PageRenameModal.jsx
@@ -134,7 +134,7 @@ const PageRenameModal = (props) => {
   }
 
   return (
-    <Modal size="lg" isOpen={props.isOpen} toggle={props.onClose}>
+    <Modal size="lg" isOpen={props.isOpen} toggle={props.onClose} autoFocus={false}>
       <ModalHeader tag="h4" toggle={props.onClose} className="bg-primary text-light">
         { t('modal_rename.label.Move/Rename page') }
       </ModalHeader>
@@ -156,6 +156,7 @@ const PageRenameModal = (props) => {
                 className="form-control"
                 onChange={e => inputChangeHandler(e.target.value)}
                 required
+                autoFocus
               />
             </form>
           </div>


### PR DESCRIPTION
モーダル展開時にinputへの自動フォーカスを追加

実装するにあたり PagePathAutoComplete, TagInput に autoFocus propsを用意し子要素の input に渡るようにしています。

- ページ複製
<img width="807" alt="Screen Shot 2020-12-22 at 9 34 36" src="https://user-images.githubusercontent.com/38426468/102959715-a0dde280-4523-11eb-81b2-f042994564bc.png">

- ページ作成
<img width="807" alt="Screen Shot 2020-12-22 at 9 34 39" src="https://user-images.githubusercontent.com/38426468/102959719-a20f0f80-4523-11eb-984d-252c915123ac.png">

- ページ移動
<img width="807" alt="Screen Shot 2020-12-22 at 9 40 43" src="https://user-images.githubusercontent.com/38426468/102959724-a3403c80-4523-11eb-9a3c-236fdde26bba.png">

- タグ編集
<img width="575" alt="Screen Shot 2020-12-22 at 9 40 50" src="https://user-images.githubusercontent.com/38426468/102959726-a3d8d300-4523-11eb-8795-ea67fe7521d2.png">




