### PR TITLE
Change message & condition of HackMD-not-available tooltip

### DIFF
--- a/src/client/js/components/Navbar/PageEditorModeManager.jsx
+++ b/src/client/js/components/Navbar/PageEditorModeManager.jsx
@@ -43,7 +43,7 @@ function PageEditorModeManager(props) {
   const isAdmin = appContainer.isAdmin;
   const isHackmdEnabled = appContainer.config.env.HACKMD_URI != null;
   const showHackmdBtn = isHackmdEnabled || isAdmin;
-  const showHackmdDisabledTooltip = isAdmin && !isHackmdEnabled;
+  const showHackmdDisabledTooltip = isAdmin && !isHackmdEnabled && editorMode !== 'hackmd';
 
   const pageEditorModeButtonClickedHandler = useCallback((viewType) => {
     if (isBtnDisabled) {
@@ -101,7 +101,7 @@ function PageEditorModeManager(props) {
       )}
       {!isBtnDisabled && showHackmdDisabledTooltip && (
         <UncontrolledTooltip placement="top" target="grw-page-editor-mode-manager-hackmd-button" fade={false}>
-          {t('HackMD editor is not available')}
+          {t('hackmd.not_set_up')}
         </UncontrolledTooltip>
       )}
     </>


### PR DESCRIPTION
#3477 の尻拭いです。

- HackMDが利用不可時にでるツールチップのメッセージを変更
- ツールチップが出る条件の変更（管理者&HackMD未設定&**HackMD未設定画面を出していない**）
- ~~`showHackmdDisabledTooltip`の削除~~

![image](https://user-images.githubusercontent.com/12870451/110238329-70371200-7f84-11eb-8ae5-2681bba6458a.png)

本当はHackMDボタンに!⃘ (！+○)のようなバッジを表示したいのですが、ボタン内の文字が窮屈になるのでどう対処したらいいのか（React BootstrapのPill Badgeコンポーネント内に「`!`」）がわからなかったので断念しました。

お願いします。