### PR TITLE
Imprv/gw4940 add a button for interactive messages

### DIFF
--- a/src/server/service/bolt.js
+++ b/src/server/service/bolt.js
@@ -116,6 +116,21 @@ class BoltService {
                 text: `${resultPaths.join('\n')}`,
               },
             },
+            {
+              type: 'actions',
+              elements: [
+                {
+                  type: 'button',
+                  text: {
+                    type: 'plain_text',
+                    emoji: true,
+                    text: '検索結果をこのチャンネルに共有する',
+                  },
+                  style: 'primary',
+                  value: 'click_me_123',
+                },
+              ],
+            },
           ],
         });
       }

--- a/src/server/service/bolt.js
+++ b/src/server/service/bolt.js
@@ -123,11 +123,9 @@ class BoltService {
                   type: 'button',
                   text: {
                     type: 'plain_text',
-                    emoji: true,
                     text: '検索結果をこのチャンネルに共有する',
                   },
                   style: 'primary',
-                  value: 'click_me_123',
                 },
               ],
             },


### PR DESCRIPTION
## 該当タスク
GW-4940 interactive messageに全体に共有するボタンを追加する

## 参考
https://api.slack.com/messaging/interactivity

## 表示
<img width="605" alt="Screen Shot 2021-02-16 at 13 13 06" src="https://user-images.githubusercontent.com/59536731/108017646-c0dbdf00-7058-11eb-93ac-8cd957ed323c.png">
