### PR TITLE
Feat/5512 radio button and modal

### DIFF
--- a/resource/locales/en_US/admin/admin.json
+++ b/resource/locales/en_US/admin/admin.json
@@ -253,6 +253,13 @@
     "delete": "Delete"
   },
   "slack_integration": {
+    "modal": {
+      "warning": "Warning",
+      "sure_change_bot_type": "Are you sure you want to change the bot type?",
+      "changes_will_be_deleted": "Settings for other bot types will be deleted.",
+      "cancel": "Cancel",
+      "change": "Change"
+    },
     "access_token_settings": {
       "discard": "Discard",
       "generate": "Generate"

--- a/resource/locales/en_US/admin/admin.json
+++ b/resource/locales/en_US/admin/admin.json
@@ -264,7 +264,7 @@
       "discard": "Discard",
       "generate": "Generate"
     },
-    "custom_bot_non_proxy_settings": "Custom bot (non-proxy) Settings",
+    "custom_bot_without_proxy_settings": "Custom Bot (Without-Proxy) Settings",
     "non_proxy": {
       "create_bot": "Create Bot"
     }

--- a/resource/locales/ja_JP/admin/admin.json
+++ b/resource/locales/ja_JP/admin/admin.json
@@ -262,7 +262,7 @@
       "discard": "破棄",
       "generate": "発行"
     },
-    "custom_bot_non_proxy_settings": "Custom bot (non-proxy) 設定",
+    "custom_bot_without_proxy_settings": "Custom Bot (Without Proxy) 設定",
     "non_proxy": {
       "create_bot": "Bot を作成する"
     }

--- a/resource/locales/ja_JP/admin/admin.json
+++ b/resource/locales/ja_JP/admin/admin.json
@@ -262,7 +262,7 @@
       "discard": "破棄",
       "generate": "発行"
     },
-    "custom_bot_without_proxy_settings": "Custom Bot (Without Proxy) 設定",
+    "custom_bot_without_proxy_settings": "Custom Bot (Without-Proxy) 設定",
     "without_proxy": {
       "create_bot": "Bot を作成する"
     }

--- a/resource/locales/ja_JP/admin/admin.json
+++ b/resource/locales/ja_JP/admin/admin.json
@@ -256,7 +256,7 @@
       "sure_change_bot_type": "Botの種類を変更しますか?",
       "changes_will_be_deleted": "他のBotの設定が消去されます。",
       "cancel": "取消",
