### PR TITLE
change timing to send response

### DIFF
--- a/src/server/routes/apiv3/slack-bot.js
+++ b/src/server/routes/apiv3/slack-bot.js
@@ -2,7 +2,6 @@
 const express = require('express');
 
 const router = express.Router();
-const ErrorV3 = require('../../models/vo/error-apiv3');
 
 module.exports = (crowi) => {
   this.app = crowi.express;

--- a/src/server/routes/apiv3/slack-bot.js
+++ b/src/server/routes/apiv3/slack-bot.js
@@ -16,15 +16,11 @@ module.exports = (crowi) => {
       return;
     }
 
-    // send response immediately to avoid opelation_timeout error
+    // Send response immediately to avoid opelation_timeout error
+    // See https://api.slack.com/apis/connections/events-api#the-events-api__responding-to-events
     res.send();
 
-    try {
-      await requestHandler(req.body);
-    }
-    catch (err) {
-      return res.apiv3Err(new ErrorV3(`Error:Slack-Bot:${err}`), 500);
-    }
+    await requestHandler(req.body);
   });
 
   return router;

--- a/src/server/routes/apiv3/slack-bot.js
+++ b/src/server/routes/apiv3/slack-bot.js
@@ -15,9 +15,12 @@ module.exports = (crowi) => {
       res.send(req.body);
       return;
     }
+
+    // send response immediately to avoid opelation_timeout error
+    res.send();
+
     try {
-      const response = await requestHandler(req.body) || null;
-      res.send(response);
+      await requestHandler(req.body);
     }
     catch (err) {
       return res.apiv3Err(new ErrorV3(`Error:Slack-Bot:${err}`), 500);

--- a/src/server/service/bolt.js
+++ b/src/server/service/bolt.js
@@ -27,7 +27,7 @@ class BoltReciever {
       body: reqBody,
       ack: (response) => {
         if (ackCalled) {
-          return null;
+          return;
         }
 
         ackCalled = true;
@@ -36,13 +36,7 @@ class BoltReciever {
           const message = response.message || 'Error occurred';
           throw new Error(message);
         }
-        else if (!response) {
-          return null;
-        }
-        else {
-          return response;
-        }
-
+        return;
       },
     };
 
@@ -140,7 +134,7 @@ class BoltService {
         this.generateMarkdownSectionBlock('*No command.*\n Hint\n `/growi [command] [keyword]`'),
       ],
     });
-    throw new Error('/growi command: Invalid first argument');
+    return;
   }
 
   async getSearchResultPaths(command, args) {
@@ -153,7 +147,7 @@ class BoltService {
           this.generateMarkdownSectionBlock('*Input keywords.*\n Hint\n `/growi search [keyword]`'),
         ],
       });
-      throw new Error('/growi command:search: Invalid keyword');
+      return;
     }
 
     // remove leading 'search'.
@@ -200,6 +194,9 @@ class BoltService {
 
   async showEphemeralSearchResults(command, args) {
     const resultPaths = await this.getSearchResultPaths(command, args);
+    if (resultPaths == null) {
+      return;
+    }
     const base = this.crowi.appService.getSiteUrl();
 
     const urls = resultPaths.map((path) => {


### PR DESCRIPTION
slackbotにはslackからのリクエスト送信から3秒以内に応答がなかったら timeoutエラーとなるので、リクエストを受け取ったらレシーバーないの処理に行く前に 空のres.send() を実行して、その後に内部の処理を実行するようにしています。（動作は確認済みです)

またレシーバー内での処理中にエラーが生じた場合もtimeout エラーが生じるため、「検索ワードが設定されていない」などはエラーとしてthrowはせず、slackユーザーにその旨のメッセージを送るだけにしています。