### PR TITLE
Imprv/hide email in default

### DIFF
--- a/src/server/models/user.js
+++ b/src/server/models/user.js
@@ -41,6 +41,7 @@ module.exports = function(crowi) {
     imageUrlCached: String,
     isGravatarEnabled: { type: Boolean, default: false },
     isEmailPublished: { type: Boolean, default: true },
+    isEmailPublishedForNewUser: { type: Boolean, default: false },
     googleId: String,
     name: { type: String },
     username: { type: String, required: true, unique: true },
@@ -542,6 +543,7 @@ module.exports = function(crowi) {
     newUser.setPassword(password);
     newUser.createdAt = Date.now();
     newUser.status = STATUS_INVITED;
+    newUser.isEmailPublishedForNewUser = false;
 
     const globalLang = configManager.getConfig('crowi', 'app:globalLang');
     if (globalLang != null) {

--- a/src/server/models/user.js
+++ b/src/server/models/user.js
@@ -41,7 +41,6 @@ module.exports = function(crowi) {
     imageUrlCached: String,
     isGravatarEnabled: { type: Boolean, default: false },
     isEmailPublished: { type: Boolean, default: true },
-    isEmailPublishedForNewUser: { type: Boolean, default: false },
     googleId: String,
     name: { type: String },
     username: { type: String, required: true, unique: true },
@@ -543,7 +542,6 @@ module.exports = function(crowi) {
     newUser.setPassword(password);
     newUser.createdAt = Date.now();
     newUser.status = STATUS_INVITED;
-    newUser.isEmailPublishedForNewUser = false;
 
     const globalLang = configManager.getConfig('crowi', 'app:globalLang');
     if (globalLang != null) {
@@ -653,6 +651,13 @@ module.exports = function(crowi) {
     }
 
     const configManager = crowi.configManager;
+
+    const isEmailPubshedForNewUser = configManager.getConfig('crowi', 'app:isEmailPubshedForNewUser');
+    if (isEmailPubshedForNewUser === false) {
+      newUser.isEmailPublished = false;
+    }
+
+
     const globalLang = configManager.getConfig('crowi', 'app:globalLang');
     if (globalLang != null) {
       newUser.lang = globalLang;

--- a/src/server/models/user.js
+++ b/src/server/models/user.js
@@ -653,8 +653,8 @@ module.exports = function(crowi) {
     const configManager = crowi.configManager;
 
     const isEmailPubshedForNewUser = configManager.getConfig('crowi', 'app:isEmailPubshedForNewUser');
-    if (isEmailPubshedForNewUser === false) {
-      newUser.isEmailPublished = false;
+    if (isEmailPubshedForNewUser !== null) {
+      newUser.isEmailPublished = isEmailPubshedForNewUser;
     }
 
 

--- a/src/server/models/user.js
+++ b/src/server/models/user.js
@@ -653,7 +653,7 @@ module.exports = function(crowi) {
     const configManager = crowi.configManager;
 
     // Default email show/hide is up to the administrator
-    const isEmailPubshedForNewUser = configManager.getConfig('crowi', 'app:isEmailPubshedForNewUser');
+    const isEmailPubshedForNewUser = configManager.getConfig('crowi', 'app:isEmailPublishedForNewUser');
     if (isEmailPubshedForNewUser !== null) {
       newUser.isEmailPublished = isEmailPubshedForNewUser;
     }

--- a/src/server/models/user.js
+++ b/src/server/models/user.js
@@ -654,9 +654,9 @@ module.exports = function(crowi) {
 
     // Default email show/hide is up to the administrator
     const isEmailPubshedForNewUser = configManager.getConfig('crowi', 'app:isEmailPublishedForNewUser');
-    if (isEmailPubshedForNewUser !== null) {
-      newUser.isEmailPublished = isEmailPubshedForNewUser;
-    }
+    // if (isEmailPubshedForNewUser !== null) {
+    newUser.isEmailPublished = isEmailPubshedForNewUser;
+    // }
 
     const globalLang = configManager.getConfig('crowi', 'app:globalLang');
     if (globalLang != null) {

--- a/src/server/models/user.js
+++ b/src/server/models/user.js
@@ -653,7 +653,7 @@ module.exports = function(crowi) {
     const configManager = crowi.configManager;
 
     // Default email show/hide is up to the administrator
-    const isEmailPubshedForNewUser = configManager.getConfig('crowi', 'app:isEmailPublishedForNewUser');
+    const isEmailPubshedForNewUser = configManager.getConfig('crowi', 'customize:isEmailPublishedForNewUser');
     // if (isEmailPubshedForNewUser !== null) {
     newUser.isEmailPublished = isEmailPubshedForNewUser;
     // }

--- a/src/server/models/user.js
+++ b/src/server/models/user.js
@@ -653,10 +653,7 @@ module.exports = function(crowi) {
     const configManager = crowi.configManager;
 
     // Default email show/hide is up to the administrator
-    const isEmailPubshedForNewUser = configManager.getConfig('crowi', 'customize:isEmailPublishedForNewUser');
-    // if (isEmailPubshedForNewUser !== null) {
-    newUser.isEmailPublished = isEmailPubshedForNewUser;
-    // }
+    newUser.isEmailPublished = configManager.getConfig('crowi', 'customize:isEmailPublishedForNewUser');
 
     const globalLang = configManager.getConfig('crowi', 'app:globalLang');
     if (globalLang != null) {

--- a/src/server/models/user.js
+++ b/src/server/models/user.js
@@ -652,11 +652,11 @@ module.exports = function(crowi) {
 
     const configManager = crowi.configManager;
 
+    // Default email show/hide is up to the administrator
     const isEmailPubshedForNewUser = configManager.getConfig('crowi', 'app:isEmailPubshedForNewUser');
     if (isEmailPubshedForNewUser !== null) {
       newUser.isEmailPublished = isEmailPubshedForNewUser;
     }
-
 
     const globalLang = configManager.getConfig('crowi', 'app:globalLang');
     if (globalLang != null) {

--- a/src/server/routes/apiv3/app-settings.js
+++ b/src/server/routes/apiv3/app-settings.js
@@ -38,7 +38,7 @@ const ErrorV3 = require('../../models/vo/error-apiv3');
  *          globalLang:
  *            type: string
  *            description: language set when create user
- *          isEmailPubshedForNewUser:
+ *          isEmailPublishedForNewUser:
  *            type: boolean
  *            description: default email show/hide setting when create user
  *          fileUpload:
@@ -157,7 +157,7 @@ module.exports = (crowi) => {
       body('title').trim(),
       body('confidential'),
       body('globalLang').isIn(listLocaleIds()),
-      body('isEmailPubshedForNewUser').isBoolean(),
+      body('isEmailPublishedForNewUser').isBoolean(),
       body('fileUpload').isBoolean(),
     ],
     siteUrlSetting: [
@@ -223,7 +223,7 @@ module.exports = (crowi) => {
       title: crowi.configManager.getConfig('crowi', 'app:title'),
       confidential: crowi.configManager.getConfig('crowi', 'app:confidential'),
       globalLang: crowi.configManager.getConfig('crowi', 'app:globalLang'),
-      isEmailPubshedForNewUser: crowi.configManager.getConfig('crowi', 'app:isEmailPubshedForNewUser'),
+      isEmailPublishedForNewUser: crowi.configManager.getConfig('crowi', 'app:isEmailPublishedForNewUser'),
       fileUpload: crowi.configManager.getConfig('crowi', 'app:fileUpload'),
       siteUrl: crowi.configManager.getConfig('crowi', 'app:siteUrl'),
       envSiteUrl: crowi.configManager.getConfigFromEnvVars('crowi', 'app:siteUrl'),
@@ -294,7 +294,7 @@ module.exports = (crowi) => {
       'app:title': req.body.title,
       'app:confidential': req.body.confidential,
       'app:globalLang': req.body.globalLang,
-      'app:isEmailPubshedForNewUser': req.body.isEmailPubshedForNewUser,
+      'app:isEmailPublishedForNewUser': req.body.isEmailPublishedForNewUser,
       'app:fileUpload': req.body.fileUpload,
     };
 
@@ -304,7 +304,7 @@ module.exports = (crowi) => {
         title: crowi.configManager.getConfig('crowi', 'app:title'),
         confidential: crowi.configManager.getConfig('crowi', 'app:confidential'),
         globalLang: crowi.configManager.getConfig('crowi', 'app:globalLang'),
-        isEmailPubshedForNewUser: crowi.configManager.getConfig('crowi', 'app:isEmailPubshedForNewUser'),
+        isEmailPublishedForNewUser: crowi.configManager.getConfig('crowi', 'app:isEmailPublishedForNewUser'),
         fileUpload: crowi.configManager.getConfig('crowi', 'app:fileUpload'),
       };
       return res.apiv3({ appSettingParams });

--- a/src/server/routes/apiv3/app-settings.js
+++ b/src/server/routes/apiv3/app-settings.js
@@ -223,7 +223,7 @@ module.exports = (crowi) => {
       title: crowi.configManager.getConfig('crowi', 'app:title'),
       confidential: crowi.configManager.getConfig('crowi', 'app:confidential'),
       globalLang: crowi.configManager.getConfig('crowi', 'app:globalLang'),
-      isEmailPublishedForNewUser: crowi.configManager.getConfig('crowi', 'app:isEmailPublishedForNewUser'),
+      isEmailPublishedForNewUser: crowi.configManager.getConfig('crowi', 'customize:isEmailPublishedForNewUser'),
       fileUpload: crowi.configManager.getConfig('crowi', 'app:fileUpload'),
       siteUrl: crowi.configManager.getConfig('crowi', 'app:siteUrl'),
       envSiteUrl: crowi.configManager.getConfigFromEnvVars('crowi', 'app:siteUrl'),
@@ -294,7 +294,7 @@ module.exports = (crowi) => {
       'app:title': req.body.title,
       'app:confidential': req.body.confidential,
       'app:globalLang': req.body.globalLang,
-      'app:isEmailPublishedForNewUser': req.body.isEmailPublishedForNewUser,
+      'customize:isEmailPublishedForNewUser': req.body.isEmailPublishedForNewUser,
       'app:fileUpload': req.body.fileUpload,
     };
 
@@ -304,7 +304,7 @@ module.exports = (crowi) => {
         title: crowi.configManager.getConfig('crowi', 'app:title'),
         confidential: crowi.configManager.getConfig('crowi', 'app:confidential'),
         globalLang: crowi.configManager.getConfig('crowi', 'app:globalLang'),
-        isEmailPublishedForNewUser: crowi.configManager.getConfig('crowi', 'app:isEmailPublishedForNewUser'),
+        isEmailPublishedForNewUser: crowi.configManager.getConfig('crowi', 'customize:isEmailPublishedForNewUser'),
         fileUpload: crowi.configManager.getConfig('crowi', 'app:fileUpload'),
       };
       return res.apiv3({ appSettingParams });

--- a/src/server/routes/apiv3/app-settings.js
+++ b/src/server/routes/apiv3/app-settings.js
@@ -38,6 +38,9 @@ const ErrorV3 = require('../../models/vo/error-apiv3');
  *          globalLang:
  *            type: string
  *            description: language set when create user
+ *          isEmailPubshedForNewUser:
+ *            type: boolean
+ *            description: default email show/hide setting when create user
  *          fileUpload:
  *            type: boolean
  *            description: enable upload file except image file
@@ -154,6 +157,7 @@ module.exports = (crowi) => {
       body('title').trim(),
       body('confidential'),
       body('globalLang').isIn(listLocaleIds()),
+      body('isEmailPubshedForNewUser').isBoolean(),
       body('fileUpload').isBoolean(),
     ],
     siteUrlSetting: [
@@ -219,6 +223,7 @@ module.exports = (crowi) => {
       title: crowi.configManager.getConfig('crowi', 'app:title'),
       confidential: crowi.configManager.getConfig('crowi', 'app:confidential'),
       globalLang: crowi.configManager.getConfig('crowi', 'app:globalLang'),
+      isEmailPubshedForNewUser: crowi.configManager.getConfig('crowi', 'app:isEmailPubshedForNewUser'),
       fileUpload: crowi.configManager.getConfig('crowi', 'app:fileUpload'),
       siteUrl: crowi.configManager.getConfig('crowi', 'app:siteUrl'),
       envSiteUrl: crowi.configManager.getConfigFromEnvVars('crowi', 'app:siteUrl'),
@@ -289,6 +294,7 @@ module.exports = (crowi) => {
       'app:title': req.body.title,
       'app:confidential': req.body.confidential,
       'app:globalLang': req.body.globalLang,
+      'app:isEmailPubshedForNewUser': req.body.isEmailPubshedForNewUser,
       'app:fileUpload': req.body.fileUpload,
     };
 
@@ -298,6 +304,7 @@ module.exports = (crowi) => {
         title: crowi.configManager.getConfig('crowi', 'app:title'),
         confidential: crowi.configManager.getConfig('crowi', 'app:confidential'),
         globalLang: crowi.configManager.getConfig('crowi', 'app:globalLang'),
+        isEmailPubshedForNewUser: crowi.configManager.getConfig('crowi', 'app:isEmailPubshedForNewUser'),
         fileUpload: crowi.configManager.getConfig('crowi', 'app:fileUpload'),
       };
       return res.apiv3({ appSettingParams });

--- a/src/server/service/config-loader.js
+++ b/src/server/service/config-loader.js
@@ -398,6 +398,12 @@ const ENV_VAR_NAME_TO_CONFIG_INFO = {
     type:    TYPES.STRING,
     default: null,
   },
+  EMAIL_PUBLISHED_BY_ADMIN: {
+    ns:      'crowi',
+    key:     'app:isEmailPubshedForNewUser',
+    type:    TYPES.BOOLEAN,
+    default: null,
+  },
 };
 
 class ConfigLoader {

--- a/src/server/service/config-loader.js
+++ b/src/server/service/config-loader.js
@@ -402,7 +402,7 @@ const ENV_VAR_NAME_TO_CONFIG_INFO = {
     ns:      'crowi',
     key:     'app:isEmailPubshedForNewUser',
     type:    TYPES.BOOLEAN,
-    default: null,
+    default: false,
   },
 };
 

--- a/src/server/service/config-loader.js
+++ b/src/server/service/config-loader.js
@@ -400,7 +400,7 @@ const ENV_VAR_NAME_TO_CONFIG_INFO = {
   },
   EMAIL_PUBLISHED_BY_ADMIN: {
     ns:      'crowi',
-    key:     'app:isEmailPubshedForNewUser',
+    key:     'app:isEmailPublishedForNewUser',
     type:    TYPES.BOOLEAN,
     default: true,
   },

--- a/src/server/service/config-loader.js
+++ b/src/server/service/config-loader.js
@@ -402,7 +402,7 @@ const ENV_VAR_NAME_TO_CONFIG_INFO = {
     ns:      'crowi',
     key:     'app:isEmailPubshedForNewUser',
     type:    TYPES.BOOLEAN,
-    default: false,
+    default: true,
   },
 };
 

--- a/src/server/service/config-loader.js
+++ b/src/server/service/config-loader.js
@@ -398,9 +398,9 @@ const ENV_VAR_NAME_TO_CONFIG_INFO = {
     type:    TYPES.STRING,
     default: null,
   },
-  EMAIL_PUBLISHED_BY_ADMIN: {
+  DEFAULT_EMAIL_PUBLISHED: {
     ns:      'crowi',
-    key:     'app:isEmailPublishedForNewUser',
+    key:     'customize:isEmailPublishedForNewUser',
     type:    TYPES.BOOLEAN,
     default: true,
   },


### PR DESCRIPTION
## 概要
管理者が User 新規作成時のメール表示 / 非表示設定を管理できるような処理を実装しました。
(バックエンド側)

- 今回の実装は一番単純な user が sign up するときの処理のみ実装しています。
- もう一つ、招待して user を作成する場合の処理は後ほど実装します(shun-m)。