### PR TITLE
allow hedgedoc integration

### DIFF
--- a/src/server/routes/hackmd.js
+++ b/src/server/routes/hackmd.js
@@ -191,8 +191,8 @@ module.exports = function(crowi, app) {
 
     const { status, headers } = hackmdResponse;
 
-    // validate HackMD/CodiMD specific header
-    if (headers['codimd-version'] == null && headers['hackmd-version'] == null) {
+    // validate HackMD/CodiMD/HedgeDoc specific header
+    if (headers['codimd-version'] == null && headers['hackmd-version'] == null && headers['hedgedoc-version'] == null) {
       const message = 'Connecting to a non-HackMD server.';
       logger.error(message);
       return res.json(ApiResponse.error(message));


### PR DESCRIPTION
Hi,

I've noticed that Growi integration with HedgeDoc failed due to invalid header check. 
As CodiMD has been forked to HedgeDoc, "codimd-version" header has been renamed to "hedgedoc-version".

Thanks.