### PR TITLE
Feat/5479 custom bot form

### DIFF
--- a/resource/locales/en_US/admin/admin.json
+++ b/resource/locales/en_US/admin/admin.json
@@ -252,6 +252,10 @@
     "download": "Download",
     "delete": "Delete"
   },
+  "slack_integration": {
+    "access_token": "Access Token",
+    "custom_button_non_proxy_settings": "Custom bot (non-proxy) Settings"
+  },
   "user_management": {
     "invite_users": "Invite new users",
     "click_twice_same_checkbox": "You should check at least one checkbox.",

--- a/resource/locales/en_US/admin/admin.json
+++ b/resource/locales/en_US/admin/admin.json
@@ -253,8 +253,14 @@
     "delete": "Delete"
   },
   "slack_integration": {
-    "access_token": "Access Token",
-    "custom_button_non_proxy_settings": "Custom bot (non-proxy) Settings"
+    "access_token_settings": {
+      "discard": "Discard",
+      "generate": "Generate"
+    },
+    "custom_bot_non_proxy_settings": "Custom bot (non-proxy) Settings",
+    "non_proxy": {
+      "create_bot": "Create Bot"
+    }
   },
   "user_management": {
     "invite_users": "Invite new users",

--- a/resource/locales/ja_JP/admin/admin.json
+++ b/resource/locales/ja_JP/admin/admin.json
@@ -251,8 +251,14 @@
     "Directory_hierarchy_tag": "ディレクトリ階層タグ"
   },
   "slack_integration": {
-    "access_token": "アクセストークン",
-    "custom_button_non_proxy_settings": "Custom bot (non-proxy) 設定"
+    "access_token_settings": {
+      "discard": "破棄",
+      "generate": "発行"
+    },
+    "custom_bot_non_proxy_settings": "Custom bot (non-proxy) 設定",
+    "non_proxy": {
+      "create_bot": "Bot を作成する"
+    }
   },
   "user_management": {
     "invite_users": "新規ユーザーの招待",

--- a/resource/locales/ja_JP/admin/admin.json
+++ b/resource/locales/ja_JP/admin/admin.json
@@ -250,6 +250,10 @@
     "page_skip": "既に GROWI 側に同名のページが存在する場合、そのページはスキップされます",
     "Directory_hierarchy_tag": "ディレクトリ階層タグ"
   },
+  "slack_integration": {
+    "access_token": "アクセストークン",
+    "custom_button_non_proxy_settings": "Custom bot (non-proxy) 設定"
+  },
   "user_management": {
     "invite_users": "新規ユーザーの招待",
     "click_twice_same_checkbox": "少なくとも一つはチェックしてください。",

--- a/resource/locales/zh_CN/admin/admin.json
+++ b/resource/locales/zh_CN/admin/admin.json
@@ -260,6 +260,10 @@
 		"download": "下载",
 		"delete": "删除"
   },
