### PR TITLE
Imprv/4883 4884 adjust the flow rate

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## v4.2.9-RC
 
-* 
+* Improvement: Add batchSize option for flow rate limit about stream 
 
 ## v4.2.8
 

--- a/src/server/service/page.js
+++ b/src/server/service/page.js
@@ -151,7 +151,7 @@ class PageService {
       .addConditionToFilteringByViewer(user)
       .query
       .lean()
-      .cursor();
+      .cursor({ batchSize: BULK_REINDEX_SIZE });
 
     const renameDescendants = this.renameDescendants.bind(this);
     const pageEvent = this.pageEvent;
@@ -353,7 +353,7 @@ class PageService {
       .addConditionToFilteringByViewer(user)
       .query
       .lean()
-      .cursor();
+      .cursor({ batchSize: BULK_REINDEX_SIZE });
 
     const duplicateDescendants = this.duplicateDescendants.bind(this);
     const pageEvent = this.pageEvent;
@@ -488,7 +488,7 @@ class PageService {
       .addConditionToFilteringByViewer(user)
       .query
       .lean()
-      .cursor();
+      .cursor({ batchSize: BULK_REINDEX_SIZE });
 
     const deleteDescendants = this.deleteDescendants.bind(this);
     let count = 0;
@@ -564,7 +564,7 @@ class PageService {
       .addConditionToFilteringByViewer(user)
       .query
       .lean()
-      .cursor();
+      .cursor({ batchSize: BULK_REINDEX_SIZE });
 
     const deleteMultipleCompletely = this.deleteMultipleCompletely.bind(this);
     let count = 0;
@@ -690,7 +690,7 @@ class PageService {
       .addConditionToFilteringByViewer(user)
       .query
       .lean()
-      .cursor();
+      .cursor({ batchSize: BULK_REINDEX_SIZE });
 
     const revertDeletedDescendants = this.revertDeletedDescendants.bind(this);
     let count = 0;

--- a/src/server/service/search-delegator/elasticsearch.js
+++ b/src/server/service/search-delegator/elasticsearch.js
@@ -390,7 +390,7 @@ class ElasticsearchDelegator {
         { path: 'revision', model: 'Revision', select: 'body' },
       ])
       .lean()
-      .cursor();
+      .cursor({ batchSize: BULK_REINDEX_SIZE });
 
     let skipped = 0;
     const thinOutStream = new Transform({


### PR DESCRIPTION
- cursor  は何もしないと batchSize が 101 に設定されるので流量を合わせました。
  - https://docs.mongodb.com/manual/tutorial/iterate-a-cursor/
  - 10,50,200 で試してみたものの、一番メモリが安定していたのは 100 件でした。
- stream 処理最中のメモリが増加してしまうのはしょうがないような気がします。
  - 処理完了後元のメモリに戻るのでメモリリークはしていないと思われます。  