### PR TITLE
reduce load of delete(rename)

### DIFF
--- a/src/server/models/page.js
+++ b/src/server/models/page.js
@@ -1137,8 +1137,7 @@ module.exports = function(crowi) {
     if (this.isDeletableName(targetPage.path)) {
       targetPage.status = STATUS_DELETED;
     }
-    const hoge = await this.renameRecursively(targetPage, newPath, user, { socketClientId, createRedirectPage: true });
-    return hoge;
+    return await this.renameRecursively(targetPage, newPath, user, { socketClientId, createRedirectPage: true });
   };
 
 

--- a/src/server/models/page.js
+++ b/src/server/models/page.js
@@ -1128,17 +1128,17 @@ module.exports = function(crowi) {
 
   pageSchema.statics.deletePageRecursively = async function(targetPage, user, options = {}) {
     const isTrashed = checkIfTrashed(targetPage.path);
-
+    const newPath = this.getDeletedPageName(targetPage.path);
     if (isTrashed) {
       throw new Error('This method does NOT supports deleting trashed pages.');
     }
 
-    // find manageable descendants (this array does not include GRANT_RESTRICTED)
-    const pages = await this.findManageableListWithDescendants(targetPage, user, options);
-
-    await Promise.all(pages.map((page) => {
-      return this.deletePage(page, user, options);
-    }));
+    const socketClientId = options.socketClientId || null;
+    if (this.isDeletableName(targetPage.path)) {
+      targetPage.status = STATUS_DELETED;
+    }
+    const hoge = await this.renameRecursively(targetPage, newPath, user, { socketClientId, createRedirectPage: true });
+    return hoge;
   };
 
 


### PR DESCRIPTION
再起的に page を delete する操作 (実質 rename 操作) のパフォーマンス修正を行いました。

現時点で elasticsearch に不具合がありますが、
この修正は takeru-n が修正 task を進行中です。

不具合の内容は、
renameRevursively において、pageEvent.emit を設定していないことによって発生します。
現状では delete した page が / trash / hoge と検索できません。
また elasticsearch の docs の deleted が 消した ページ分だけ増えるのですが現状では増えません。