### PR TITLE
Imprv/gw5259 show help search

### DIFF
--- a/src/server/service/bolt.js
+++ b/src/server/service/bolt.js
@@ -169,7 +169,23 @@ class BoltService {
       this.client.chat.postEphemeral({
         channel: command.channel_id,
         user: command.user_id,
-        blocks: [this.generateMarkdownSectionBlock(`*No page that matches your keyword(s) "${args}".*`)],
+        // blocks: [this.generateMarkdownSectionBlock(`*No page that matches your keyword(s) "${args}".*`), searchingHelp()],
+        blocks: [
+          this.generateMarkdownSectionBlock(`*No page that matches your keyword(s) "${args}".*`),
+          this.generateMarkdownSectionBlock(':mag: *Searching Help*'),
+          {
+            type: 'divider',
+          },
+          {
+            type: 'section',
+            text: {
+              type: 'mrkdwn',
+              text: '`word1` `word2` \n Search pages that include both {{word1}}, {{word2}} in the title or body',
+            },
+          },
+          {
+            type: 'divider',
+          }],
       });
       return;
     }

--- a/src/server/service/bolt.js
+++ b/src/server/service/bolt.js
@@ -171,7 +171,7 @@ class BoltService {
         user: command.user_id,
         blocks: [
           this.generateMarkdownSectionBlock(`*No page that matches your keyword(s) "${args}".*`),
-          this.generateMarkdownSectionBlock(':mag: *Searching Help*'),
+          this.generateMarkdownSectionBlock(':mag: *Help: Searching*'),
           this.divider(),
           this.generateMarkdownSectionBlock('`word1` `word2` (divide with space) \n Search pages that include both word1, word2 in the title or body'),
           this.divider(),

--- a/src/server/service/bolt.js
+++ b/src/server/service/bolt.js
@@ -181,7 +181,7 @@ class BoltService {
           this.divider(),
           this.generateMarkdownSectionBlock('`prefix:/user/` \n Search only the pages that the title start with /user/'),
           this.divider(),
-          this.generateMarkdownSectionBlock('`-prefix:/user/` \nExclude the pages that the title start with /user/'),
+          this.generateMarkdownSectionBlock('`-prefix:/user/` \n Exclude the pages that the title start with /user/'),
           this.divider(),
           this.generateMarkdownSectionBlock('`tag:wiki` \n Search for pages with wiki tag'),
           this.divider(),

--- a/src/server/service/bolt.js
+++ b/src/server/service/bolt.js
@@ -169,23 +169,24 @@ class BoltService {
       this.client.chat.postEphemeral({
         channel: command.channel_id,
         user: command.user_id,
-        // blocks: [this.generateMarkdownSectionBlock(`*No page that matches your keyword(s) "${args}".*`), searchingHelp()],
         blocks: [
           this.generateMarkdownSectionBlock(`*No page that matches your keyword(s) "${args}".*`),
           this.generateMarkdownSectionBlock(':mag: *Searching Help*'),
-          {
-            type: 'divider',
-          },
-          {
-            type: 'section',
-            text: {
-              type: 'mrkdwn',
-              text: '`word1` `word2` \n Search pages that include both {{word1}}, {{word2}} in the title or body',
-            },
-          },
-          {
-            type: 'divider',
-          }],
+          this.divider(),
+          this.generateMarkdownSectionBlock('`word1` `word2` (divide with space) \n Search pages that include both word1, word2 in the title or body'),
+          this.divider(),
+          this.generateMarkdownSectionBlock('`"This is GROWI"` (surround with double quotes) \n Search pages that include the phrase "This is GROWI"'),
+          this.divider(),
+          this.generateMarkdownSectionBlock('`-keyword` \n Exclude pages that include keyword in the title or body'),
+          this.divider(),
+          this.generateMarkdownSectionBlock('`prefix:/user/` \n Search only the pages that the title start with /user/'),
+          this.divider(),
+          this.generateMarkdownSectionBlock('`-prefix:/user/` \nExclude the pages that the title start with /user/'),
+          this.divider(),
+          this.generateMarkdownSectionBlock('`tag:wiki` \n Search for pages with wiki tag'),
+          this.divider(),
+          this.generateMarkdownSectionBlock('`-tag:wiki` \n Exclude pages with wiki tag'),
+        ],
       });
       return;
     }
@@ -356,6 +357,12 @@ class BoltService {
         type: 'mrkdwn',
         text: blocks,
       },
+    };
+  }
+
+  divider() {
+    return {
+      type: 'divider',
     };
   }
 


### PR DESCRIPTION
## Task
GW-5259 検索オプションのヘルプをslackからも閲覧できるようにする。

## Description
検索結果が'0'の場合に、検索方法のヘルプも表示するようにしました。

## View
<img width="722" alt="Screen Shot 2021-02-26 at 23 31 43" src="https://user-images.githubusercontent.com/59536731/109313301-64b06080-788b-11eb-9784-1eada6312953.png">

## Reference
![Screen Shot 2021-02-26 at 21 14 45](https://user-images.githubusercontent.com/59536731/109314227-6fb7c080-788c-11eb-8110-cc07550843f9.png)
