### PR TITLE
Imprv/create duplicate tags test

### DIFF
--- a/src/test/service/page.test.js
+++ b/src/test/service/page.test.js
@@ -6,6 +6,7 @@ const { getInstance } = require('../setup-crowi');
 let testUser1;
 let testUser2;
 let parentTag;
+let parentTag2;
 let childTag;
 
 let parentForRename1;
@@ -151,14 +152,17 @@ describe('PageService', () => {
 
     await Tag.insertMany([
       { name: 'Parent' },
+      { name: 'Parent2' },
       { name: 'Child' },
     ]);
 
     parentTag = await Tag.findOne({ name: 'Parent' });
+    parentTag2 = await Tag.findOne({ name: 'Parent2' });
     childTag = await Tag.findOne({ name: 'Child' });
 
     await PageTagRelation.insertMany([
       { relatedPage: parentForDuplicate, relatedTag: parentTag },
+      { relatedPage: parentForDuplicate, relatedTag: parentTag2 },
       { relatedPage: childForDuplicate, relatedTag: childTag },
     ]);
 
@@ -358,7 +362,8 @@ describe('PageService', () => {
       const pageTagRelationAfterDuplicated = await PageTagRelation.find({ relatedPage: newPageDummy });
       const parentoForDuplicateTags = await PageTagRelation.find({ relatedPage: parentForDuplicate });
 
-      expect(pageTagRelationAfterDuplicated.relatedTag).toEqual(parentoForDuplicateTags.relatedTag);
+      expect(pageTagRelationAfterDuplicated[0].relatedTag).toEqual(parentoForDuplicateTags[0].relatedTag);
+      expect(pageTagRelationAfterDuplicated[1].relatedTag).toEqual(parentoForDuplicateTags[1].relatedTag);
     });
   });
 

--- a/src/test/service/page.test.js
+++ b/src/test/service/page.test.js
@@ -360,7 +360,6 @@ describe('PageService', () => {
 
       await crowi.pageService.duplicateTags(pageIdMapping);
       const parentoForDuplicateTags = await PageTagRelation.find({ relatedPage: parentForDuplicate });
-
       const pageTagRelationAfterDuplicated = await PageTagRelation.find({ relatedPage: newPageDummy });
 
       expect(pageTagRelationAfterDuplicated[0].relatedTag).toEqual(parentoForDuplicateTags[0].relatedTag);

--- a/src/test/service/page.test.js
+++ b/src/test/service/page.test.js
@@ -429,29 +429,16 @@ describe('PageService', () => {
     });
 
     test('duplicateTags()', async() => {
-
-      const newPageDummy = [{
-        _id: '60110bdd85339d7dc732dddd',
-        path: '/newPageDummyPath',
-        creator: parentForDuplicate._id,
-        grant: parentForDuplicate.grant,
-        grantedGroup: parentForDuplicate.grantedGroup,
-        grantedUsers: parentForDuplicate.grantedUsers,
-        lastUpdateUser: parentForDuplicate._id,
-        redirectTo: null,
-        revision: parentForDuplicate.revisionId,
-      }];
-
       const pageIdMapping = {
         [parentForDuplicate._id]: '60110bdd85339d7dc732dddd',
       };
 
       const duplicateTagsReturn = await crowi.pageService.duplicateTags(pageIdMapping);
-      const parentoForDuplicateTags = await PageTagRelation.find({ relatedPage: parentForDuplicate });
-      const pageTagRelationAfterDuplicated = await PageTagRelation.find({ relatedPage: newPageDummy });
+      const parentoForDuplicateTags = await PageTagRelation.findOne({ relatedPage: parentForDuplicate });
+      const pageTagRelationAfterDuplicated = await PageTagRelation.findOne({ relatedPage: duplicateTagsReturn[0].relatedPage });
 
       expect(duplicateTagsReturn).toHaveLength(1);
-      expect(pageTagRelationAfterDuplicated.relatedTag).toEqual(parentoForDuplicateTags.relatedTag);
+      expect(pageTagRelationAfterDuplicated.relatedTag[0]).toEqual(parentoForDuplicateTags.relatedTag[0]);
     });
   });
 

