### PR TITLE
Imprv/gw 4881 is able to show tag lagbel

### DIFF
--- a/src/client/js/components/Navbar/GrowiSubNavigation.jsx
+++ b/src/client/js/components/Navbar/GrowiSubNavigation.jsx
@@ -117,8 +117,6 @@ const GrowiSubNavigation = (props) => {
 
   const { isGuestUser } = appContainer;
   const isEditorMode = editorMode !== 'view';
-  // Tags cannot be edited while the new page and editorMode is view
-  const isTagLabelHidden = (editorMode !== 'edit' && isPageNotFound);
   // TODO: activate with GW-4402
   // const isSharedPage = shareLinkId != null;
   const isSharedPage = false;

--- a/src/client/js/components/Navbar/GrowiSubNavigation.jsx
+++ b/src/client/js/components/Navbar/GrowiSubNavigation.jsx
@@ -139,8 +139,7 @@ const GrowiSubNavigation = (props) => {
         ) }
 
         <div className="grw-path-nav-container">
-          {/* TODO: add other two judgements and expand isAbleToShowTagLabel by GW-4881 */}
-          { isAbleToShowTagLabel && !isCompactMode && !isTagLabelHidden && (
+          { isAbleToShowTagLabel && !isCompactMode && (
             <div className="grw-taglabels-container">
               {/* <TagLabels editorMode={editorMode} /> */}
             </div>

--- a/src/stores/ui.tsx
+++ b/src/stores/ui.tsx
@@ -55,6 +55,7 @@ export const useIsAbleToShowTagLabel = (): responseInterface<boolean, any> => {
     mutate(key, false);
   }
   else {
+    // Tags cannot be edited while the new page and editorMode is view
     mutate(key, !isUserPage(page.path) && !isSharedPage(page.path) && !(editorMode === 'view' && isNotFoundPage));
   }
 
@@ -96,7 +97,6 @@ export const useIsAbleToShowPageEditorModeManager = (): responseInterface<boolea
     mutate(key, false);
   }
   else {
-    // Tags cannot be edited while the new page and editorMode is view
     mutate(key, isCreatablePage(page.path) && !isForbidden && !isTrashPage && !isSharedUser);
   }
 

--- a/src/stores/ui.tsx
+++ b/src/stores/ui.tsx
@@ -55,7 +55,7 @@ export const useIsAbleToShowTagLabel = (): responseInterface<boolean, any> => {
     mutate(key, false);
   }
   else {
-    // Tags cannot be edited while the new page and editorMode is view
+    // Tags cannot be edited while the new page and editorMode is 'view'
     mutate(key, !isUserPage(page.path) && !isSharedPage(page.path) && !(editorMode === 'view' && isNotFoundPage));
   }
 

--- a/src/stores/ui.tsx
+++ b/src/stores/ui.tsx
@@ -47,17 +47,18 @@ export const useIsAbleToShowLikeButton = (): responseInterface<boolean, any> => 
 export const useIsAbleToShowTagLabel = (): responseInterface<boolean, any> => {
   const key = 'isAbleToShowTagLabel';
   const { data: page } = useCurrentPageSWR();
+  const { data: isNotFoundPage } = useNotFound();
 
   if (page == null) {
     mutate(key, false);
   }
   else {
     const { path } = page as Page;
-    mutate(key, !isUserPage(path) && !isSharedPage(path));
+    mutate(key, !isUserPage(path) && !isSharedPage(path) && !(/* editorMode  === 'view' && */ isNotFoundPage));
   }
 
   // [TODO: add other two judgements and expand isAbleToShowTagLabel by GW-4881]
-  // isAbleToShowTagLabel = (!isCompactMode && !isUserPage && !isSharedPage && !(editorMode === 'view' && !isPageExist));
+  // isAbleToShowTagLabel = ( !isUserPage && !isSharedPage && !(editorMode === 'view' && !isPageExist));
   return useStaticSWR(key);
 };
 

--- a/src/stores/ui.tsx
+++ b/src/stores/ui.tsx
@@ -96,6 +96,7 @@ export const useIsAbleToShowPageEditorModeManager = (): responseInterface<boolea
     mutate(key, false);
   }
   else {
+    // Tags cannot be edited while the new page and editorMode is view
     mutate(key, isCreatablePage(page.path) && !isForbidden && !isTrashPage && !isSharedUser);
   }
 

--- a/src/stores/ui.tsx
+++ b/src/stores/ui.tsx
@@ -48,17 +48,16 @@ export const useIsAbleToShowTagLabel = (): responseInterface<boolean, any> => {
   const key = 'isAbleToShowTagLabel';
   const { data: page } = useCurrentPageSWR();
   const { data: isNotFoundPage } = useNotFound();
+  // [TODO: getting if the current mode is 'view' or 'edit']
+  const editorMode = 'view';
 
   if (page == null) {
     mutate(key, false);
   }
   else {
-    const { path } = page as Page;
-    mutate(key, !isUserPage(path) && !isSharedPage(path) && !(/* editorMode  === 'view' && */ isNotFoundPage));
+    mutate(key, !isUserPage(page.path) && !isSharedPage(page.path) && !(editorMode === 'view' && isNotFoundPage));
   }
 
-  // [TODO: add other two judgements and expand isAbleToShowTagLabel by GW-4881]
-  // isAbleToShowTagLabel = ( !isUserPage && !isSharedPage && !(editorMode === 'view' && !isPageExist));
   return useStaticSWR(key);
 };
 


### PR DESCRIPTION
## 該当タスク
- GW-4881 swr化されたisAbleToShowTagLabelの拡張

## 参考
[/資料/外部仕様/クライアント側で可能な操作一覧](https://dev.growi.org/5fabddf8bbeb1a0048bcb9e9)