### PR TITLE
Imprv/gw5038 make comments button unvisiable in the top and the shared user's pages

### DIFF
--- a/src/client/js/components/ContentLinkButtons.jsx
+++ b/src/client/js/components/ContentLinkButtons.jsx
@@ -1,8 +1,10 @@
 import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 
+import { isTopPage } from '@commons/util/path-utils';
 import NavigationContainer from '../services/NavigationContainer';
 import PageContainer from '../services/PageContainer';
+import AppContainer from '../services/AppContainer';
 
 import { withUnstatedContainers } from './UnstatedUtils';
 
@@ -16,9 +18,10 @@ const WIKI_HEADER_LINK = 120;
  */
 const ContentLinkButtons = (props) => {
 
-  const { navigationContainer, pageContainer } = props;
+  const { navigationContainer, pageContainer, appContainer } = props;
   const { pageUser } = pageContainer.state;
   const { isPageExist } = pageContainer.state;
+  const { isSharedUser } = appContainer;
 
   // get element for smoothScroll
   const getCommentListDom = useMemo(() => { return document.getElementById('page-comments-list') }, []);
@@ -71,7 +74,7 @@ const ContentLinkButtons = (props) => {
 
   return (
     <>
-      {isPageExist && <CommentLinkButton />}
+      {isPageExist && !isSharedUser && !isTopPage && <CommentLinkButton />}
 
       <div className="mt-3 d-flex justify-content-between">
         {pageUser && <><BookMarkLinkButton /><RecentlyCreatedLinkButton /></>}
@@ -84,6 +87,7 @@ const ContentLinkButtons = (props) => {
 ContentLinkButtons.propTypes = {
   navigationContainer: PropTypes.instanceOf(NavigationContainer).isRequired,
   pageContainer: PropTypes.instanceOf(PageContainer).isRequired,
+  appContainer: PropTypes.instanceOf(AppContainer).isRequired,
 };
 
-export default withUnstatedContainers(ContentLinkButtons, [NavigationContainer, PageContainer]);
+export default withUnstatedContainers(ContentLinkButtons, [AppContainer, NavigationContainer, PageContainer]);

--- a/src/client/js/components/ContentLinkButtons.jsx
+++ b/src/client/js/components/ContentLinkButtons.jsx
@@ -2,9 +2,9 @@ import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 
 import { isTopPage } from '@commons/util/path-utils';
+import AppContainer from '../services/AppContainer';
 import NavigationContainer from '../services/NavigationContainer';
 import PageContainer from '../services/PageContainer';
-import AppContainer from '../services/AppContainer';
 
 import { withUnstatedContainers } from './UnstatedUtils';
 
@@ -18,7 +18,7 @@ const WIKI_HEADER_LINK = 120;
  */
 const ContentLinkButtons = (props) => {
 
-  const { navigationContainer, pageContainer, appContainer } = props;
+  const { appContainer, navigationContainer, pageContainer } = props;
   const { pageUser } = pageContainer.state;
   const { isPageExist } = pageContainer.state;
   const { isSharedUser } = appContainer;
@@ -85,9 +85,9 @@ const ContentLinkButtons = (props) => {
 };
 
 ContentLinkButtons.propTypes = {
+  appContainer: PropTypes.instanceOf(AppContainer).isRequired,
   navigationContainer: PropTypes.instanceOf(NavigationContainer).isRequired,
   pageContainer: PropTypes.instanceOf(PageContainer).isRequired,
-  appContainer: PropTypes.instanceOf(AppContainer).isRequired,
 };
 
 export default withUnstatedContainers(ContentLinkButtons, [AppContainer, NavigationContainer, PageContainer]);

--- a/src/client/js/components/ContentLinkButtons.jsx
+++ b/src/client/js/components/ContentLinkButtons.jsx
@@ -19,9 +19,11 @@ const WIKI_HEADER_LINK = 120;
 const ContentLinkButtons = (props) => {
 
   const { appContainer, navigationContainer, pageContainer } = props;
-  const { pageUser } = pageContainer.state;
+  const { pageUser, path } = pageContainer.state;
   const { isPageExist } = pageContainer.state;
   const { isSharedUser } = appContainer;
+
+  const isTopPagePath = isTopPage(path);
 
   // get element for smoothScroll
   const getCommentListDom = useMemo(() => { return document.getElementById('page-comments-list') }, []);
@@ -74,7 +76,7 @@ const ContentLinkButtons = (props) => {
 
   return (
     <>
-      {isPageExist && !isSharedUser && !isTopPage && <CommentLinkButton />}
+      {isPageExist && !isSharedUser && !isTopPagePath && <CommentLinkButton />}
 
       <div className="mt-3 d-flex justify-content-between">
         {pageUser && <><BookMarkLinkButton /><RecentlyCreatedLinkButton /></>}


### PR DESCRIPTION
## 対象タスク
GW-5038 commentsボタンの表示を修正する
commentのエリアがないページにもコメントに飛ぶボタンが表示されてしまっていたので修正しました。

## commentsボタンを表示しないページ
### Top page(追加)
<img width="1541" alt="Screen Shot 2021-01-28 at 19 24 12" src="https://user-images.githubusercontent.com/59536731/106124962-ffd7ec80-619e-11eb-8064-ccf26819fc14.png">


### shared user's page(追加)
<img width="1616" alt="Screen Shot 2021-01-28 at 19 24 39" src="https://user-images.githubusercontent.com/59536731/106124970-023a4680-619f-11eb-86e2-93240de63eaf.png">


## commentsボタンを表示するページ

### Guest User's page
<img width="1616" alt="Screen Shot 2021-01-28 at 19 26 13" src="https://user-images.githubusercontent.com/59536731/106124992-049ca080-619f-11eb-90ac-3d2ef3594e95.png">

## Others
<img width="1021" alt="Screen Shot 2021-01-28 at 19 31 23" src="https://user-images.githubusercontent.com/59536731/106125397-77a61700-619f-11eb-9c9c-305cfee51ac3.png">
