### PR TITLE
Fix/4685 4957 fail to save temporary url cached

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,8 @@
 
 ## v4.2.6-RC
 
-* 
+* Fix: Failed to save temporaryUrlCached with using gcs
+    * Introduced by v4.2.3
 
 ## v4.2.5-RC
 

--- a/src/server/service/file-uploader/gcs.js
+++ b/src/server/service/file-uploader/gcs.js
@@ -71,7 +71,7 @@ module.exports = function(crowi) {
 
     // issue signed url (default: expires 120 seconds)
     // https://cloud.google.com/storage/docs/access-control/signed-urls
-    const signedUrl = await file.getSignedUrl({
+    const [signedUrl] = await file.getSignedUrl({
       action: 'read',
       expires: Date.now() + lifetimeSecForTemporaryUrl * 1000,
     });


### PR DESCRIPTION
公式の取得方法に倣いました
https://cloud.google.com/storage/docs/access-control/signing-urls-with-helpers#code-samples
配列であっても redirect はされてしっかり画像は表示されていたが、
MongoDB 保存時に CastError エラーが出てました。

エラーの内容
```
05:04:37.829Z ERROR growi:
  Unhandled Rejection: Promise: Promise {
    <rejected> Error: Attachment validation failed: temporaryUrlCached: Cast to string failed for value "[
      'https://storage.googleapis.com/growi/attachment%2F94dc319471af2023da588149a2002e7d.png?GoogleAccessId=growi-test%40secure-bolt-237611.iam.gserviceaccount.com&Expires=1611119198&Signature=V8pkNi5vL%2FMt21eSxwH1%2FZum4jgs1dxswsUipK8ZpLQOVoZ5VTBSH0m5uRus6ERMeGVv5MsEkG9a%2BKsQxEEs2cnpDWZ8f7Qzkdxuhuk1P3XlZ5MplC2zSVPE0PCu4%2FDBMbA0I5V8RnxVHYhIexbw8h3ibZ40gwbKOMUz4MaYgm3tlpKInAa%2F7bN6%2B0hFAQ7HWqsRJHXqHIS98TpyaJAuhEjY9HDv9ZXmZTAbWrWKkn1SEj%2FTJQeV5xHKx4B9L9NhKdz5lahLRnuy9Fa06WCFf29HgqxzsZSezLHoAv53QfetOTWgGMf0WHcqT4oKLtfjOjPW%2FYP%2BJ2dp8to8mEKFaw%3D%3D'
    ]" at path "temporaryUrlCached"
        at ValidationError.inspect (/workspace/growi/node_modules/mongoose/lib/error/validation.js:47:26)
        at internal/per_context/primordials.js:23:32
        at formatValue (internal/util/inspect.js:774:19)
        at formatPromise (internal/util/inspect.js:1670:17)
        at formatRaw (internal/util/inspect.js:1014:14)
        at formatValue (internal/util/inspect.js:803:10)
        at inspect (internal/util/inspect.js:336:10)
        at formatWithOptionsInternal (internal/util/inspect.js:2006:40)
        at Logger.format (internal/util/inspect.js:1880:10)
        at mkRecord (/workspace/growi/node_modules/bunyan/lib/bunyan.js:984:22)
        at Logger.error (/workspace/growi/node_modules/bunyan/lib/bunyan.js:1044:19)
        at process.<anonymous> (/workspace/growi/src/server/app.js:23:10)
        at process.emit (events.js:327:22)
        at processPromiseRejections (internal/process/promises.js:245:33)
        at processTicksAndRejections (internal/process/task_queues.js:94:32) {
      errors: { temporaryUrlCached: [CastError] },
      _message: 'Attachment validation failed'
    }
  } Reason: Error: Attachment validation failed: temporaryUrlCached: Cast to string failed for value "[
    'https://storage.googleapis.com/growi/attachment%2F94dc319471af2023da588149a2002e7d.png?GoogleAccessId=growi-test%40secure-bolt-237611.iam.gserviceaccount.com&Expires=1611119198&Signature=V8pkNi5vL%2FMt21eSxwH1%2FZum4jgs1dxswsUipK8ZpLQOVoZ5VTBSH0m5uRus6ERMeGVv5MsEkG9a%2BKsQxEEs2cnpDWZ8f7Qzkdxuhuk1P3XlZ5MplC2zSVPE0PCu4%2FDBMbA0I5V8RnxVHYhIexbw8h3ibZ40gwbKOMUz4MaYgm3tlpKInAa%2F7bN6%2B0hFAQ7HWqsRJHXqHIS98TpyaJAuhEjY9HDv9ZXmZTAbWrWKkn1SEj%2FTJQeV5xHKx4B9L9NhKdz5lahLRnuy9Fa06WCFf29HgqxzsZSezLHoAv53QfetOTWgGMf0WHcqT4oKLtfjOjPW%2FYP%2BJ2dp8to8mEKFaw%3D%3D'
  ]" at path "temporaryUrlCached"
      at ValidationError.inspect (/workspace/growi/node_modules/mongoose/lib/error/validation.js:47:26)
      at internal/per_context/primordials.js:23:32
      at formatValue (internal/util/inspect.js:774:19)
      at inspect (internal/util/inspect.js:336:10)
      at formatWithOptionsInternal (internal/util/inspect.js:2006:40)
      at Logger.format (internal/util/inspect.js:1880:10)
      at mkRecord (/workspace/growi/node_modules/bunyan/lib/bunyan.js:984:22)
      at Logger.error (/workspace/growi/node_modules/bunyan/lib/bunyan.js:1044:19)
      at process.<anonymous> (/workspace/growi/src/server/app.js:23:10)
      at process.emit (events.js:327:22)
      at processPromiseRejections (internal/process/promises.js:245:33)
      at processTicksAndRejections (internal/process/task_queues.js:94:32) {
    errors: {
      temporaryUrlCached: CastError: Cast to string failed for value "[
        'https://storage.googleapis.com/growi/attachment%2F94dc319471af2023da588149a2002e7d.png?GoogleAccessId=growi-test%40secure-bolt-237611.iam.gserviceaccount.com&Expires=1611119198&Signature=V8pkNi5vL%2FMt21eSxwH1%2FZum4jgs1dxswsUipK8ZpLQOVoZ5VTBSH0m5uRus6ERMeGVv5MsEkG9a%2BKsQxEEs2cnpDWZ8f7Qzkdxuhuk1P3XlZ5MplC2zSVPE0PCu4%2FDBMbA0I5V8RnxVHYhIexbw8h3ibZ40gwbKOMUz4MaYgm3tlpKInAa%2F7bN6%2B0hFAQ7HWqsRJHXqHIS98TpyaJAuhEjY9HDv9ZXmZTAbWrWKkn1SEj%2FTJQeV5xHKx4B9L9NhKdz5lahLRnuy9Fa06WCFf29HgqxzsZSezLHoAv53QfetOTWgGMf0WHcqT4oKLtfjOjPW%2FYP%2BJ2dp8to8mEKFaw%3D%3D'
      ]" at path "temporaryUrlCached"
          at SchemaString.cast (/workspace/growi/node_modules/mongoose/lib/schema/string.js:610:11)
          at SchemaString.SchemaType.applySetters (/workspace/growi/node_modules/mongoose/lib/schematype.js:1075:12)
          at model.$set (/workspace/growi/node_modules/mongoose/lib/document.js:1250:20)
          at model.set [as temporaryUrlCached] (/workspace/growi/node_modules/mongoose/lib/helpers/document/compile.js:161:19)
          at model.attachmentSchema.methods.cashTemporaryUrlByProvideSec (/workspace/growi/src/server/models/attachment.js:87:29)
          at Uploader.lib.respond (/workspace/growi/src/server/service/file-uploader/gcs.js:82:25)
          at processTicksAndRejections (internal/process/task_queues.js:93:5) {
        stringValue: '"[\n' +
          "  'https://storage.googleapis.com/growi/attachment%2F94dc319471af2023da588149a2002e7d.png?GoogleAccessId=growi-test%40secure-bolt-237611.iam.gserviceaccount.com&Expires=1611119198&Signature=V8pkNi5vL%2FMt21eSxwH1%2FZum4jgs1dxswsUipK8ZpLQOVoZ5VTBSH0m5uRus6ERMeGVv5MsEkG9a%2BKsQxEEs2cnpDWZ8f7Qzkdxuhuk1P3XlZ5MplC2zSVPE0PCu4%2FDBMbA0I5V8RnxVHYhIexbw8h3ibZ40gwbKOMUz4MaYgm3tlpKInAa%2F7bN6%2B0hFAQ7HWqsRJHXqHIS98TpyaJAuhEjY9HDv9ZXmZTAbWrWKkn1SEj%2FTJQeV5xHKx4B9L9NhKdz5lahLRnuy9Fa06WCFf29HgqxzsZSezLHoAv53QfetOTWgGMf0WHcqT4oKLtfjOjPW%2FYP%2BJ2dp8to8mEKFaw%3D%3D'\n" +
          ']"',
        messageFormat: undefined,
        kind: 'string',
        value: [Array],
        path: 'temporaryUrlCached',
        reason: null
      }
    },
    _message: 'Attachment validation failed'
  }
ValidationError: Attachment validation failed: temporaryUrlCached: Cast to string failed for value "[
  'https://storage.googleapis.com/growi/attachment%2F94dc319471af2023da588149a2002e7d.png?GoogleAccessId=growi-test%40secure-bolt-237611.iam.gserviceaccount.com&Expires=1611119198&Signature=V8pkNi5vL%2FMt21eSxwH1%2FZum4jgs1dxswsUipK8ZpLQOVoZ5VTBSH0m5uRus6ERMeGVv5MsEkG9a%2BKsQxEEs2cnpDWZ8f7Qzkdxuhuk1P3XlZ5MplC2zSVPE0PCu4%2FDBMbA0I5V8RnxVHYhIexbw8h3ibZ40gwbKOMUz4MaYgm3tlpKInAa%2F7bN6%2B0hFAQ7HWqsRJHXqHIS98TpyaJAuhEjY9HDv9ZXmZTAbWrWKkn1SEj%2FTJQeV5xHKx4B9L9NhKdz5lahLRnuy9Fa06WCFf29HgqxzsZSezLHoAv53QfetOTWgGMf0WHcqT4oKLtfjOjPW%2FYP%2BJ2dp8to8mEKFaw%3D%3D'
]" at path "temporaryUrlCached"
    at model.Document.invalidate (/workspace/growi/node_modules/mongoose/lib/document.js:2626:32)
    at model.$set (/workspace/growi/node_modules/mongoose/lib/document.js:1290:12)
    at model.set [as temporaryUrlCached] (/workspace/growi/node_modules/mongoose/lib/helpers/document/compile.js:161:19)
    at model.attachmentSchema.methods.cashTemporaryUrlByProvideSec (/workspace/growi/src/server/models/attachment.js:87:29)
    at Uploader.lib.respond (/workspace/growi/src/server/service/file-uploader/gcs.js:82:25)
    at processTicksAndRejections (internal/process/task_queues.js:93:5) {
  errors: {
    temporaryUrlCached: CastError: Cast to string failed for value "[
      'https://storage.googleapis.com/growi/attachment%2F94dc319471af2023da588149a2002e7d.png?GoogleAccessId=growi-test%40secure-bolt-237611.iam.gserviceaccount.com&Expires=1611119198&Signature=V8pkNi5vL%2FMt21eSxwH1%2FZum4jgs1dxswsUipK8ZpLQOVoZ5VTBSH0m5uRus6ERMeGVv5MsEkG9a%2BKsQxEEs2cnpDWZ8f7Qzkdxuhuk1P3XlZ5MplC2zSVPE0PCu4%2FDBMbA0I5V8RnxVHYhIexbw8h3ibZ40gwbKOMUz4MaYgm3tlpKInAa%2F7bN6%2B0hFAQ7HWqsRJHXqHIS98TpyaJAuhEjY9HDv9ZXmZTAbWrWKkn1SEj%2FTJQeV5xHKx4B9L9NhKdz5lahLRnuy9Fa06WCFf29HgqxzsZSezLHoAv53QfetOTWgGMf0WHcqT4oKLtfjOjPW%2FYP%2BJ2dp8to8mEKFaw%3D%3D'
    ]" at path "temporaryUrlCached"
        at SchemaString.cast (/workspace/growi/node_modules/mongoose/lib/schema/string.js:610:11)
        at SchemaString.SchemaType.applySetters (/workspace/growi/node_modules/mongoose/lib/schematype.js:1075:12)
        at model.$set (/workspace/growi/node_modules/mongoose/lib/document.js:1250:20)
        at model.set [as temporaryUrlCached] (/workspace/growi/node_modules/mongoose/lib/helpers/document/compile.js:161:19)
        at model.attachmentSchema.methods.cashTemporaryUrlByProvideSec (/workspace/growi/src/server/models/attachment.js:87:29)
        at Uploader.lib.respond (/workspace/growi/src/server/service/file-uploader/gcs.js:82:25)
        at processTicksAndRejections (internal/process/task_queues.js:93:5) {
      stringValue: '"[\n' +
        "  'https://storage.googleapis.com/growi/attachment%2F94dc319471af2023da588149a2002e7d.png?GoogleAccessId=growi-test%40secure-bolt-237611.iam.gserviceaccount.com&Expires=1611119198&Signature=V8pkNi5vL%2FMt21eSxwH1%2FZum4jgs1dxswsUipK8ZpLQOVoZ5VTBSH0m5uRus6ERMeGVv5MsEkG9a%2BKsQxEEs2cnpDWZ8f7Qzkdxuhuk1P3XlZ5MplC2zSVPE0PCu4%2FDBMbA0I5V8RnxVHYhIexbw8h3ibZ40gwbKOMUz4MaYgm3tlpKInAa%2F7bN6%2B0hFAQ7HWqsRJHXqHIS98TpyaJAuhEjY9HDv9ZXmZTAbWrWKkn1SEj%2FTJQeV5xHKx4B9L9NhKdz5lahLRnuy9Fa06WCFf29HgqxzsZSezLHoAv53QfetOTWgGMf0WHcqT4oKLtfjOjPW%2FYP%2BJ2dp8to8mEKFaw%3D%3D'\n" +
        ']"',
      messageFormat: undefined,
      kind: 'string',
      value: [Array],
      path: 'temporaryUrlCached',
      reason: null
    }
  },
  _message: 'Attachment validation failed'
}
```