### PR TITLE
Imprv/gw5463 link and comment button color

### DIFF
--- a/src/client/styles/scss/theme/spring.scss
+++ b/src/client/styles/scss/theme/spring.scss
@@ -97,7 +97,7 @@ html[dark] {
   //Button
   // Outline buttons are applyed the accent color to this spring theme cuz the primary is too light and it looks like unable to click them.
   .btn.btn-outline-primary {
-    @include button-outline-variant($accentcolor, $accentcolor, lighten($accentcolor, 20%), $accentcolor);
+    @include btn-page-editor-mode-manager(darken($primary, 50%), darken($primary, 50%), lighten($primary, 10%));
   }
   .btn-group.grw-page-editor-mode-manager {
     .btn.btn-outline-primary {

--- a/src/client/styles/scss/theme/spring.scss
+++ b/src/client/styles/scss/theme/spring.scss
@@ -150,8 +150,6 @@ html[dark] {
 
   h1,
   h2 {
-    color: $subthemecolor;
-
     svg {
       fill: $subthemecolor;
     }


### PR DESCRIPTION
## Task
GW-5463 font colorとcomment buttonの配色改善をする

## View

### Before
- ページの見出しの色が、リンクの色と同じで見辛い
<img width="309" alt="Screen Shot 2021-03-24 at 21 49 46" src="https://user-images.githubusercontent.com/59536731/112313876-b2ce4d80-8ceb-11eb-9a5d-09bb85454006.png">

- Comment buttonがCancel buttonと比べて薄いので、invalidかと思ってしまう問題
<img width="269" alt="Screen Shot 2021-03-24 at 21 49 59" src="https://user-images.githubusercontent.com/59536731/112313884-b366e400-8ceb-11eb-981b-6800d6f7e322.png">





### After
- button outlineの色を、３連ボタンに寄せました。
<img width="186" alt="Screen Shot 2021-03-24 at 21 59 32" src="https://user-images.githubusercontent.com/59536731/112314353-44d65600-8cec-11eb-9dcf-b402b1de9c6d.png">

- hover時の色
<img width="193" alt="Screen Shot 2021-03-24 at 21 59 41" src="https://user-images.githubusercontent.com/59536731/112314358-4738b000-8cec-11eb-95a6-14ee3596de92.png">


- 見出しの色の指定を消して、標準の色に戻した。
<img width="837" alt="Screen Shot 2021-03-24 at 21 40 28" src="https://user-images.githubusercontent.com/59536731/112314056-e9a46380-8ceb-11eb-9583-ef2c540bee6c.png">



