### PR TITLE
Fix/gw 5480 rename external notification to slack integration

### DIFF
--- a/resource/locales/en_US/translation.json
+++ b/resource/locales/en_US/translation.json
@@ -111,7 +111,7 @@
   "Notification Settings": "Notification Settings",
   "slack_integration": "Slack Integration",
   "External_Notification": "External Notification",
-  "Legacy_External_Notification": "Legacy External Notification",
+  "Legacy_Slack_Integration": "Legacy_Slack_Integration",
   "User_Management": "User Management",
   "external_account_management": "External Account Management",
   "UserGroup Management": "UserGroup Management",

--- a/resource/locales/en_US/translation.json
+++ b/resource/locales/en_US/translation.json
@@ -111,7 +111,7 @@
   "Notification Settings": "Notification Settings",
   "slack_integration": "Slack Integration",
   "External_Notification": "External Notification",
-  "Legacy_Slack_Integration": "Legacy_Slack_Integration",
+  "Legacy_Slack_Integration": "Legacy Slack Integration",
   "User_Management": "User Management",
   "external_account_management": "External Account Management",
   "UserGroup Management": "UserGroup Management",

--- a/resource/locales/ja_JP/translation.json
+++ b/resource/locales/ja_JP/translation.json
@@ -112,7 +112,7 @@
   "Notification Settings": "通知設定",
   "slack_integration": "Slack連携",
   "External_Notification": "外部ツールへの通知",
-  "Legacy_External_Notification": "外部ツールへの通知 (レガシー)",
+  "Legacy_Slack_Integration": "Slack連携 (レガシー)",
   "User_Management": "ユーザー管理",
   "external_account_management": "外部アカウント管理",
   "UserGroup Management": "グループ管理",

--- a/resource/locales/zh_CN/translation.json
+++ b/resource/locales/zh_CN/translation.json
@@ -120,7 +120,7 @@
 	"Notification Settings": "通知设置",
   "slack_integration": "Slack一体化",
   "External_Notification": "外部通知",
-  "Legacy_External_Notification": "旧版外部通知",
+  "Legacy_Slack_Integration": "旧版Slack一体化",
 	"User_Management": "用户管理",
 	"external_account_management": "外部账户管理",
 	"UserGroup Management": "用户组管理",

