### PR TITLE
Imprv/gw 5258 switch search rusults numbers

### DIFF
--- a/src/server/service/bolt.js
+++ b/src/server/service/bolt.js
@@ -189,8 +189,11 @@ class BoltService {
       const url = new URL(path, base);
       return `<${decodeURI(url.href)} | ${decodeURI(url.pathname)}>`;
     });
-    // TODO: This search results numbers will be improved by GW-5258
-    const keywords = `keyword(s) : "${args}" \n 10 results.`;
+
+    const searchResultsNum = resultPaths.length;
+    const searchResultsDescription = searchResultsNum > 10 ? 'more than 10 pages are found' : `${searchResultsNum} pages are found`;
+
+    const keywords = `keyword(s) : "${args}" \n ${searchResultsDescription}.`;
 
     try {
       await this.client.chat.postEphemeral({

--- a/src/server/service/bolt.js
+++ b/src/server/service/bolt.js
@@ -191,11 +191,24 @@ class BoltService {
     });
 
     const searchResultsNum = resultPaths.length;
-    const searchResultsDescription = searchResultsNum === 10
-      ? 'Maximum number of results that can be displayed is 10'
-      : `${searchResultsNum} pages found`;
+    let searchResultsDesc;
 
-    const keywordsAndDesc = `keyword(s) : "${args}" \n ${searchResultsDescription}.`;
+
+    switch (searchResultsNum) {
+      case 10:
+        searchResultsDesc = 'Maximum number of results that can be displayed is 10';
+        break;
+
+      case 1:
+        searchResultsDesc = `${searchResultsNum} page is found`;
+        break;
+
+      default:
+        searchResultsDesc = `${searchResultsNum} pages are found`;
+        break;
+    }
+
+    const keywordsAndDesc = `keyword(s) : "${args}" \n ${searchResultsDesc}.`;
 
     try {
       await this.client.chat.postEphemeral({

--- a/src/server/service/bolt.js
+++ b/src/server/service/bolt.js
@@ -193,7 +193,6 @@ class BoltService {
     const searchResultsNum = resultPaths.length;
     let searchResultsDesc;
 
-
     switch (searchResultsNum) {
       case 10:
         searchResultsDesc = 'Maximum number of results that can be displayed is 10';

--- a/src/server/service/bolt.js
+++ b/src/server/service/bolt.js
@@ -193,14 +193,14 @@ class BoltService {
     const searchResultsNum = resultPaths.length;
     const searchResultsDescription = searchResultsNum > 10 ? 'more than 10 pages are found' : `${searchResultsNum} pages are found`;
 
-    const keywords = `keyword(s) : "${args}" \n ${searchResultsDescription}.`;
+    const keywordsAndDesc = `keyword(s) : "${args}" \n ${searchResultsDescription}.`;
 
     try {
       await this.client.chat.postEphemeral({
         channel: command.channel_id,
         user: command.user_id,
         blocks: [
-          this.generateMarkdownSectionBlock(keywords),
+          this.generateMarkdownSectionBlock(keywordsAndDesc),
           this.generateMarkdownSectionBlock(`${urls.join('\n')}`),
           {
             type: 'actions',
@@ -213,7 +213,7 @@ class BoltService {
                 },
                 style: 'primary',
                 action_id: 'shareSearchResults',
-                value: `${keywords} \n\n ${urls.join('\n')}`,
+                value: `${keywordsAndDesc} \n\n ${urls.join('\n')}`,
               },
             ],
           },

--- a/src/server/service/bolt.js
+++ b/src/server/service/bolt.js
@@ -191,7 +191,9 @@ class BoltService {
     });
 
     const searchResultsNum = resultPaths.length;
-    const searchResultsDescription = searchResultsNum > 10 ? 'more than 10 pages are found' : `${searchResultsNum} pages are found`;
+    const searchResultsDescription = searchResultsNum === 10
+      ? 'Maximum number of results that can be displayed is 10'
+      : `${searchResultsNum} pages found`;
 
     const keywordsAndDesc = `keyword(s) : "${args}" \n ${searchResultsDescription}.`;
 


### PR DESCRIPTION
## Task
GW-5258 ページ検索数が10件未満の場合、検索数の表示を切り替える

**※ [GW-5269 PR & Merge(5257)](https://github.com/weseek/growi/pull/3465)がすでにマージされている場合、マージ先は`feat/growi-bot`になります。**
## Description
ページの検索数に関わらず`10 results`が表示されてしまっていたのを修正しました。

## View
取得したページ数が、
1. 10以上の場合
2. 1~9つの場合
3. 1つの場合

で説明文が変わります。
<img width="494" alt="Screen Shot 2021-02-25 at 20 16 30" src="https://user-images.githubusercontent.com/59536731/109146355-13c73c00-77a7-11eb-93ab-68bac071f0f1.png">