-      "change": "変更する"
+      "change": "変更する",
     "use_env_var_if_empty": "データベース側の値が空の場合、環境変数 <code>{{variable}}</code> の値を利用します",
     "access_token_settings": {
       "discard": "破棄",

--- a/resource/locales/ja_JP/admin/admin.json
+++ b/resource/locales/ja_JP/admin/admin.json
@@ -256,7 +256,8 @@
       "sure_change_bot_type": "Botの種類を変更しますか?",
       "changes_will_be_deleted": "他のBotの設定が消去されます。",
       "cancel": "取消",
-      "change": "変更する",
+      "change": "変更する"
+    },
     "use_env_var_if_empty": "データベース側の値が空の場合、環境変数 <code>{{variable}}</code> の値を利用します",
     "access_token_settings": {
       "discard": "破棄",

--- a/resource/locales/ja_JP/admin/admin.json
+++ b/resource/locales/ja_JP/admin/admin.json
@@ -251,6 +251,13 @@
     "Directory_hierarchy_tag": "ディレクトリ階層タグ"
   },
   "slack_integration": {
+    "modal": {
+      "warning": "注意",
+      "sure_change_bot_type": "Botの種類を変更しますか?",
+      "changes_will_be_deleted": "他のBotの設定が消去されます。",
+      "cancel": "取消",
+      "change": "変更する"
+    },
     "access_token_settings": {
       "discard": "破棄",
       "generate": "発行"

--- a/resource/locales/zh_CN/admin/admin.json
+++ b/resource/locales/zh_CN/admin/admin.json
@@ -261,6 +261,13 @@
 		"delete": "删除"
   },
   "slack_integration": {
+    "modal": {
+      "warning": "警告",
+      "sure_change_bot_type": "您确定要更改设置吗？",
+      "changes_will_be_deleted": "其他Bot类型的设置将被删除。",
+      "cancel": "取消",
+      "change": "改变"
+    },
     "access_token_settings": {
       "discard": "丢弃",
       "generate": "生成"

--- a/resource/locales/zh_CN/admin/admin.json
+++ b/resource/locales/zh_CN/admin/admin.json
@@ -192,7 +192,7 @@
 			"upload": "Upload",
 			"discard": "Discard uploaded data",
 			"errors": {
-        "versions_not_met": "this growi and the uploarded data versions are not met",
+        "versions_not_met": "this growi and the uploaded data versions are not met",
 				"at_least_one": "Select one or more collections.",
 				"page_and_revision": "'Pages' and 'Revisions' must be imported both.",
 				"depends": "'{{target}}' must be selected when '{{condition}}' is selected."

--- a/resource/locales/zh_CN/admin/admin.json
+++ b/resource/locales/zh_CN/admin/admin.json
@@ -272,7 +272,7 @@
       "discard": "丢弃",
       "generate": "生成"
     },
-    "custom_bot_non_proxy_settings": "Custom bot (non-proxy) 设置",
+    "custom_bot_without_proxy_settings": "Custom Bot (Without-Proxy) 设置",
     "non_proxy": {
       "create_bot": "创建 Bot"
     }

--- a/src/client/js/components/Admin/SlackIntegration/ConfirmBotChangeModal.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/ConfirmBotChangeModal.jsx
@@ -1,5 +1,5 @@
 import React, { useRef, useEffect } from 'react';
-
+import PropTypes from 'prop-types';
 
 const ConfirmBotChangeModal = ({ show, onButtonClick }) => {
   const dialog = useRef({});
@@ -44,6 +44,11 @@ const ConfirmBotChangeModal = ({ show, onButtonClick }) => {
       </div>
     </div>
   );
+};
+
+ConfirmBotChangeModal.propTypes = {
+  show: PropTypes.bool.isRequired,
+  onButtonClick: PropTypes.func.isRequired,
 };
 
 export default ConfirmBotChangeModal;

--- a/src/client/js/components/Admin/SlackIntegration/ConfirmBotChangeModal.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/ConfirmBotChangeModal.jsx
@@ -5,12 +5,27 @@ import {
   Modal, ModalHeader, ModalBody, ModalFooter,
 } from 'reactstrap';
 
-const ConfirmBotChangeModal = ({ show, onConfirmClick, onCancelClick }) => {
+const ConfirmBotChangeModal = (props) => {
   const { t } = useTranslation('admin');
+  let isOpen = false;
+  let onConfirmClick = null;
+  let onCancelClick = null;
+
+  if (props.isOpen != null) {
+    isOpen = props.isOpen;
+  }
+
+  if (props.onConfirmClick != null) {
+    onConfirmClick = props.onConfirmClick;
+  }
+
+  if (props.onCancelClick != null) {
+    onCancelClick = props.onCancelClick;
+  }
 
   return (
     <>
-      <Modal isOpen={show} centered>
+      <Modal isOpen={isOpen} centered>
         <ModalHeader toggle={onCancelClick}>
           {t('slack_integration.modal.warning')}
         </ModalHeader>
@@ -36,9 +51,9 @@ const ConfirmBotChangeModal = ({ show, onConfirmClick, onCancelClick }) => {
 };
 
 ConfirmBotChangeModal.propTypes = {
-  show: PropTypes.bool.isRequired,
-  onConfirmClick: PropTypes.func.isRequired,
-  onCancelClick: PropTypes.func.isRequired,
+  isOpen: PropTypes.bool,
+  onConfirmClick: PropTypes.func,
+  onCancelClick: PropTypes.func,
 };
 
 export default ConfirmBotChangeModal;

--- a/src/client/js/components/Admin/SlackIntegration/ConfirmBotChangeModal.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/ConfirmBotChangeModal.jsx
@@ -7,25 +7,22 @@ import {
 
 const ConfirmBotChangeModal = (props) => {
   const { t } = useTranslation('admin');
-  let isOpen = false;
-  let onConfirmClick = null;
-  let onCancelClick = null;
 
-  if (props.isOpen != null) {
-    isOpen = props.isOpen;
+  const handleCancelButton = () => {
+    if (props.onCancelClick != null) {
+      props.onCancelClick();
+    }
   }
 
-  if (props.onConfirmClick != null) {
-    onConfirmClick = props.onConfirmClick;
-  }
-
-  if (props.onCancelClick != null) {
-    onCancelClick = props.onCancelClick;
+  const handleChangeButton = () => {
+    if (props.onConfirmClick != null) {
+      props.onConfirmClick();
+    }
   }
 
   return (
-    <Modal isOpen={isOpen} centered>
-      <ModalHeader toggle={onCancelClick}>
+    <Modal isOpen={props.isOpen} centered>
+      <ModalHeader toggle={handleCancelButton}>
         {t('slack_integration.modal.warning')}
       </ModalHeader>
       <ModalBody>
@@ -37,10 +34,10 @@ const ConfirmBotChangeModal = (props) => {
         </div>
       </ModalBody>
       <ModalFooter>
-        <button type="button" className="btn btn-secondary" onClick={onCancelClick}>
+        <button type="button" className="btn btn-secondary" onClick={handleCancelButton}>
           {t('slack_integration.modal.cancel')}
         </button>
-        <button type="button" className="btn btn-primary" onClick={onConfirmClick}>
+        <button type="button" className="btn btn-primary" onClick={handleChangeButton}>
           {t('slack_integration.modal.change')}
         </button>
       </ModalFooter>

--- a/src/client/js/components/Admin/SlackIntegration/ConfirmBotChangeModal.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/ConfirmBotChangeModal.jsx
@@ -1,56 +1,44 @@
-import React, { useRef, useEffect } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
+import {
+  Button, Modal, ModalHeader, ModalBody, ModalFooter,
+} from 'reactstrap';
 
-const ConfirmBotChangeModal = ({ show, onButtonClick }) => {
+const ConfirmBotChangeModal = ({ show, onConfirmClick, onCancelClick }) => {
   const { t } = useTranslation('admin');
-  const dialog = useRef({});
-  useEffect(() => {
-    $(dialog.current).modal(show ? 'show' : 'hide');
-  }, [show]);
-  useEffect(() => {
-    $(dialog.current).on('hide.bs.modal', () => onButtonClick('close'));
-  }, [onButtonClick]);
 
   return (
-    <div className="modal fade" ref={dialog} id="modalDialog" tabIndex="-1" role="dialog" aria-labelledby="modalDialogLabel" aria-hidden="true">
-      <div className="modal-dialog modal-dialog-centered" role="document">
-        <div className="modal-content">
-          <div className="modal-header">
-            <h5 className="modal-title" id="modalDialogLabel">
-              {t('slack_integration.modal.warning')}
-            </h5>
-            <button type="button" className="close" aria-label="Close" onClick={() => onButtonClick('close')}>
-              <span aria-hidden="true">&times;</span>
-            </button>
+    <>
+      <Modal isOpen={show} centered>
+        <ModalHeader toggle={onCancelClick}>
+          {t('slack_integration.modal.warning')}
+        </ModalHeader>
+        <ModalBody>
+          <div>
+            <h4>{t('slack_integration.modal.sure_change_bot_type')}</h4>
           </div>
-
-          <div className="modal-body">
-            <div>
-              <h4>{t('slack_integration.modal.sure_change_bot_type')}</h4>
-            </div>
-            <div>
-              <p>{t('slack_integration.modal.changes_will_be_deleted')}</p>
-            </div>
+          <div>
+            <p>{t('slack_integration.modal.changes_will_be_deleted')}</p>
           </div>
-
-          <div className="modal-footer">
-            <button type="button" className="btn btn-secondary" onClick={() => onButtonClick('close')}>
-              {t('slack_integration.modal.cancel')}
-            </button>
-            <button type="button" className="btn btn-primary" onClick={() => onButtonClick('change')}>
-              {t('slack_integration.modal.change')}
-            </button>
-          </div>
-        </div>
-      </div>
-    </div>
+        </ModalBody>
+        <ModalFooter>
+          <Button color="secondary" onClick={onCancelClick}>
+            {t('slack_integration.modal.cancel')}
+          </Button>
+          <Button color="primary" onClick={onConfirmClick}>
+            {t('slack_integration.modal.change')}
+          </Button>
+        </ModalFooter>
+      </Modal>
+    </>
   );
 };
 
 ConfirmBotChangeModal.propTypes = {
   show: PropTypes.bool.isRequired,
-  onButtonClick: PropTypes.func.isRequired,
+  onConfirmClick: PropTypes.func.isRequired,
+  onCancelClick: PropTypes.func.isRequired,
 };
 
 export default ConfirmBotChangeModal;

--- a/src/client/js/components/Admin/SlackIntegration/ConfirmBotChangeModal.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/ConfirmBotChangeModal.jsx
@@ -1,9 +1,9 @@
 import React, { useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
-// import { useTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 
 const ConfirmBotChangeModal = ({ show, onButtonClick }) => {
-  // const { t } = useTranslation();
+  const { t } = useTranslation('admin');
   const dialog = useRef({});
   useEffect(() => {
     $(dialog.current).modal(show ? 'show' : 'hide');
@@ -18,7 +18,7 @@ const ConfirmBotChangeModal = ({ show, onButtonClick }) => {
         <div className="modal-content">
           <div className="modal-header">
             <h5 className="modal-title" id="modalDialogLabel">
-              Warning
+              {t('slack_integration.modal.warning')}
             </h5>
             <button type="button" className="close" aria-label="Close" onClick={() => onButtonClick('close')}>
               <span aria-hidden="true">&times;</span>
@@ -27,19 +27,19 @@ const ConfirmBotChangeModal = ({ show, onButtonClick }) => {
 
           <div className="modal-body">
             <div>
-              <h4>Are you sure you want to change the bot type?</h4>
+              <h4>{t('slack_integration.modal.sure_change_bot_type')}</h4>
             </div>
             <div>
-              <p>Settings from other bots will be deleted.</p>
+              <p>{t('slack_integration.modal.changes_will_be_deleted')}</p>
             </div>
           </div>
 
           <div className="modal-footer">
             <button type="button" className="btn btn-secondary" onClick={() => onButtonClick('close')}>
-              Cancel
+              {t('slack_integration.modal.cancel')}
             </button>
             <button type="button" className="btn btn-primary" onClick={() => onButtonClick('change')}>
-              Change
+              {t('slack_integration.modal.change')}
             </button>
           </div>
         </div>

--- a/src/client/js/components/Admin/SlackIntegration/ConfirmBotChangeModal.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/ConfirmBotChangeModal.jsx
@@ -49,7 +49,7 @@ const ConfirmBotChangeModal = (props) => {
 };
 
 ConfirmBotChangeModal.propTypes = {
-  isOpen: PropTypes.bool,
+  isOpen: PropTypes.bool.isRequired,
   onConfirmClick: PropTypes.func,
   onCancelClick: PropTypes.func,
 };

--- a/src/client/js/components/Admin/SlackIntegration/ConfirmBotChangeModal.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/ConfirmBotChangeModal.jsx
@@ -1,50 +1,42 @@
 import React, { useRef, useEffect } from 'react';
 
-const ConfirmBotChangeModal = ({ show, onButtonClick }) => {
 
+const ConfirmBotChangeModal = ({ show, onButtonClick }) => {
   const dialog = useRef({});
-  useEffect(() => { $(dialog.current).modal(show ? 'show' : 'hide') }, [show]);
-  useEffect(() => { $(dialog.current).on('hide.bs.modal', () => onButtonClick('close')) }, []);
+  useEffect(() => {
+    $(dialog.current).modal(show ? 'show' : 'hide');
+  }, [show]);
+  useEffect(() => {
+    $(dialog.current).on('hide.bs.modal', () => onButtonClick('close'));
+  }, [onButtonClick]);
 
   return (
-    <div
-      className="modal fade"
-      ref={dialog}
-      id="modalDialog"
-      tabIndex="-1"
-      role="dialog"
-      aria-labelledby="modalDialogLabel"
-      aria-hidden="true"
-    >
-      <div className="modal-dialog" role="document">
+    <div className="modal fade" ref={dialog} id="modalDialog" tabIndex="-1" role="dialog" aria-labelledby="modalDialogLabel" aria-hidden="true">
+      <div className="modal-dialog modal-dialog-centered" role="document">
         <div className="modal-content">
           <div className="modal-header">
-            <h5 className="modal-title" id="modalDialogLabel">TITLE</h5>
-            <button
-              type="button"
-              className="close"
-              aria-label="Close"
-              onClick={() => onButtonClick('close')}
-          >
+            <h5 className="modal-title" id="modalDialogLabel">
+              Warning
+            </h5>
+            <button type="button" className="close" aria-label="Close" onClick={() => onButtonClick('close')}>
               <span aria-hidden="true">&times;</span>
             </button>
           </div>
+
           <div className="modal-body">
-            <h1>asdfasdfasdfasdf</h1>
+            <div>
+              <h4>Are you sure you want to change the bot type?</h4>
+            </div>
+            <div>
+              <p>Settings from other bots will be deleted.</p>
+            </div>
           </div>
+
           <div className="modal-footer">
-            <button
-              type="button"
-              className="btn btn-secondary"
-              onClick={() => onButtonClick('close')}
-            >
+            <button type="button" className="btn btn-secondary" onClick={() => onButtonClick('close')}>
               Close
             </button>
-            <button
-              type="button"
-              className="btn btn-primary"
-              onClick={() => onButtonClick('save')}
-            >
+            <button type="button" className="btn btn-primary" onClick={() => onButtonClick('save')}>
               Save
             </button>
           </div>

--- a/src/client/js/components/Admin/SlackIntegration/ConfirmBotChangeModal.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/ConfirmBotChangeModal.jsx
@@ -1,7 +1,9 @@
 import React, { useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
+// import { useTranslation } from 'react-i18next';
 
 const ConfirmBotChangeModal = ({ show, onButtonClick }) => {
+  // const { t } = useTranslation();
   const dialog = useRef({});
   useEffect(() => {
     $(dialog.current).modal(show ? 'show' : 'hide');

--- a/src/client/js/components/Admin/SlackIntegration/ConfirmBotChangeModal.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/ConfirmBotChangeModal.jsx
@@ -24,29 +24,27 @@ const ConfirmBotChangeModal = (props) => {
   }
 
   return (
-    <>
-      <Modal isOpen={isOpen} centered>
-        <ModalHeader toggle={onCancelClick}>
-          {t('slack_integration.modal.warning')}
-        </ModalHeader>
-        <ModalBody>
-          <div>
-            <h4>{t('slack_integration.modal.sure_change_bot_type')}</h4>
-          </div>
-          <div>
-            <p>{t('slack_integration.modal.changes_will_be_deleted')}</p>
-          </div>
-        </ModalBody>
-        <ModalFooter>
-          <button type="button" className="btn btn-secondary" onClick={onCancelClick}>
-            {t('slack_integration.modal.cancel')}
-          </button>
-          <button type="button" className="btn btn-primary" onClick={onConfirmClick}>
-            {t('slack_integration.modal.change')}
-          </button>
-        </ModalFooter>
-      </Modal>
-    </>
+    <Modal isOpen={isOpen} centered>
+      <ModalHeader toggle={onCancelClick}>
+        {t('slack_integration.modal.warning')}
+      </ModalHeader>
+      <ModalBody>
+        <div>
+          <h4>{t('slack_integration.modal.sure_change_bot_type')}</h4>
+        </div>
+        <div>
+          <p>{t('slack_integration.modal.changes_will_be_deleted')}</p>
+        </div>
+      </ModalBody>
+      <ModalFooter>
+        <button type="button" className="btn btn-secondary" onClick={onCancelClick}>
+          {t('slack_integration.modal.cancel')}
+        </button>
+        <button type="button" className="btn btn-primary" onClick={onConfirmClick}>
+          {t('slack_integration.modal.change')}
+        </button>
+      </ModalFooter>
+    </Modal>
   );
 };
 

--- a/src/client/js/components/Admin/SlackIntegration/ConfirmBotChangeModal.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/ConfirmBotChangeModal.jsx
@@ -12,13 +12,13 @@ const ConfirmBotChangeModal = (props) => {
     if (props.onCancelClick != null) {
       props.onCancelClick();
     }
-  }
+  };
 
   const handleChangeButton = () => {
     if (props.onConfirmClick != null) {
       props.onConfirmClick();
     }
-  }
+  };
 
   return (
     <Modal isOpen={props.isOpen} centered>

--- a/src/client/js/components/Admin/SlackIntegration/ConfirmBotChangeModal.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/ConfirmBotChangeModal.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
 import {
-  Button, Modal, ModalHeader, ModalBody, ModalFooter,
+  Modal, ModalHeader, ModalBody, ModalFooter,
 } from 'reactstrap';
 
 const ConfirmBotChangeModal = ({ show, onConfirmClick, onCancelClick }) => {
@@ -23,12 +23,12 @@ const ConfirmBotChangeModal = ({ show, onConfirmClick, onCancelClick }) => {
           </div>
         </ModalBody>
         <ModalFooter>
-          <Button color="secondary" onClick={onCancelClick}>
+          <button type="button" className="btn btn-secondary" onClick={onCancelClick}>
             {t('slack_integration.modal.cancel')}
-          </Button>
-          <Button color="primary" onClick={onConfirmClick}>
+          </button>
+          <button type="button" className="btn btn-primary" onClick={onConfirmClick}>
             {t('slack_integration.modal.change')}
-          </Button>
+          </button>
         </ModalFooter>
       </Modal>
     </>

--- a/src/client/js/components/Admin/SlackIntegration/ConfirmBotChangeModal.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/ConfirmBotChangeModal.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const ConfirmBotChangeModal = () => {
+  return(
+    <>
+      <h1>Hi</h1>
+    </>
+  )
+
+}
+
+export default ConfirmBotChangeModal;

--- a/src/client/js/components/Admin/SlackIntegration/ConfirmBotChangeModal.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/ConfirmBotChangeModal.jsx
@@ -1,12 +1,33 @@
 import React from 'react';
 
 const ConfirmBotChangeModal = () => {
-  return(
+  return (
     <>
-      <h1>Hi</h1>
-    </>
-  )
+      <button type="button" className="btn btn-primary" data-toggle="modal" data-target="#staticBackdrop">
+        Launch static backdrop modal
+      </button>
 
+      <div className="modal fade" id="staticBackdrop" data-backdrop="static" data-keyboard="false" tabIndex="-1" aria-labelledby="staticBackdropLabel" aria-hidden="true">
+        <div className="modal-dialog">
+          <div className="modal-content">
+            <div className="modal-header">
+              <h5 className="modal-title" id="staticBackdropLabel">Modal title</h5>
+              <button type="button" className="close" data-dismiss="modal" aria-label="Close">
+                <span aria-hidden="true">&times;</span>
+              </button>
+            </div>
+            <div className="modal-body">
+              ...
+            </div>
+            <div className="modal-footer">
+              <button type="button" className="btn btn-secondary" data-dismiss="modal">Close</button>
+              <button type="button" className="btn btn-primary">Understood</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
 }
 
 export default ConfirmBotChangeModal;

--- a/src/client/js/components/Admin/SlackIntegration/ConfirmBotChangeModal.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/ConfirmBotChangeModal.jsx
@@ -34,10 +34,10 @@ const ConfirmBotChangeModal = ({ show, onButtonClick }) => {
 
           <div className="modal-footer">
             <button type="button" className="btn btn-secondary" onClick={() => onButtonClick('close')}>
-              Close
+              Cancel
             </button>
-            <button type="button" className="btn btn-primary" onClick={() => onButtonClick('save')}>
-              Save
+            <button type="button" className="btn btn-primary" onClick={() => onButtonClick('change')}>
+              Change
             </button>
           </div>
         </div>

--- a/src/client/js/components/Admin/SlackIntegration/ConfirmBotChangeModal.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/ConfirmBotChangeModal.jsx
@@ -1,13 +1,57 @@
-import React from 'react';
+import React, { useRef, useEffect } from 'react';
 
-const ConfirmBotChangeModal = () => {
+const ConfirmBotChangeModal = ({ show, onButtonClick }) => {
+
+  const dialog = useRef({});
+  useEffect(() => { $(dialog.current).modal(show ? 'show' : 'hide') }, [show]);
+  useEffect(() => { $(dialog.current).on('hide.bs.modal', () => onButtonClick('close')) }, []);
+
   return (
-    <>
-      <div className="modal">
-        aa
+    <div
+      className="modal fade"
+      ref={dialog}
+      id="modalDialog"
+      tabIndex="-1"
+      role="dialog"
+      aria-labelledby="modalDialogLabel"
+      aria-hidden="true"
+    >
+      <div className="modal-dialog" role="document">
+        <div className="modal-content">
+          <div className="modal-header">
+            <h5 className="modal-title" id="modalDialogLabel">TITLE</h5>
+            <button
+              type="button"
+              className="close"
+              aria-label="Close"
+              onClick={() => onButtonClick('close')}
+          >
+              <span aria-hidden="true">&times;</span>
+            </button>
+          </div>
+          <div className="modal-body">
+            <h1>asdfasdfasdfasdf</h1>
+          </div>
+          <div className="modal-footer">
+            <button
+              type="button"
+              className="btn btn-secondary"
+              onClick={() => onButtonClick('close')}
+            >
+              Close
+            </button>
+            <button
+              type="button"
+              className="btn btn-primary"
+              onClick={() => onButtonClick('save')}
+            >
+              Save
+            </button>
+          </div>
+        </div>
       </div>
-    </>
+    </div>
   );
-}
+};
 
 export default ConfirmBotChangeModal;

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotNonProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotNonProxySettings.jsx
@@ -5,7 +5,6 @@ import { useTranslation } from 'react-i18next';
 import AdminUpdateButtonRow from '../Common/AdminUpdateButtonRow';
 
 function CustomBotNonProxySettings() {
-
   const { t } = useTranslation('admin');
   const [secret, setSecret] = useState('');
   const [token, setToken] = useState('');
@@ -15,39 +14,35 @@ function CustomBotNonProxySettings() {
   }
 
   return (
-    <>
-      <div className="row my-5">
-        <div className="mx-auto">
-          <button type="button" className="btn btn-primary text-nowrap mx-1" onClick={() => window.open('https://api.slack.com/apps', '_blank')}>
-            {t('slack_integration.non_proxy.create_bot')}
-          </button>
-        </div>
-      </div>
+    <div className="row">
+      <div className="col-lg-12">
+        <h2 className="admin-setting-header">{t('slack_integration.custom_bot_non_proxy_settings')}</h2>
 
-      <div className="form-group row">
-        <label className="text-left text-md-right col-md-3 col-form-label">Signing Secret</label>
-        <div className="col-md-6">
-          <input
-            className="form-control"
-            type="text"
-            onChange={e => setSecret(e.target.value)}
-          />
+        <div className="row my-5">
+          <div className="mx-auto">
+            <button type="button" className="btn btn-primary text-nowrap mx-1" onClick={() => window.open('https://api.slack.com/apps', '_blank')}>
+              {t('slack_integration.non_proxy.create_bot')}
+            </button>
+          </div>
         </div>
-      </div>
 
-      <div className="form-group row mb-5">
-        <label className="text-left text-md-right col-md-3 col-form-label">Bot User OAuth Token</label>
-        <div className="col-md-6">
-          <input
-            className="form-control"
-            type="text"
-            onChange={e => setToken(e.target.value)}
-          />
+        <div className="form-group row">
+          <label className="text-left text-md-right col-md-3 col-form-label">Signing Secret</label>
+          <div className="col-md-6">
+            <input className="form-control" type="text" onChange={e => setSecret(e.target.value)} />
+          </div>
         </div>
-      </div>
 
-      <AdminUpdateButtonRow onClick={updateHandler} disabled={false} />
-    </>
+        <div className="form-group row mb-5">
+          <label className="text-left text-md-right col-md-3 col-form-label">Bot User OAuth Token</label>
+          <div className="col-md-6">
+            <input className="form-control" type="text" onChange={e => setToken(e.target.value)} />
+          </div>
+        </div>
+
+        <AdminUpdateButtonRow onClick={updateHandler} disabled={false} />
+      </div>
+    </div>
   );
 }
 

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotNonProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotNonProxySettings.jsx
@@ -52,6 +52,7 @@ const CustomBotNonProxySettings = (props) => {
 
   return (
     <>
+      <h2 className="admin-setting-header">{t('admin:slack_integration.custom_bot_non_proxy_settings')}</h2>
       <div className="row my-5">
         <div className="mx-auto">
           <button
@@ -59,11 +60,11 @@ const CustomBotNonProxySettings = (props) => {
             className="btn btn-primary text-nowrap mx-1"
             onClick={() => window.open('https://api.slack.com/apps', '_blank')}
           >
-            {t('slack_integration.non_proxy.create_bot')}
+            {t('admin:slack_integration.non_proxy.create_bot')}
           </button>
         </div>
       </div>
-      
+
       <div className="form-group row">
         <label className="text-left text-md-right col-md-3 col-form-label">Signing Secret</label>
         <div className="col-md-6">

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const CustomBotWithProxySettings = () => {
+
+  return (
+    <div className="row my-5">
+      <h1>With Proxy Component</h1>
+    </div>
+  );
+}
+
+export default CustomBotWithProxySettings;

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -6,7 +6,7 @@ import { withUnstatedContainers } from '../../UnstatedUtils';
 import { toastSuccess, toastError } from '../../../util/apiNotification';
 import AdminUpdateButtonRow from '../Common/AdminUpdateButtonRow';
 
-const CustomBotNonProxySettings = (props) => {
+const CustomBotWithoutProxySettings = (props) => {
   const { appContainer } = props;
   const { t } = useTranslation();
 
@@ -43,7 +43,7 @@ const CustomBotNonProxySettings = (props) => {
         slackBotToken,
         botType,
       });
-      toastSuccess(t('toaster.update_successed', { target: t('admin:slack_integration.custom_bot_non_proxy_settings') }));
+      toastSuccess(t('toaster.update_successed', { target: t('admin:slack_integration.custom_bot_without_proxy_settings') }));
     }
     catch (err) {
       toastError(err);
@@ -52,7 +52,7 @@ const CustomBotNonProxySettings = (props) => {
 
   return (
     <>
-      <h2 className="admin-setting-header">{t('admin:slack_integration.custom_bot_non_proxy_settings')}</h2>
+      <h2 className="admin-setting-header">{t('admin:slack_integration.custom_bot_without_proxy_settings')}</h2>
       <div className="row my-5">
         <div className="mx-auto">
           <button
@@ -93,10 +93,10 @@ const CustomBotNonProxySettings = (props) => {
   );
 };
 
-const CustomBotNonProxySettingsWrapper = withUnstatedContainers(CustomBotNonProxySettings, [AppContainer]);
+const CustomBotWithoutProxySettingsWrapper = withUnstatedContainers(CustomBotWithoutProxySettings, [AppContainer]);
 
-CustomBotNonProxySettings.propTypes = {
+CustomBotWithoutProxySettings.propTypes = {
   appContainer: PropTypes.instanceOf(AppContainer).isRequired,
 };
 
-export default CustomBotNonProxySettingsWrapper;
+export default CustomBotWithoutProxySettingsWrapper;

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -59,7 +59,7 @@ const CustomBotWithoutProxySettings = (props) => {
             className="btn btn-primary text-nowrap mx-1"
             onClick={() => window.open('https://api.slack.com/apps', '_blank')}
           >
-            {t('slack_integration.without_proxy.create_bot')}
+            {t('admin:slack_integration.without_proxy.create_bot')}
           </button>
         </div>
       </div>

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -15,7 +15,6 @@ const CustomBotWithoutProxySettings = (props) => {
   const [slackSigningSecretEnv, setSlackSigningSecretEnv] = useState('');
   const [slackBotTokenEnv, setSlackBotTokenEnv] = useState('');
   const botType = 'non-proxy';
-
   const fetchData = useCallback(async() => {
     try {
       const res = await appContainer.apiv3.get('/slack-integration/');

--- a/src/client/js/components/Admin/SlackIntegration/OfficialBotSettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/OfficialBotSettings.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const OfficialBotSettings = () => {
+
+  return (
+    <div className="row my-5">
+      <h1>OfficialBotSettings Component</h1>
+    </div>
+  );
+}
+
+export default OfficialBotSettings;

--- a/src/client/js/components/Admin/SlackIntegration/OfficialBotSettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/OfficialBotSettings.jsx
@@ -4,9 +4,9 @@ const OfficialBotSettings = () => {
 
   return (
     <div className="row my-5">
-      <h1>OfficialBotSettings Component</h1>
+      <h1>Official Bot Settings Component</h1>
     </div>
   );
-}
+};
 
 export default OfficialBotSettings;

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -33,8 +33,6 @@ const SlackIntegration = () => {
       break;
   }
 
-
-
   return (
     <>
       <div className="container">

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -9,14 +9,16 @@ import ConfirmBotChangeModal from './ConfirmBotChangeModal';
 const SlackIntegration = () => {
 
   const [modalVisibility, setmodalVisibility] = useState(false);
+  const [currentBotType, setcurrentBotType] = useState('custom-bot-non-proxy');
+  let settingsComponent = null;
+
+  const changeBotSettings = (botType) => {
+    console.log(botType);
+  }
 
   const handleBotTypeSelect = (clickedBotType) => {
-    console.log(clickedBotType);
     setmodalVisibility(true);
   };
-
-  const currentBotType = 'custom-bot-non-proxy';
-  let settingsComponent = null;
 
   switch (currentBotType) {
     case 'official-bot':
@@ -41,7 +43,7 @@ const SlackIntegration = () => {
           show={modalVisibility}
           onButtonClick={(button) => {
             if (button === 'close') setmodalVisibility(false);
-            if (button === 'save') console.log('save button clicked');
+            if (button === 'change') changeBotSettings();
           }}
         />
       </div>

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -32,31 +32,6 @@ const SlackIntegration = () => {
 
   return (
     <>
-
-      <button type="button" className="btn btn-primary" data-toggle="modal" data-target="#staticBackdrop">
-        Launch static backdrop modal
-      </button>
-
-      <div className="modal fade" id="staticBackdrop" data-backdrop="static" data-keyboard="false" tabIndex="-1" aria-labelledby="staticBackdropLabel" aria-hidden="false">
-        <div className="modal-dialog modal-dialog-centered">
-          <div className="modal-content">
-            <div className="modal-header">
-              <h5 className="modal-title" id="staticBackdropLabel">Modal title</h5>
-              <button type="button" className="close" data-dismiss="modal" aria-label="Close">
-                <span aria-hidden="true">&times;</span>
-              </button>
-            </div>
-            <div className="modal-body">
-              ...
-            </div>
-            <div className="modal-footer">
-              <button type="button" className="btn btn-secondary" data-dismiss="modal">Close</button>
-              <button type="button" className="btn btn-primary">Understood</button>
-            </div>
-          </div>
-        </div>
-      </div>
-
       <ConfirmBotChangeModal />
 
       <div className="row">

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -16,7 +16,7 @@ const SlackIntegration = () => {
       return;
     }
     if (currentBotType === null) {
-      setSelectedBotType(clickedBotType);
+      setcurrentBotType(clickedBotType);
       return;
     }
     setSelectedBotType(clickedBotType);

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -7,31 +7,31 @@ import CustomBotWithProxySettings from './CustomBotWithProxySettings';
 import ConfirmBotChangeModal from './ConfirmBotChangeModal';
 
 const SlackIntegration = () => {
-  const [currentBotType, setcurrentBotType] = useState(null);
+  const [currentBotType, setCurrentBotType] = useState(null);
   const [selectedBotType, setSelectedBotType] = useState(null);
-  const [modalVisibility, setmodalVisibility] = useState(false);
+  const [isConfirmBotChangeModalOpen, setIsConfirmBotChangeModalOpen] = useState(false);
 
   const handleBotTypeSelect = (clickedBotType) => {
     if (clickedBotType === currentBotType) {
       return;
     }
     if (currentBotType === null) {
-      setcurrentBotType(clickedBotType);
+      setCurrentBotType(clickedBotType);
       return;
     }
     setSelectedBotType(clickedBotType);
-    setmodalVisibility(true);
+    setIsConfirmBotChangeModalOpen(true);
   };
 
   const handleBotChangeCancel = () => {
     setSelectedBotType(null);
-    setmodalVisibility(false);
+    setIsConfirmBotChangeModalOpen(false);
   };
 
   const changeCurrentBotSettings = () => {
-    setcurrentBotType(selectedBotType);
+    setCurrentBotType(selectedBotType);
     setSelectedBotType(null);
-    setmodalVisibility(false);
+    setIsConfirmBotChangeModalOpen(false);
   };
 
   let settingsComponent = null;
@@ -52,7 +52,7 @@ const SlackIntegration = () => {
     <>
       <div className="container">
         <ConfirmBotChangeModal
-          show={modalVisibility}
+          isOpen = {isConfirmBotChangeModalOpen}
           onConfirmClick={changeCurrentBotSettings}
           onCancelClick={handleBotChangeCancel}
         />
@@ -71,8 +71,8 @@ const SlackIntegration = () => {
 
           <div
             className={`card mx-3 py-5 rounded ${currentBotType === 'official-bot' ? 'border-info' : ''}`}
-            onClick={) => handleBotTypeSelect('official-bot')}
-            style={{cursor: pointer}}
+            onClick={() => handleBotTypeSelect('official-bot')}
+            style={{ cursor: 'pointer' }}
           >
             <div className="card-body">
               <h5 className="card-title">Official Bot</h5>
@@ -83,7 +83,7 @@ const SlackIntegration = () => {
           <div
             className={`card mx-3 py-5 rounded ${currentBotType === 'custom-bot-without-proxy' ? 'border-info' : ''}`}
             onClick={() => handleBotTypeSelect('custom-bot-without-proxy')}
-            style={{cursor: pointer}}
+            style={{ cursor: 'pointer' }}
           >
             <div className="card-body">
               <h5 className="card-title">Custom Bot (Without Proxy)</h5>
@@ -94,7 +94,7 @@ const SlackIntegration = () => {
           <div
             className={`card mx-3 py-5 rounded ${currentBotType === 'custom-bot-with-proxy' ? 'border-info' : ''}`}
             onClick={() => handleBotTypeSelect('custom-bot-with-proxy')}
-            style={{cursor: pointer}}
+            style={{ cursor: 'pointer' }}
           >
             <div className="card-body">
               <h5 className="card-title">Custom Bot (With Proxy)</h5>

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -1,24 +1,19 @@
 import React from 'react';
-import { useTranslation } from 'react-i18next';
 
 import AccessTokenSettings from './AccessTokenSettings';
-import OfficialBotSettings from './CustomBotNonProxySettings';
+import OfficialBotSettings from './OfficialBotSettings';
 import CustomBotNonProxySettings from './CustomBotNonProxySettings';
 import CustomBotWithProxySettings from './CustomBotWithProxySettings';
 
 const SlackIntegration = () => {
-
-
-  const handleBotTypeSelect = (e) => {
+  const handleBotTypeSelect = e => {
     console.log(e.target.value);
   };
 
-  // const selectedBotType = 'official-bot';
-  const selectedBotType = 'custom-bot-non-proxy';
-  // const selectedBotType = 'custom-bot-with-proxy';
-  let settingsComponent = '';
+  let currentBotType = null;
+  let settingsComponent = null;
 
-  switch (selectedBotType) {
+  switch (currentBotType) {
     case 'custom-bot-non-proxy':
       settingsComponent = <CustomBotNonProxySettings />;
       break;
@@ -40,26 +35,38 @@ const SlackIntegration = () => {
       </div>
 
       <div className="row my-5">
-        <div className="mx-auto form-check" onChange={handleBotTypeSelect}>
-          <div className="form-check-inline">
-            <input className="form-check-input" type="radio" id="checkbox1" value="official-bot" />
-            <label className="form-check-label" htmlFor="checkbox1">Official Bot</label>
+        <div className="card-group mx-auto">
+
+          <div className="card mx-3 py-5">
+            <div className="card-body">
+              <h5 className="card-title">Official Bot</h5>
+              <p className="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
+              <a href="#" className="stretched-link" onClick={handleBotTypeSelect} />
+            </div>
           </div>
-          <div className="form-check-inline">
-            <input className="form-check-input" type="radio" id="checkbox2" value="custom-bot-non-proxy" />
-            <label className="form-check-label" htmlFor="checkbox2">Custom Bot (Non Proxy)</label>
+
+          <div className="card mx-3 py-5">
+            <div className="card-body">
+              <h5 className="card-title">Custom Bot (Non Proxy)</h5>
+              <p className="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
+              <a href="#" className="stretched-link" onClick={handleBotTypeSelect} />
+            </div>
           </div>
-          <div className="form-check-inline">
-            <input className="form-check-input" type="radio" id="checkbox3" value="custom-bot-with-proxy" />
-            <label className="form-check-label" htmlFor="checkbox3">Custom Bot (With Proxy)</label>
+
+          <div className="card mx-3 py-5">
+            <div className="card-body">
+              <h5 className="card-title">Custom Bot (With Proxy)</h5>
+              <p className="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
+              <a href="#" className="stretched-link" onClick={handleBotTypeSelect} />
+            </div>
           </div>
+
         </div>
       </div>
 
       {settingsComponent}
-
     </>
   );
-}
+};
 
 export default SlackIntegration;

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -15,6 +15,10 @@ const SlackIntegration = () => {
     if (clickedBotType === currentBotType) {
       return;
     }
+    if (currentBotType === null) {
+      setSelectedBotType(clickedBotType);
+      return;
+    }
     setSelectedBotType(clickedBotType);
     setmodalVisibility(true);
   };

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -7,19 +7,27 @@ import CustomBotWithProxySettings from './CustomBotWithProxySettings';
 import ConfirmBotChangeModal from './ConfirmBotChangeModal';
 
 const SlackIntegration = () => {
-
+  const [currentBotType, setcurrentBotType] = useState(null);
+  const [selectedBotType, setSelectedBotType] = useState(null);
   const [modalVisibility, setmodalVisibility] = useState(false);
-  const [currentBotType, setcurrentBotType] = useState('custom-bot-non-proxy');
-  let settingsComponent = null;
-
-  const changeBotSettings = (botType) => {
-    console.log(botType);
-  }
 
   const handleBotTypeSelect = (clickedBotType) => {
-    console.log(clickedBotType);
+    setSelectedBotType(clickedBotType);
     setmodalVisibility(true);
   };
+
+  const handleBotChangeCancel = () => {
+    setSelectedBotType(null);
+    setmodalVisibility(false);
+  };
+
+  const changeCurrentBotSettings = () => {
+    setcurrentBotType(selectedBotType);
+    setSelectedBotType(null);
+    setmodalVisibility(false);
+  };
+
+  let settingsComponent = null;
 
   switch (currentBotType) {
     case 'official-bot':
@@ -31,9 +39,6 @@ const SlackIntegration = () => {
     case 'custom-bot-with-proxy':
       settingsComponent = <CustomBotWithProxySettings />;
       break;
-    default:
-      settingsComponent = <OfficialBotSettings />;
-      break;
   }
 
   return (
@@ -42,8 +47,8 @@ const SlackIntegration = () => {
         <ConfirmBotChangeModal
           show={modalVisibility}
           onButtonClick={(button) => {
-            if (button === 'close') setmodalVisibility(false);
-            if (button === 'change') changeBotSettings();
+            if (button === 'close') handleBotChangeCancel();
+            if (button === 'change') changeCurrentBotSettings();
           }}
         />
       </div>
@@ -61,7 +66,7 @@ const SlackIntegration = () => {
           <div className={`card mx-3 py-5 rounded ${currentBotType === 'official-bot' ? 'border-info' : ''}`}>
             <div className="card-body">
               <h5 className="card-title">Official Bot</h5>
-              <p className="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
+              <p className="card-text">This is a wider card with supporting text below as a natural lead-in to additional content.</p>
               <a href="#" className="stretched-link" onClick={() => handleBotTypeSelect('official-bot')} />
             </div>
           </div>
@@ -77,7 +82,7 @@ const SlackIntegration = () => {
           <div className={`card mx-3 py-5 rounded ${currentBotType === 'custom-bot-with-proxy' ? 'border-info' : ''}`}>
             <div className="card-body">
               <h5 className="card-title">Custom Bot (With Proxy)</h5>
-              <p className="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This content is a little bit longerThis is a wider card with supporting text below as a natural lead-This is a wider card with supporting text below as a natural lead-This is a wider card with supporting text below as a natural lead-This is a wider card with supporting text below as a natural lead-</p>
+              <p className="card-text">This is a wider card with supporting text below as a natural lead-in to additional content.</p>
               <a href="#" className="stretched-link" onClick={() => handleBotTypeSelect('custom-bot-with-proxy')} />
             </div>
           </div>

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -9,7 +9,6 @@ import ConfirmBotChangeModal from './ConfirmBotChangeModal';
 const SlackIntegration = () => {
   const [currentBotType, setCurrentBotType] = useState(null);
   const [selectedBotType, setSelectedBotType] = useState(null);
-  // const [isConfirmBotChangeModalOpen, setIsConfirmBotChangeModalOpen] = useState(false);
 
   const handleBotTypeSelect = (clickedBotType) => {
     if (clickedBotType === currentBotType) {
@@ -20,18 +19,15 @@ const SlackIntegration = () => {
       return;
     }
     setSelectedBotType(clickedBotType);
-    // setIsConfirmBotChangeModalOpen(true);
   };
 
-  const handleBotChangeCancel = () => {
+  const handleCancelBotChange = () => {
     setSelectedBotType(null);
-    // setIsConfirmBotChangeModalOpen(false);
   };
 
   const changeCurrentBotSettings = () => {
     setCurrentBotType(selectedBotType);
     setSelectedBotType(null);
-    // setIsConfirmBotChangeModalOpen(false);
   };
 
   let settingsComponent = null;
@@ -54,7 +50,7 @@ const SlackIntegration = () => {
         <ConfirmBotChangeModal
           isOpen={selectedBotType != null}
           onConfirmClick={changeCurrentBotSettings}
-          onCancelClick={handleBotChangeCancel}
+          onCancelClick={handleCancelBotChange}
         />
       </div>
 

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -40,7 +40,7 @@ const SlackIntegration = () => {
     case 'official-bot':
       settingsComponent = <OfficialBotSettings />;
       break;
-    case 'custom-bot-non-proxy':
+    case 'custom-bot-without-proxy':
       settingsComponent = <CustomBotWithoutProxySettings />;
       break;
     case 'custom-bot-with-proxy':
@@ -78,9 +78,9 @@ const SlackIntegration = () => {
 
           <div className={`card mx-3 py-5 rounded ${currentBotType === 'custom-bot-non-proxy' ? 'border-info' : ''}`}>
             <div className="card-body">
-              <h5 className="card-title">Custom Bot (Non Proxy)</h5>
+              <h5 className="card-title">Custom Bot (Without Proxy)</h5>
               <p className="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. </p>
-              <a href="#" className="stretched-link" onClick={() => handleBotTypeSelect('custom-bot-non-proxy')} />
+              <a href="#" className="stretched-link" onClick={() => handleBotTypeSelect('custom-bot-without-proxy')} />
             </div>
           </div>
 

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -2,11 +2,34 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 
 import AccessTokenSettings from './AccessTokenSettings';
+import OfficialBotSettings from './CustomBotNonProxySettings';
 import CustomBotNonProxySettings from './CustomBotNonProxySettings';
+import CustomBotWithProxySettings from './CustomBotWithProxySettings';
 
-function SlackIntegration() {
+const SlackIntegration = () => {
 
-  const { t } = useTranslation('admin');
+
+  const handleBotTypeSelect = (e) => {
+    console.log(e.target.value);
+  };
+
+  // const selectedBotType = 'official-bot';
+  const selectedBotType = 'custom-bot-non-proxy';
+  // const selectedBotType = 'custom-bot-with-proxy';
+  let settingsComponent = '';
+
+  switch (selectedBotType) {
+    case 'custom-bot-non-proxy':
+      settingsComponent = <CustomBotNonProxySettings />;
+      break;
+    case 'custom-bot-with-proxy':
+      settingsComponent = <CustomBotWithProxySettings />;
+      break;
+    default:
+      settingsComponent = <OfficialBotSettings />;
+      break;
+  }
+
   return (
     <>
       <div className="row">
@@ -16,24 +39,25 @@ function SlackIntegration() {
         </div>
       </div>
 
-      <div className="row mx-auto my-5 btn-group btn-group-toggle" data-toggle="buttons">
-        <label className="btn btn-secondary active">
-          <input type="radio" name="options" id="option1" checked /> Official Bot
-        </label>
-        <label className="btn btn-secondary">
-          <input type="radio" name="options" id="option2" /> Custom Bot (Non-Proxy)
-        </label>
-        <label className="btn btn-secondary">
-          <input type="radio" name="options" id="option3" /> Custom Bot (With-Proxy)
-        </label>
-      </div>
-
-      <div className="row">
-        <div className="col-lg-12">
-          <h2 className="admin-setting-header">{t('slack_integration.custom_bot_non_proxy_settings')}</h2>
-          <CustomBotNonProxySettings />
+      <div className="row my-5">
+        <div className="mx-auto form-check" onChange={handleBotTypeSelect}>
+          <div className="form-check-inline">
+            <input className="form-check-input" type="radio" id="checkbox1" value="official-bot" />
+            <label className="form-check-label" htmlFor="checkbox1">Official Bot</label>
+          </div>
+          <div className="form-check-inline">
+            <input className="form-check-input" type="radio" id="checkbox2" value="custom-bot-non-proxy" />
+            <label className="form-check-label" htmlFor="checkbox2">Custom Bot (Non Proxy)</label>
+          </div>
+          <div className="form-check-inline">
+            <input className="form-check-input" type="radio" id="checkbox3" value="custom-bot-with-proxy" />
+            <label className="form-check-label" htmlFor="checkbox3">Custom Bot (With Proxy)</label>
+          </div>
         </div>
       </div>
+
+      {settingsComponent}
+
     </>
   );
 }

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -17,6 +17,7 @@ const SlackIntegration = () => {
   }
 
   const handleBotTypeSelect = (clickedBotType) => {
+    console.log(clickedBotType);
     setmodalVisibility(true);
   };
 
@@ -39,7 +40,6 @@ const SlackIntegration = () => {
     <>
       <div className="container">
         <ConfirmBotChangeModal
-          title="Modal Title"
           show={modalVisibility}
           onButtonClick={(button) => {
             if (button === 'close') setmodalVisibility(false);

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -9,7 +9,7 @@ import ConfirmBotChangeModal from './ConfirmBotChangeModal';
 const SlackIntegration = () => {
   const [currentBotType, setCurrentBotType] = useState(null);
   const [selectedBotType, setSelectedBotType] = useState(null);
-  const [isConfirmBotChangeModalOpen, setIsConfirmBotChangeModalOpen] = useState(false);
+  // const [isConfirmBotChangeModalOpen, setIsConfirmBotChangeModalOpen] = useState(false);
 
   const handleBotTypeSelect = (clickedBotType) => {
     if (clickedBotType === currentBotType) {
@@ -20,18 +20,18 @@ const SlackIntegration = () => {
       return;
     }
     setSelectedBotType(clickedBotType);
-    setIsConfirmBotChangeModalOpen(true);
+    // setIsConfirmBotChangeModalOpen(true);
   };
 
   const handleBotChangeCancel = () => {
     setSelectedBotType(null);
-    setIsConfirmBotChangeModalOpen(false);
+    // setIsConfirmBotChangeModalOpen(false);
   };
 
   const changeCurrentBotSettings = () => {
     setCurrentBotType(selectedBotType);
     setSelectedBotType(null);
-    setIsConfirmBotChangeModalOpen(false);
+    // setIsConfirmBotChangeModalOpen(false);
   };
 
   let settingsComponent = null;
@@ -52,7 +52,7 @@ const SlackIntegration = () => {
     <>
       <div className="container">
         <ConfirmBotChangeModal
-          isOpen = {isConfirmBotChangeModalOpen}
+          isOpen={selectedBotType != null}
           onConfirmClick={changeCurrentBotSettings}
           onCancelClick={handleBotChangeCancel}
         />

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -66,9 +66,8 @@ const SlackIntegration = () => {
         <div className="card-deck mx-auto">
 
           <div
-            className={`card mx-3 py-5 rounded ${currentBotType === 'official-bot' ? 'border-info' : ''}`}
+            className={`card admin-bot-card mx-3 py-5 rounded ${currentBotType === 'official-bot' ? 'border-info' : ''}`}
             onClick={() => handleBotTypeSelect('official-bot')}
-            style={{ cursor: 'pointer' }}
           >
             <div className="card-body">
               <h5 className="card-title">Official Bot</h5>
@@ -77,9 +76,8 @@ const SlackIntegration = () => {
           </div>
 
           <div
-            className={`card mx-3 py-5 rounded ${currentBotType === 'custom-bot-without-proxy' ? 'border-info' : ''}`}
+            className={`card admin-bot-card mx-3 py-5 rounded ${currentBotType === 'custom-bot-without-proxy' ? 'border-info' : ''}`}
             onClick={() => handleBotTypeSelect('custom-bot-without-proxy')}
-            style={{ cursor: 'pointer' }}
           >
             <div className="card-body">
               <h5 className="card-title">Custom Bot (Without Proxy)</h5>
@@ -88,9 +86,8 @@ const SlackIntegration = () => {
           </div>
 
           <div
-            className={`card mx-3 py-5 rounded ${currentBotType === 'custom-bot-with-proxy' ? 'border-info' : ''}`}
+            className={`card admin-bot-card mx-3 py-5 rounded ${currentBotType === 'custom-bot-with-proxy' ? 'border-info' : ''}`}
             onClick={() => handleBotTypeSelect('custom-bot-with-proxy')}
-            style={{ cursor: 'pointer' }}
           >
             <div className="card-body">
               <h5 className="card-title">Custom Bot (With Proxy)</h5>

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -7,9 +7,12 @@ import CustomBotWithProxySettings from './CustomBotWithProxySettings';
 import ConfirmBotChangeModal from './ConfirmBotChangeModal';
 
 const SlackIntegration = () => {
+
+  const [modalVisibility, setmodalVisibility] = useState(false);
+
   const handleBotTypeSelect = (clickedBotType) => {
     console.log(clickedBotType);
-    // showModal();
+    setmodalVisibility(true);
   };
 
   const currentBotType = 'custom-bot-non-proxy';
@@ -30,28 +33,19 @@ const SlackIntegration = () => {
       break;
   }
 
-  const [showDialog, setShowDialog] = useState(false);
+
 
   return (
     <>
       <div className="container">
         <ConfirmBotChangeModal
           title="Modal Title"
-          show={showDialog}
+          show={modalVisibility}
           onButtonClick={(button) => {
-            if (button === 'close') setShowDialog(false);
+            if (button === 'close') setmodalVisibility(false);
             if (button === 'save') console.log('save button clicked');
           }}
         />
-        <button
-          className="btn btn-primary"
-          type="button"
-          onClick={() => {
-          setShowDialog(true);
-        }}
-        >
-          Show Dialog
-        </button>
       </div>
 
       <div className="row">

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -4,16 +4,21 @@ import AccessTokenSettings from './AccessTokenSettings';
 import OfficialBotSettings from './OfficialBotSettings';
 import CustomBotNonProxySettings from './CustomBotNonProxySettings';
 import CustomBotWithProxySettings from './CustomBotWithProxySettings';
+import ConfirmBotChangeModal from './ConfirmBotChangeModal';
 
 const SlackIntegration = () => {
-  const handleBotTypeSelect = e => {
-    console.log(e.target.value);
+  const handleBotTypeSelect = (clickedBotType) => {
+    console.log(clickedBotType);
+    // showModal();
   };
 
-  let currentBotType = null;
+  const currentBotType = 'custom-bot-with-proxy';
   let settingsComponent = null;
 
   switch (currentBotType) {
+    case 'official-bot':
+      settingsComponent = <OfficialBotSettings />;
+      break;
     case 'custom-bot-non-proxy':
       settingsComponent = <CustomBotNonProxySettings />;
       break;
@@ -27,6 +32,33 @@ const SlackIntegration = () => {
 
   return (
     <>
+
+      <button type="button" className="btn btn-primary" data-toggle="modal" data-target="#staticBackdrop">
+        Launch static backdrop modal
+      </button>
+
+      <div className="modal fade" id="staticBackdrop" data-backdrop="static" data-keyboard="false" tabIndex="-1" aria-labelledby="staticBackdropLabel" aria-hidden="false">
+        <div className="modal-dialog modal-dialog-centered">
+          <div className="modal-content">
+            <div className="modal-header">
+              <h5 className="modal-title" id="staticBackdropLabel">Modal title</h5>
+              <button type="button" className="close" data-dismiss="modal" aria-label="Close">
+                <span aria-hidden="true">&times;</span>
+              </button>
+            </div>
+            <div className="modal-body">
+              ...
+            </div>
+            <div className="modal-footer">
+              <button type="button" className="btn btn-secondary" data-dismiss="modal">Close</button>
+              <button type="button" className="btn btn-primary">Understood</button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <ConfirmBotChangeModal />
+
       <div className="row">
         <div className="col-lg-12">
           <h2 className="admin-setting-header">Access Token</h2>
@@ -35,29 +67,29 @@ const SlackIntegration = () => {
       </div>
 
       <div className="row my-5">
-        <div className="card-group mx-auto">
+        <div className="card-deck mx-auto">
 
-          <div className="card mx-3 py-5">
+          <div className={`card mx-3 py-5 rounded ${currentBotType === 'official-bot' ? 'border-info' : ''}`}>
             <div className="card-body">
               <h5 className="card-title">Official Bot</h5>
               <p className="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
-              <a href="#" className="stretched-link" onClick={handleBotTypeSelect} />
+              <a href="#" className="stretched-link" onClick={() => handleBotTypeSelect('official-bot')} />
             </div>
           </div>
 
-          <div className="card mx-3 py-5">
+          <div className={`card mx-3 py-5 rounded ${currentBotType === 'custom-bot-non-proxy' ? 'border-info' : ''}`}>
             <div className="card-body">
               <h5 className="card-title">Custom Bot (Non Proxy)</h5>
-              <p className="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
-              <a href="#" className="stretched-link" onClick={handleBotTypeSelect} />
+              <p className="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. </p>
+              <a href="#" className="stretched-link" onClick={() => handleBotTypeSelect('custom-bot-non-proxy')} />
             </div>
           </div>
 
-          <div className="card mx-3 py-5">
+          <div className={`card mx-3 py-5 rounded ${currentBotType === 'custom-bot-with-proxy' ? 'border-info' : ''}`}>
             <div className="card-body">
               <h5 className="card-title">Custom Bot (With Proxy)</h5>
-              <p className="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
-              <a href="#" className="stretched-link" onClick={handleBotTypeSelect} />
+              <p className="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This content is a little bit longerThis is a wider card with supporting text below as a natural lead-This is a wider card with supporting text below as a natural lead-This is a wider card with supporting text below as a natural lead-This is a wider card with supporting text below as a natural lead-</p>
+              <a href="#" className="stretched-link" onClick={() => handleBotTypeSelect('custom-bot-with-proxy')} />
             </div>
           </div>
 

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -16,6 +16,18 @@ function SlackIntegration() {
         </div>
       </div>
 
+      <div className="row mx-auto my-5 btn-group btn-group-toggle" data-toggle="buttons">
+        <label className="btn btn-secondary active">
+          <input type="radio" name="options" id="option1" checked /> Official Bot
+        </label>
+        <label className="btn btn-secondary">
+          <input type="radio" name="options" id="option2" /> Custom Bot (Non-Proxy)
+        </label>
+        <label className="btn btn-secondary">
+          <input type="radio" name="options" id="option3" /> Custom Bot (With-Proxy)
+        </label>
+      </div>
+
       <div className="row">
         <div className="col-lg-12">
           <h2 className="admin-setting-header">{t('slack_integration.custom_bot_non_proxy_settings')}</h2>

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -76,7 +76,7 @@ const SlackIntegration = () => {
             </div>
           </div>
 
-          <div className={`card mx-3 py-5 rounded ${currentBotType === 'custom-bot-non-proxy' ? 'border-info' : ''}`}>
+          <div className={`card mx-3 py-5 rounded ${currentBotType === 'custom-bot-without-proxy' ? 'border-info' : ''}`}>
             <div className="card-body">
               <h5 className="card-title">Custom Bot (Without Proxy)</h5>
               <p className="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. </p>

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 
 import AccessTokenSettings from './AccessTokenSettings';
 import OfficialBotSettings from './OfficialBotSettings';
-import CustomBotNonProxySettings from './CustomBotNonProxySettings';
+import CustomBotWithoutProxySettings from './CustomBotWithoutProxySettings';
 import CustomBotWithProxySettings from './CustomBotWithProxySettings';
 import ConfirmBotChangeModal from './ConfirmBotChangeModal';
 
@@ -12,6 +12,9 @@ const SlackIntegration = () => {
   const [modalVisibility, setmodalVisibility] = useState(false);
 
   const handleBotTypeSelect = (clickedBotType) => {
+    if (clickedBotType === currentBotType) {
+      return;
+    }
     setSelectedBotType(clickedBotType);
     setmodalVisibility(true);
   };
@@ -34,7 +37,7 @@ const SlackIntegration = () => {
       settingsComponent = <OfficialBotSettings />;
       break;
     case 'custom-bot-non-proxy':
-      settingsComponent = <CustomBotNonProxySettings />;
+      settingsComponent = <CustomBotWithoutProxySettings />;
       break;
     case 'custom-bot-with-proxy':
       settingsComponent = <CustomBotWithProxySettings />;
@@ -46,10 +49,8 @@ const SlackIntegration = () => {
       <div className="container">
         <ConfirmBotChangeModal
           show={modalVisibility}
-          onButtonClick={(button) => {
-            if (button === 'close') handleBotChangeCancel();
-            if (button === 'change') changeCurrentBotSettings();
-          }}
+          onConfirmClick={changeCurrentBotSettings}
+          onCancelClick={handleBotChangeCancel}
         />
       </div>
 

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -69,27 +69,36 @@ const SlackIntegration = () => {
       <div className="row my-5">
         <div className="card-deck mx-auto">
 
-          <div className={`card mx-3 py-5 rounded ${currentBotType === 'official-bot' ? 'border-info' : ''}`}>
+          <div
+            className={`card mx-3 py-5 rounded ${currentBotType === 'official-bot' ? 'border-info' : ''}`}
+            onClick={) => handleBotTypeSelect('official-bot')}
+            style={{cursor: pointer}}
+          >
             <div className="card-body">
               <h5 className="card-title">Official Bot</h5>
               <p className="card-text">This is a wider card with supporting text below as a natural lead-in to additional content.</p>
-              <a href="#" className="stretched-link" onClick={() => handleBotTypeSelect('official-bot')} />
             </div>
           </div>
 
-          <div className={`card mx-3 py-5 rounded ${currentBotType === 'custom-bot-without-proxy' ? 'border-info' : ''}`}>
+          <div
+            className={`card mx-3 py-5 rounded ${currentBotType === 'custom-bot-without-proxy' ? 'border-info' : ''}`}
+            onClick={() => handleBotTypeSelect('custom-bot-without-proxy')}
+            style={{cursor: pointer}}
+          >
             <div className="card-body">
               <h5 className="card-title">Custom Bot (Without Proxy)</h5>
               <p className="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. </p>
-              <a href="#" className="stretched-link" onClick={() => handleBotTypeSelect('custom-bot-without-proxy')} />
             </div>
           </div>
 
-          <div className={`card mx-3 py-5 rounded ${currentBotType === 'custom-bot-with-proxy' ? 'border-info' : ''}`}>
+          <div
+            className={`card mx-3 py-5 rounded ${currentBotType === 'custom-bot-with-proxy' ? 'border-info' : ''}`}
+            onClick={() => handleBotTypeSelect('custom-bot-with-proxy')}
+            style={{cursor: pointer}}
+          >
             <div className="card-body">
               <h5 className="card-title">Custom Bot (With Proxy)</h5>
               <p className="card-text">This is a wider card with supporting text below as a natural lead-in to additional content.</p>
-              <a href="#" className="stretched-link" onClick={() => handleBotTypeSelect('custom-bot-with-proxy')} />
             </div>
           </div>
 

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import AccessTokenSettings from './AccessTokenSettings';
 import OfficialBotSettings from './OfficialBotSettings';
@@ -30,9 +30,29 @@ const SlackIntegration = () => {
       break;
   }
 
+  const [showDialog, setShowDialog] = useState(false);
+
   return (
     <>
-      <ConfirmBotChangeModal />
+      <div className="container">
+        <ConfirmBotChangeModal
+          title="Modal Title"
+          show={showDialog}
+          onButtonClick={(button) => {
+            if (button === 'close') setShowDialog(false);
+            if (button === 'save') console.log('save button clicked');
+          }}
+        />
+        <button
+          className="btn btn-primary"
+          type="button"
+          onClick={() => {
+          setShowDialog(true);
+        }}
+        >
+          Show Dialog
+        </button>
+      </div>
 
       <div className="row">
         <div className="col-lg-12">

--- a/src/client/styles/scss/_admin.scss
+++ b/src/client/styles/scss/_admin.scss
@@ -84,7 +84,7 @@
   }
 
   .admin-bot-card {
-    cursor: 'pointer;
+    cursor: pointer;
   }
 
   //// TODO: migrate to Bootstrap 4

--- a/src/client/styles/scss/_admin.scss
+++ b/src/client/styles/scss/_admin.scss
@@ -83,6 +83,10 @@
     }
   }
 
+  .admin-bot-card {
+    cursor: 'pointer;
+  }
+
   //// TODO: migrate to Bootstrap 4
   //// omit all .btn-toggle and use Switches
   //// https://getbootstrap.com/docs/4.2/components/forms/#switches


### PR DESCRIPTION
Botを選択できる仮のカードと、変更する際にモーダルを表示するようにさせました。

【未選択の場合】
<img width="1430" alt="Screen Shot 2021-03-31 at 11 14 51" src="https://user-images.githubusercontent.com/66785624/113089327-62db1380-9222-11eb-990c-e1c789ba55d6.png">

【選択された場合】
<img width="1420" alt="Screen Shot 2021-03-31 at 11 15 30" src="https://user-images.githubusercontent.com/66785624/113089330-6373aa00-9222-11eb-8df7-fc8f0d93aba9.png">

【英語のモーダル】
<img width="515" alt="English Modal" src="https://user-images.githubusercontent.com/66785624/113089324-61a9e680-9222-11eb-969a-1a7e46a1a8a4.png">

【日本語のモーダル】
<img width="527" alt="Japanese Modal" src="https://user-images.githubusercontent.com/66785624/113089325-62427d00-9222-11eb-9e23-a12970819baf.png">

【中国語のモーダル】
<img width="516" alt="ChineseModal" src="https://user-images.githubusercontent.com/66785624/113089322-61115000-9222-11eb-843d-cbdacf34cd54.png">

モーダルはBotを変更する場合にのみ表示され、Botが未選択の状態から選択した場合は表示されません。


