### PR TITLE
Imprv/reverse order of break point radio

### DIFF
--- a/src/client/js/components/PageEditor/GridEditModal.jsx
+++ b/src/client/js/components/PageEditor/GridEditModal.jsx
@@ -9,9 +9,9 @@ import BootstrapGrid from '../../models/BootstrapGrid';
 
 const resSizes = BootstrapGrid.ResponsiveSize;
 const resSizeObj = {
-  [resSizes.XS_SIZE]: { iconClass: 'icon-screen-smartphone', displayText: 'grid_edit.smart_no' },
-  [resSizes.SM_SIZE]: { iconClass: 'icon-screen-tablet', displayText: 'tablet' },
   [resSizes.MD_SIZE]: { iconClass: 'icon-screen-desktop', displayText: 'desktop' },
+  [resSizes.SM_SIZE]: { iconClass: 'icon-screen-tablet', displayText: 'tablet' },
+  [resSizes.XS_SIZE]: { iconClass: 'icon-screen-smartphone', displayText: 'grid_edit.smart_no' },
 };
 class GridEditModal extends React.Component {
 

--- a/src/client/js/components/PageEditor/GridEditModal.jsx
+++ b/src/client/js/components/PageEditor/GridEditModal.jsx
@@ -9,9 +9,9 @@ import BootstrapGrid from '../../models/BootstrapGrid';
 
 const resSizes = BootstrapGrid.ResponsiveSize;
 const resSizeObj = {
-  [resSizes.MD_SIZE]: { iconClass: 'icon-screen-desktop', displayText: 'desktop' },
-  [resSizes.SM_SIZE]: { iconClass: 'icon-screen-tablet', displayText: 'tablet' },
   [resSizes.XS_SIZE]: { iconClass: 'icon-screen-smartphone', displayText: 'grid_edit.smart_no' },
+  [resSizes.SM_SIZE]: { iconClass: 'icon-screen-tablet', displayText: 'tablet' },
+  [resSizes.MD_SIZE]: { iconClass: 'icon-screen-desktop', displayText: 'desktop' },
 };
 class GridEditModal extends React.Component {
 

--- a/src/client/js/components/PageEditor/GridEditModal.jsx
+++ b/src/client/js/components/PageEditor/GridEditModal.jsx
@@ -145,10 +145,10 @@ class GridEditModal extends React.Component {
     const isXsSelected = this.state.responsiveSize === BootstrapGrid.ResponsiveSize.XS_SIZE;
     return (
       <div className="row">
-        <div className="col-lg-6">
-          <label className="d-block mt-2"><i className="pr-2 icon-screen-desktop"></i>{t('desktop')}</label>
-          <div className="desktop-preview d-block">
-            {this.renderGridPreview(false)}
+        <div className="col-lg-3">
+          <label className="d-block mt-2"><i className="pr-2 icon-screen-smartphone"></i>{t('phone')}</label>
+          <div className="mobile-preview d-block">
+            {this.renderGridPreview(!isXsSelected)}
           </div>
         </div>
         <div className="col-lg-3">
@@ -157,10 +157,10 @@ class GridEditModal extends React.Component {
             {this.renderGridPreview(isMdSelected)}
           </div>
         </div>
-        <div className="col-lg-3">
-          <label className="d-block mt-2"><i className="pr-2 icon-screen-smartphone"></i>{t('phone')}</label>
-          <div className="mobile-preview d-block">
-            {this.renderGridPreview(!isXsSelected)}
+        <div className="col-lg-6">
+          <label className="d-block mt-2"><i className="pr-2 icon-screen-desktop"></i>{t('desktop')}</label>
+          <div className="desktop-preview d-block">
+            {this.renderGridPreview(false)}
           </div>
         </div>
       </div>

--- a/src/client/js/components/PageEditor/GridEditModal.jsx
+++ b/src/client/js/components/PageEditor/GridEditModal.jsx
@@ -140,138 +140,40 @@ class GridEditModal extends React.Component {
   }
 
   renderPreview() {
-
-    // TODO GW-3721 make objects and simplify all loops
-    /* const prevSize = BootstrapGrid.ResponsiveSize;
-    const prevSizeObj = {
-      [prevSize.MD_SIZE]: {
-        [prevSize.MD_SIZE]: {
-          iconClass: 'icon-screen-desktop', prevClass: 'desktop-preview', prevText: 'Desktop', prevRender: this.renderNoBreakPreview(),
-        },
-        [prevSize.SM_SIZE]: {
-          iconClass: 'icon-screen-tablet', prevClass: 'tablet-preview', prevText: 'Tablet', prevRender: this.renderBreakPreview(),
-        },
-        [prevSize.XS_SIZE]: {
-          iconClass: 'icon-screen-smartphone', prevClass: 'mobile-preview', prevText: 'Smartphone', prevRender: this.renderBreakPreview(),
-        },
-      },
-      [prevSize.SM_SIZE]: {
-        [prevSize.MD_SIZE]: {
-          iconClass: 'icon-screen-desktop', prevClass: 'desktop-preview', prevText: 'Desktop', prevRender: this.renderNoBreakPreview(),
-        },
-        [prevSize.SM_SIZE]: {
-          iconClass: 'icon-screen-tablet', prevClass: 'tablet-preview', prevText: 'Tablet', prevRender: this.renderNoBreakPreview(),
-        },
-        [prevSize.XS_SIZE]: {
-          iconClass: 'icon-screen-smartphone', prevClass: 'mobile-preview', prevText: 'Smartphone', prevRender: this.renderBreakPreview(),
-        },
-      },
-      [prevSize.MD_SIZE]: {
-        [prevSize.MD_SIZE]: {
-          iconClass: 'icon-screen-desktop', prevClass: 'desktop-preview', prevText: 'Desktop', prevRender: this.renderNoBreakPreview(),
-        },
-        [prevSize.SM_SIZE]: {
-          iconClass: 'icon-screen-tablet', prevClass: 'tablet-preview', prevText: 'Tablet', prevRender: this.renderNoBreakPreview(),
-        },
-        [prevSize.XS_SIZE]: {
-          iconClass: 'icon-screen-smartphone', prevClass: 'mobile-preview', prevText: 'Smartphone', prevRender: this.renderNoBreakPreview(),
-        },
-      },
-    }; */
     const { t } = this.props;
-    if (this.state.responsiveSize === BootstrapGrid.ResponsiveSize.MD_SIZE) {
-      return (
-        <div className="row">
-          <div className="col-lg-6">
-            <label className="d-block mt-2"><i className="pr-2 icon-screen-desktop"></i>{t('desktop')}</label>
-            <div className="desktop-preview d-block">
-              {this.renderNoBreakPreview()}
-            </div>
-          </div>
-          <div className="col-lg-3">
-            <label className="d-block mt-2"><i className="pr-2 icon-screen-tablet"></i>{t('tablet')}</label>
-            <div className="tablet-preview d-block">
-              {this.renderBreakPreview()}
-            </div>
-          </div>
-          <div className="col-lg-3">
-            <label className="d-block mt-2"><i className="pr-2 icon-screen-smartphone"></i>{t('phone')}</label>
-            <div className="mobile-preview d-block">
-              {this.renderBreakPreview()}
-            </div>
-          </div>
-        </div>
-      );
-    }
-    if (this.state.responsiveSize === BootstrapGrid.ResponsiveSize.SM_SIZE) {
-      return (
-        <div className="row">
-          <div className="col-lg-6">
-            <label className="d-block mt-2"><i className="pr-2 icon-screen-desktop"></i>{t('desktop')}</label>
-            <div className="desktop-preview d-block">
-              {this.renderNoBreakPreview()}
-            </div>
-          </div>
-          <div className="col-lg-3">
-            <label className="d-block mt-2"><i className="pr-2 icon-screen-tablet"></i>{t('tablet')}</label>
-            <div className="tablet-preview d-block">
-              {this.renderNoBreakPreview()}
-            </div>
-          </div>
-          <div className="col-lg-3">
-            <label className="d-block mt-2"><i className="pr-2 icon-screen-smartphone"></i>{t('phone')}</label>
-            <div className="mobile-preview d-block">
-              {this.renderBreakPreview()}
-            </div>
-          </div>
-        </div>
-      );
-    }
-    if (this.state.responsiveSize === BootstrapGrid.ResponsiveSize.XS_SIZE) {
-      return (
-        <div className="row">
-          <div className="col-lg-6">
-            <label className="d-block mt-2"><i className="pr-2 icon-screen-desktop"></i>{t('desktop')}</label>
-            <div className="desktop-preview d-block">
-              {this.renderNoBreakPreview()}
-            </div>
-          </div>
-          <div className="col-lg-3">
-            <label className="d-block mt-2"><i className="pr-2 icon-screen-tablet"></i>{t('tablet')}</label>
-            <div className="tablet-preview d-block">
-              {this.renderNoBreakPreview()}
-            </div>
-          </div>
-          <div className="col-lg-3">
-            <label className="d-block mt-2"><i className="pr-2 icon-screen-smartphone"></i>{t('phone')}</label>
-            <div className="mobile-preview d-block">
-              {this.renderNoBreakPreview()}
-            </div>
-          </div>
-        </div>
-      );
-    }
-  }
-
-  renderNoBreakPreview() {
-    const { colsRatios } = this.state;
-    const convertedHTML = colsRatios.map((colsRatio, i) => {
-      const key = `grid-preview-col-${i}`;
-      const className = `col-${colsRatio} border`;
-      return (
-        <div key={key} className={className}></div>
-      );
-    });
+    const isMdSelected = this.state.responsiveSize === BootstrapGrid.ResponsiveSize.MD_SIZE;
+    const isXsSelected = this.state.responsiveSize === BootstrapGrid.ResponsiveSize.XS_SIZE;
     return (
-      <div className="row">{convertedHTML}</div>
+      <div className="row">
+        <div className="col-lg-6">
+          <label className="d-block mt-2"><i className="pr-2 icon-screen-desktop"></i>{t('desktop')}</label>
+          <div className="desktop-preview d-block">
+            {this.renderGridPreview(false)}
+          </div>
+        </div>
+        <div className="col-lg-3">
+          <label className="d-block mt-2"><i className="pr-2 icon-screen-tablet"></i>{t('tablet')}</label>
+          <div className="tablet-preview d-block">
+            {this.renderGridPreview(isMdSelected)}
+          </div>
+        </div>
+        <div className="col-lg-3">
+          <label className="d-block mt-2"><i className="pr-2 icon-screen-smartphone"></i>{t('phone')}</label>
+          <div className="mobile-preview d-block">
+            {this.renderGridPreview(!isXsSelected)}
+          </div>
+        </div>
+      </div>
     );
   }
 
-  renderBreakPreview() {
+  renderGridPreview(isBreakEnabled) {
     const { colsRatios } = this.state;
+
     const convertedHTML = colsRatios.map((colsRatio, i) => {
+      const ratio = isBreakEnabled ? 12 : colsRatio;
       const key = `grid-preview-col-${i}`;
-      const className = 'col-12 border';
+      const className = `col-${ratio} border`;
       return (
         <div key={key} className={className}></div>
       );


### PR DESCRIPTION
ラジオボタンの選択肢の順序を変更し、プレビューの表示順と合わせました。

デフォルトが smartphone/no break なので変更後は一番右のラジオボタンが選択されます。

- before

<img width="1148" alt="Screen Shot 2020-12-23 at 13 50 06" src="https://user-images.githubusercontent.com/38426468/102960948-793c4980-4526-11eb-8e9e-22512d2828f4.png">

- after

<img width="1148" alt="Screen Shot 2020-12-23 at 13 49 06" src="https://user-images.githubusercontent.com/38426468/102960942-75a8c280-4526-11eb-8e43-64a61b6a8dd9.png">

