### PR TITLE
imprv/allows check the setup status of BoltService on the management screen

### DIFF
--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -21,6 +21,7 @@ const CustomBotWithoutProxySettings = (props) => {
   // get site name from this GROWI
   // eslint-disable-next-line no-unused-vars
   const [siteName, setSiteName] = useState('');
+  const [isBoltSetup, setIsBoltSetup] = useState(null);
   const currentBotType = 'custom-bot-without-proxy';
 
   const getSlackWSInWithoutProxy = useCallback(async() => {
@@ -38,13 +39,14 @@ const CustomBotWithoutProxySettings = (props) => {
       await adminAppContainer.retrieveAppSettingsData();
       const res = await appContainer.apiv3.get('/slack-integration/');
       const {
-        slackSigningSecret, slackBotToken, slackSigningSecretEnvVars, slackBotTokenEnvVars,
+        slackSigningSecret, slackBotToken, slackSigningSecretEnvVars, slackBotTokenEnvVars, isBoltSetup
       } = res.data.slackBotSettingParams.customBotWithoutProxySettings;
       setSlackSigningSecret(slackSigningSecret);
       setSlackBotToken(slackBotToken);
       setSlackSigningSecretEnv(slackSigningSecretEnvVars);
       setSlackBotTokenEnv(slackBotTokenEnvVars);
       setSiteName(adminAppContainer.state.title);
+      setIsBoltSetup(isBoltSetup);
     }
     catch (err) {
       toastError(err);

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -21,7 +21,6 @@ const CustomBotWithoutProxySettings = (props) => {
   // get site name from this GROWI
   // eslint-disable-next-line no-unused-vars
   const [siteName, setSiteName] = useState('');
-  const [isBoltSetup, setIsBoltSetup] = useState(null);
   const currentBotType = 'custom-bot-without-proxy';
 
   const getSlackWSInWithoutProxy = useCallback(async() => {
@@ -46,7 +45,7 @@ const CustomBotWithoutProxySettings = (props) => {
       setSlackSigningSecretEnv(slackSigningSecretEnvVars);
       setSlackBotTokenEnv(slackBotTokenEnvVars);
       setSiteName(adminAppContainer.state.title);
-      setIsBoltSetup(isBoltSetup);
+      console.log('isBoltSetup', isBoltSetup);
     }
     catch (err) {
       toastError(err);

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -21,6 +21,7 @@ const CustomBotWithoutProxySettings = (props) => {
   // get site name from this GROWI
   // eslint-disable-next-line no-unused-vars
   const [siteName, setSiteName] = useState('');
+  const [isBoltSetup, setIsBoltSetup] = useState(null);
   const currentBotType = 'custom-bot-without-proxy';
 
   const getSlackWSInWithoutProxy = useCallback(async() => {
@@ -45,12 +46,13 @@ const CustomBotWithoutProxySettings = (props) => {
       setSlackSigningSecretEnv(slackSigningSecretEnvVars);
       setSlackBotTokenEnv(slackBotTokenEnvVars);
       setSiteName(adminAppContainer.state.title);
-      console.log('isBoltSetup', isBoltSetup);
+      setIsBoltSetup(isBoltSetup);
     }
     catch (err) {
       toastError(err);
     }
   }, [appContainer, adminAppContainer]);
+
 
   useEffect(() => {
     fetchData();

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -53,6 +53,7 @@ const CustomBotWithoutProxySettings = (props) => {
     }
   }, [appContainer, adminAppContainer]);
 
+  console.log(isBoltSetup);
 
   useEffect(() => {
     fetchData();

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -21,7 +21,7 @@ const CustomBotWithoutProxySettings = (props) => {
   // get site name from this GROWI
   // eslint-disable-next-line no-unused-vars
   const [siteName, setSiteName] = useState('');
-// eslint-disable-next-line no-unused-vars
+  // eslint-disable-next-line no-unused-vars
   const [isBoltSetup, setIsBoltSetup] = useState(null);
   const currentBotType = 'custom-bot-without-proxy';
 
@@ -53,8 +53,6 @@ const CustomBotWithoutProxySettings = (props) => {
       toastError(err);
     }
   }, [appContainer, adminAppContainer]);
-
-  console.log(isBoltSetup);
 
   useEffect(() => {
     fetchData();

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -39,7 +39,7 @@ const CustomBotWithoutProxySettings = (props) => {
       await adminAppContainer.retrieveAppSettingsData();
       const res = await appContainer.apiv3.get('/slack-integration/');
       const {
-        slackSigningSecret, slackBotToken, slackSigningSecretEnvVars, slackBotTokenEnvVars, isBoltSetup
+        slackSigningSecret, slackBotToken, slackSigningSecretEnvVars, slackBotTokenEnvVars, isBoltSetup,
       } = res.data.slackBotSettingParams.customBotWithoutProxySettings;
       setSlackSigningSecret(slackSigningSecret);
       setSlackBotToken(slackBotToken);

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -21,6 +21,7 @@ const CustomBotWithoutProxySettings = (props) => {
   // get site name from this GROWI
   // eslint-disable-next-line no-unused-vars
   const [siteName, setSiteName] = useState('');
+// eslint-disable-next-line no-unused-vars
   const [isBoltSetup, setIsBoltSetup] = useState(null);
   const currentBotType = 'custom-bot-without-proxy';
 

--- a/src/server/routes/apiv3/slack-integration.js
+++ b/src/server/routes/apiv3/slack-integration.js
@@ -87,7 +87,6 @@ module.exports = (crowi) => {
    */
   router.get('/', accessTokenParser, loginRequiredStrictly, adminRequired, async(req, res) => {
     const slackBotSettingParams = {
-      isBoltSetup: crowi.boltService.isBoltSetup,
       currentBotType: crowi.configManager.getConfig('crowi', 'slackbot:currentBotType'),
       // TODO impl when creating official bot
       officialBotSettings: {
@@ -101,6 +100,7 @@ module.exports = (crowi) => {
         slackBotTokenEnvVars: crowi.configManager.getConfigFromEnvVars('crowi', 'slackbot:token'),
         slackSigningSecret: crowi.configManager.getConfig('crowi', 'slackbot:signingSecret'),
         slackBotToken: crowi.configManager.getConfig('crowi', 'slackbot:token'),
+        isBoltSetup: crowi.boltService.isBoltSetup,
       },
       // TODO imple when creating with proxy
       customBotWithProxySettings: {

--- a/src/server/routes/apiv3/slack-integration.js
+++ b/src/server/routes/apiv3/slack-integration.js
@@ -76,8 +76,8 @@ module.exports = (crowi) => {
    *            description: Succeeded to get slackBot setting params.
    */
   router.get('/', accessTokenParser, loginRequiredStrictly, adminRequired, async(req, res) => {
-
     const slackBotSettingParams = {
+      isBoltSetup: crowi.boltService.isBoltSetup,
       slackBotType: crowi.configManager.getConfig('crowi', 'slackbot:type'),
       // TODO impl when creating official bot
       officialBotSettings: {

--- a/src/server/routes/apiv3/slack-integration.js
+++ b/src/server/routes/apiv3/slack-integration.js
@@ -87,6 +87,7 @@ module.exports = (crowi) => {
    */
   router.get('/', accessTokenParser, loginRequiredStrictly, adminRequired, async(req, res) => {
     const slackBotSettingParams = {
+      isBoltSetup: crowi.boltService.isBoltSetup,
       currentBotType: crowi.configManager.getConfig('crowi', 'slackbot:currentBotType'),
       // TODO impl when creating official bot
       officialBotSettings: {


### PR DESCRIPTION
Slack連携 -> Custom Bot (Without Proxy) のコンソール画面にてBoltServiceのsetupの状態を確認できるようにしました。
<img width="430" alt="スクリーンショット 2021-04-05 16 06 24" src="https://user-images.githubusercontent.com/34241526/113547461-ec2a8580-9628-11eb-8233-58b6607591fe.png">