--- a/src/test/service/page.test.js
+++ b/src/test/service/page.test.js
@@ -336,8 +336,29 @@ describe('PageService', () => {
       expect(3).toBe(3);
     });
 
-    test('duplicateTags()', () => {
-      expect(3).toBe(3);
+    test('duplicateTags()', async() => {
+
+      const newPageDummy = [];
+      newPageDummy.push({
+        _id: '60110bdd85339d7dc732dddd',
+        path: '/newPageDummyPath',
+        creator: parentForDuplicate._id,
+        grant: parentForDuplicate.grant,
+        grantedGroup: parentForDuplicate.grantedGroup,
+        grantedUsers: parentForDuplicate.grantedUsers,
+        lastUpdateUser: parentForDuplicate._id,
+        redirectTo: null,
+        revision: parentForDuplicate.revisionId,
+      });
+
+      const pageIdMapping = {};
+      pageIdMapping[parentForDuplicate._id] = newPageDummy[0]._id;
+
+      await crowi.pageService.duplicateTags(pageIdMapping);
+      const pageTagRelationAfterDuplicateTags = await PageTagRelation.find({ relatedPage: newPageDummy });
+      const parentoForDuplicateTags = await PageTagRelation.find({ relatedPage: parentForDuplicate });
+
+      expect(pageTagRelationAfterDuplicateTags.relatedTag).toEqual(parentoForDuplicateTags.relatedTag);
     });
   });
 

--- a/src/test/service/page.test.js
+++ b/src/test/service/page.test.js
@@ -359,8 +359,9 @@ describe('PageService', () => {
       pageIdMapping[parentForDuplicate._id] = newPageDummy[0]._id;
 
       await crowi.pageService.duplicateTags(pageIdMapping);
-      const pageTagRelationAfterDuplicated = await PageTagRelation.find({ relatedPage: newPageDummy });
       const parentoForDuplicateTags = await PageTagRelation.find({ relatedPage: parentForDuplicate });
+
+      const pageTagRelationAfterDuplicated = await PageTagRelation.find({ relatedPage: newPageDummy });
 
       expect(pageTagRelationAfterDuplicated[0].relatedTag).toEqual(parentoForDuplicateTags[0].relatedTag);
       expect(pageTagRelationAfterDuplicated[1].relatedTag).toEqual(parentoForDuplicateTags[1].relatedTag);

--- a/src/test/service/page.test.js
+++ b/src/test/service/page.test.js
@@ -450,6 +450,7 @@ describe('PageService', () => {
       const parentoForDuplicateTags = await PageTagRelation.find({ relatedPage: parentForDuplicate });
       const pageTagRelationAfterDuplicated = await PageTagRelation.find({ relatedPage: newPageDummy });
 
+      expect(duplicateTagsReturn).toHaveLength(1);
       expect(pageTagRelationAfterDuplicated.relatedTag).toEqual(parentoForDuplicateTags.relatedTag);
     });
   });

--- a/src/test/service/page.test.js
+++ b/src/test/service/page.test.js
@@ -355,10 +355,10 @@ describe('PageService', () => {
       pageIdMapping[parentForDuplicate._id] = newPageDummy[0]._id;
 
       await crowi.pageService.duplicateTags(pageIdMapping);
-      const pageTagRelationAfterDuplicateTags = await PageTagRelation.find({ relatedPage: newPageDummy });
+      const pageTagRelationAfterDuplicated = await PageTagRelation.find({ relatedPage: newPageDummy });
       const parentoForDuplicateTags = await PageTagRelation.find({ relatedPage: parentForDuplicate });
 
-      expect(pageTagRelationAfterDuplicateTags.relatedTag).toEqual(parentoForDuplicateTags.relatedTag);
+      expect(pageTagRelationAfterDuplicated.relatedTag).toEqual(parentoForDuplicateTags.relatedTag);
     });
   });
 

