### PR TITLE
Fixed cannot destructure error

### DIFF
--- a/src/server/service/bolt.js
+++ b/src/server/service/bolt.js
@@ -189,7 +189,7 @@ class BoltService {
           this.generateMarkdownSectionBlock('`-tag:wiki` \n Exclude pages with wiki tag'),
         ],
       });
-      return;
+      return { resultPaths: [] };
     }
 
     const resultPaths = results.data.map((data) => {
@@ -208,9 +208,10 @@ class BoltService {
 
     const keywords = this.getKeywords(args);
 
-    if (resultPaths == null) {
+    if (resultPaths.length === 0) {
       return;
     }
+
     const base = this.crowi.appService.getSiteUrl();
 
     const urls = resultPaths.map((path) => {


### PR DESCRIPTION
Slackにて、/growi searchコマンド実行時に検索結果が0の場合にエラーが出ていたので修正しました。

【Before】
```
[ERROR]  bolt-app UnknownError: Cannot destructure property 'resultPaths' of '(intermediate value)' as it is undefined.
    at Object.asCodedError (/workspace/growi/node_modules/@slack/bolt/dist/errors.js:25:12)
    at App.handleError (/workspace/growi/node_modules/@slack/bolt/dist/App.js:486:43)
    at App.processEvent (/workspace/growi/node_modules/@slack/bolt/dist/App.js:479:25)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
    at async BoltReciever.requestHandler (/workspace/growi/src/server/service/bolt.js:45:5)
    at async /workspace/growi/src/server/routes/apiv3/slack-bot.js:39:5 {
  code: 'slack_bolt_unknown_error',
  original: TypeError: Cannot destructure property 'resultPaths' of '(intermediate value)' as it is undefined.
      at BoltService.showEphemeralSearchResults (/workspace/growi/src/server/service/bolt.js:206:7)
      at processTicksAndRejections (internal/process/task_queues.js:93:5)
      at async /workspace/growi/src/server/service/bolt.js:86:11
      at async Array.<anonymous> (/workspace/growi/node_modules/@slack/bolt/dist/middleware/builtin.js:209:9)
      at async Array.onlyCommands (/workspace/growi/node_modules/@slack/bolt/dist/middleware/builtin.js:43:5)
}
```

【After】

<img width="786" alt="Screen Shot 2021-03-26 at 12 47 58" src="https://user-images.githubusercontent.com/66785624/112574725-3bef9c80-8e32-11eb-8570-0b582a2d8b14.png">
