### PR TITLE
Imprv/old ios

### DIFF
--- a/src/client/js/util/old-ios.js
+++ b/src/client/js/util/old-ios.js
@@ -1,5 +1,4 @@
 const userAgent = window.navigator.userAgent.toLowerCase();
-// TODO: impl more accurate logic
 // https://youtrack.weseek.co.jp/issue/GW-4826
 const isOldIos = /iphone os 12/.test(userAgent);
 

--- a/src/client/js/util/old-ios.js
+++ b/src/client/js/util/old-ios.js
@@ -1,6 +1,6 @@
 const userAgent = window.navigator.userAgent.toLowerCase();
 // https://youtrack.weseek.co.jp/issue/GW-4826
-const isOldIos = /iphone os 12/.test(userAgent);
+const isOldIos = /(iphone|ipad|ipod) os (9|10|11|12)/.test(userAgent);
 
 /**
  * Apply 'oldIos' attribute to <html></html>


### PR DESCRIPTION
### 該当タスク
GW-4826 古い iOS であることを検出するロジックを拡張する

武井さんがタスク詳細に記載してくれた
`const isOldIos = /(iphone|ipad) os (9|10|11|12)/.test(userAgent);`でいいと思ったので参考にしたのですが、どうでしょうか

### memo
[/user/kaori-t/iOSのバージョンによって表示を切り替える](https://dev.growi.org/5ff29bb4343ec10048a60bfe)
