### PR TITLE
width and padding adjustment for the preview area on edit mode

### DIFF
--- a/src/client/styles/scss/_on-edit.scss
+++ b/src/client/styles/scss/_on-edit.scss
@@ -236,7 +236,7 @@ body.on-edit {
 
     .page-editor-preview-body {
       max-width: 980px;
-      padding: 18px 30px 0;
+      padding: 18px 15px 0;
       overflow-y: scroll;
     }
 

--- a/src/client/styles/scss/_on-edit.scss
+++ b/src/client/styles/scss/_on-edit.scss
@@ -235,9 +235,8 @@ body.on-edit {
     }
 
     .page-editor-preview-body {
-      padding-top: 18px;
-      padding-right: 15px;
-      padding-left: 15px;
+      max-width: 980px;
+      padding: 18px 30px 0;
       overflow-y: scroll;
     }
 


### PR DESCRIPTION
## 該当タスク
- GW-4807 デザイン実装

>- 横幅最大値を980pxに設定する(記事エリア)
>- 左右のPaddingを30pxに設定する
>## XD
>- https://xd.adobe.com/view/cd3cb2f8-625d-4a6b-b6e4-917f75c675c5-986f/screen/5337bc82-f365-4e61-ad04-8d49c0bc701b/

### 変更前
![Screen Shot 2021-01-08 at 12 10 45](https://user-images.githubusercontent.com/59536731/103970019-9ae63380-51aa-11eb-9367-2a43a599b546.png)

### 変更後
- edit modeのpreviewの画面の横幅に少しだけpadddingが追加された
![Screen Shot 2021-01-08 at 12 09 50](https://user-images.githubusercontent.com/59536731/103970007-96217f80-51aa-11eb-83e2-c0ea6d024582.png)
