### PR TITLE
Imprv/gw 5141 show tab contens in security page 1

### DIFF
--- a/src/client/js/components/Admin/Security/LocalSecuritySetting.jsx
+++ b/src/client/js/components/Admin/Security/LocalSecuritySetting.jsx
@@ -5,42 +5,93 @@ import PropTypes from 'prop-types';
 import { withUnstatedContainers } from '../../UnstatedUtils';
 import { toastError } from '../../../util/apiNotification';
 import { toArrayIfNot } from '~/utils/array-utils';
-import { withLoadingSppiner } from '../../SuspenseUtils';
+// import { withLoadingSppiner } from '../../SuspenseUtils';
 
 import AdminLocalSecurityContainer from '../../../services/AdminLocalSecurityContainer';
 
 import LocalSecuritySettingContents from './LocalSecuritySettingContents';
 
-let retrieveErrors = null;
-function LocalSecuritySetting(props) {
-  const { adminLocalSecurityContainer } = props;
-  if (adminLocalSecurityContainer.state.registrationMode === adminLocalSecurityContainer.dummyRegistrationMode) {
-    throw (async() => {
-      try {
-        await adminLocalSecurityContainer.retrieveSecurityData();
-      }
-      catch (err) {
-        const errs = toArrayIfNot(err);
-        toastError(errs);
-        retrieveErrors = errs;
-        adminLocalSecurityContainer.setState({ registrationMode: adminLocalSecurityContainer.dummyRegistrationModeForError });
-      }
-    })();
-  }
+const retrieveErrors = null;
+export const LocalSecuritySetting = (props) => {
+  // const { adminLocalSecurityContainer } = props;
+  // if (adminLocalSecurityContainer.state.registrationMode === adminLocalSecurityContainer.dummyRegistrationMode) {
+  //   throw (async() => {
+  //     try {
+  //       await adminLocalSecurityContainer.retrieveSecurityData();
+  //     }
+  //     catch (err) {
+  //       const errs = toArrayIfNot(err);
+  //       toastError(errs);
+  //       retrieveErrors = errs;
+  //       adminLocalSecurityContainer.setState({ registrationMode: adminLocalSecurityContainer.dummyRegistrationModeForError });
+  //     }
+  //   })();
+  // }
 
-  if (adminLocalSecurityContainer.state.registrationMode === adminLocalSecurityContainer.dummyRegistrationModeForError) {
-    throw new Error(`${retrieveErrors.length} errors occured`);
-  }
+  // if (adminLocalSecurityContainer.state.registrationMode === adminLocalSecurityContainer.dummyRegistrationModeForError) {
+  //   throw new Error(`${retrieveErrors.length} errors occured`);
+  // }
 
-  return <LocalSecuritySettingContents />;
-}
-
-LocalSecuritySetting.propTypes = {
-  adminLocalSecurityContainer: PropTypes.instanceOf(AdminLocalSecurityContainer).isRequired,
+  // return <LocalSecuritySettingContents />;
+  return 'aa';
 };
 
-const LocalSecuritySettingWithUnstatedContainer = withUnstatedContainers(withLoadingSppiner(LocalSecuritySetting), [
+
+// LocalSecuritySetting.propTypes = {
+//   adminLocalSecurityContainer: PropTypes.instanceOf(AdminLocalSecurityContainer).isRequired,
+// };
+
+const LocalSecuritySettingWithUnstatedContainer = withUnstatedContainers(LocalSecuritySetting, [
   AdminLocalSecurityContainer,
 ]);
 
-export default LocalSecuritySettingWithUnstatedContainer;
+// export default LocalSecuritySettingWithUnstatedContainer;
+
+
+/* eslint-disable react/no-danger */
+// import React from 'react';
+// import PropTypes from 'prop-types';
+
+// import { withUnstatedContainers } from '../../UnstatedUtils';
+// import { toastError } from '../../../util/apiNotification';
+// import { toArrayIfNot } from '~/utils/array-utils';
+// import { withLoadingSppiner } from '../../SuspenseUtils';
+
+// import AdminLocalSecurityContainer from '../../../services/AdminLocalSecurityContainer';
+
+// import LocalSecuritySettingContents from './LocalSecuritySettingContents';
+
+// let retrieveErrors = null;
+// function LocalSecuritySetting(props) {
+//   const { adminLocalSecurityContainer } = props;
+//   if (adminLocalSecurityContainer.state.registrationMode === adminLocalSecurityContainer.dummyRegistrationMode) {
+//     throw (async() => {
+//       try {
+//         await adminLocalSecurityContainer.retrieveSecurityData();
+//       }
+//       catch (err) {
+//         const errs = toArrayIfNot(err);
+//         toastError(errs);
+//         retrieveErrors = errs;
+//         adminLocalSecurityContainer.setState({ registrationMode: adminLocalSecurityContainer.dummyRegistrationModeForError });
+//       }
+//     })();
+//   }
+
+//   if (adminLocalSecurityContainer.state.registrationMode === adminLocalSecurityContainer.dummyRegistrationModeForError) {
+//     throw new Error(`${retrieveErrors.length} errors occured`);
+//   }
+
+//   // return <LocalSecuritySettingContents />;
+//   return 'aa';
+// }
+
+// LocalSecuritySetting.propTypes = {
+//   adminLocalSecurityContainer: PropTypes.instanceOf(AdminLocalSecurityContainer).isRequired,
+// };
+
+// const LocalSecuritySettingWithUnstatedContainer = withUnstatedContainers(withLoadingSppiner(LocalSecuritySetting), [
+//   AdminLocalSecurityContainer,
+// ]);
+
+// export default LocalSecuritySettingWithUnstatedContainer;

--- a/src/client/js/components/Admin/Security/LocalSecuritySetting.jsx
+++ b/src/client/js/components/Admin/Security/LocalSecuritySetting.jsx
@@ -12,8 +12,8 @@ import AdminLocalSecurityContainer from '../../../services/AdminLocalSecurityCon
 import LocalSecuritySettingContents from './LocalSecuritySettingContents';
 
 const retrieveErrors = null;
-export const LocalSecuritySetting = (props) => {
-  // const { adminLocalSecurityContainer } = props;
+const LocalSecuritySetting = (props) => {
+  const { adminLocalSecurityContainer } = props;
   // if (adminLocalSecurityContainer.state.registrationMode === adminLocalSecurityContainer.dummyRegistrationMode) {
   //   throw (async() => {
   //     try {
@@ -36,15 +36,14 @@ export const LocalSecuritySetting = (props) => {
 };
 
 
-// LocalSecuritySetting.propTypes = {
-//   adminLocalSecurityContainer: PropTypes.instanceOf(AdminLocalSecurityContainer).isRequired,
-// };
+LocalSecuritySetting.propTypes = {
+  adminLocalSecurityContainer: PropTypes.instanceOf(AdminLocalSecurityContainer).isRequired,
+};
 
-const LocalSecuritySettingWithUnstatedContainer = withUnstatedContainers(LocalSecuritySetting, [
-  AdminLocalSecurityContainer,
+const LocalSecuritySettingWithUnstatedContainer = withUnstatedContainers(LocalSecuritySetting, [AdminLocalSecurityContainer,
 ]);
 
-// export default LocalSecuritySettingWithUnstatedContainer;
+export default LocalSecuritySettingWithUnstatedContainer;
 
 
 /* eslint-disable react/no-danger */

--- a/src/client/js/components/Admin/Security/LocalSecuritySetting.jsx
+++ b/src/client/js/components/Admin/Security/LocalSecuritySetting.jsx
@@ -32,8 +32,7 @@ export const LocalSecuritySetting = (props) => {
   //   throw new Error(`${retrieveErrors.length} errors occured`);
   // }
 
-  // return <LocalSecuritySettingContents />;
-  return 'aa';
+  return <LocalSecuritySettingContents />;
 };
 
 

--- a/src/components/Admin/Security/LocalSecuritySetting.jsx
+++ b/src/components/Admin/Security/LocalSecuritySetting.jsx
@@ -45,6 +45,9 @@ const LocalSecuritySettingWithUnstatedContainer = withUnstatedContainers(LocalSe
 
 export default LocalSecuritySettingWithUnstatedContainer;
 
+/*
+  Original codes
+*/
 
 /* eslint-disable react/no-danger */
 // import React from 'react';

--- a/src/components/Admin/Security/LocalSecuritySetting.jsx
+++ b/src/components/Admin/Security/LocalSecuritySetting.jsx
@@ -2,14 +2,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { withUnstatedContainers } from '../../UnstatedUtils';
-import { toastError } from '../../../util/apiNotification';
+import { withUnstatedContainers } from '~/client/js/components/UnstatedUtils';
+import { toastError } from '~/client/js/util/apiNotification';
 import { toArrayIfNot } from '~/utils/array-utils';
 // import { withLoadingSppiner } from '../../SuspenseUtils';
 
-import AdminLocalSecurityContainer from '../../../services/AdminLocalSecurityContainer';
+import AdminLocalSecurityContainer from '~/client/js/services/AdminLocalSecurityContainer';
 
-import LocalSecuritySettingContents from './LocalSecuritySettingContents';
+import LocalSecuritySettingContents from '~/client/js/components/Admin/Security/LocalSecuritySettingContents';
 
 const retrieveErrors = null;
 const LocalSecuritySetting = (props) => {

--- a/src/components/Admin/Security/LocalSecuritySetting.tsx
+++ b/src/components/Admin/Security/LocalSecuritySetting.tsx
@@ -7,7 +7,7 @@ import React, { FC } from 'react';
 
 import AdminLocalSecurityContainer from '~/client/js/services/AdminLocalSecurityContainer';
 
-import LocalSecuritySettingContents from '~/client/js/components/Admin/Security/LocalSecuritySettingContents';
+import LocalSecuritySettingContents from '~/components/Admin/Security/LocalSecuritySettingContents';
 
 type Props = {
   adminLocalSecurityContainer: AdminLocalSecurityContainer,

--- a/src/components/Admin/Security/LocalSecuritySetting.tsx
+++ b/src/components/Admin/Security/LocalSecuritySetting.tsx
@@ -1,19 +1,20 @@
 /* eslint-disable react/no-danger */
-import React from 'react';
-import PropTypes from 'prop-types';
+import React, { FC } from 'react';
 
-import { withUnstatedContainers } from '~/client/js/components/UnstatedUtils';
-import { toastError } from '~/client/js/util/apiNotification';
-import { toArrayIfNot } from '~/utils/array-utils';
+// import { toastError } from '~/client/js/util/apiNotification';
+// import { toArrayIfNot } from '~/utils/array-utils';
 // import { withLoadingSppiner } from '../../SuspenseUtils';
 
 import AdminLocalSecurityContainer from '~/client/js/services/AdminLocalSecurityContainer';
 
 import LocalSecuritySettingContents from '~/client/js/components/Admin/Security/LocalSecuritySettingContents';
 
+type Props = {
+  adminLocalSecurityContainer: AdminLocalSecurityContainer,
+}
+
 const retrieveErrors = null;
-const LocalSecuritySetting = (props) => {
-  const { adminLocalSecurityContainer } = props;
+export const LocalSecuritySetting: FC<Props> = (props: Props) => {
   // if (adminLocalSecurityContainer.state.registrationMode === adminLocalSecurityContainer.dummyRegistrationMode) {
   //   throw (async() => {
   //     try {
@@ -34,16 +35,6 @@ const LocalSecuritySetting = (props) => {
 
   return <LocalSecuritySettingContents />;
 };
-
-
-LocalSecuritySetting.propTypes = {
-  adminLocalSecurityContainer: PropTypes.instanceOf(AdminLocalSecurityContainer).isRequired,
-};
-
-const LocalSecuritySettingWithUnstatedContainer = withUnstatedContainers(LocalSecuritySetting, [AdminLocalSecurityContainer,
-]);
-
-export default LocalSecuritySettingWithUnstatedContainer;
 
 /*
   Original codes

--- a/src/components/Admin/Security/LocalSecuritySetting.tsx
+++ b/src/components/Admin/Security/LocalSecuritySetting.tsx
@@ -15,6 +15,9 @@ type Props = {
 
 const retrieveErrors = null;
 export const LocalSecuritySetting: FC<Props> = (props: Props) => {
+
+  // TODO: improve following error handling by GW 5182
+
   // if (adminLocalSecurityContainer.state.registrationMode === adminLocalSecurityContainer.dummyRegistrationMode) {
   //   throw (async() => {
   //     try {

--- a/src/components/Admin/Security/LocalSecuritySetting.tsx
+++ b/src/components/Admin/Security/LocalSecuritySetting.tsx
@@ -75,7 +75,6 @@ export const LocalSecuritySetting: FC<Props> = (props: Props) => {
 //   }
 
 //   // return <LocalSecuritySettingContents />;
-//   return 'aa';
 // }
 
 // LocalSecuritySetting.propTypes = {

--- a/src/components/Admin/Security/LocalSecuritySettingContents.jsx
+++ b/src/components/Admin/Security/LocalSecuritySettingContents.jsx
@@ -3,12 +3,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { withTranslation } from 'react-i18next';
 
-import { withUnstatedContainers } from '../../UnstatedUtils';
-import { toastSuccess, toastError } from '../../../util/apiNotification';
+import { withUnstatedContainers } from '../../../client/js/components/UnstatedUtils';
+import { toastSuccess, toastError } from '../../../client/js/util/apiNotification';
 
-import AppContainer from '../../../services/AppContainer';
-import AdminGeneralSecurityContainer from '../../../services/AdminGeneralSecurityContainer';
-import AdminLocalSecurityContainer from '../../../services/AdminLocalSecurityContainer';
+import AppContainer from '../../../client/js/services/AppContainer';
+import AdminGeneralSecurityContainer from '../../../client/js/services/AdminGeneralSecurityContainer';
+import AdminLocalSecurityContainer from '../../../client/js/services/AdminLocalSecurityContainer';
 
 class LocalSecuritySettingContents extends React.Component {
 

--- a/src/components/Admin/Security/SecurityManagementContents.tsx
+++ b/src/components/Admin/Security/SecurityManagementContents.tsx
@@ -5,7 +5,7 @@ import { TabContent, TabPane } from 'reactstrap';
 import { useTranslation } from '~/i18n';
 
 import LdapSecuritySetting from '~/client/js/components/Admin/Security/LdapSecuritySetting';
-import LocalSecuritySetting from '~/client/js/components/Admin/Security/LocalSecuritySetting';
+import LocalSecuritySetting from '~/components/Admin/Security/LocalSecuritySetting';
 import SamlSecuritySetting from '~/client/js/components/Admin/Security/SamlSecuritySetting';
 import OidcSecuritySetting from '~/client/js/components/Admin/Security/OidcSecuritySetting';
 import SecuritySetting from '~/client/js/components/Admin/Security/SecuritySetting';

--- a/src/components/Admin/Security/SecurityManagementContents.tsx
+++ b/src/components/Admin/Security/SecurityManagementContents.tsx
@@ -5,7 +5,7 @@ import { TabContent, TabPane } from 'reactstrap';
 import { useTranslation } from '~/i18n';
 
 import LdapSecuritySetting from '~/client/js/components/Admin/Security/LdapSecuritySetting';
-import LocalSecuritySetting from '~/components/Admin/Security/LocalSecuritySetting';
+import { LocalSecuritySetting } from '~/components/Admin/Security/LocalSecuritySetting';
 import SamlSecuritySetting from '~/client/js/components/Admin/Security/SamlSecuritySetting';
 import OidcSecuritySetting from '~/client/js/components/Admin/Security/OidcSecuritySetting';
 import SecuritySetting from '~/client/js/components/Admin/Security/SecuritySetting';

--- a/src/components/Admin/Security/SecurityManagementContents.tsx
+++ b/src/components/Admin/Security/SecurityManagementContents.tsx
@@ -5,7 +5,7 @@ import { TabContent, TabPane } from 'reactstrap';
 import { useTranslation } from '~/i18n';
 
 import LdapSecuritySetting from '~/client/js/components/Admin/Security/LdapSecuritySetting';
-import { LocalSecuritySetting } from '~/client/js/components/Admin/Security/LocalSecuritySetting';
+import LocalSecuritySetting from '~/client/js/components/Admin/Security/LocalSecuritySetting';
 import SamlSecuritySetting from '~/client/js/components/Admin/Security/SamlSecuritySetting';
 import OidcSecuritySetting from '~/client/js/components/Admin/Security/OidcSecuritySetting';
 import SecuritySetting from '~/client/js/components/Admin/Security/SecuritySetting';

--- a/src/components/Admin/Security/SecurityManagementContents.tsx
+++ b/src/components/Admin/Security/SecurityManagementContents.tsx
@@ -5,7 +5,7 @@ import { TabContent, TabPane } from 'reactstrap';
 import { useTranslation } from '~/i18n';
 
 import LdapSecuritySetting from '~/client/js/components/Admin/Security/LdapSecuritySetting';
-import LocalSecuritySetting from '~/client/js/components/Admin/Security/LocalSecuritySetting';
+import { LocalSecuritySetting } from '~/client/js/components/Admin/Security/LocalSecuritySetting';
 import SamlSecuritySetting from '~/client/js/components/Admin/Security/SamlSecuritySetting';
 import OidcSecuritySetting from '~/client/js/components/Admin/Security/OidcSecuritySetting';
 import SecuritySetting from '~/client/js/components/Admin/Security/SecuritySetting';
@@ -118,7 +118,7 @@ export const SecurityManagementContents: FC<Props> = (props: Props) => {
         {/* TODO: show tab contents by GW-5141 */}
         <TabContent activeTab={activeTab} className="p-5">
           <TabPane tabId="passport_local">
-            {/* {activeComponents.has('passport_local') && <LocalSecuritySetting />} */}
+            {activeComponents.has('passport_local') && <LocalSecuritySetting />}
           </TabPane>
           <TabPane tabId="passport_ldap">
             {/* {activeComponents.has('passport_ldap') && <LdapSecuritySetting />} */}


### PR DESCRIPTION
## 該当タスク
GW-5141 【セキュリティ設定】 TabContentsの表示1 (ID/Pass)


## 表示
<img width="796" alt="Screen Shot 2021-02-14 at 20 38 18" src="https://user-images.githubusercontent.com/59536731/107875670-9da01b00-6f04-11eb-8835-c59c6521e8dd.png">
