### PR TITLE
Imprv/gw5112 use type ahead in page rename modal

### DIFF
--- a/src/client/js/components/SearchTypeahead.jsx
+++ b/src/client/js/components/SearchTypeahead.jsx
@@ -8,7 +8,6 @@ import { apiGet } from '~/client/js/util/apiv1-client';
 import UserPicture from './User/UserPicture';
 import PageListMeta from './PageList/PageListMeta';
 import PagePathLabel from './PageList/PagePathLabel';
-// import AppContainer from '../services/AppContainer';
 import { withUnstatedContainers } from './UnstatedUtils';
 
 class SearchTypeahead extends React.Component {
@@ -229,15 +228,9 @@ class SearchTypeahead extends React.Component {
 }
 
 /**
- * Wrapper component for using unstated
- */
-// const SearchTypeaheadWrapper = withUnstatedContainers(SearchTypeahead, [AppContainer]);
-
-/**
  * Properties
  */
 SearchTypeahead.propTypes = {
-  // appContainer: PropTypes.instanceOf(AppContainer).isRequired,
 
   onSearchSuccess: PropTypes.func,
   onSearchError:   PropTypes.func,
@@ -270,5 +263,4 @@ SearchTypeahead.defaultProps = {
   onInputChange: () => {},
 };
 
-// export default SearchTypeaheadWrapper;
 export default SearchTypeahead;

--- a/src/client/js/components/SearchTypeahead.jsx
+++ b/src/client/js/components/SearchTypeahead.jsx
@@ -78,7 +78,7 @@ class SearchTypeahead extends React.Component {
 
     this.setState({ isLoading: true });
 
-    /* this.props.appContainer. */ apiGet('/search', { q: keyword })
+    apiGet('/search', { q: keyword })
       .then((res) => { this.onSearchSuccess(res) })
       .catch((err) => { this.onSearchError(err) });
   }

--- a/src/client/js/components/SearchTypeahead.jsx
+++ b/src/client/js/components/SearchTypeahead.jsx
@@ -3,11 +3,12 @@ import PropTypes from 'prop-types';
 
 import { noop } from 'lodash/noop';
 import { AsyncTypeahead } from 'react-bootstrap-typeahead';
+import { apiGet } from '~/client/js/util/apiv1-client';
 
 import UserPicture from './User/UserPicture';
 import PageListMeta from './PageList/PageListMeta';
 import PagePathLabel from './PageList/PagePathLabel';
-import AppContainer from '../services/AppContainer';
+// import AppContainer from '../services/AppContainer';
 import { withUnstatedContainers } from './UnstatedUtils';
 
 class SearchTypeahead extends React.Component {
@@ -78,7 +79,7 @@ class SearchTypeahead extends React.Component {
 
     this.setState({ isLoading: true });
 
-    this.props.appContainer.apiGet('/search', { q: keyword })
+    /* this.props.appContainer. */ apiGet('/search', { q: keyword })
       .then((res) => { this.onSearchSuccess(res) })
       .catch((err) => { this.onSearchError(err) });
   }
@@ -230,13 +231,13 @@ class SearchTypeahead extends React.Component {
 /**
  * Wrapper component for using unstated
  */
-const SearchTypeaheadWrapper = withUnstatedContainers(SearchTypeahead, [AppContainer]);
+// const SearchTypeaheadWrapper = withUnstatedContainers(SearchTypeahead, [AppContainer]);
 
 /**
  * Properties
  */
 SearchTypeahead.propTypes = {
-  appContainer: PropTypes.instanceOf(AppContainer).isRequired,
+  // appContainer: PropTypes.instanceOf(AppContainer).isRequired,
 
   onSearchSuccess: PropTypes.func,
   onSearchError:   PropTypes.func,
@@ -269,4 +270,5 @@ SearchTypeahead.defaultProps = {
   onInputChange: () => {},
 };
 
-export default SearchTypeaheadWrapper;
+// export default SearchTypeaheadWrapper;
+export default SearchTypeahead;

--- a/src/components/PageManagement/PageRenameModal.tsx
+++ b/src/components/PageManagement/PageRenameModal.tsx
@@ -57,19 +57,30 @@ export const PageRenameModal:FC<Props> = (props:Props) => {
             </div>
             {/* TODO imprv submitHandler by GW 5088 */}
             {/* <form className="flex-fill" onSubmit={(e) => { e.preventDefault(); rename() }}> */}
-            <form className="flex-fill" onSubmit={handleSubmit(submitHandler)}>
-              <input
+            {/* <form className="flex-fill" onSubmit={handleSubmit(submitHandler)}> */}
+            {/* <input
                 name="pagename"
                 type="text"
                 className="form-control"
-                // value={pageNameInput}
-                // onChange={e => inputChangeHandler(e.target.value)}
+                value={pageNameInput}
+                onChange={e => inputChangeHandler(e.target.value)}
                 required
                 autoFocus
                 ref={register}
-              />
-              <SearchTypeahead />
-            </form>
+              /> */}
+            {/* </form> */}
+            <SearchTypeahead
+              onSubmit={handleSubmit(submitHandler)}
+                // onChange={inputChangeHandler}
+                // onInputChange={props.onInputChange}
+              inputName="new_path"
+              emptyLabelExceptError={null}
+              placeholder="Input page path"
+                // keywordOnInit={getKeywordOnInit(initializedPath)}
+              name="pagename"
+              required
+              autoFocus
+            />
           </div>
         </div>
         <div className="custom-control custom-checkbox custom-checkbox-warning">

--- a/src/components/PageManagement/PageRenameModal.tsx
+++ b/src/components/PageManagement/PageRenameModal.tsx
@@ -7,8 +7,9 @@ import { useForm } from 'react-hook-form';
 import {
   Modal, ModalHeader, ModalBody, ModalFooter,
 } from 'reactstrap';
-
 import { debounce } from 'throttle-debounce';
+import SearchTypeahead from '~/client/js/components/SearchTypeahead';
+
 import { useTranslation } from '~/i18n';
 
 import { useCurrentPagePath } from '~/stores/context';
@@ -67,6 +68,7 @@ export const PageRenameModal:FC<Props> = (props:Props) => {
                 autoFocus
                 ref={register}
               />
+              <SearchTypeahead />
             </form>
           </div>
         </div>

--- a/src/components/PageManagement/PageRenameModal.tsx
+++ b/src/components/PageManagement/PageRenameModal.tsx
@@ -37,6 +37,7 @@ export const PageRenameModal:FC<Props> = (props:Props) => {
   const { register, handleSubmit } = useForm();
   const { data: currentPagePath } = useCurrentPagePath();
   const { t } = useTranslation();
+  const [searchError, setSearchError] = useState(null);
 
   const {
     addTrailingSlash, onSubmit, onInputChange, initializedPath,
@@ -71,6 +72,9 @@ export const PageRenameModal:FC<Props> = (props:Props) => {
       ? pathUtils.addTrailingSlash(path)
       : pathUtils.removeTrailingSlash(path);
   }
+  const emptyLabel = (searchError !== null)
+    ? 'Error on searching.'
+    : t('search.search page bodies');
 
   return (
     <Modal size="lg" isOpen={props.isOpen} toggle={props.onClose} autoFocus={false}>
@@ -104,12 +108,11 @@ export const PageRenameModal:FC<Props> = (props:Props) => {
             {/* </form> */}
             <SearchTypeahead
               onSubmit={submitHandler}
+              onSearchError={setSearchError}
               onChange={inputChangeHandler}
               onInputChange={props.onInputChange}
               inputName="new_path"
-              // emptyLabel={emptyLabel}
               placeholder="Input page path"
-              // keywordOnInit={getKeywordOnInit(initializedPath)}
               keywordOnInit={props.keyword}
               name="pagename"
               required

--- a/src/components/PageManagement/PageRenameModal.tsx
+++ b/src/components/PageManagement/PageRenameModal.tsx
@@ -1,9 +1,8 @@
 import React, {
   useState, useEffect, useCallback, FC,
 } from 'react';
-import PropTypes from 'prop-types';
 import { useForm } from 'react-hook-form';
-
+import { pathUtils } from 'growi-commons';
 import {
   Modal, ModalHeader, ModalBody, ModalFooter,
 } from 'reactstrap';
@@ -27,6 +26,9 @@ type Props = {
   isOpen: boolean,
   path?: string,
   onClose:() => void,
+  onInputChange: (p: string) => void,
+  initializedPath: string,
+  addTrailingSlash: boolean,
 }
 
 export const PageRenameModal:FC<Props> = (props:Props) => {
@@ -34,10 +36,31 @@ export const PageRenameModal:FC<Props> = (props:Props) => {
   const { data: currentPagePath } = useCurrentPagePath();
   const { t } = useTranslation();
 
+  const {
+    addTrailingSlash, onSubmit, onInputChange, initializedPath,
+  } = props;
+
   // TODO imprv submitHandler by GW 5088
   const submitHandler = (data) => {
     alert(JSON.stringify(data));
   };
+
+  function inputChangeHandler(pages) {
+    if (onInputChange == null) {
+      return;
+    }
+    const page = pages[0]; // should be single page selected
+
+    if (page != null) {
+      onInputChange(page.path);
+    }
+  }
+
+  function getKeywordOnInit(path) {
+    return addTrailingSlash
+      ? pathUtils.addTrailingSlash(path)
+      : pathUtils.removeTrailingSlash(path);
+  }
 
   return (
     <Modal size="lg" isOpen={props.isOpen} toggle={props.onClose} autoFocus={false}>
@@ -71,12 +94,12 @@ export const PageRenameModal:FC<Props> = (props:Props) => {
             {/* </form> */}
             <SearchTypeahead
               onSubmit={handleSubmit(submitHandler)}
-                // onChange={inputChangeHandler}
-                // onInputChange={props.onInputChange}
+              onChange={inputChangeHandler}
+              onInputChange={props.onInputChange}
               inputName="new_path"
               emptyLabelExceptError={null}
               placeholder="Input page path"
-                // keywordOnInit={getKeywordOnInit(initializedPath)}
+              // keywordOnInit={getKeywordOnInit(initializedPath)}
               name="pagename"
               required
               autoFocus

--- a/src/components/PageManagement/PageRenameModal.tsx
+++ b/src/components/PageManagement/PageRenameModal.tsx
@@ -29,6 +29,7 @@ type Props = {
   onInputChange: (p: string) => void,
   initializedPath: string,
   addTrailingSlash: boolean,
+  onSubmit: () => void,
 }
 
 export const PageRenameModal:FC<Props> = (props:Props) => {
@@ -41,9 +42,17 @@ export const PageRenameModal:FC<Props> = (props:Props) => {
   } = props;
 
   // TODO imprv submitHandler by GW 5088
-  const submitHandler = (data) => {
-    alert(JSON.stringify(data));
-  };
+  // const submitHandler = (data) => {
+  //   alert(JSON.stringify(data));
+  // };
+
+  function submitHandler() {
+    if (onSubmit == null) {
+      return;
+    }
+    onSubmit();
+  }
+
 
   function inputChangeHandler(pages) {
     if (onInputChange == null) {
@@ -93,7 +102,7 @@ export const PageRenameModal:FC<Props> = (props:Props) => {
               /> */}
             {/* </form> */}
             <SearchTypeahead
-              onSubmit={handleSubmit(submitHandler)}
+              onSubmit={submitHandler}
               onChange={inputChangeHandler}
               onInputChange={props.onInputChange}
               inputName="new_path"

--- a/src/components/PageManagement/PageRenameModal.tsx
+++ b/src/components/PageManagement/PageRenameModal.tsx
@@ -95,17 +95,6 @@ export const PageRenameModal:FC<Props> = (props:Props) => {
             {/* TODO imprv submitHandler by GW 5088 */}
             {/* <form className="flex-fill" onSubmit={(e) => { e.preventDefault(); rename() }}> */}
             {/* <form className="flex-fill" onSubmit={handleSubmit(submitHandler)}> */}
-            {/* <input
-                name="pagename"
-                type="text"
-                className="form-control"
-                value={pageNameInput}
-                onChange={e => inputChangeHandler(e.target.value)}
-                required
-                autoFocus
-                ref={register}
-              /> */}
-            {/* </form> */}
             <SearchTypeahead
               onSubmit={submitHandler}
               onSearchError={setSearchError}
@@ -118,6 +107,7 @@ export const PageRenameModal:FC<Props> = (props:Props) => {
               required
               autoFocus
             />
+            {/* </form> */}
           </div>
         </div>
         <div className="custom-control custom-checkbox custom-checkbox-warning">

--- a/src/components/PageManagement/PageRenameModal.tsx
+++ b/src/components/PageManagement/PageRenameModal.tsx
@@ -26,10 +26,11 @@ type Props = {
   isOpen: boolean,
   path?: string,
   onClose:() => void,
-  onInputChange: (p: string) => void,
+  onInputChange: (string) => void,
   initializedPath: string,
   addTrailingSlash: boolean,
   onSubmit: () => void,
+  keyword?: string,
 }
 
 export const PageRenameModal:FC<Props> = (props:Props) => {
@@ -106,9 +107,10 @@ export const PageRenameModal:FC<Props> = (props:Props) => {
               onChange={inputChangeHandler}
               onInputChange={props.onInputChange}
               inputName="new_path"
-              emptyLabelExceptError={null}
+              // emptyLabel={emptyLabel}
               placeholder="Input page path"
               // keywordOnInit={getKeywordOnInit(initializedPath)}
+              keywordOnInit={props.keyword}
               name="pagename"
               required
               autoFocus


### PR DESCRIPTION
GW-5112 【PageRenameModal】SearchTypeaheadを使えるようにする

<img width="819" alt="Screen Shot 2021-02-12 at 14 45 33" src="https://user-images.githubusercontent.com/59536731/107734530-faeb6f00-6d40-11eb-90e1-bdaeb3f53e0c.png">

<img width="841" alt="Screen Shot 2021-02-12 at 14 43 36" src="https://user-images.githubusercontent.com/59536731/107734422-beb80e80-6d40-11eb-8b38-534a8b0910db.png">
ただ、既存の`SandBox`などは表示されないです。
これは、全文検索ができる`omit-unstated`でも同じく表示されないので、後々別タスクで改善されるもの(バグではない)と認識しました。