### PR TITLE
Feat/5456 show access token

### DIFF
--- a/resource/locales/en_US/admin/admin.json
+++ b/resource/locales/en_US/admin/admin.json
@@ -254,6 +254,7 @@
   },
   "slack_integration": {
     "bot_reset_successful": "Bot settings have been reset.",
+    "copied_to_clipboard": "Copied to clipboard",
     "modal": {
       "warning": "Warning",
       "sure_change_bot_type": "Are you sure you want to change the bot type?",

--- a/resource/locales/ja_JP/admin/admin.json
+++ b/resource/locales/ja_JP/admin/admin.json
@@ -252,6 +252,7 @@
   },
   "slack_integration": {
     "bot_reset_successful": "Botの設定を消去しました。",
+    "copied_to_clipboard": "クリップボードにコピーされました。",
     "modal": {
       "warning": "注意",
       "sure_change_bot_type": "Botの種類を変更しますか?",

--- a/resource/locales/zh_CN/admin/admin.json
+++ b/resource/locales/zh_CN/admin/admin.json
@@ -262,6 +262,7 @@
   },
   "slack_integration": {
     "bot_reset_successful": "删除了BOT设置。",
+    "copied_to_clipboard": "它已复制到剪贴板。",
     "modal": {
       "warning": "警告",
       "sure_change_bot_type": "您确定要更改设置吗？",

--- a/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
@@ -22,48 +22,46 @@ const AccessTokenSettings = (props) => {
   };
 
   const discardTokenHandler = async() => {
-    // try {
-
-    // }
-    // catch (err) {
-    // }
-    // eslint-disable-next-line no-console
-    console.log('discard');
+    try {
+      const res = await appContainer.apiv3.put('slack-integration/access-token', { deleteAccessToken: true });
+      setAccessToken(res.data.accessToken);
+    }
+    catch (err) {
+      toastError(err);
+    }
   };
 
   const textboxClickHandler = () => {
-    const a = navigator.permissions.query({name: "clipboard-write"});
+    const a = navigator.permissions.query({ name: 'clipboard-write' });
     console.log(a);
-    
-
   };
 
   return (
-    <>
-      <div className="form-group row my-5">
-        <label className="text-left text-md-right col-md-3 col-form-label">Access Token</label>
-        <div className="col-md-6">
-          <input
-            className="form-control"
-            type="text"
-            value={accessToken}
-            onClick={textboxClickHandler}
-            readOnly
-          />
-        </div>
-      </div>
+    <div className="row">
+      <div className="col-lg-12">
 
-      <div className="row">
-        <div className="mx-auto">
-          <button type="button" className="btn btn-outline-secondary text-nowrap mx-1" onClick={discardTokenHandler}>
-            {t('slack_integration.access_token_settings.discard')}
-          </button>
-          <button type="button" className="btn btn-primary text-nowrap mx-1" onClick={generateTokenHandler}>
-            {t('slack_integration.access_token_settings.generate')}
-          </button>
+        <h2 className="admin-setting-header">Access Token</h2>
+
+        <div className="form-group row my-5">
+          <label className="text-left text-md-right col-md-3 col-form-label">Access Token</label>
+          <div className="col-md-6">
+            <input className="form-control" type="text" value={accessToken} onClick={textboxClickHandler} readOnly />
+          </div>
         </div>
+
+        <div className="row">
+          <div className="mx-auto">
+            <button type="button" className="btn btn-outline-secondary text-nowrap mx-1" onClick={discardTokenHandler}>
+              {t('slack_integration.access_token_settings.discard')}
+            </button>
+            <button type="button" className="btn btn-primary text-nowrap mx-1" onClick={generateTokenHandler}>
+              {t('slack_integration.access_token_settings.generate')}
+            </button>
+          </div>
+        </div>
+
       </div>
-    </>
+    </div>
   );
 };
 

--- a/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
@@ -8,13 +8,13 @@ const AccessTokenSettings = (props) => {
   const { t } = useTranslation('admin');
 
   const onClickDiscardButton = () => {
-    if (props.onClickDiscardButton) {
+    if (props.onClickDiscardButton != null) {
       props.onClickDiscardButton();
     }
   };
 
   const onClickGenerateToken = () => {
-    if (props.onClickGenerateToken) {
+    if (props.onClickGenerateToken != null) {
       props.onClickGenerateToken();
     }
   };
@@ -30,7 +30,7 @@ const AccessTokenSettings = (props) => {
         <div className="form-group row my-5">
           <label className="text-left text-md-right col-md-3 col-form-label">Access Token</label>
           <div className="col-md-6">
-            {props.accessToken == null ? (
+            {accessToken.length === 0 ? (
               <input className="form-control" type="text" value={accessToken} readOnly />
             ) : (
               <CopyToClipboard text={accessToken} onCopy={() => toastSuccess(t('slack_integration.copied_to_clipboard'))}>
@@ -42,7 +42,7 @@ const AccessTokenSettings = (props) => {
 
         <div className="row">
           <div className="mx-auto">
-            <button type="button" className="btn btn-outline-secondary text-nowrap mx-1" onClick={onClickDiscardButton} disabled={!props.accessToken}>
+            <button type="button" className="btn btn-outline-secondary text-nowrap mx-1" onClick={onClickDiscardButton} disabled={accessToken.length === 0}>
               {t('slack_integration.access_token_settings.discard')}
             </button>
             <button type="button" className="btn btn-primary text-nowrap mx-1" onClick={onClickGenerateToken}>

--- a/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
@@ -13,8 +13,8 @@ const AccessTokenSettings = (props) => {
 
   const generateTokenHandler = async() => {
     try {
-      const accessToken = await appContainer.apiv3.put('slack-integration/access-token')
-      console.log(accessToken)
+      const res = await appContainer.apiv3.put('slack-integration/access-token');
+      setAccessToken(res.data.accessToken);
     }
     catch (err) {
       toastError(err);

--- a/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
@@ -1,39 +1,68 @@
-/* eslint-disable no-console */
-import React from 'react';
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
+import AppContainer from '../../../services/AppContainer';
+import { withUnstatedContainers } from '../../UnstatedUtils';
+import { toastError } from '../../../util/apiNotification';
 
-function AccessTokenSettings() {
-
+const AccessTokenSettings = (props) => {
+  const { appContainer } = props;
   const { t } = useTranslation('admin');
-  function discardHandler() {
-    console.log('Discard button pressed');
-  }
 
-  function generateHandler() {
-    console.log('Generate button pressed');
-  }
+  const [accessToken, setAccessToken] = useState('asdfasdf');
+
+  const generateTokenHandler = async() => {
+    try {
+      const accessToken = await appContainer.apiv3.put('slack-integration/access-token')
+      console.log(accessToken)
+    }
+    catch (err) {
+      toastError(err);
+    }
+  };
+
+  const discardTokenHandler = async() => {
+    // try {
+
+    // }
+    // catch (err) {
+      
+    // }
+    console.log('discard');
+  };
 
   return (
     <>
       <div className="form-group row my-5">
         <label className="text-left text-md-right col-md-3 col-form-label">Access Token</label>
         <div className="col-md-6">
-          <input className="form-control" type="text" placeholder="access-token" />
+          <input
+            className="form-control"
+            type="text"
+            value={accessToken}
+            readOnly
+          />
         </div>
       </div>
 
       <div className="row">
         <div className="mx-auto">
-          <button type="button" className="btn btn-outline-secondary text-nowrap mx-1" onClick={discardHandler}>
+          <button type="button" className="btn btn-outline-secondary text-nowrap mx-1" onClick={discardTokenHandler}>
             {t('slack_integration.access_token_settings.discard')}
           </button>
-          <button type="button" className="btn btn-primary text-nowrap mx-1" onClick={generateHandler}>
+          <button type="button" className="btn btn-primary text-nowrap mx-1" onClick={generateTokenHandler}>
             {t('slack_integration.access_token_settings.generate')}
           </button>
         </div>
       </div>
     </>
   );
-}
+};
 
-export default AccessTokenSettings;
+const AccessTokenSettingsWrapper = withUnstatedContainers(AccessTokenSettings, [AppContainer]);
+
+AccessTokenSettings.propTypes = {
+  appContainer: PropTypes.instanceOf(AppContainer).isRequired,
+};
+
+export default AccessTokenSettingsWrapper;

--- a/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
+import { CopyToClipboard } from 'react-copy-to-clipboard';
 import { toastSuccess } from '../../../util/apiNotification';
 
 const AccessTokenSettings = (props) => {
@@ -18,12 +19,8 @@ const AccessTokenSettings = (props) => {
     }
   };
 
-  const textboxClickHandler = (e) => {
-    e.target.select();
-    if (props.accessToken) {
-      navigator.clipboard.writeText(props.accessToken)
-        .then(() => { toastSuccess(t('slack_integration.copied_to_clipboard')) });
-    }
+  const showCopiedToaster = () => {
+    toastSuccess(t('slack_integration.copied_to_clipboard'));
   };
 
   return (
@@ -35,7 +32,9 @@ const AccessTokenSettings = (props) => {
         <div className="form-group row my-5">
           <label className="text-left text-md-right col-md-3 col-form-label">Access Token</label>
           <div className="col-md-6">
-            <input className="form-control" type="text" value={props.accessToken} onClick={e => textboxClickHandler(e)} readOnly />
+            <CopyToClipboard text={props.accessToken ? props.accessToken : null} onCopy={showCopiedToaster}>
+              <input className="form-control" type="text" value={props.accessToken} readOnly />
+            </CopyToClipboard>
           </div>
         </div>
 

--- a/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
@@ -31,6 +31,10 @@ const AccessTokenSettings = (props) => {
     console.log('discard');
   };
 
+  const textboxFocusHandler = (e) => {
+    e.target.select();
+  }
+
   return (
     <>
       <div className="form-group row my-5">
@@ -40,6 +44,7 @@ const AccessTokenSettings = (props) => {
             className="form-control"
             type="text"
             value={accessToken}
+            onFocus={textboxFocusHandler}
             readOnly
           />
         </div>

--- a/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
@@ -33,7 +33,7 @@ const AccessTokenSettings = (props) => {
             {props.accessToken == null ? (
               <input className="form-control" type="text" value={accessToken} readOnly />
             ) : (
-              <CopyToClipboard text={accessToken} onCopy={toastSuccess(t('slack_integration.copied_to_clipboard'))}>
+              <CopyToClipboard text={accessToken} onCopy={() => toastSuccess(t('slack_integration.copied_to_clipboard'))}>
                 <input className="form-control" type="text" value={accessToken} readOnly />
               </CopyToClipboard>
             )}

--- a/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
 import AppContainer from '../../../services/AppContainer';
 import { withUnstatedContainers } from '../../UnstatedUtils';
-import { toastError } from '../../../util/apiNotification';
+import { toastSuccess, toastError } from '../../../util/apiNotification';
 
 const AccessTokenSettings = (props) => {
   const { appContainer } = props;
@@ -26,14 +26,16 @@ const AccessTokenSettings = (props) => {
 
     // }
     // catch (err) {
-      
     // }
+    // eslint-disable-next-line no-console
     console.log('discard');
   };
 
-  const textboxFocusHandler = (e) => {
+  const textboxClickHandler = (e) => {
     e.target.select();
-  }
+    document.execCommand('copy');
+    toastSuccess('Copied');
+  };
 
   return (
     <>
@@ -44,7 +46,7 @@ const AccessTokenSettings = (props) => {
             className="form-control"
             type="text"
             value={accessToken}
-            onFocus={textboxFocusHandler}
+            onClick={textboxClickHandler}
             readOnly
           />
         </div>

--- a/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
-import AppContainer from '../../../services/AppContainer';
-import { withUnstatedContainers } from '../../UnstatedUtils';
 import { toastSuccess } from '../../../util/apiNotification';
 
 const AccessTokenSettings = (props) => {
@@ -57,13 +55,10 @@ const AccessTokenSettings = (props) => {
   );
 };
 
-const AccessTokenSettingsWrapper = withUnstatedContainers(AccessTokenSettings, [AppContainer]);
-
 AccessTokenSettings.propTypes = {
-  appContainer: PropTypes.instanceOf(AppContainer).isRequired,
   accessToken: PropTypes.string,
   discardTokenHandler: PropTypes.func,
   generateTokenHandler: PropTypes.func,
 };
 
-export default AccessTokenSettingsWrapper;
+export default AccessTokenSettings;

--- a/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
@@ -6,15 +6,15 @@ import { toastSuccess } from '../../../util/apiNotification';
 const AccessTokenSettings = (props) => {
   const { t } = useTranslation('admin');
 
-  const discardTokenHandler = () => {
-    if (props.discardTokenHandler) {
-      props.discardTokenHandler();
+  const onClickDiscardButton = () => {
+    if (props.onClickDiscardButton) {
+      props.onClickDiscardButton();
     }
   };
 
-  const generateTokenHandler = () => {
-    if (props.generateTokenHandler) {
-      props.generateTokenHandler();
+  const onClickGenerateToken = () => {
+    if (props.onClickGenerateToken) {
+      props.onClickGenerateToken();
     }
   };
 
@@ -41,10 +41,10 @@ const AccessTokenSettings = (props) => {
 
         <div className="row">
           <div className="mx-auto">
-            <button type="button" className="btn btn-outline-secondary text-nowrap mx-1" onClick={discardTokenHandler} disabled={!props.accessToken}>
+            <button type="button" className="btn btn-outline-secondary text-nowrap mx-1" onClick={onClickDiscardButton} disabled={!props.accessToken}>
               {t('slack_integration.access_token_settings.discard')}
             </button>
-            <button type="button" className="btn btn-primary text-nowrap mx-1" onClick={generateTokenHandler}>
+            <button type="button" className="btn btn-primary text-nowrap mx-1" onClick={onClickGenerateToken}>
               {t('slack_integration.access_token_settings.generate')}
             </button>
           </div>
@@ -57,8 +57,8 @@ const AccessTokenSettings = (props) => {
 
 AccessTokenSettings.propTypes = {
   accessToken: PropTypes.string,
-  discardTokenHandler: PropTypes.func,
-  generateTokenHandler: PropTypes.func,
+  onClickDiscardButton: PropTypes.func,
+  onClickGenerateToken: PropTypes.func,
 };
 
 export default AccessTokenSettings;

--- a/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
@@ -32,7 +32,7 @@ const AccessTokenSettings = (props) => {
         <div className="form-group row my-5">
           <label className="text-left text-md-right col-md-3 col-form-label">Access Token</label>
           <div className="col-md-6">
-            <CopyToClipboard text={props.accessToken} onCopy={showCopiedToaster ? props.accessToken : null}>
+            <CopyToClipboard text={props.accessToken} onCopy={props.accessToken ? showCopiedToaster : null}>
               <input className="form-control" type="text" value={props.accessToken} readOnly />
             </CopyToClipboard>
           </div>

--- a/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
@@ -25,16 +25,18 @@ const AccessTokenSettings = (props) => {
     try {
       const res = await appContainer.apiv3.put('slack-integration/access-token', { deleteAccessToken: true });
       setAccessToken(res.data.accessToken);
+      toastSuccess(t('slack_integration.bot_reset_successful'));
     }
     catch (err) {
       toastError(err);
     }
   };
 
-  const textboxClickHandler = () => {
+  const textboxClickHandler = (e) => {
+    e.target.select();
     if (accessToken) {
       navigator.clipboard.writeText(accessToken)
-        .then(() => { toastSuccess('Copied to clipboard') });
+        .then(() => { toastSuccess('slack_integration.copied_to_clipboard') });
     }
 
   };
@@ -48,7 +50,7 @@ const AccessTokenSettings = (props) => {
         <div className="form-group row my-5">
           <label className="text-left text-md-right col-md-3 col-form-label">Access Token</label>
           <div className="col-md-6">
-            <input className="form-control" type="text" value={accessToken} onClick={textboxClickHandler} readOnly />
+            <input className="form-control" type="text" value={accessToken} onClick={e => textboxClickHandler(e)} readOnly />
           </div>
         </div>
 

--- a/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
@@ -7,13 +7,13 @@ const AccessTokenSettings = (props) => {
   const { t } = useTranslation('admin');
 
   const discardTokenHandler = () => {
-    if (props.discardTokenHandler != null) {
+    if (props.discardTokenHandler) {
       props.discardTokenHandler();
     }
   };
 
   const generateTokenHandler = () => {
-    if (props.generateTokenHandler != null) {
+    if (props.generateTokenHandler) {
       props.generateTokenHandler();
     }
   };

--- a/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
@@ -32,14 +32,15 @@ const AccessTokenSettings = (props) => {
         <div className="form-group row my-5">
           <label className="text-left text-md-right col-md-3 col-form-label">Access Token</label>
           <div className="col-md-6">
-{props.accessToken == null ? (
-  <input className="form-control" type="text" value={props.accessToken} readOnly />
-): (
-<CopyToClipboard text={props.accessToken} onCopy={showCopiedToaster}>
-<input className="form-control" type="text" value={props.accessToken} readOnly />
-</CopyToClipboard>
-)}
-            </CopyToClipboard>
+            {props.accessToken == null
+              ? (
+                <input className="form-control" type="text" value={props.accessToken} readOnly />
+              ) : (
+                <CopyToClipboard text={props.accessToken} onCopy={showCopiedToaster}>
+                  <input className="form-control" type="text" value={props.accessToken} readOnly />
+                </CopyToClipboard>
+              )
+            }
           </div>
         </div>
 

--- a/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
@@ -32,8 +32,11 @@ const AccessTokenSettings = (props) => {
   };
 
   const textboxClickHandler = () => {
-    const a = navigator.permissions.query({ name: 'clipboard-write' });
-    console.log(a);
+    if (accessToken) {
+      navigator.clipboard.writeText(accessToken)
+        .then(() => { toastSuccess('Copied to clipboard') });
+    }
+
   };
 
   return (

--- a/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
@@ -23,6 +23,8 @@ const AccessTokenSettings = (props) => {
     toastSuccess(t('slack_integration.copied_to_clipboard'));
   };
 
+  const accessToken = props.accessToken ? props.accessToken : '';
+
   return (
     <div className="row">
       <div className="col-lg-12">
@@ -32,15 +34,13 @@ const AccessTokenSettings = (props) => {
         <div className="form-group row my-5">
           <label className="text-left text-md-right col-md-3 col-form-label">Access Token</label>
           <div className="col-md-6">
-            {props.accessToken == null
-              ? (
-                <input className="form-control" type="text" value={props.accessToken} readOnly />
-              ) : (
-                <CopyToClipboard text={props.accessToken} onCopy={showCopiedToaster}>
-                  <input className="form-control" type="text" value={props.accessToken} readOnly />
-                </CopyToClipboard>
-              )
-            }
+            {props.accessToken == null ? (
+              <input className="form-control" type="text" value={accessToken} readOnly />
+            ) : (
+              <CopyToClipboard text={accessToken} onCopy={showCopiedToaster}>
+                <input className="form-control" type="text" value={accessToken} readOnly />
+              </CopyToClipboard>
+            )}
           </div>
         </div>
 

--- a/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
@@ -22,7 +22,7 @@ const AccessTokenSettings = (props) => {
     e.target.select();
     if (props.accessToken) {
       navigator.clipboard.writeText(props.accessToken)
-        .then(() => { toastSuccess('slack_integration.copied_to_clipboard') });
+        .then(() => { toastSuccess(t('slack_integration.copied_to_clipboard')) });
     }
   };
 

--- a/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
@@ -41,7 +41,7 @@ const AccessTokenSettings = (props) => {
 
         <div className="row">
           <div className="mx-auto">
-            <button type="button" className="btn btn-outline-secondary text-nowrap mx-1" onClick={discardTokenHandler}>
+            <button type="button" className="btn btn-outline-secondary text-nowrap mx-1" onClick={discardTokenHandler} disabled={!props.accessToken}>
               {t('slack_integration.access_token_settings.discard')}
             </button>
             <button type="button" className="btn btn-primary text-nowrap mx-1" onClick={generateTokenHandler}>

--- a/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
@@ -19,10 +19,6 @@ const AccessTokenSettings = (props) => {
     }
   };
 
-  const showCopiedToaster = () => {
-    toastSuccess(t('slack_integration.copied_to_clipboard'));
-  };
-
   const accessToken = props.accessToken ? props.accessToken : '';
 
   return (
@@ -37,7 +33,7 @@ const AccessTokenSettings = (props) => {
             {props.accessToken == null ? (
               <input className="form-control" type="text" value={accessToken} readOnly />
             ) : (
-              <CopyToClipboard text={accessToken} onCopy={showCopiedToaster}>
+              <CopyToClipboard text={accessToken} onCopy={toastSuccess(t('slack_integration.copied_to_clipboard'))}>
                 <input className="form-control" type="text" value={accessToken} readOnly />
               </CopyToClipboard>
             )}

--- a/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
@@ -32,7 +32,7 @@ const AccessTokenSettings = (props) => {
         <div className="form-group row my-5">
           <label className="text-left text-md-right col-md-3 col-form-label">Access Token</label>
           <div className="col-md-6">
-            <CopyToClipboard text={props.accessToken ? props.accessToken : null} onCopy={showCopiedToaster}>
+            <CopyToClipboard text={props.accessToken} onCopy={showCopiedToaster ? props.accessToken : null}>
               <input className="form-control" type="text" value={props.accessToken} readOnly />
             </CopyToClipboard>
           </div>

--- a/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
@@ -9,7 +9,7 @@ const AccessTokenSettings = (props) => {
   const { appContainer } = props;
   const { t } = useTranslation('admin');
 
-  const [accessToken, setAccessToken] = useState('asdfasdf');
+  const [accessToken, setAccessToken] = useState('');
 
   const generateTokenHandler = async() => {
     try {
@@ -31,10 +31,11 @@ const AccessTokenSettings = (props) => {
     console.log('discard');
   };
 
-  const textboxClickHandler = (e) => {
-    e.target.select();
-    document.execCommand('copy');
-    toastSuccess('Copied');
+  const textboxClickHandler = () => {
+    const a = navigator.permissions.query({name: "clipboard-write"});
+    console.log(a);
+    
+
   };
 
   return (

--- a/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
 import AppContainer from '../../../services/AppContainer';
@@ -6,39 +6,26 @@ import { withUnstatedContainers } from '../../UnstatedUtils';
 import { toastSuccess, toastError } from '../../../util/apiNotification';
 
 const AccessTokenSettings = (props) => {
-  const { appContainer } = props;
   const { t } = useTranslation('admin');
 
-  const [accessToken, setAccessToken] = useState('');
+  const discardTokenHandler = () => {
+    if (props.discardTokenHandler != null) {
+      props.discardTokenHandler();
+    }
+  }
 
-  const generateTokenHandler = async() => {
-    try {
-      const res = await appContainer.apiv3.put('slack-integration/access-token');
-      setAccessToken(res.data.accessToken);
+  const generateTokenHandler = () => {
+    if (props.generateTokenHandler != null) {
+      props.generateTokenHandler();
     }
-    catch (err) {
-      toastError(err);
-    }
-  };
-
-  const discardTokenHandler = async() => {
-    try {
-      const res = await appContainer.apiv3.put('slack-integration/access-token', { deleteAccessToken: true });
-      setAccessToken(res.data.accessToken);
-      toastSuccess(t('slack_integration.bot_reset_successful'));
-    }
-    catch (err) {
-      toastError(err);
-    }
-  };
+  }
 
   const textboxClickHandler = (e) => {
     e.target.select();
-    if (accessToken) {
-      navigator.clipboard.writeText(accessToken)
+    if (props.accessToken != null) {
+      navigator.clipboard.writeText(props.accessToken)
         .then(() => { toastSuccess('slack_integration.copied_to_clipboard') });
     }
-
   };
 
   return (
@@ -50,7 +37,7 @@ const AccessTokenSettings = (props) => {
         <div className="form-group row my-5">
           <label className="text-left text-md-right col-md-3 col-form-label">Access Token</label>
           <div className="col-md-6">
-            <input className="form-control" type="text" value={accessToken} onClick={e => textboxClickHandler(e)} readOnly />
+            <input className="form-control" type="text" value={props.accessToken} onClick={e => textboxClickHandler(e)} readOnly />
           </div>
         </div>
 
@@ -74,6 +61,9 @@ const AccessTokenSettingsWrapper = withUnstatedContainers(AccessTokenSettings, [
 
 AccessTokenSettings.propTypes = {
   appContainer: PropTypes.instanceOf(AppContainer).isRequired,
+  accessToken: PropTypes.string,
+  discardTokenHandler: PropTypes.func,
+  generateTokenHandler: PropTypes.func,
 };
 
 export default AccessTokenSettingsWrapper;

--- a/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
@@ -22,7 +22,7 @@ const AccessTokenSettings = (props) => {
 
   const textboxClickHandler = (e) => {
     e.target.select();
-    if (props.accessToken != null) {
+    if (props.accessToken) {
       navigator.clipboard.writeText(props.accessToken)
         .then(() => { toastSuccess('slack_integration.copied_to_clipboard') });
     }

--- a/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
 import AppContainer from '../../../services/AppContainer';
 import { withUnstatedContainers } from '../../UnstatedUtils';
-import { toastSuccess, toastError } from '../../../util/apiNotification';
+import { toastSuccess } from '../../../util/apiNotification';
 
 const AccessTokenSettings = (props) => {
   const { t } = useTranslation('admin');
@@ -12,13 +12,13 @@ const AccessTokenSettings = (props) => {
     if (props.discardTokenHandler != null) {
       props.discardTokenHandler();
     }
-  }
+  };
 
   const generateTokenHandler = () => {
     if (props.generateTokenHandler != null) {
       props.generateTokenHandler();
     }
-  }
+  };
 
   const textboxClickHandler = (e) => {
     e.target.select();

--- a/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
@@ -32,8 +32,13 @@ const AccessTokenSettings = (props) => {
         <div className="form-group row my-5">
           <label className="text-left text-md-right col-md-3 col-form-label">Access Token</label>
           <div className="col-md-6">
-            <CopyToClipboard text={props.accessToken} onCopy={props.accessToken ? showCopiedToaster : null}>
-              <input className="form-control" type="text" value={props.accessToken} readOnly />
+{props.accessToken == null ? (
+  <input className="form-control" type="text" value={props.accessToken} readOnly />
+): (
+<CopyToClipboard text={props.accessToken} onCopy={showCopiedToaster}>
+<input className="form-control" type="text" value={props.accessToken} readOnly />
+</CopyToClipboard>
+)}
             </CopyToClipboard>
           </div>
         </div>

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -60,6 +60,7 @@ const CustomBotWithoutProxySettings = (props) => {
             onClick={() => window.open('https://api.slack.com/apps', '_blank')}
           >
             {t('admin:slack_integration.without_proxy.create_bot')}
+            <i className="fas fa-external-link-alt"></i>
           </button>
         </div>
       </div>

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -60,7 +60,6 @@ const CustomBotWithoutProxySettings = (props) => {
             onClick={() => window.open('https://api.slack.com/apps', '_blank')}
           >
             {t('admin:slack_integration.without_proxy.create_bot')}
-            <i className="fas fa-external-link-alt"></i>
           </button>
         </div>
       </div>

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -112,8 +112,8 @@ const SlackIntegration = (props) => {
 
       <AccessTokenSettings
         accessToken={accessToken}
-        discardTokenHandler={discardTokenHandler}
-        generateTokenHandler={generateTokenHandler}
+        onClickDiscardButton={discardTokenHandler}
+        onClickGenerateToken={generateTokenHandler}
       />
 
       <div className="row my-5">

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -16,6 +16,7 @@ const SlackIntegration = (props) => {
   const { t } = useTranslation();
   const [currentBotType, setCurrentBotType] = useState(null);
   const [selectedBotType, setSelectedBotType] = useState(null);
+  const [accessToken, setAccessToken] = useState('');
 
   const fetchData = useCallback(async() => {
     try {
@@ -63,6 +64,27 @@ const SlackIntegration = (props) => {
     }
   };
 
+  const generateTokenHandler = async() => {
+    try {
+      const res = await appContainer.apiv3.put('slack-integration/access-token');
+      setAccessToken(res.data.accessToken);
+    }
+    catch (err) {
+      toastError(err);
+    }
+  };
+
+  const discardTokenHandler = async() => {
+    try {
+      const res = await appContainer.apiv3.put('slack-integration/access-token', { deleteAccessToken: true });
+      setAccessToken(res.data.accessToken);
+      toastSuccess(t('slack_integration.bot_reset_successful'));
+    }
+    catch (err) {
+      toastError(err);
+    }
+  };
+
   let settingsComponent = null;
 
   switch (currentBotType) {
@@ -87,7 +109,11 @@ const SlackIntegration = (props) => {
         />
       </div>
 
-      <AccessTokenSettings />
+      <AccessTokenSettings
+        accessToken={accessToken}
+        discardTokenHandler={discardTokenHandler}
+        generateTokenHandler={generateTokenHandler}
+      />
 
       <div className="row my-5">
         <div className="card-deck mx-auto">

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -75,9 +75,6 @@ const SlackIntegration = (props) => {
   };
 
   const discardTokenHandler = async() => {
-    if (!accessToken) {
-      return;
-    }
     try {
       const res = await appContainer.apiv3.put('slack-integration/access-token', { deleteAccessToken: true });
       setAccessToken(res.data.accessToken);

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -75,6 +75,9 @@ const SlackIntegration = (props) => {
   };
 
   const discardTokenHandler = async() => {
+    if (!accessToken) {
+      return;
+    }
     try {
       const res = await appContainer.apiv3.put('slack-integration/access-token', { deleteAccessToken: true });
       setAccessToken(res.data.accessToken);

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -77,7 +77,7 @@ const SlackIntegration = (props) => {
 
   const discardTokenHandler = async() => {
     try {
-      const res = await appContainer.apiv3.put('slack-integration/access-token', { deleteAccessToken: true });
+      const res = await appContainer.apiv3.put('slack-integration/access-token');
       setAccessToken(res.data.accessToken);
       toastSuccess(t('admin:slack_integration.bot_reset_successful'));
     }

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -73,13 +73,7 @@ const SlackIntegration = (props) => {
         />
       </div>
 
-      <div className="row">
-        <div className="col-lg-12">
-          <h2 className="admin-setting-header">Access Token</h2>
-          <AccessTokenSettings />
-        </div>
-      </div>
-
+      <AccessTokenSettings />
 
       <div className="row my-5">
         <div className="card-deck mx-auto">

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import AppContainer from '../../../services/AppContainer';
 import { withUnstatedContainers } from '../../UnstatedUtils';
 import { toastSuccess, toastError } from '../../../util/apiNotification';
+
 import AccessTokenSettings from './AccessTokenSettings';
 import OfficialBotSettings from './OfficialBotSettings';
 import CustomBotWithoutProxySettings from './CustomBotWithoutProxySettings';

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -78,7 +78,7 @@ const SlackIntegration = (props) => {
     try {
       const res = await appContainer.apiv3.put('slack-integration/access-token', { deleteAccessToken: true });
       setAccessToken(res.data.accessToken);
-      toastSuccess(t('slack_integration.bot_reset_successful'));
+      toastSuccess(t('admin:slack_integration.bot_reset_successful'));
     }
     catch (err) {
       toastError(err);
@@ -101,13 +101,11 @@ const SlackIntegration = (props) => {
 
   return (
     <>
-      <div className="container">
-        <ConfirmBotChangeModal
-          isOpen={selectedBotType != null}
-          onConfirmClick={handleChangeCurrentBotSettings}
-          onCancelClick={handleCancelBotChange}
-        />
-      </div>
+      <ConfirmBotChangeModal
+        isOpen={selectedBotType != null}
+        onConfirmClick={handleChangeCurrentBotSettings}
+        onCancelClick={handleCancelBotChange}
+      />
 
       <AccessTokenSettings
         accessToken={accessToken}

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -77,8 +77,8 @@ const SlackIntegration = (props) => {
 
   const discardTokenHandler = async() => {
     try {
-      const res = await appContainer.apiv3.put('slack-integration/access-token');
-      setAccessToken(res.data.accessToken);
+      await appContainer.apiv3.delete('slack-integration/access-token');
+      setAccessToken('');
       toastSuccess(t('admin:slack_integration.bot_reset_successful'));
     }
     catch (err) {

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -31,19 +31,6 @@ const SlackIntegration = (props) => {
     fetchData();
   }, [fetchData]);
 
-  const resetBotType = async() => {
-    try {
-      await appContainer.apiv3.put('slack-integration/custom-bot-without-proxy', {
-        slackSigningSecret: '',
-        slackBotToken: '',
-        botType: selectedBotType,
-      });
-    }
-    catch (err) {
-      toastError(err);
-    }
-  };
-
   const handleBotTypeSelect = (clickedBotType) => {
     if (clickedBotType === currentBotType) {
       return;

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -68,7 +68,7 @@ const SlackIntegration = (props) => {
   const generateTokenHandler = async() => {
     try {
       const res = await appContainer.apiv3.put('slack-integration/access-token');
-      setAccessToken(res.data.accessToken);
+      fetchData()
     }
     catch (err) {
       toastError(err);

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -22,8 +22,9 @@ const SlackIntegration = (props) => {
   const fetchData = useCallback(async() => {
     try {
       const response = await appContainer.apiv3.get('slack-integration/');
-      const { currentBotType } = response.data.slackBotSettingParams;
+      const { currentBotType, accessToken } = response.data.slackBotSettingParams;
       setCurrentBotType(currentBotType);
+      setAccessToken(accessToken);
     }
     catch (err) {
       toastError(err);
@@ -45,11 +46,11 @@ const SlackIntegration = (props) => {
     setSelectedBotType(clickedBotType);
   };
 
-  const handleCancelBotChange = () => {
+  const cancelBotChangeHandler = () => {
     setSelectedBotType(null);
   };
 
-  const handleChangeCurrentBotSettings = async() => {
+  const changeCurrentBotSettingsHandler = async() => {
     try {
       const res = await appContainer.apiv3.put('slack-integration/custom-bot-without-proxy', {
         slackSigningSecret: '',
@@ -67,8 +68,8 @@ const SlackIntegration = (props) => {
 
   const generateTokenHandler = async() => {
     try {
-      const res = await appContainer.apiv3.put('slack-integration/access-token');
-      fetchData()
+      await appContainer.apiv3.put('slack-integration/access-token');
+      fetchData();
     }
     catch (err) {
       toastError(err);
@@ -78,7 +79,7 @@ const SlackIntegration = (props) => {
   const discardTokenHandler = async() => {
     try {
       await appContainer.apiv3.delete('slack-integration/access-token');
-      setAccessToken('');
+      fetchData();
       toastSuccess(t('admin:slack_integration.bot_reset_successful'));
     }
     catch (err) {
@@ -106,8 +107,8 @@ const SlackIntegration = (props) => {
     <>
       <ConfirmBotChangeModal
         isOpen={selectedBotType != null}
-        onConfirmClick={handleChangeCurrentBotSettings}
-        onCancelClick={handleCancelBotChange}
+        onConfirmClick={changeCurrentBotSettingsHandler}
+        onCancelClick={cancelBotChangeHandler}
       />
 
       <AccessTokenSettings

--- a/src/server/routes/apiv3/slack-integration.js
+++ b/src/server/routes/apiv3/slack-integration.js
@@ -258,11 +258,7 @@ module.exports = (crowi) => {
   router.put('/access-token', loginRequiredStrictly, adminRequired, csrf, async(req, res) => {
 
     try {
-      let accessToken = '';
-
-      if (req.body.deleteAccessToken !== true) {
-        accessToken = generateAccessToken(req.user);
-      }
+      const accessToken = generateAccessToken(req.user);
       await updateSlackBotSettings({ 'slackbot:access-token': accessToken });
 
       // initialize bolt service

--- a/src/server/routes/apiv3/slack-integration.js
+++ b/src/server/routes/apiv3/slack-integration.js
@@ -78,6 +78,7 @@ module.exports = (crowi) => {
   router.get('/', accessTokenParser, loginRequiredStrictly, adminRequired, async(req, res) => {
 
     const slackBotSettingParams = {
+      accessToken: crowi.configManager.getConfig('crowi', 'slackbot:accessToken'),
       slackBotType: crowi.configManager.getConfig('crowi', 'slackbot:type'),
       // TODO impl when creating official bot
       officialBotSettings: {
@@ -168,7 +169,11 @@ module.exports = (crowi) => {
   router.put('/access-token', loginRequiredStrictly, adminRequired, async(req, res) => {
 
     try {
-      const accessToken = generateAccessToken(req.user);
+      let accessToken = '';
+
+      if (req.body.deleteAccessToken !== true) {
+        accessToken = generateAccessToken(req.user);
+      }
       await updateSlackBotSettings({ 'slackbot:access-token': accessToken });
 
       return res.apiv3({ accessToken });

--- a/src/server/routes/apiv3/slack-integration.js
+++ b/src/server/routes/apiv3/slack-integration.js
@@ -87,7 +87,7 @@ module.exports = (crowi) => {
    */
   router.get('/', accessTokenParser, loginRequiredStrictly, adminRequired, async(req, res) => {
     const slackBotSettingParams = {
-      accessToken: crowi.configManager.getConfig('crowi', 'slackbot:accessToken'),
+      accessToken: crowi.configManager.getConfig('crowi', 'slackbot:access-token'),
       currentBotType: crowi.configManager.getConfig('crowi', 'slackbot:currentBotType'),
       // TODO impl when creating official bot
       officialBotSettings: {

--- a/src/server/service/config-loader.js
+++ b/src/server/service/config-loader.js
@@ -410,6 +410,12 @@ const ENV_VAR_NAME_TO_CONFIG_INFO = {
     type:    TYPES.STRING,
     default: null,
   },
+  SLACK_BOT_ACCESS_TOKEN: {
+    ns:      'crowi',
+    key:     'slackbot:accessToken',
+    type:    TYPES.STRING,
+    default: null,
+  },
   SLACK_BOT_TYPE: {
     ns:      'crowi',
     key:     'slackbot:type', // eg. official || custom-without-proxy || custom-with-proxy

--- a/src/server/service/config-loader.js
+++ b/src/server/service/config-loader.js
@@ -412,7 +412,7 @@ const ENV_VAR_NAME_TO_CONFIG_INFO = {
   },
   SLACK_BOT_ACCESS_TOKEN: {
     ns:      'crowi',
-    key:     'slackbot:accessToken',
+    key:     'slackbot:access-token',
     type:    TYPES.STRING,
     default: null,
   },


### PR DESCRIPTION
Access Token発行ボタンを押すとAccess TokenがInputに出力されます。
<img width="1076" alt="Screen Shot 2021-04-05 at 10 51 23" src="https://user-images.githubusercontent.com/66785624/113528865-e28b2880-95fc-11eb-9a73-d5bb9fb6ca23.png">

Inputを押すとクリップボードにAccess Tokenがコピーされ、成功した場合のみToasterで成功メッセージが出ます。
<img width="679" alt="Toaster" src="https://user-images.githubusercontent.com/66785624/113528927-077f9b80-95fd-11eb-8471-67bc7c2bbc7e.png">

破棄ボタンは、InputにAccess Tokenが表示されている場合のみ押すことができます。