--- a/src/client/js/components/Admin/Common/AdminNavigation.jsx
+++ b/src/client/js/components/Admin/Common/AdminNavigation.jsx
@@ -21,8 +21,8 @@ const AdminNavigation = (props) => {
       case 'importer':          return <><i className="icon-fw icon-cloud-upload"></i>    { t('Import Data') }</>;
       case 'export':            return <><i className="icon-fw icon-cloud-download"></i>  { t('Export Archive Data') }</>;
       case 'notification':      return <><i className="icon-fw icon-bell"></i>            { t('External_Notification') }</>;
-      // TODO change icon for legacy-external-notification by GW-5466
-      case 'legacy-external-notification':  return <> <i className="icon-fw icon-bell"></i>{ t('Legacy_External_Notification') }</>;
+      // TODO change icon for legacy-slack-integration by GW-5466
+      case 'legacy-slack-integration':  return <> <i className="icon-fw icon-bell"></i>{ t('Legacy_Slack_Integration') }</>;
       case 'slack-integration': return <><i className="icon-fw icon-paper-plane"></i>     { t('slack_integration') }</>;
       case 'users':             return <><i className="icon-fw icon-user"></i>            { t('User_Management') }</>;
       case 'user-groups':       return <><i className="icon-fw icon-people"></i>          { t('UserGroup Management') }</>;
@@ -64,8 +64,8 @@ const AdminNavigation = (props) => {
         <MenuLink menu="importer"     isListGroupItems isActive={isActiveMenu('/importer')} />
         <MenuLink menu="export"       isListGroupItems isActive={isActiveMenu('/export')} />
         <MenuLink menu="notification" isListGroupItems isActive={isActiveMenu('/notification') || isActiveMenu('/global-notification')} />
-        <MenuLink menu="legacy-external-notification" isListGroupItems isActive={isActiveMenu('/legacy-external-notification')} />
         <MenuLink menu="slack-integration" isListGroupItems isActive={isActiveMenu('/slack-integration')} />
+        <MenuLink menu="legacy-slack-integration" isListGroupItems isActive={isActiveMenu('/legacy-slack-integration')} />
         <MenuLink menu="users"        isListGroupItems isActive={isActiveMenu('/users')} />
         <MenuLink menu="user-groups"  isListGroupItems isActive={isActiveMenu('/user-groups')} />
         <MenuLink menu="search"       isListGroupItems isActive={isActiveMenu('/search')} />

--- a/src/client/js/components/Admin/Common/AdminNavigation.jsx
+++ b/src/client/js/components/Admin/Common/AdminNavigation.jsx
@@ -22,7 +22,7 @@ const AdminNavigation = (props) => {
       case 'export':            return <><i className="icon-fw icon-cloud-download"></i>  { t('Export Archive Data') }</>;
       case 'notification':      return <><i className="icon-fw icon-bell"></i>            { t('External_Notification') }</>;
       // TODO change icon for legacy-slack-integration by GW-5466
-      case 'legacy-slack-integration':  return <> <i className="icon-fw icon-bell"></i>{ t('Legacy_Slack_Integration') }</>;
+      case 'legacy-slack-integration':  return <> <i className="icon-fw icon-paper-plane"></i>    { t('Legacy_Slack_Integration') }</>;
       case 'slack-integration': return <><i className="icon-fw icon-paper-plane"></i>     { t('slack_integration') }</>;
       case 'users':             return <><i className="icon-fw icon-user"></i>            { t('User_Management') }</>;
       case 'user-groups':       return <><i className="icon-fw icon-people"></i>          { t('UserGroup Management') }</>;

--- a/src/server/routes/admin.js
+++ b/src/server/routes/admin.js
@@ -223,9 +223,9 @@ module.exports = function(crowi, app) {
     return res.render('admin/external-accounts');
   };
 
-  actions.legacyExternalNotification = {};
-  actions.legacyExternalNotification = function(req, res) {
-    return res.render('admin/legacy-external-notification');
+  actions.legacySlackIntegration = {};
+  actions.legacySlackIntegration = function(req, res) {
+    return res.render('admin/legacy-slack-integration');
   };
 
   actions.slackIntegration = {};

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -93,7 +93,7 @@ module.exports = function(crowi, app) {
   app.get('/admin/notification/slackSetting/disconnect' , loginRequiredStrictly , adminRequired , admin.notification.disconnectFromSlack);
   app.get('/admin/global-notification/new'              , loginRequiredStrictly , adminRequired , admin.globalNotification.detail);
   app.get('/admin/global-notification/:id'              , loginRequiredStrictly , adminRequired , admin.globalNotification.detail);
-  app.get('/admin/legacy-external-notification'         , loginRequiredStrictly , adminRequired,  admin.legacyExternalNotification);
+  app.get('/admin/legacy-slack-integration'         , loginRequiredStrictly , adminRequired,  admin.legacySlackIntegration);
   app.get('/admin/slack-integration'                    , loginRequiredStrictly , adminRequired,  admin.slackIntegration);
 
   app.get('/admin/users'                                , loginRequiredStrictly , adminRequired , admin.user.index);

--- a/src/server/views/admin/legacy-slack-integration.html
+++ b/src/server/views/admin/legacy-slack-integration.html
@@ -1,9 +1,9 @@
 {% extends '../layout/admin.html' %}
 
-{% block html_title %}{{ customizeService.generateCustomTitleForFixedPageName(t('Legacy_External_Notification')) }}{% endblock %}
+{% block html_title %}{{ customizeService.generateCustomTitleForFixedPageName(t('Legacy_Slack_Integration')) }}{% endblock %}
 
 {% block content_header %}
-<h1 class="title">{{ t('Legacy_External_Notification') }}</h1>
+<h1 class="title">{{ t('Legacy_Slack_Integration') }}</h1>
 {% endblock %}
 
 {% block content_main %}


### PR DESCRIPTION
GW-5480 fix「外部ツールへの通知(レガシー)」を「Slack連携(レガシー)」に修正

<img width="357" alt="スクリーンショット 2021-03-25 16 32 03" src="https://user-images.githubusercontent.com/34241526/112435275-de9f1100-8d87-11eb-8f72-c5c0ab8029d8.png">

<img width="338" alt="スクリーンショット 2021-03-25 16 32 32" src="https://user-images.githubusercontent.com/34241526/112435319-ea8ad300-8d87-11eb-8322-2c8979ab8d9d.png">

<img width="284" alt="スクリーンショット 2021-03-25 16 32 52" src="https://user-images.githubusercontent.com/34241526/112435332-ee1e5a00-8d87-11eb-80c1-1c19c8c5059f.png">