--- a/src/test/service/page.test.js
+++ b/src/test/service/page.test.js
@@ -432,13 +432,11 @@ describe('PageService', () => {
       const pageIdMapping = {
         [parentForDuplicate._id]: '60110bdd85339d7dc732dddd',
       };
-
       const duplicateTagsReturn = await crowi.pageService.duplicateTags(pageIdMapping);
-      const parentoForDuplicateTags = await PageTagRelation.findOne({ relatedPage: parentForDuplicate });
-      const pageTagRelationAfterDuplicated = await PageTagRelation.findOne({ relatedPage: duplicateTagsReturn[0].relatedPage });
+      const parentoForDuplicateTag = await PageTagRelation.findOne({ relatedPage: parentForDuplicate });
 
       expect(duplicateTagsReturn).toHaveLength(1);
-      expect(pageTagRelationAfterDuplicated.relatedTag[0]).toEqual(parentoForDuplicateTags.relatedTag[0]);
+      expect(duplicateTagsReturn[0].relatedTag).toEqual(parentoForDuplicateTag.relatedTag);
     });
   });
 

--- a/src/test/service/page.test.js
+++ b/src/test/service/page.test.js
@@ -151,7 +151,6 @@ describe('PageService', () => {
 
     await Tag.insertMany([
       { name: 'Parent' },
-      { name: 'Parent2' },
       { name: 'Child' },
     ]);
 

--- a/src/test/service/page.test.js
+++ b/src/test/service/page.test.js
@@ -430,8 +430,7 @@ describe('PageService', () => {
 
     test('duplicateTags()', async() => {
 
-      const newPageDummy = [];
-      newPageDummy.push({
+      const newPageDummy = [{
         _id: '60110bdd85339d7dc732dddd',
         path: '/newPageDummyPath',
         creator: parentForDuplicate._id,
@@ -441,12 +440,13 @@ describe('PageService', () => {
         lastUpdateUser: parentForDuplicate._id,
         redirectTo: null,
         revision: parentForDuplicate.revisionId,
-      });
+      }];
 
-      const pageIdMapping = {};
-      pageIdMapping[parentForDuplicate._id] = newPageDummy[0]._id;
+      const pageIdMapping = {
+        [parentForDuplicate._id]: '60110bdd85339d7dc732dddd',
+      };
 
-      await crowi.pageService.duplicateTags(pageIdMapping);
+      const duplicateTagsReturn = await crowi.pageService.duplicateTags(pageIdMapping);
       const parentoForDuplicateTags = await PageTagRelation.find({ relatedPage: parentForDuplicate });
       const pageTagRelationAfterDuplicated = await PageTagRelation.find({ relatedPage: newPageDummy });
 

--- a/src/test/service/page.test.js
+++ b/src/test/service/page.test.js
@@ -6,7 +6,6 @@ const { getInstance } = require('../setup-crowi');
 let testUser1;
 let testUser2;
 let parentTag;
-let parentTag2;
 let childTag;
 
 let parentForRename1;
@@ -157,12 +156,10 @@ describe('PageService', () => {
     ]);
 
     parentTag = await Tag.findOne({ name: 'Parent' });
-    parentTag2 = await Tag.findOne({ name: 'Parent2' });
     childTag = await Tag.findOne({ name: 'Child' });
 
     await PageTagRelation.insertMany([
       { relatedPage: parentForDuplicate, relatedTag: parentTag },
-      { relatedPage: parentForDuplicate, relatedTag: parentTag2 },
       { relatedPage: childForDuplicate, relatedTag: childTag },
     ]);
 
@@ -362,8 +359,7 @@ describe('PageService', () => {
       const parentoForDuplicateTags = await PageTagRelation.find({ relatedPage: parentForDuplicate });
       const pageTagRelationAfterDuplicated = await PageTagRelation.find({ relatedPage: newPageDummy });
 
-      expect(pageTagRelationAfterDuplicated[0].relatedTag).toEqual(parentoForDuplicateTags[0].relatedTag);
-      expect(pageTagRelationAfterDuplicated[1].relatedTag).toEqual(parentoForDuplicateTags[1].relatedTag);
+      expect(pageTagRelationAfterDuplicated.relatedTag).toEqual(parentoForDuplicateTags.relatedTag);
     });
   });
 


### PR DESCRIPTION
duplicateTags の機能は新しく作成したページに tag が insertMany されることだと考えました。
```js
    return PageTagRelation.insertMany(newPageTagRelation, { ordered: false });
```
よって複製元の tag と 複製元の page と 複製後の tag が一致する test を書いています。
漏れがあったら助言願います。
