### PR TITLE
Feat/impl notify slack ws put test button

### DIFF
--- a/src/server/routes/apiv3/slack-integration.js
+++ b/src/server/routes/apiv3/slack-integration.js
@@ -275,7 +275,9 @@ module.exports = (crowi) => {
       return res.apiv3({ slackBotToken });
     }
     catch (error) {
-      console.log('error dayo');
+      const msg = 'Error occured in testing to notify slack work space';
+      logger.error('Error', error);
+      return res.apiv3Err(new ErrorV3(msg, 'test-notify-slack-work-space-failed'), 500);
     }
   });
 

--- a/src/server/routes/apiv3/slack-integration.js
+++ b/src/server/routes/apiv3/slack-integration.js
@@ -269,7 +269,13 @@ module.exports = (crowi) => {
   });
 
   router.put('/test-notification-to-slack-work-space', async(req, res) => {
-
+    const slackBotToken = crowi.configManager.getConfig('crowi', 'slackbot:token');
+    try {
+      console.log(slackBotToken);
+    }
+    catch (error) {
+      console.log('error dayo');
+    }
   });
 
   /**

--- a/src/server/routes/apiv3/slack-integration.js
+++ b/src/server/routes/apiv3/slack-integration.js
@@ -284,12 +284,8 @@ module.exports = (crowi) => {
     try {
       this.client.chat.postMessage({
         channel: '#general',
-        blocks: [{
-          type: 'section',
-          text: {
-            type: 'mrkdwn',
-          },
-        }],
+        text: 'Your test was successful!',
+
       });
       console.log(slackBotToken);
       return res.apiv3({ slackBotToken });

--- a/src/server/routes/apiv3/slack-integration.js
+++ b/src/server/routes/apiv3/slack-integration.js
@@ -271,7 +271,6 @@ module.exports = (crowi) => {
   });
 
   router.post('/test-notification-to-slack-work-space', async(req, res) => {
-
     const isConnectedToSlack = crowi.slackBotService.isConnectedToSlack;
     if (!isConnectedToSlack) {
       const msg = 'Bot User OAuth Token is not setup.';

--- a/src/server/routes/apiv3/slack-integration.js
+++ b/src/server/routes/apiv3/slack-integration.js
@@ -277,7 +277,15 @@ module.exports = (crowi) => {
       return 'Bot User OAuth Token is not setup.';
     }
 
+    this.client = new WebClient(slackBotToken, { logLevel: LogLevel.DEBUG });
+    logger.debug('SlackBot: setup is done');
+
     try {
+      this.client.postMessage({
+        channel: this.client.channels,
+        text: '届いたよ',
+
+      });
       console.log(slackBotToken);
       return res.apiv3({ slackBotToken });
     }

--- a/src/server/routes/apiv3/slack-integration.js
+++ b/src/server/routes/apiv3/slack-integration.js
@@ -275,6 +275,7 @@ module.exports = (crowi) => {
 
     if (slackBotToken == null) {
       const msg = 'Bot User OAuth Token is not setup.';
+      logger.error('Error', msg);
       return res.apiv3Err(new ErrorV3(msg, 'not-setup-slack-bot-token', 400));
     }
 

--- a/src/server/routes/apiv3/slack-integration.js
+++ b/src/server/routes/apiv3/slack-integration.js
@@ -270,17 +270,14 @@ module.exports = (crowi) => {
     }
   });
 
-  function checkConnectedToSlack(res) {
+  router.post('/test-notification-to-slack-work-space', async(req, res) => {
+
     const isConnectedToSlack = crowi.slackBotService.isConnectedToSlack;
     if (!isConnectedToSlack) {
       const msg = 'Bot User OAuth Token is not setup.';
       logger.error('Error', msg);
       return res.apiv3Err(new ErrorV3(msg, 'not-setup-slack-bot-token', 400));
     }
-  }
-
-  router.post('/test-notification-to-slack-work-space', async(req, res) => {
-    checkConnectedToSlack(res);
 
     const slackBotToken = crowi.configManager.getConfig('crowi', 'slackbot:token');
     this.client = new WebClient(slackBotToken, { logLevel: LogLevel.DEBUG });

--- a/src/server/routes/apiv3/slack-integration.js
+++ b/src/server/routes/apiv3/slack-integration.js
@@ -289,7 +289,7 @@ module.exports = (crowi) => {
       logger.info('SlackTest: send success massage to slack work space at #general.');
       logger.info('If you do not receive a message, you may not have invited the bot to the #general channel.');
       // eslint-disable-next-line max-len
-      const message = 'Successfully send message to Slack work space. If you do not receive a message, you may not have invited the bot to the #general channel.';
+      const message = 'Successfully send message to Slack work space. See #general channel. If you do not receive a message, you may not have invited the bot to the #general channel.';
       return res.apiv3({ message });
     }
     catch (error) {

--- a/src/server/routes/apiv3/slack-integration.js
+++ b/src/server/routes/apiv3/slack-integration.js
@@ -46,7 +46,6 @@ module.exports = (crowi) => {
   const adminRequired = require('../../middlewares/admin-required')(crowi);
   const csrf = require('../../middlewares/csrf')(crowi);
   const apiV3FormValidator = require('../../middlewares/apiv3-form-validator')(crowi);
-  const url = crowi.appService.getSiteUrl();
 
   const validator = {
     CustomBotWithoutProxy: [
@@ -289,7 +288,6 @@ module.exports = (crowi) => {
           type: 'section',
           text: {
             type: 'mrkdwn',
-            text: `Success your test! \n Go back to your app. ${url}`,
           },
         }],
       });

--- a/src/server/routes/apiv3/slack-integration.js
+++ b/src/server/routes/apiv3/slack-integration.js
@@ -305,10 +305,10 @@ module.exports = (crowi) => {
           channel: `#${channel}`,
           text: 'Your test was successful!',
         });
-        logger.info('SlackTest: send success massage to slack work space at #general.');
-        logger.info('If you do not receive a message, you may not have invited the bot to the #general channel.');
+        logger.info(`SlackTest: send success massage to slack work space at #${channel}.`);
+        logger.info(`If you do not receive a message, you may not have invited the bot to the #${channel} channel.`);
         // eslint-disable-next-line max-len
-        const message = 'Successfully send message to Slack work space. See #general channel. If you do not receive a message, you may not have invited the bot to the #general channel.';
+        const message = `Successfully send message to Slack work space. See #general channel. If you do not receive a message, you may not have invited the bot to the #${channel} channel.`;
         return res.apiv3({ message });
       }
       catch (error) {

--- a/src/server/routes/apiv3/slack-integration.js
+++ b/src/server/routes/apiv3/slack-integration.js
@@ -7,7 +7,6 @@ const crypto = require('crypto');
 const { WebClient, LogLevel } = require('@slack/web-api');
 const ErrorV3 = require('../../models/vo/error-apiv3');
 
-
 const router = express.Router();
 
 /**
@@ -272,7 +271,7 @@ module.exports = (crowi) => {
 
   router.post('/test-notification-to-slack-work-space', async(req, res) => {
     const isConnectedToSlack = crowi.slackBotService.isConnectedToSlack;
-    if (!isConnectedToSlack) {
+    if (isConnectedToSlack === false) {
       const msg = 'Bot User OAuth Token is not setup.';
       logger.error('Error', msg);
       return res.apiv3Err(new ErrorV3(msg, 'not-setup-slack-bot-token', 400));

--- a/src/server/routes/apiv3/slack-integration.js
+++ b/src/server/routes/apiv3/slack-integration.js
@@ -269,6 +269,19 @@ module.exports = (crowi) => {
     }
   });
 
+  /**
+   * @swagger
+   *
+   *    /slack-integration/test-notification-to-slack-work-space:
+   *      post:
+   *        tags: [SlackIntegration]
+   *        operationId: postSlackMessageToSlackWorkSpace
+   *        summary: test to send message to slack work space
+   *        description: post message to slack work space
+   *        responses:
+   *          200:
+   *            description: Succeeded to send a message to slack work space
+   */
   router.post('/test-notification-to-slack-work-space', async(req, res) => {
     const isConnectedToSlack = crowi.slackBotService.isConnectedToSlack;
     if (isConnectedToSlack === false) {

--- a/src/server/routes/apiv3/slack-integration.js
+++ b/src/server/routes/apiv3/slack-integration.js
@@ -288,7 +288,8 @@ module.exports = (crowi) => {
       });
       logger.info('SlackTest: send success massage to slack work space at #general.');
       logger.info('If you do not receive a message, you may not have invited the bot to the #general channel.');
-      return res.apiv3({ slackBotToken });
+      const message = 'Send massage to slack work space at #general. If you do not receive a message, you may not have invited the bot to the #general channel.';
+      return res.apiv3({ message });
     }
     catch (error) {
       const msg = 'Error occured in testing to notify slack work space';

--- a/src/server/routes/apiv3/slack-integration.js
+++ b/src/server/routes/apiv3/slack-integration.js
@@ -272,7 +272,7 @@ module.exports = (crowi) => {
     const slackBotToken = crowi.configManager.getConfig('crowi', 'slackbot:token');
     try {
       console.log(slackBotToken);
-      return 'hoge';
+      return res.apiv3({ slackBotToken });
     }
     catch (error) {
       console.log('error dayo');

--- a/src/server/routes/apiv3/slack-integration.js
+++ b/src/server/routes/apiv3/slack-integration.js
@@ -280,18 +280,15 @@ module.exports = (crowi) => {
     this.client = new WebClient(slackBotToken, { logLevel: LogLevel.DEBUG });
     logger.debug('SlackBot: setup is done');
 
-    console.log(this.client);
     try {
       this.client.chat.postMessage({
         channel: '#general',
         text: 'Your test was successful!',
 
       });
-      console.log(slackBotToken);
       return res.apiv3({ slackBotToken });
     }
     catch (error) {
-      console.log(error);
       const msg = 'Error occured in testing to notify slack work space';
       logger.error('Error', error);
       return res.apiv3Err(new ErrorV3(msg, 'test-notify-slack-work-space-failed'), 500);

--- a/src/server/routes/apiv3/slack-integration.js
+++ b/src/server/routes/apiv3/slack-integration.js
@@ -270,15 +270,19 @@ module.exports = (crowi) => {
     }
   });
 
-  router.post('/test-notification-to-slack-work-space', async(req, res) => {
-    const slackBotToken = crowi.configManager.getConfig('crowi', 'slackbot:token');
-
-    if (slackBotToken == null) {
+  function checkConnectedToSlack(res) {
+    const isConnectedToSlack = crowi.slackBotService.isConnectedToSlack;
+    if (!isConnectedToSlack) {
       const msg = 'Bot User OAuth Token is not setup.';
       logger.error('Error', msg);
       return res.apiv3Err(new ErrorV3(msg, 'not-setup-slack-bot-token', 400));
     }
+  }
 
+  router.post('/test-notification-to-slack-work-space', async(req, res) => {
+    checkConnectedToSlack(res);
+
+    const slackBotToken = crowi.configManager.getConfig('crowi', 'slackbot:token');
     this.client = new WebClient(slackBotToken, { logLevel: LogLevel.DEBUG });
     logger.debug('SlackBot: setup is done');
 

--- a/src/server/routes/apiv3/slack-integration.js
+++ b/src/server/routes/apiv3/slack-integration.js
@@ -288,7 +288,7 @@ module.exports = (crowi) => {
   router.post('/notification-test-to-slack-work-space',
     loginRequiredStrictly, adminRequired, csrf, validator.NotificationTestToSlackWorkSpace, apiV3FormValidator, async(req, res) => {
       const isConnectedToSlack = crowi.slackBotService.isConnectedToSlack;
-      const channel = req.body.channel;
+      const { channel } = req.body;
 
       if (isConnectedToSlack === false) {
         const msg = 'Bot User OAuth Token is not setup.';
@@ -314,7 +314,7 @@ module.exports = (crowi) => {
       catch (error) {
         const msg = 'Error occured in testing to notify slack work space';
         logger.error('Error', error);
-        return res.apiv3Err(new ErrorV3(msg, 'test-notify-slack-work-space-failed'), 500);
+        return res.apiv3Err(new ErrorV3(msg, 'notification-test-slack-work-space-failed'), 500);
       }
     });
 

--- a/src/server/routes/apiv3/slack-integration.js
+++ b/src/server/routes/apiv3/slack-integration.js
@@ -282,7 +282,7 @@ module.exports = (crowi) => {
    *          200:
    *            description: Succeeded to send a message to slack work space
    */
-  router.post('/test-notification-to-slack-work-space', async(req, res) => {
+  router.post('/test-notification-to-slack-work-space', loginRequiredStrictly, adminRequired, csrf, async(req, res) => {
     const isConnectedToSlack = crowi.slackBotService.isConnectedToSlack;
     const channel = req.body.channel;
     console.log(channel);

--- a/src/server/routes/apiv3/slack-integration.js
+++ b/src/server/routes/apiv3/slack-integration.js
@@ -274,7 +274,7 @@ module.exports = (crowi) => {
    *
    *    /slack-integration/test-notification-to-slack-work-space:
    *      post:
-   *        tags: [SlackIntegration]
+   *        tags: [SlackTestToWorkSpace]
    *        operationId: postSlackMessageToSlackWorkSpace
    *        summary: test to send message to slack work space
    *        description: post message to slack work space

--- a/src/server/routes/apiv3/slack-integration.js
+++ b/src/server/routes/apiv3/slack-integration.js
@@ -46,6 +46,7 @@ module.exports = (crowi) => {
   const adminRequired = require('../../middlewares/admin-required')(crowi);
   const csrf = require('../../middlewares/csrf')(crowi);
   const apiV3FormValidator = require('../../middlewares/apiv3-form-validator')(crowi);
+  const url = crowi.appService.getSiteUrl();
 
   const validator = {
     CustomBotWithoutProxy: [
@@ -284,13 +285,19 @@ module.exports = (crowi) => {
     try {
       this.client.chat.postMessage({
         channel: '#general',
-        text: '届いたよ',
-
+        blocks: [{
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: `Success your test! \n Go back to your app. ${url}`,
+          },
+        }],
       });
       console.log(slackBotToken);
       return res.apiv3({ slackBotToken });
     }
     catch (error) {
+      console.log(error);
       const msg = 'Error occured in testing to notify slack work space';
       logger.error('Error', error);
       return res.apiv3Err(new ErrorV3(msg, 'test-notify-slack-work-space-failed'), 500);

--- a/src/server/routes/apiv3/slack-integration.js
+++ b/src/server/routes/apiv3/slack-integration.js
@@ -56,6 +56,9 @@ module.exports = (crowi) => {
       body('currentBotType')
         .isIn(['official-bot', 'custom-bot-without-proxy', 'custom-bot-with-proxy']),
     ],
+    NotificationTestToSlackWorkSpace: [
+      body('channel').isString(),
+    ],
   };
 
   async function updateSlackBotSettings(params) {

--- a/src/server/routes/apiv3/slack-integration.js
+++ b/src/server/routes/apiv3/slack-integration.js
@@ -284,6 +284,8 @@ module.exports = (crowi) => {
    */
   router.post('/test-notification-to-slack-work-space', async(req, res) => {
     const isConnectedToSlack = crowi.slackBotService.isConnectedToSlack;
+    const channel = req.body.channel;
+    console.log(channel);
     if (isConnectedToSlack === false) {
       const msg = 'Bot User OAuth Token is not setup.';
       logger.error('Error', msg);
@@ -296,7 +298,7 @@ module.exports = (crowi) => {
 
     try {
       this.client.chat.postMessage({
-        channel: '#general',
+        channel: `#${channel}`,
         text: 'Your test was successful!',
       });
       logger.info('SlackTest: send success massage to slack work space at #general.');

--- a/src/server/routes/apiv3/slack-integration.js
+++ b/src/server/routes/apiv3/slack-integration.js
@@ -285,7 +285,7 @@ module.exports = (crowi) => {
   router.post('/test-notification-to-slack-work-space', loginRequiredStrictly, adminRequired, csrf, async(req, res) => {
     const isConnectedToSlack = crowi.slackBotService.isConnectedToSlack;
     const channel = req.body.channel;
-    console.log(channel);
+
     if (isConnectedToSlack === false) {
       const msg = 'Bot User OAuth Token is not setup.';
       logger.error('Error', msg);

--- a/src/server/routes/apiv3/slack-integration.js
+++ b/src/server/routes/apiv3/slack-integration.js
@@ -273,10 +273,13 @@ module.exports = (crowi) => {
   router.post('/test-notification-to-slack-work-space', async(req, res) => {
     const slackBotToken = crowi.configManager.getConfig('crowi', 'slackbot:token');
 
-    if (slackBotToken != null) {
-      this.client = new WebClient(slackBotToken, { logLevel: LogLevel.DEBUG });
-      logger.debug('SlackBot: setup is done');
+    if (slackBotToken == null) {
+      const msg = 'Bot User OAuth Token is not setup.';
+      return res.apiv3Err(new ErrorV3(msg, 'not-setup-slack-bot-token', 400));
     }
+
+    this.client = new WebClient(slackBotToken, { logLevel: LogLevel.DEBUG });
+    logger.debug('SlackBot: setup is done');
 
     try {
       this.client.chat.postMessage({
@@ -290,10 +293,9 @@ module.exports = (crowi) => {
       return res.apiv3({ message });
     }
     catch (error) {
-      console.log(error);
-      // const msg = 'Error occured in testing to notify slack work space';
+      const msg = 'Error occured in testing to notify slack work space';
       logger.error('Error', error);
-      return res.apiv3Err(new ErrorV3(error, 'test-notify-slack-work-space-failed'), 500);
+      return res.apiv3Err(new ErrorV3(msg, 'test-notify-slack-work-space-failed'), 500);
     }
   });
 

--- a/src/server/routes/apiv3/slack-integration.js
+++ b/src/server/routes/apiv3/slack-integration.js
@@ -270,10 +270,11 @@ module.exports = (crowi) => {
     }
   });
 
-  router.put('/test-notification-to-slack-work-space', async(req, res) => {
+  router.post('/test-notification-to-slack-work-space', async(req, res) => {
     const slackBotToken = crowi.configManager.getConfig('crowi', 'slackbot:token');
 
     if (slackBotToken === null) {
+      // i18n
       return 'Bot User OAuth Token is not setup.';
     }
 
@@ -284,8 +285,8 @@ module.exports = (crowi) => {
       this.client.chat.postMessage({
         channel: '#general',
         text: 'Your test was successful!',
-
       });
+      logger.info('SlackTest: send success massage to slack work space at #general');
       return res.apiv3({ slackBotToken });
     }
     catch (error) {

--- a/src/server/routes/apiv3/slack-integration.js
+++ b/src/server/routes/apiv3/slack-integration.js
@@ -288,7 +288,8 @@ module.exports = (crowi) => {
       });
       logger.info('SlackTest: send success massage to slack work space at #general.');
       logger.info('If you do not receive a message, you may not have invited the bot to the #general channel.');
-      const message = 'Send massage to slack work space at #general. If you do not receive a message, you may not have invited the bot to the #general channel.';
+      // eslint-disable-next-line max-len
+      const message = 'Successfully send message to Slack work space. If you do not receive a message, you may not have invited the bot to the #general channel.';
       return res.apiv3({ message });
     }
     catch (error) {

--- a/src/server/routes/apiv3/slack-integration.js
+++ b/src/server/routes/apiv3/slack-integration.js
@@ -4,7 +4,9 @@ const logger = loggerFactory('growi:routes:apiv3:notification-setting');
 const express = require('express');
 const { body } = require('express-validator');
 const crypto = require('crypto');
+const { WebClient, LogLevel } = require('@slack/web-api');
 const ErrorV3 = require('../../models/vo/error-apiv3');
+
 
 const router = express.Router();
 
@@ -270,6 +272,11 @@ module.exports = (crowi) => {
 
   router.put('/test-notification-to-slack-work-space', async(req, res) => {
     const slackBotToken = crowi.configManager.getConfig('crowi', 'slackbot:token');
+
+    if (slackBotToken === null) {
+      return 'Bot User OAuth Token is not setup.';
+    }
+
     try {
       console.log(slackBotToken);
       return res.apiv3({ slackBotToken });

--- a/src/server/routes/apiv3/slack-integration.js
+++ b/src/server/routes/apiv3/slack-integration.js
@@ -268,6 +268,10 @@ module.exports = (crowi) => {
     }
   });
 
+  router.put('/test-notification-to-slack-work-space', async(req, res) => {
+
+  });
+
   /**
    * @swagger
    *

--- a/src/server/routes/apiv3/slack-integration.js
+++ b/src/server/routes/apiv3/slack-integration.js
@@ -272,6 +272,7 @@ module.exports = (crowi) => {
     const slackBotToken = crowi.configManager.getConfig('crowi', 'slackbot:token');
     try {
       console.log(slackBotToken);
+      return 'hoge';
     }
     catch (error) {
       console.log('error dayo');

--- a/src/server/routes/apiv3/slack-integration.js
+++ b/src/server/routes/apiv3/slack-integration.js
@@ -286,7 +286,8 @@ module.exports = (crowi) => {
         channel: '#general',
         text: 'Your test was successful!',
       });
-      logger.info('SlackTest: send success massage to slack work space at #general');
+      logger.info('SlackTest: send success massage to slack work space at #general.');
+      logger.info('If you do not receive a message, you may not have invited the bot to the #general channel.');
       return res.apiv3({ slackBotToken });
     }
     catch (error) {

--- a/src/server/routes/apiv3/slack-integration.js
+++ b/src/server/routes/apiv3/slack-integration.js
@@ -280,9 +280,10 @@ module.exports = (crowi) => {
     this.client = new WebClient(slackBotToken, { logLevel: LogLevel.DEBUG });
     logger.debug('SlackBot: setup is done');
 
+    console.log(this.client);
     try {
-      this.client.postMessage({
-        channel: this.client.channels,
+      this.client.chat.postMessage({
+        channel: '#general',
         text: '届いたよ',
 
       });

--- a/src/server/routes/apiv3/slack-integration.js
+++ b/src/server/routes/apiv3/slack-integration.js
@@ -282,37 +282,38 @@ module.exports = (crowi) => {
    *          200:
    *            description: Succeeded to send a message to slack work space
    */
-  router.post('/test-notification-to-slack-work-space', loginRequiredStrictly, adminRequired, csrf, async(req, res) => {
-    const isConnectedToSlack = crowi.slackBotService.isConnectedToSlack;
-    const channel = req.body.channel;
+  router.post('/notification-test-to-slack-work-space',
+    loginRequiredStrictly, adminRequired, csrf, validator.NotificationTestToSlackWorkSpace, apiV3FormValidator, async(req, res) => {
+      const isConnectedToSlack = crowi.slackBotService.isConnectedToSlack;
+      const channel = req.body.channel;
 
-    if (isConnectedToSlack === false) {
-      const msg = 'Bot User OAuth Token is not setup.';
-      logger.error('Error', msg);
-      return res.apiv3Err(new ErrorV3(msg, 'not-setup-slack-bot-token', 400));
-    }
+      if (isConnectedToSlack === false) {
+        const msg = 'Bot User OAuth Token is not setup.';
+        logger.error('Error', msg);
+        return res.apiv3Err(new ErrorV3(msg, 'not-setup-slack-bot-token', 400));
+      }
 
-    const slackBotToken = crowi.configManager.getConfig('crowi', 'slackbot:token');
-    this.client = new WebClient(slackBotToken, { logLevel: LogLevel.DEBUG });
-    logger.debug('SlackBot: setup is done');
+      const slackBotToken = crowi.configManager.getConfig('crowi', 'slackbot:token');
+      this.client = new WebClient(slackBotToken, { logLevel: LogLevel.DEBUG });
+      logger.debug('SlackBot: setup is done');
 
-    try {
-      this.client.chat.postMessage({
-        channel: `#${channel}`,
-        text: 'Your test was successful!',
-      });
-      logger.info('SlackTest: send success massage to slack work space at #general.');
-      logger.info('If you do not receive a message, you may not have invited the bot to the #general channel.');
-      // eslint-disable-next-line max-len
-      const message = 'Successfully send message to Slack work space. See #general channel. If you do not receive a message, you may not have invited the bot to the #general channel.';
-      return res.apiv3({ message });
-    }
-    catch (error) {
-      const msg = 'Error occured in testing to notify slack work space';
-      logger.error('Error', error);
-      return res.apiv3Err(new ErrorV3(msg, 'test-notify-slack-work-space-failed'), 500);
-    }
-  });
+      try {
+        this.client.chat.postMessage({
+          channel: `#${channel}`,
+          text: 'Your test was successful!',
+        });
+        logger.info('SlackTest: send success massage to slack work space at #general.');
+        logger.info('If you do not receive a message, you may not have invited the bot to the #general channel.');
+        // eslint-disable-next-line max-len
+        const message = 'Successfully send message to Slack work space. See #general channel. If you do not receive a message, you may not have invited the bot to the #general channel.';
+        return res.apiv3({ message });
+      }
+      catch (error) {
+        const msg = 'Error occured in testing to notify slack work space';
+        logger.error('Error', error);
+        return res.apiv3Err(new ErrorV3(msg, 'test-notify-slack-work-space-failed'), 500);
+      }
+    });
 
   /**
    * @swagger

--- a/src/server/routes/apiv3/slack-integration.js
+++ b/src/server/routes/apiv3/slack-integration.js
@@ -273,13 +273,10 @@ module.exports = (crowi) => {
   router.post('/test-notification-to-slack-work-space', async(req, res) => {
     const slackBotToken = crowi.configManager.getConfig('crowi', 'slackbot:token');
 
-    if (slackBotToken === null) {
-      // i18n
-      return 'Bot User OAuth Token is not setup.';
+    if (slackBotToken != null) {
+      this.client = new WebClient(slackBotToken, { logLevel: LogLevel.DEBUG });
+      logger.debug('SlackBot: setup is done');
     }
-
-    this.client = new WebClient(slackBotToken, { logLevel: LogLevel.DEBUG });
-    logger.debug('SlackBot: setup is done');
 
     try {
       this.client.chat.postMessage({
@@ -293,9 +290,10 @@ module.exports = (crowi) => {
       return res.apiv3({ message });
     }
     catch (error) {
-      const msg = 'Error occured in testing to notify slack work space';
+      console.log(error);
+      // const msg = 'Error occured in testing to notify slack work space';
       logger.error('Error', error);
-      return res.apiv3Err(new ErrorV3(msg, 'test-notify-slack-work-space-failed'), 500);
+      return res.apiv3Err(new ErrorV3(error, 'test-notify-slack-work-space-failed'), 500);
     }
   });
 


### PR DESCRIPTION
## 概要
<img width="656" alt="スクリーンショット 2021-04-09 12 48 12" src="https://user-images.githubusercontent.com/57100766/114150157-b05c2c80-9956-11eb-99f2-ebaf34aa91af.png">

test を押した時に、work space に通知がいくようなエンドポイントを作成しました。
- 成功時
  - 成功 logger を出す 
  - message を返す
- 失敗時
  - 失敗 logger を出す
  - error message を返す