### PR TITLE
Imprv/5467 move legacy contents to notification

### DIFF
--- a/src/client/js/admin.jsx
+++ b/src/client/js/admin.jsx
@@ -10,6 +10,7 @@ import ErrorBoundary from './components/ErrorBoudary';
 import AdminHome from './components/Admin/AdminHome/AdminHome';
 import UserGroupDetailPage from './components/Admin/UserGroupDetail/UserGroupDetailPage';
 import NotificationSetting from './components/Admin/Notification/NotificationSetting';
+import SlackIntegrationNotificationSetting from './components/Admin/Notification/SlackIntegrationNotificationSetting'
 import SlackIntegration from './components/Admin/SlackIntegration/SlackIntegration';
 import ManageGlobalNotification from './components/Admin/Notification/ManageGlobalNotification';
 import MarkdownSetting from './components/Admin/MarkdownSetting/MarkDownSetting';
@@ -64,6 +65,7 @@ const adminCustomizeContainer = new AdminCustomizeContainer(appContainer);
 const adminUsersContainer = new AdminUsersContainer(appContainer);
 const adminExternalAccountsContainer = new AdminExternalAccountsContainer(appContainer);
 const adminNotificationContainer = new AdminNotificationContainer(appContainer);
+const adminSlackIntegrationNotificationSetting = new AdminNotificationContainer(appContainer)
 const adminMarkDownContainer = new AdminMarkDownContainer(appContainer);
 const adminUserGroupDetailContainer = new AdminUserGroupDetailContainer(appContainer);
 const injectableContainers = [
@@ -98,6 +100,7 @@ Object.assign(componentMappings, {
   'admin-export-page': <ExportArchiveDataPage />,
   'admin-notification-setting': <NotificationSetting />,
   'admin-slack-integration': <SlackIntegration />,
+  'admin-slack-integration-notification-setting': <SlackIntegrationNotificationSetting />,
   'admin-global-notification-setting': <ManageGlobalNotification />,
   'admin-user-page': <UserManagement />,
   'admin-external-account-setting': <ManageExternalAccount />,

--- a/src/client/js/admin.jsx
+++ b/src/client/js/admin.jsx
@@ -10,7 +10,7 @@ import ErrorBoundary from './components/ErrorBoudary';
 import AdminHome from './components/Admin/AdminHome/AdminHome';
 import UserGroupDetailPage from './components/Admin/UserGroupDetail/UserGroupDetailPage';
 import NotificationSetting from './components/Admin/Notification/NotificationSetting';
-import SlackIntegrationNotificationSetting from './components/Admin/Notification/SlackIntegrationNotificationSetting'
+import SlackIntegrationNotificationSetting from './components/Admin/Notification/SlackIntegrationNotificationSetting';
 import SlackIntegration from './components/Admin/SlackIntegration/SlackIntegration';
 import ManageGlobalNotification from './components/Admin/Notification/ManageGlobalNotification';
 import MarkdownSetting from './components/Admin/MarkdownSetting/MarkDownSetting';
@@ -65,7 +65,6 @@ const adminCustomizeContainer = new AdminCustomizeContainer(appContainer);
 const adminUsersContainer = new AdminUsersContainer(appContainer);
 const adminExternalAccountsContainer = new AdminExternalAccountsContainer(appContainer);
 const adminNotificationContainer = new AdminNotificationContainer(appContainer);
-const adminSlackIntegrationNotificationSetting = new AdminNotificationContainer(appContainer)
 const adminMarkDownContainer = new AdminMarkDownContainer(appContainer);
 const adminUserGroupDetailContainer = new AdminUserGroupDetailContainer(appContainer);
 const injectableContainers = [

--- a/src/client/js/components/Admin/Notification/NotificationSetting.jsx
+++ b/src/client/js/components/Admin/Notification/NotificationSetting.jsx
@@ -13,7 +13,6 @@ import AdminNotificationContainer from '../../../services/AdminNotificationConta
 
 import { CustomNavTab } from '../../CustomNavigation/CustomNav';
 
-import SlackAppConfiguration from './SlackAppConfiguration';
 import UserTriggerNotification from './UserTriggerNotification';
 import GlobalNotification from './GlobalNotification';
 
@@ -23,8 +22,8 @@ let retrieveErrors = null;
 function NotificationSetting(props) {
   const { adminNotificationContainer } = props;
 
-  const [activeTab, setActiveTab] = useState('slack_configuration');
-  const [activeComponents, setActiveComponents] = useState(new Set(['slack_configuration']));
+  const [activeTab, setActiveTab] = useState('user_trigger_notification');
+  const [activeComponents, setActiveComponents] = useState(new Set(['user_trigger_notification']));
 
   const switchActiveTab = (selectedTab) => {
     setActiveTab(selectedTab);
@@ -52,20 +51,15 @@ function NotificationSetting(props) {
 
   const navTabMapping = useMemo(() => {
     return {
-      slack_configuration: {
-        Icon: () => <i className="icon-settings" />,
-        i18n: 'Slack configuration',
-        index: 0,
-      },
       user_trigger_notification: {
         Icon: () => <i className="icon-settings" />,
         i18n: 'User trigger notification',
-        index: 1,
+        index: 0,
       },
       global_notification: {
         Icon: () => <i className="icon-settings" />,
         i18n: 'Global notification',
-        index: 2,
+        index: 1,
       },
     };
   }, []);
@@ -75,9 +69,6 @@ function NotificationSetting(props) {
       <CustomNavTab activeTab={activeTab} navTabMapping={navTabMapping} onNavSelected={switchActiveTab} hideBorderBottom />
 
       <TabContent activeTab={activeTab} className="p-5">
-        <TabPane tabId="slack_configuration">
-          {activeComponents.has('slack_configuration') && <SlackAppConfiguration />}
-        </TabPane>
         <TabPane tabId="user_trigger_notification">
           {activeComponents.has('user_trigger_notification') && <UserTriggerNotification />}
         </TabPane>

--- a/src/client/js/components/Admin/Notification/SlackIntegrationNotificationSetting.jsx
+++ b/src/client/js/components/Admin/Notification/SlackIntegrationNotificationSetting.jsx
@@ -54,7 +54,7 @@ function NotificationSetting(props) {
         Icon: () => <i className="icon-settings" />,
         i18n: 'Slack configuration',
         index: 0,
-      }
+      },
     };
   }, []);
 

--- a/src/client/js/components/Admin/Notification/SlackIntegrationNotificationSetting.jsx
+++ b/src/client/js/components/Admin/Notification/SlackIntegrationNotificationSetting.jsx
@@ -1,0 +1,82 @@
+import React, { useMemo, useState } from 'react';
+import PropTypes from 'prop-types';
+
+import loggerFactory from '@alias/logger';
+
+import { TabContent, TabPane } from 'reactstrap';
+import { withUnstatedContainers } from '../../UnstatedUtils';
+import { toastError } from '../../../util/apiNotification';
+import toArrayIfNot from '../../../../../lib/util/toArrayIfNot';
+import { withLoadingSppiner } from '../../SuspenseUtils';
+
+import AdminNotificationContainer from '../../../services/AdminNotificationContainer';
+
+import { CustomNavTab } from '../../CustomNavigation/CustomNav';
+
+import SlackAppConfiguration from './SlackAppConfiguration';
+
+const logger = loggerFactory('growi:NotificationSetting');
+
+let retrieveErrors = null;
+function NotificationSetting(props) {
+  const { adminNotificationContainer } = props;
+
+  const [activeTab, setActiveTab] = useState('slack_configuration');
+  const [activeComponents, setActiveComponents] = useState(new Set(['slack_configuration']));
+
+  const switchActiveTab = (selectedTab) => {
+    setActiveTab(selectedTab);
+    setActiveComponents(activeComponents.add(selectedTab));
+  };
+
+
+
+  if (adminNotificationContainer.state.webhookUrl === adminNotificationContainer.dummyWebhookUrl) {
+    throw (async() => {
+      try {
+        await adminNotificationContainer.retrieveNotificationData();
+      }
+      catch (err) {
+        const errs = toArrayIfNot(err);
+        toastError(errs);
+        logger.error(errs);
+        retrieveErrors = errs;
+        adminNotificationContainer.setState({ webhookUrl: adminNotificationContainer.dummyWebhookUrlForError });
+      }
+    })();
+  }
+
+  if (adminNotificationContainer.state.webhookUrl === adminNotificationContainer.dummyWebhookUrlForError) {
+    throw new Error(`${retrieveErrors.length} errors occured`);
+  }
+
+  const navTabMapping = useMemo(() => {
+    return {
+      slack_configuration: {
+        Icon: () => <i className="icon-settings" />,
+        i18n: 'Slack configuration',
+        index: 0,
+      }
+    };
+  }, []);
+
+  return (
+    <>
+      <CustomNavTab activeTab={activeTab} navTabMapping={navTabMapping} onNavSelected={switchActiveTab} hideBorderBottom />
+
+      <TabContent activeTab={activeTab} className="p-5">
+        <TabPane tabId="slack_configuration">
+          {activeComponents.has('slack_configuration') && <SlackAppConfiguration />}
+        </TabPane>
+      </TabContent>
+    </>
+  );
+}
+
+const NotificationSettingWithUnstatedContainer = withUnstatedContainers(withLoadingSppiner(NotificationSetting), [AdminNotificationContainer]);
+
+NotificationSetting.propTypes = {
+  adminNotificationContainer: PropTypes.instanceOf(AdminNotificationContainer).isRequired,
+};
+
+export default NotificationSettingWithUnstatedContainer;

--- a/src/client/js/components/Admin/Notification/SlackIntegrationNotificationSetting.jsx
+++ b/src/client/js/components/Admin/Notification/SlackIntegrationNotificationSetting.jsx
@@ -29,8 +29,6 @@ function NotificationSetting(props) {
     setActiveComponents(activeComponents.add(selectedTab));
   };
 
-
-
   if (adminNotificationContainer.state.webhookUrl === adminNotificationContainer.dummyWebhookUrl) {
     throw (async() => {
       try {

--- a/src/server/views/admin/legacy-slack-integration.html
+++ b/src/server/views/admin/legacy-slack-integration.html
@@ -7,6 +7,6 @@
 {% endblock %}
 
 {% block content_main %}
-<!-- TODO: move contents from notification settings by GW-5467  -->
+<div id="admin-notification-setting" class="admin-notification-setting"></div>
 {% endblock content_main %}
 

--- a/src/server/views/admin/legacy-slack-integration.html
+++ b/src/server/views/admin/legacy-slack-integration.html
@@ -7,6 +7,6 @@
 {% endblock %}
 
 {% block content_main %}
-<div id="admin-notification-setting" class="admin-notification-setting"></div>
+<div id="admin-slack-integration-notification-setting" class="admin-slack-integration-notification-setting"></div>
 {% endblock content_main %}
 


### PR DESCRIPTION
GW-5467 [通知]レガシーにコンテンツを移動させる

【Before】
<img width="1414" alt="スクリーンショット 2021-03-29 17 34 59" src="https://user-images.githubusercontent.com/34241526/112809735-466d9880-90b5-11eb-8da8-f1a3e33f03ab.png">

<img width="1410" alt="スクリーンショット 2021-03-29 17 37 37" src="https://user-images.githubusercontent.com/34241526/112809884-79b02780-90b5-11eb-8574-981b6972272a.png">

【After】
<img width="1422" alt="スクリーンショット 2021-03-29 16 28 19" src="https://user-images.githubusercontent.com/34241526/112801413-d3135900-90ab-11eb-93f1-6dbf58f289b5.png">

<img width="1417" alt="スクリーンショット 2021-03-29 13 32 07" src="https://user-images.githubusercontent.com/34241526/112787580-cbe05100-9093-11eb-9fd5-0e1420ab55fa.png">
