### PR TITLE
Fix/5408 5415 can get emails except admin page

### DIFF
--- a/src/server/models/bookmark.js
+++ b/src/server/models/bookmark.js
@@ -70,43 +70,6 @@ module.exports = function(crowi) {
     }));
   };
 
-  /**
-   * option = {
-   *  limit: Int
-   *  offset: Int
-   *  requestUser: User
-   * }
-   */
-  bookmarkSchema.statics.findByUser = function(user, option) {
-    const Bookmark = this;
-    const requestUser = option.requestUser || null;
-
-    debug('Finding bookmark with requesting user:', requestUser);
-
-    const limit = option.limit || 50;
-    const offset = option.offset || 0;
-    const populatePage = option.populatePage || false;
-
-    return new Promise(((resolve, reject) => {
-      Bookmark
-        .find({ user: user._id })
-        .sort({ createdAt: -1 })
-        .skip(offset)
-        .limit(limit)
-        .exec((err, bookmarks) => {
-          if (err) {
-            return reject(err);
-          }
-
-          if (!populatePage) {
-            return resolve(bookmarks);
-          }
-
-          return Bookmark.populatePage(bookmarks, requestUser).then(resolve);
-        });
-    }));
-  };
-
   bookmarkSchema.statics.add = async function(page, user) {
     const Bookmark = this;
 

--- a/src/server/models/bookmark.js
+++ b/src/server/models/bookmark.js
@@ -43,18 +43,6 @@ module.exports = function(crowi) {
     return idToCountMap;
   };
 
-  bookmarkSchema.statics.populatePage = async function(bookmarks) {
-    const Bookmark = this;
-    const User = crowi.model('User');
-
-    return Bookmark.populate(bookmarks, {
-      path: 'page',
-      populate: {
-        path: 'lastUpdateUser', model: 'User', select: User.USER_PUBLIC_FIELDS,
-      },
-    });
-  };
-
   // bookmark チェック用
   bookmarkSchema.statics.findByPageIdAndUserId = function(pageId, userId) {
     const Bookmark = this;

--- a/src/server/models/page.js
+++ b/src/server/models/page.js
@@ -429,7 +429,7 @@ module.exports = function(crowi) {
     validateCrowi();
 
     const User = crowi.model('User');
-    return populateDataToShowRevision(this, User.USER_PUBLIC_FIELDS)
+    return populateDataToShowRevision(this, User.USER_FIELDS_EXCEPT_CONFIDENTIAL)
       .execPopulate();
   };
 
@@ -748,7 +748,7 @@ module.exports = function(crowi) {
     const totalCount = await builder.query.exec('count');
 
     // find
-    builder.populateDataToList(User.USER_PUBLIC_FIELDS);
+    builder.populateDataToList(User.USER_FIELDS_EXCEPT_CONFIDENTIAL);
     const pages = await builder.query.exec('find');
 
     const result = {
@@ -791,7 +791,7 @@ module.exports = function(crowi) {
 
     // find
     builder.addConditionToPagenate(opt.offset, opt.limit, sortOpt);
-    builder.populateDataToList(User.USER_PUBLIC_FIELDS);
+    builder.populateDataToList(User.USER_FIELDS_EXCEPT_CONFIDENTIAL);
     const pages = await builder.query.exec('find');
 
     const result = {

--- a/src/server/models/revision.js
+++ b/src/server/models/revision.js
@@ -71,26 +71,6 @@ module.exports = function(crowi) {
       .exec();
   };
 
-  revisionSchema.statics.findRevisionList = function(path, options) {
-    const Revision = this;
-
-
-    const User = crowi.model('User');
-
-    return new Promise(((resolve, reject) => {
-      Revision.find({ path })
-        .sort({ createdAt: -1 })
-        .populate('author', User.USER_PUBLIC_FIELDS)
-        .exec((err, data) => {
-          if (err) {
-            return reject(err);
-          }
-
-          return resolve(data);
-        });
-    }));
-  };
-
   revisionSchema.statics.updateRevisionListByPath = function(path, updateData, options) {
     const Revision = this;
 

--- a/src/server/models/revision.js
+++ b/src/server/models/revision.js
@@ -27,43 +27,6 @@ module.exports = function(crowi) {
   });
   revisionSchema.plugin(mongoosePaginate);
 
-  /*
-   * preparation for https://github.com/weseek/growi/issues/216
-   */
-  // // create a XSS Filter instance
-  // // TODO read options
-  // this.xss = new Xss(true);
-  // // prevent XSS when pre save
-  // revisionSchema.pre('save', function(next) {
-  //   this.body = xss.process(this.body);
-  //   next();
-  // });
-
-  revisionSchema.statics.findRevisions = function(ids) {
-    const Revision = this;
-
-
-    const User = crowi.model('User');
-
-    if (!Array.isArray(ids)) {
-      return Promise.reject(new Error('The argument was not Array.'));
-    }
-
-    return new Promise(((resolve, reject) => {
-      Revision
-        .find({ _id: { $in: ids } })
-        .sort({ createdAt: -1 })
-        .populate('author', User.USER_PUBLIC_FIELDS)
-        .exec((err, revisions) => {
-          if (err) {
-            return reject(err);
-          }
-
-          return resolve(revisions);
-        });
-    }));
-  };
-
   revisionSchema.statics.findRevisionIdList = function(path) {
     return this.find({ path })
       .select('_id author createdAt hasDiffToPrev')

--- a/src/server/models/user.js
+++ b/src/server/models/user.js
@@ -21,7 +21,7 @@ module.exports = function(crowi) {
   const STATUS_SUSPENDED = 3;
   const STATUS_DELETED = 4;
   const STATUS_INVITED = 5;
-  const USER_PUBLIC_FIELDS = '_id image isEmailPublished isGravatarEnabled googleId name username email introduction'
+  const USER_FIELDS_EXCEPT_CONFIDENTIAL = '_id image isEmailPublished isGravatarEnabled googleId name username email introduction'
   + ' status lang createdAt lastLoginAt admin imageUrlCached';
 
   const PAGE_ITEMS = 50;
@@ -724,7 +724,7 @@ module.exports = function(crowi) {
   userSchema.statics.STATUS_SUSPENDED = STATUS_SUSPENDED;
   userSchema.statics.STATUS_DELETED = STATUS_DELETED;
   userSchema.statics.STATUS_INVITED = STATUS_INVITED;
-  userSchema.statics.USER_PUBLIC_FIELDS = USER_PUBLIC_FIELDS;
+  userSchema.statics.USER_FIELDS_EXCEPT_CONFIDENTIAL = USER_FIELDS_EXCEPT_CONFIDENTIAL;
   userSchema.statics.PAGE_ITEMS = PAGE_ITEMS;
 
   return mongoose.model('User', userSchema);

--- a/src/server/routes/apiv3/attachment.js
+++ b/src/server/routes/apiv3/attachment.js
@@ -6,6 +6,7 @@ const express = require('express');
 
 const router = express.Router();
 const { query } = require('express-validator');
+const { serializeUserSecurely } = require('../../models/serializers/user-serializer');
 
 const ErrorV3 = require('../../models/vo/error-apiv3');
 
@@ -69,15 +70,13 @@ module.exports = (crowi) => {
         {
           limit,
           offset,
-          populate: {
-            path: 'creator',
-            select: User.USER_PUBLIC_FIELDS,
-          },
+          populate: 'creator',
         },
       );
+
       paginateResult.docs.forEach((doc) => {
         if (doc.creator != null && doc.creator instanceof User) {
-          doc.creator = doc.creator.toObject();
+          doc.creator = serializeUserSecurely(doc.creator);
         }
       });
 

--- a/src/server/routes/apiv3/bookmarks.js
+++ b/src/server/routes/apiv3/bookmarks.js
@@ -213,11 +213,10 @@ module.exports = (crowi) => {
         },
       );
 
-      // serialize user
-      paginationResult.docs = paginationResult.docs.map((doc) => {
-        const serializedDoc = doc;
-        serializedDoc.page.lastUpdateUser = serializeUserSecurely(doc.page.lastUpdateUser);
-        return serializedDoc;
+      paginationResult.docs.forEach((doc) => {
+        if (doc.page.lastUpdateUser != null && doc.page.lastUpdateUser instanceof User) {
+          doc.page.lastUpdateUser = serializeUserSecurely(doc.page.lastUpdateUser);
+        }
       });
 
       return res.apiv3({ paginationResult });

--- a/src/server/routes/apiv3/bookmarks.js
+++ b/src/server/routes/apiv3/bookmarks.js
@@ -4,6 +4,7 @@ const logger = loggerFactory('growi:routes:apiv3:bookmarks'); // eslint-disable-
 
 const express = require('express');
 const { body, query, param } = require('express-validator');
+const { serializeUserSecurely } = require('../../models/serializers/user-serializer');
 
 const router = express.Router();
 
@@ -205,13 +206,20 @@ module.exports = (crowi) => {
             populate: {
               path: 'lastUpdateUser',
               model: 'User',
-              select: User.USER_PUBLIC_FIELDS,
             },
           },
           page,
           limit,
         },
       );
+
+      // serialize user
+      paginationResult.docs = paginationResult.docs.map((doc) => {
+        const serializedDoc = doc;
+        serializedDoc.page.lastUpdateUser = serializeUserSecurely(doc.page.lastUpdateUser);
+        return serializedDoc;
+      });
+
       return res.apiv3({ paginationResult });
     }
     catch (err) {

--- a/src/server/routes/apiv3/pages.js
+++ b/src/server/routes/apiv3/pages.js
@@ -112,6 +112,7 @@ module.exports = (crowi) => {
   const apiV3FormValidator = require('../../middlewares/apiv3-form-validator')(crowi);
 
   const Page = crowi.model('Page');
+  const User = crowi.model('User');
   const PageTagRelation = crowi.model('PageTagRelation');
   const GlobalNotificationSetting = crowi.model('GlobalNotificationSetting');
 
@@ -120,6 +121,7 @@ module.exports = (crowi) => {
 
   const { serializePageSecurely } = require('../../models/serializers/page-serializer');
   const { serializeRevisionSecurely } = require('../../models/serializers/revision-serializer');
+  const { serializeUserSecurely } = require('../../models/serializers/user-serializer');
 
   const validator = {
     createPage: [
@@ -299,6 +301,12 @@ module.exports = (crowi) => {
         result.pages.pop();
       }
 
+      result.pages.forEach((page) => {
+        if (page.lastUpdateUser != null && page.lastUpdateUser instanceof User) {
+          page.lastUpdateUser = serializeUserSecurely(page.lastUpdateUser);
+        }
+      });
+
       return res.apiv3(result);
     }
     catch (err) {
@@ -470,6 +478,13 @@ module.exports = (crowi) => {
 
     try {
       const result = await Page.findListWithDescendants(path, req.user, queryOptions);
+
+      result.pages.forEach((page) => {
+        if (page.lastUpdateUser != null && page.lastUpdateUser instanceof User) {
+          page.lastUpdateUser = serializeUserSecurely(page.lastUpdateUser);
+        }
+      });
+
       return res.apiv3(result);
     }
     catch (err) {

--- a/src/server/routes/apiv3/revisions.js
+++ b/src/server/routes/apiv3/revisions.js
@@ -5,6 +5,7 @@ const logger = loggerFactory('growi:routes:apiv3:pages');
 const express = require('express');
 
 const { query, param } = require('express-validator');
+const { serializeUserSecurely } = require('../../models/serializers/user-serializer');
 const ErrorV3 = require('../../models/vo/error-apiv3');
 
 const router = express.Router();
@@ -128,12 +129,15 @@ module.exports = (crowi) => {
           page: selectedPage,
           limit,
           sort: { createdAt: -1 },
-          populate: {
-            path: 'author',
-            select: User.USER_PUBLIC_FIELDS,
-          },
+          populate: 'author',
         },
       );
+
+      paginateResult.docs.forEach((doc) => {
+        if (doc.author != null && doc.author instanceof User) {
+          doc.author = serializeUserSecurely(doc.author);
+        }
+      });
 
       return res.apiv3(paginateResult);
     }
@@ -181,7 +185,12 @@ module.exports = (crowi) => {
     }
 
     try {
-      const revision = await Revision.findById(revisionId).populate('author', User.USER_PUBLIC_FIELDS);
+      const revision = await Revision.findById(revisionId).populate('author');
+
+      if (revision.author != null && revision.author instanceof User) {
+        revision.author = serializeUserSecurely(revision.author);
+      }
+
       return res.apiv3({ revision });
     }
     catch (err) {

--- a/src/server/routes/comment.js
+++ b/src/server/routes/comment.js
@@ -4,6 +4,8 @@
  *    name: Comments
  */
 
+const { serializeUserSecurely } = require('../models/serializers/user-serializer');
+
 /**
  * @swagger
  *
@@ -130,11 +132,14 @@ module.exports = function(crowi, app) {
       return res.json(ApiResponse.error(err));
     }
 
-    const comments = await fetcher.populate(
-      { path: 'creator', select: User.USER_PUBLIC_FIELDS },
-    );
+    const comments = await fetcher.populate('creator');
+    const serializedComments = comments.map((comment) => {
+      const serializedComment = comment;
+      serializedComment.creator = serializeUserSecurely(comment.creator);
+      return serializedComment;
+    });
 
-    res.json(ApiResponse.success({ comments }));
+    res.json(ApiResponse.success({ comments: serializedComments }));
   };
 
   api.validators.add = function() {

--- a/src/server/routes/comment.js
+++ b/src/server/routes/comment.js
@@ -239,11 +239,6 @@ module.exports = function(crowi, app) {
     let createdComment;
     try {
       createdComment = await Comment.create(pageId, req.user._id, revisionId, comment, position, isMarkdown, replyTo);
-
-      await Comment.populate(createdComment, [
-        { path: 'creator', model: 'User', select: User.USER_PUBLIC_FIELDS },
-      ]);
-
     }
     catch (err) {
       logger.error(err);

--- a/src/server/routes/comment.js
+++ b/src/server/routes/comment.js
@@ -133,13 +133,13 @@ module.exports = function(crowi, app) {
     }
 
     const comments = await fetcher.populate('creator');
-    const serializedComments = comments.map((comment) => {
-      const serializedComment = comment;
-      serializedComment.creator = serializeUserSecurely(comment.creator);
-      return serializedComment;
+    comments.forEach((comment) => {
+      if (comment.creator != null && comment.creator instanceof User) {
+        comment.creator = serializeUserSecurely(comment.creator);
+      }
     });
 
-    res.json(ApiResponse.success({ comments: serializedComments }));
+    res.json(ApiResponse.success({ comments }));
   };
 
   api.validators.add = function() {

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -133,7 +133,6 @@ module.exports = function(crowi, app) {
 
   app.get('/_api/check_username'           , user.api.checkUsername);
   app.get('/_api/me/user-group-relations'  , accessTokenParser , loginRequiredStrictly , me.api.userGroupRelations);
-  app.get('/_api/user/bookmarks'           , loginRequired , user.api.bookmarks);
 
   // HTTP RPC Styled API (に徐々に移行していいこうと思う)
   app.get('/_api/users.list'          , accessTokenParser , loginRequired , user.api.list);

--- a/src/server/routes/page.js
+++ b/src/server/routes/page.js
@@ -1,5 +1,6 @@
 const { serializePageSecurely } = require('../models/serializers/page-serializer');
 const { serializeRevisionSecurely } = require('../models/serializers/revision-serializer');
+const { serializeUserSecurely } = require('../models/serializers/user-serializer');
 
 /**
  * @swagger
@@ -222,12 +223,11 @@ module.exports = function(crowi, app) {
     renderVars.revision = page.revision;
   }
 
-  async function addRenderVarsForUserPage(renderVars, page, requestUser) {
+  async function addRenderVarsForUserPage(renderVars, page) {
     const userData = await User.findUserByUsername(User.getUsernameByPath(page.path));
 
     if (userData != null) {
-      renderVars.pageUser = userData.toObject();
-      renderVars.bookmarkList = await Bookmark.findByUser(userData, { limit: 10, populatePage: true, requestUser });
+      renderVars.pageUser = serializeUserSecurely(userData);
     }
   }
 
@@ -371,7 +371,7 @@ module.exports = function(crowi, app) {
     if (isUserPage(page.path)) {
       // change template
       view = 'layout-growi/user_page';
-      await addRenderVarsForUserPage(renderVars, page, req.user);
+      await addRenderVarsForUserPage(renderVars, page);
     }
 
     await interceptorManager.process('beforeRenderPage', req, res, renderVars);

--- a/src/server/routes/page.js
+++ b/src/server/routes/page.js
@@ -135,7 +135,6 @@ module.exports = function(crowi, app) {
 
   const Page = crowi.model('Page');
   const User = crowi.model('User');
-  const Bookmark = crowi.model('Bookmark');
   const PageTagRelation = crowi.model('PageTagRelation');
   const GlobalNotificationSetting = crowi.model('GlobalNotificationSetting');
   const ShareLink = crowi.model('ShareLink');

--- a/src/server/routes/page.js
+++ b/src/server/routes/page.js
@@ -654,6 +654,12 @@ module.exports = function(crowi, app) {
         result.pages.pop();
       }
 
+      result.pages.forEach((page) => {
+        if (page.lastUpdateUser != null && page.lastUpdateUser instanceof User) {
+          page.lastUpdateUser = serializeUserSecurely(page.lastUpdateUser);
+        }
+      });
+
       return res.json(ApiResponse.success(result));
     }
     catch (err) {

--- a/src/server/routes/search.js
+++ b/src/server/routes/search.js
@@ -1,3 +1,5 @@
+const { serializeUserSecurely } = require('../models/serializers/user-serializer');
+
 /**
  * @swagger
  *
@@ -27,6 +29,7 @@
 module.exports = function(crowi, app) {
   // var debug = require('debug')('growi:routes:search')
   const Page = crowi.model('Page');
+  const User = crowi.model('User');
   const ApiResponse = require('../util/apiResponse');
   const ApiPaginate = require('../util/apiPaginate');
 
@@ -159,6 +162,9 @@ module.exports = function(crowi, app) {
       result.totalCount = findResult.totalCount;
       result.data = findResult.pages
         .map((page) => {
+          if (page.lastUpdateUser != null && page.lastUpdateUser instanceof User) {
+            page.lastUpdateUser = serializeUserSecurely(page.lastUpdateUser);
+          }
           page.bookmarkCount = (page._source && page._source.bookmark_count) || 0;
           return page;
         })

--- a/src/server/routes/user.js
+++ b/src/server/routes/user.js
@@ -47,7 +47,6 @@
 
 module.exports = function(crowi, app) {
   const User = crowi.model('User');
-  const Bookmark = crowi.model('Bookmark');
   const ApiResponse = require('../util/apiResponse');
 
   const actions = {};
@@ -56,16 +55,6 @@ module.exports = function(crowi, app) {
   const api = {};
 
   actions.api = api;
-
-  api.bookmarks = function(req, res) {
-    const options = {
-      skip: req.query.offset || 0,
-      limit: req.query.limit || 50,
-    };
-    Bookmark.findByUser(req.user, options, (err, bookmarks) => {
-      res.json(bookmarks);
-    });
-  };
 
   api.checkUsername = function(req, res) {
     const username = req.query.username;


### PR DESCRIPTION
調査の結果
https://dev.growi.org/605016625ea133004833567e

routes で使われている USER_PUBLIC_FIELDS は特定できたので置き換えましたが、
models/page で使われているものに関してはバグが怖いので rename だけに留めています。

いくつか models/page のメソッドを使っている場所は探せて、USER_PUBLIC_FIELDS で populate したドキュメントに serialize をして email を除外するという 二重掛けをしている箇所があります。