+  "slack_integration": {
+    "access_token": "Access token",
+    "custom_button_non_proxy_settings": "Custom bot (non-proxy) 设置"
+  },
 	"user_management": {
 		"invite_users": "邀请新用户",
 		"click_twice_same_checkbox": "您应该至少选中一个复选框。",

--- a/resource/locales/zh_CN/admin/admin.json
+++ b/resource/locales/zh_CN/admin/admin.json
@@ -261,8 +261,14 @@
 		"delete": "删除"
   },
   "slack_integration": {
-    "access_token": "Access token",
-    "custom_button_non_proxy_settings": "Custom bot (non-proxy) 设置"
+    "access_token_settings": {
+      "discard": "丢弃",
+      "generate": "生成"
+    },
+    "custom_bot_non_proxy_settings": "Custom bot (non-proxy) 设置",
+    "non_proxy": {
+      "create_bot": "创建 Bot"
+    }
   },
 	"user_management": {
 		"invite_users": "邀请新用户",

--- a/src/client/js/components/Admin/Common/AdminUpdateButtonRow.jsx
+++ b/src/client/js/components/Admin/Common/AdminUpdateButtonRow.jsx
@@ -16,7 +16,6 @@ const AdminUpdateButtonRow = (props) => {
 
 AdminUpdateButtonRow.propTypes = {
   t: PropTypes.func.isRequired, // i18next
-
   onClick: PropTypes.func.isRequired,
   disabled: PropTypes.bool.isRequired,
 };

--- a/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
@@ -7,13 +7,13 @@ class AccessTokenSettings extends React.Component {
   }
 
   discardHandler() {
-    console.log('Discard button pressed');
+    console.log('Generate button pressed');
   }
 
   render() {
     return (
       <Fragment>
-        <div className="form-group row">
+        <div className="form-group row my-5">
           {/* <label className="text-left text-md-right col-md-3 col-form-label">{t('admin:app_setting.site_name')}</label> */}
           <label className="text-left text-md-right col-md-3 col-form-label">Access Token</label>
           <div className="col-md-6">
@@ -21,13 +21,13 @@ class AccessTokenSettings extends React.Component {
           </div>
         </div>
 
-        <div className="row my-3">
-          <div className="offset-4 col-5">
-            <button type="button" className="btn btn-primary text-nowrap mx-1" onClick={this.updateHandler}>
-              Update
-            </button>
-            <button type="button" className="btn btn-primary text-nowrap mx-1" onClick={this.discardHandler}>
+        <div className="row">
+          <div className="mx-auto">
+            <button type="button" className="btn btn-outline-secondary text-nowrap mx-1" onClick={this.discardHandler}>
               Discard
+            </button>
+            <button type="button" className="btn btn-primary text-nowrap mx-1" onClick={this.updateHandler}>
+              Generate
             </button>
           </div>
         </div>

--- a/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
@@ -1,47 +1,39 @@
-import React, { Fragment } from 'react';
-import PropTypes from 'prop-types';
-import { withTranslation } from 'react-i18next';
+/* eslint-disable no-console */
+import React from 'react';
+import { useTranslation } from 'react-i18next';
 
-class AccessTokenSettings extends React.Component {
+function AccessTokenSettings() {
 
-  updateHandler() {
-    console.log('Update button pressed');
+  const { t } = useTranslation('admin');
+  function discardHandler() {
+    console.log('Discard button pressed');
   }
 
-  discardHandler() {
+  function generateHandler() {
     console.log('Generate button pressed');
   }
 
-  render() {
-    const { t } = this.props;
-
-    return (
-      <Fragment>
-        <div className="form-group row my-5">
-          <label className="text-left text-md-right col-md-3 col-form-label">Access Token</label>
-          <div className="col-md-6">
-            <input className="form-control" type="text" placeholder="access-token" />
-          </div>
+  return (
+    <>
+      <div className="form-group row my-5">
+        <label className="text-left text-md-right col-md-3 col-form-label">Access Token</label>
+        <div className="col-md-6">
+          <input className="form-control" type="text" placeholder="access-token" />
         </div>
+      </div>
 
-        <div className="row">
-          <div className="mx-auto">
-            <button type="button" className="btn btn-outline-secondary text-nowrap mx-1" onClick={this.discardHandler}>
-              {t('admin:slack_integration.access_token_settings.discard')}
-            </button>
-            <button type="button" className="btn btn-primary text-nowrap mx-1" onClick={this.updateHandler}>
-              {t('admin:slack_integration.access_token_settings.generate')}
-            </button>
-          </div>
+      <div className="row">
+        <div className="mx-auto">
+          <button type="button" className="btn btn-outline-secondary text-nowrap mx-1" onClick={discardHandler}>
+            {t('slack_integration.access_token_settings.discard')}
+          </button>
+          <button type="button" className="btn btn-primary text-nowrap mx-1" onClick={generateHandler}>
+            {t('slack_integration.access_token_settings.generate')}
+          </button>
         </div>
-      </Fragment>
-    );
-  }
-
+      </div>
+    </>
+  );
 }
 
-AccessTokenSettings.propTypes = {
-  t: PropTypes.func.isRequired, // i18next
-};
-
-export default withTranslation()(AccessTokenSettings);
+export default AccessTokenSettings;

--- a/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
@@ -1,0 +1,40 @@
+import React, { Fragment } from 'react';
+
+class AccessTokenSettings extends React.Component {
+
+  updateHandler() {
+    console.log('Update button pressed');
+  }
+
+  discardHandler() {
+    console.log('Discard button pressed');
+  }
+
+  render() {
+    return (
+      <Fragment>
+        <div className="form-group row">
+          {/* <label className="text-left text-md-right col-md-3 col-form-label">{t('admin:app_setting.site_name')}</label> */}
+          <label className="text-left text-md-right col-md-3 col-form-label">Access Token</label>
+          <div className="col-md-6">
+            <input className="form-control" type="text" placeholder="access-token" />
+          </div>
+        </div>
+
+        <div className="row my-3">
+          <div className="offset-4 col-5">
+            <button type="button" className="btn btn-primary text-nowrap mx-1" onClick={this.updateHandler}>
+              Update
+            </button>
+            <button type="button" className="btn btn-primary text-nowrap mx-1" onClick={this.discardHandler}>
+              Discard
+            </button>
+          </div>
+        </div>
+      </Fragment>
+    );
+  }
+
+}
+
+export default AccessTokenSettings;

--- a/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
@@ -1,4 +1,6 @@
 import React, { Fragment } from 'react';
+import PropTypes from 'prop-types';
+import { withTranslation } from 'react-i18next';
 
 class AccessTokenSettings extends React.Component {
 
@@ -11,10 +13,11 @@ class AccessTokenSettings extends React.Component {
   }
 
   render() {
+    const { t } = this.props;
+
     return (
       <Fragment>
         <div className="form-group row my-5">
-          {/* <label className="text-left text-md-right col-md-3 col-form-label">{t('admin:app_setting.site_name')}</label> */}
           <label className="text-left text-md-right col-md-3 col-form-label">Access Token</label>
           <div className="col-md-6">
             <input className="form-control" type="text" placeholder="access-token" />
@@ -24,10 +27,10 @@ class AccessTokenSettings extends React.Component {
         <div className="row">
           <div className="mx-auto">
             <button type="button" className="btn btn-outline-secondary text-nowrap mx-1" onClick={this.discardHandler}>
-              Discard
+              {t('admin:slack_integration.access_token_settings.discard')}
             </button>
             <button type="button" className="btn btn-primary text-nowrap mx-1" onClick={this.updateHandler}>
-              Generate
+              {t('admin:slack_integration.access_token_settings.generate')}
             </button>
           </div>
         </div>
@@ -37,4 +40,8 @@ class AccessTokenSettings extends React.Component {
 
 }
 
-export default AccessTokenSettings;
+AccessTokenSettings.propTypes = {
+  t: PropTypes.func.isRequired, // i18next
+};
+
+export default withTranslation()(AccessTokenSettings);

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotNonProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotNonProxySettings.jsx
@@ -22,7 +22,7 @@ class CustomBotNonProxySettings extends React.Component {
       <Fragment>
         <div className="row my-5">
           <div className="mx-auto">
-            <button type="button" className="btn btn-primary text-nowrap mx-1" onClick={() => window.open('https://google.com', '_blank')}>
+            <button type="button" className="btn btn-primary text-nowrap mx-1" onClick={() => window.open('https://api.slack.com/apps', '_blank')}>
               Create Bot
             </button>
           </div>

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotNonProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotNonProxySettings.jsx
@@ -1,67 +1,54 @@
-import React, { Fragment } from 'react';
-import PropTypes from 'prop-types';
-import { withTranslation } from 'react-i18next';
+/* eslint-disable no-console */
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
 import AdminUpdateButtonRow from '../Common/AdminUpdateButtonRow';
 
-class CustomBotNonProxySettings extends React.Component {
+function CustomBotNonProxySettings() {
 
-  constructor(props) {
-    super(props);
-    this.state = {
-      secretState: '',
-      authState: '',
-    };
-    this.updateHandler = this.updateHandler.bind(this);
+  const { t } = useTranslation('admin');
+  const [secret, setSecret] = useState('');
+  const [token, setToken] = useState('');
+
+  function updateHandler() {
+    console.log(`Signing Secret: ${secret}, Bot User OAuth Token: ${token}`);
   }
 
-  updateHandler() {
-    console.log(`Signing Secret: ${this.state.secretState}, Bot User OAuth Token: ${this.state.authState}`);
-  }
-
-  render() {
-    const { t } = this.props;
-
-    return (
-      <Fragment>
-        <div className="row my-5">
-          <div className="mx-auto">
-            <button type="button" className="btn btn-primary text-nowrap mx-1" onClick={() => window.open('https://api.slack.com/apps', '_blank')}>
-              {t('admin:slack_integration.non_proxy.create_bot')}
-            </button>
-          </div>
+  return (
+    <>
+      <div className="row my-5">
+        <div className="mx-auto">
+          <button type="button" className="btn btn-primary text-nowrap mx-1" onClick={() => window.open('https://api.slack.com/apps', '_blank')}>
+            {t('slack_integration.non_proxy.create_bot')}
+          </button>
         </div>
+      </div>
 
-        <div className="form-group row">
-          <label className="text-left text-md-right col-md-3 col-form-label">Signing Secret</label>
-          <div className="col-md-6">
-            <input
-              className="form-control"
-              type="text"
-              onChange={(e) => { this.state.secretState = e.target.value }}
-            />
-          </div>
+      <div className="form-group row">
+        <label className="text-left text-md-right col-md-3 col-form-label">Signing Secret</label>
+        <div className="col-md-6">
+          <input
+            className="form-control"
+            type="text"
+            onChange={e => setSecret(e.target.value)}
+          />
         </div>
+      </div>
 
-        <div className="form-group row mb-5">
-          <label className="text-left text-md-right col-md-3 col-form-label">Bot User OAuth Token</label>
-          <div className="col-md-6">
-            <input
-              className="form-control"
-              type="text"
-              onChange={(e) => { this.state.authState = e.target.value }}
-            />
-          </div>
+      <div className="form-group row mb-5">
+        <label className="text-left text-md-right col-md-3 col-form-label">Bot User OAuth Token</label>
+        <div className="col-md-6">
+          <input
+            className="form-control"
+            type="text"
+            onChange={e => setToken(e.target.value)}
+          />
         </div>
+      </div>
 
-        <AdminUpdateButtonRow onClick={this.updateHandler} disabled={false} />
-      </Fragment>
-    );
-  }
-
+      <AdminUpdateButtonRow onClick={updateHandler} disabled={false} />
+    </>
+  );
 }
 
-CustomBotNonProxySettings.propTypes = {
-  t: PropTypes.func.isRequired, // i18next
-};
-
-export default withTranslation()(CustomBotNonProxySettings);
+export default CustomBotNonProxySettings;

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotNonProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotNonProxySettings.jsx
@@ -1,0 +1,69 @@
+import React, { Fragment } from 'react';
+// import AdminUpdateButtonRow from '../Common/AdminUpdateButtonRow';
+
+class CustomBotNonProxySettings extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      secretState: '',
+      authState: '',
+    };
+    this.updateHandler = this.updateHandler.bind(this);
+  }
+
+  updateHandler() {
+    console.log(`Signing Secret: ${this.state.secretState}, Bot User OAuth Token: ${this.state.authState}`);
+  }
+
+  render() {
+
+    return (
+      <Fragment>
+        <div className="row my-5">
+          <div className="mx-auto">
+            <button type="button" className="btn btn-primary text-nowrap mx-1" onClick={() => window.open('https://google.com', '_blank')}>
+              Create Bot
+            </button>
+          </div>
+        </div>
+
+        <div className="form-group row">
+          {/* <label className="text-left text-md-right col-md-3 col-form-label">{t('admin:app_setting.site_name')}</label> */}
+          <label className="text-left text-md-right col-md-3 col-form-label">Signing Secret</label>
+          <div className="col-md-6">
+            <input
+              className="form-control"
+              type="text"
+              onChange={(e) => { this.state.secretState = e.target.value }}
+            />
+          </div>
+        </div>
+
+        <div className="form-group row mb-5">
+          {/* <label className="text-left text-md-right col-md-3 col-form-label">{t('admin:app_setting.site_name')}</label> */}
+          <label className="text-left text-md-right col-md-3 col-form-label">Bot User OAuth Token</label>
+          <div className="col-md-6">
+            <input
+              className="form-control"
+              type="text"
+              onChange={(e) => { this.state.authState = e.target.value }}
+            />
+          </div>
+        </div>
+
+        {/* <AdminUpdateButtonRow /> */}
+        <div className="row">
+          <div className="mx-auto">
+            <button type="button" className="btn btn-primary text-nowrap mx-1" onClick={this.updateHandler}>
+              Update
+            </button>
+          </div>
+        </div>
+      </Fragment>
+    );
+  }
+
+}
+
+export default CustomBotNonProxySettings;

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotNonProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotNonProxySettings.jsx
@@ -1,5 +1,7 @@
 import React, { Fragment } from 'react';
-// import AdminUpdateButtonRow from '../Common/AdminUpdateButtonRow';
+import PropTypes from 'prop-types';
+import { withTranslation } from 'react-i18next';
+import AdminUpdateButtonRow from '../Common/AdminUpdateButtonRow';
 
 class CustomBotNonProxySettings extends React.Component {
 
@@ -17,19 +19,19 @@ class CustomBotNonProxySettings extends React.Component {
   }
 
   render() {
+    const { t } = this.props;
 
     return (
       <Fragment>
         <div className="row my-5">
           <div className="mx-auto">
             <button type="button" className="btn btn-primary text-nowrap mx-1" onClick={() => window.open('https://api.slack.com/apps', '_blank')}>
-              Create Bot
+              {t('admin:slack_integration.non_proxy.create_bot')}
             </button>
           </div>
         </div>
 
         <div className="form-group row">
-          {/* <label className="text-left text-md-right col-md-3 col-form-label">{t('admin:app_setting.site_name')}</label> */}
           <label className="text-left text-md-right col-md-3 col-form-label">Signing Secret</label>
           <div className="col-md-6">
             <input
@@ -41,7 +43,6 @@ class CustomBotNonProxySettings extends React.Component {
         </div>
 
         <div className="form-group row mb-5">
-          {/* <label className="text-left text-md-right col-md-3 col-form-label">{t('admin:app_setting.site_name')}</label> */}
           <label className="text-left text-md-right col-md-3 col-form-label">Bot User OAuth Token</label>
           <div className="col-md-6">
             <input
@@ -52,18 +53,15 @@ class CustomBotNonProxySettings extends React.Component {
           </div>
         </div>
 
-        {/* <AdminUpdateButtonRow /> */}
-        <div className="row">
-          <div className="mx-auto">
-            <button type="button" className="btn btn-primary text-nowrap mx-1" onClick={this.updateHandler}>
-              Update
-            </button>
-          </div>
-        </div>
+        <AdminUpdateButtonRow onClick={this.updateHandler} disabled={false} />
       </Fragment>
     );
   }
 
 }
 
-export default CustomBotNonProxySettings;
+CustomBotNonProxySettings.propTypes = {
+  t: PropTypes.func.isRequired, // i18next
+};
+
+export default withTranslation()(CustomBotNonProxySettings);

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -15,14 +15,14 @@ class SlackIntegration extends React.Component {
       <Fragment>
         <div className="row">
           <div className="col-lg-12">
-            <h2 className="admin-setting-header">{t('admin:slack_integration.access_token')}</h2>
+            <h2 className="admin-setting-header">Access Token</h2>
             <AccessTokenSettings />
           </div>
         </div>
 
         <div className="row">
           <div className="col-lg-12">
-            <h2 className="admin-setting-header">{t('admin:slack_integration.custom_button_non_proxy_settings')}</h2>
+            <h2 className="admin-setting-header">{t('admin:slack_integration.custom_bot_non_proxy_settings')}</h2>
             <CustomBotNonProxySettings />
           </div>
         </div>

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -1,8 +1,7 @@
 import React, { Fragment } from 'react';
-// import PropTypes from 'prop-types';
+import PropTypes from 'prop-types';
+import { withTranslation } from 'react-i18next';
 
-// import { withUnstatedContainers } from '../../UnstatedUtils';
-// import AppContainer from '../../../services/AppContainer';
 
 import AccessTokenSettings from './AccessTokenSettings';
 import CustomBotNonProxySettings from './CustomBotNonProxySettings';
@@ -10,22 +9,20 @@ import CustomBotNonProxySettings from './CustomBotNonProxySettings';
 class SlackIntegration extends React.Component {
 
   render() {
-    // const { t } = this.props;
+    const { t } = this.props;
 
     return (
       <Fragment>
         <div className="row">
           <div className="col-lg-12">
-            {/* <h2 className="admin-setting-header">{t('Access Token')}</h2> */}
-            <h2 className="admin-setting-header">Access Token</h2>
+            <h2 className="admin-setting-header">{t('admin:slack_integration.access_token')}</h2>
             <AccessTokenSettings />
           </div>
         </div>
 
         <div className="row">
           <div className="col-lg-12">
-            {/* <h2 className="admin-setting-header">{t('Access Token')}</h2> */}
-            <h2 className="admin-setting-header">Custom bot (non-proxy) Settings</h2>
+            <h2 className="admin-setting-header">{t('admin:slack_integration.custom_button_non_proxy_settings')}</h2>
             <CustomBotNonProxySettings />
           </div>
         </div>
@@ -36,12 +33,8 @@ class SlackIntegration extends React.Component {
 
 }
 
-// const SlackIntegrationWrapper = withUnstatedContainers(SlackIntegration, [AppContainer]);
+SlackIntegration.propTypes = {
+  t: PropTypes.func.isRequired, // i18next
+};
 
-// SlackIntegration.propTypes = {
-//   t: PropTypes.func.isRequired, // i18next
-//   appContainer: PropTypes.instanceOf(AppContainer).isRequired,
-// slackIntegrationContainer: PropTypes.instanceOf(SlackIntegrationContainer).isRequired,
-// };
-
-export default SlackIntegration;
+export default withTranslation()(SlackIntegration);

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -3,15 +3,10 @@ import React, { Fragment } from 'react';
 
 // import { withUnstatedContainers } from '../../UnstatedUtils';
 // import AppContainer from '../../../services/AppContainer';
+
+import AccessTokenSettings from './AccessTokenSettings';
+
 class SlackIntegration extends React.Component {
-
-  updateHandler() {
-    console.log('Update button pressed');
-  }
-
-  discardHandler() {
-    console.log('Discard button pressed');
-  }
 
   render() {
     // const { t } = this.props;
@@ -23,25 +18,8 @@ class SlackIntegration extends React.Component {
             {/* <h2 className="admin-setting-header">{t('Access Token')}</h2> */}
             <h2 className="admin-setting-header">Access Token</h2>
 
-            <div className="form-group row">
-              {/* <label className="text-left text-md-right col-md-3 col-form-label">{t('admin:app_setting.site_name')}</label> */}
-              <label className="text-left text-md-right col-md-3 col-form-label">Access Token</label>
-              <div className="col-md-6">
-                <input className="form-control" type="text" placeholder="access-token" />
-              </div>
-            </div>
+            <AccessTokenSettings />
 
-            <div className="row my-3">
-              <div className="offset-4 col-5">
-                <button type="button" className="btn btn-primary text-nowrap mx-1" onClick={this.updateHandler}>
-                  Update
-                </button>
-                <button type="button" className="btn btn-primary text-nowrap mx-1" onClick={this.discardHandler}>
-                  Discard
-                </button>
-              </div>
-
-            </div>
           </div>
         </div>
       </Fragment>

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -2,7 +2,6 @@ import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { withTranslation } from 'react-i18next';
 
-
 import AccessTokenSettings from './AccessTokenSettings';
 import CustomBotNonProxySettings from './CustomBotNonProxySettings';
 

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -3,8 +3,15 @@ import React, { Fragment } from 'react';
 
 // import { withUnstatedContainers } from '../../UnstatedUtils';
 // import AppContainer from '../../../services/AppContainer';
-
 class SlackIntegration extends React.Component {
+
+  updateHandler() {
+    console.log('Update button pressed');
+  }
+
+  discardHandler() {
+    console.log('Discard button pressed');
+  }
 
   render() {
     // const { t } = this.props;
@@ -15,13 +22,25 @@ class SlackIntegration extends React.Component {
           <div className="col-lg-12">
             {/* <h2 className="admin-setting-header">{t('Access Token')}</h2> */}
             <h2 className="admin-setting-header">Access Token</h2>
+
             <div className="form-group row">
               {/* <label className="text-left text-md-right col-md-3 col-form-label">{t('admin:app_setting.site_name')}</label> */}
               <label className="text-left text-md-right col-md-3 col-form-label">Access Token</label>
-
               <div className="col-md-6">
                 <input className="form-control" type="text" placeholder="access-token" />
               </div>
+            </div>
+
+            <div className="row my-3">
+              <div className="offset-4 col-5">
+                <button type="button" className="btn btn-primary text-nowrap mx-1" onClick={this.updateHandler}>
+                  Update
+                </button>
+                <button type="button" className="btn btn-primary text-nowrap mx-1" onClick={this.discardHandler}>
+                  Discard
+                </button>
+              </div>
+
             </div>
           </div>
         </div>

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -1,39 +1,29 @@
-import React, { Fragment } from 'react';
-import PropTypes from 'prop-types';
-import { withTranslation } from 'react-i18next';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
 
 import AccessTokenSettings from './AccessTokenSettings';
 import CustomBotNonProxySettings from './CustomBotNonProxySettings';
 
-class SlackIntegration extends React.Component {
+function SlackIntegration() {
 
-  render() {
-    const { t } = this.props;
-
-    return (
-      <Fragment>
-        <div className="row">
-          <div className="col-lg-12">
-            <h2 className="admin-setting-header">Access Token</h2>
-            <AccessTokenSettings />
-          </div>
+  const { t } = useTranslation('admin');
+  return (
+    <>
+      <div className="row">
+        <div className="col-lg-12">
+          <h2 className="admin-setting-header">Access Token</h2>
+          <AccessTokenSettings />
         </div>
+      </div>
 
-        <div className="row">
-          <div className="col-lg-12">
-            <h2 className="admin-setting-header">{t('admin:slack_integration.custom_bot_non_proxy_settings')}</h2>
-            <CustomBotNonProxySettings />
-          </div>
+      <div className="row">
+        <div className="col-lg-12">
+          <h2 className="admin-setting-header">{t('slack_integration.custom_bot_non_proxy_settings')}</h2>
+          <CustomBotNonProxySettings />
         </div>
-
-      </Fragment>
-    );
-  }
-
+      </div>
+    </>
+  );
 }
 
-SlackIntegration.propTypes = {
-  t: PropTypes.func.isRequired, // i18next
-};
-
-export default withTranslation()(SlackIntegration);
+export default SlackIntegration;

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -5,6 +5,7 @@ import React, { Fragment } from 'react';
 // import AppContainer from '../../../services/AppContainer';
 
 import AccessTokenSettings from './AccessTokenSettings';
+import CustomBotNonProxySettings from './CustomBotNonProxySettings';
 
 class SlackIntegration extends React.Component {
 
@@ -17,11 +18,18 @@ class SlackIntegration extends React.Component {
           <div className="col-lg-12">
             {/* <h2 className="admin-setting-header">{t('Access Token')}</h2> */}
             <h2 className="admin-setting-header">Access Token</h2>
-
             <AccessTokenSettings />
-
           </div>
         </div>
+
+        <div className="row">
+          <div className="col-lg-12">
+            {/* <h2 className="admin-setting-header">{t('Access Token')}</h2> */}
+            <h2 className="admin-setting-header">Custom bot (non-proxy) Settings</h2>
+            <CustomBotNonProxySettings />
+          </div>
+        </div>
+
       </Fragment>
     );
   }


### PR DESCRIPTION
Slack連携画面のCustom botセクションを追加しました。

【日本語】
<img width="1908" alt="Japanese" src="https://user-images.githubusercontent.com/66785624/112438867-c29d6e80-8d8b-11eb-85e9-438af79d5989.png">

【英語】
<img width="1910" alt="English" src="https://user-images.githubusercontent.com/66785624/112438866-c204d800-8d8b-11eb-8a3f-d67b0ed53500.png">

【中国語】
<img width="1904" alt="Chinese" src="https://user-images.githubusercontent.com/66785624/112438862-c0d3ab00-8d8b-11eb-8c36-d2150667c27a.png">

「Botを作成」ボタンを押すと[api.slack.com/apps](url)に行き、更新ボタンを押すとコンソールログするようになっています。
<img width="1614" alt="Screen Shot 2021-03-25 at 16 56 44" src="https://user-images.githubusercontent.com/66785624/112439194-2889f600-8d8c-11eb-9750-fbbc26efdc54.png">

