### PR TITLE
Changed slack icon

### DIFF
--- a/src/client/js/components/Admin/Common/AdminNavigation.jsx
+++ b/src/client/js/components/Admin/Common/AdminNavigation.jsx
@@ -21,8 +21,8 @@ const AdminNavigation = (props) => {
       case 'importer':                 return <><i className="icon-fw icon-cloud-upload"></i>    { t('Import Data') }</>;
       case 'export':                   return <><i className="icon-fw icon-cloud-download"></i>  { t('Export Archive Data') }</>;
       case 'notification':             return <><i className="icon-fw icon-bell"></i>            { t('External_Notification')}</>;
-      case 'legacy-slack-integration': return <><i className="fa fa-slack"></i>                  { t('Legacy_Slack_Integration')}</>;
-      case 'slack-integration':        return <><i className="fa fa-slack"></i>                  { t('slack_integration') }</>;
+      case 'legacy-slack-integration': return <><i className="fa fa-slack mr-2"></i>             { t('Legacy_Slack_Integration')}</>;
+      case 'slack-integration':        return <><i className="fa fa-slack mr-2"></i>             { t('slack_integration') }</>;
       case 'users':                    return <><i className="icon-fw icon-user"></i>            { t('User_Management') }</>;
       case 'user-groups':              return <><i className="icon-fw icon-people"></i>          { t('UserGroup Management') }</>;
       case 'search':                   return <><i className="icon-fw icon-magnifier"></i>       { t('Full Text Search Management') }</>;

--- a/src/client/js/components/Admin/Common/AdminNavigation.jsx
+++ b/src/client/js/components/Admin/Common/AdminNavigation.jsx
@@ -14,20 +14,19 @@ const AdminNavigation = (props) => {
   // eslint-disable-next-line react/prop-types
   const MenuLabel = ({ menu }) => {
     switch (menu) {
-      case 'app':               return <><i className="icon-fw icon-settings"></i>        { t('App Settings') }</>;
-      case 'security':          return <><i className="icon-fw icon-shield"></i>          { t('security_settings') }</>;
-      case 'markdown':          return <><i className="icon-fw icon-note"></i>            { t('Markdown Settings') }</>;
-      case 'customize':         return <><i className="icon-fw icon-wrench"></i>          { t('Customize') }</>;
-      case 'importer':          return <><i className="icon-fw icon-cloud-upload"></i>    { t('Import Data') }</>;
-      case 'export':            return <><i className="icon-fw icon-cloud-download"></i>  { t('Export Archive Data') }</>;
-      case 'notification':      return <><i className="icon-fw icon-bell"></i>            { t('External_Notification') }</>;
-      // TODO change icon for legacy-slack-integration by GW-5466
-      case 'legacy-slack-integration':  return <> <i className="icon-fw icon-paper-plane"></i>    { t('Legacy_Slack_Integration') }</>;
-      case 'slack-integration': return <><i className="icon-fw icon-paper-plane"></i>     { t('slack_integration') }</>;
-      case 'users':             return <><i className="icon-fw icon-user"></i>            { t('User_Management') }</>;
-      case 'user-groups':       return <><i className="icon-fw icon-people"></i>          { t('UserGroup Management') }</>;
-      case 'search':            return <><i className="icon-fw icon-magnifier"></i>       { t('Full Text Search Management') }</>;
-      default:                  return <><i className="icon-fw icon-home"></i>            { t('Wiki Management Home Page') }</>;
+      case 'app':                      return <><i className="icon-fw icon-settings"></i>        { t('App Settings') }</>;
+      case 'security':                 return <><i className="icon-fw icon-shield"></i>          { t('security_settings') }</>;
+      case 'markdown':                 return <><i className="icon-fw icon-note"></i>            { t('Markdown Settings') }</>;
+      case 'customize':                return <><i className="icon-fw icon-wrench"></i>          { t('Customize') }</>;
+      case 'importer':                 return <><i className="icon-fw icon-cloud-upload"></i>    { t('Import Data') }</>;
+      case 'export':                   return <><i className="icon-fw icon-cloud-download"></i>  { t('Export Archive Data') }</>;
+      case 'notification':             return <><i className="icon-fw icon-bell"></i>            { t('External_Notification')}</>;
+      case 'legacy-slack-integration': return <><i className="fa fa-slack"></i>                  { t('Legacy_Slack_Integration')}</>;
+      case 'slack-integration':        return <><i className="fa fa-slack"></i>                  { t('slack_integration') }</>;
+      case 'users':                    return <><i className="icon-fw icon-user"></i>            { t('User_Management') }</>;
+      case 'user-groups':              return <><i className="icon-fw icon-people"></i>          { t('UserGroup Management') }</>;
+      case 'search':                   return <><i className="icon-fw icon-magnifier"></i>       { t('Full Text Search Management') }</>;
+      default:                         return <><i className="icon-fw icon-home"></i>            { t('Wiki Management Home Page') }</>;
     }
   };
 


### PR DESCRIPTION
Slack連携のアイコンを紙飛行機からSlackのアイコンに変えました。

Before
<img width="375" alt="Screen Shot 2021-03-29 at 18 09 18" src="https://user-images.githubusercontent.com/66785624/112814259-11b01000-90ba-11eb-859f-4e49a1da3df0.png">

After
<img width="370" alt="Screen Shot 2021-03-29 at 18 05 08" src="https://user-images.githubusercontent.com/66785624/112813881-a8300180-90b9-11eb-9294-7a54cfad79c3.png">