### PR TITLE
Feat/custom bot with proxy integration ui

### DIFF
--- a/resource/locales/en_US/admin/admin.json
+++ b/resource/locales/en_US/admin/admin.json
@@ -299,7 +299,7 @@
       "how_to_create_a_bot": "How to create a bot"
     },
     "custom_bot_without_proxy_integration": "Custom bot without proxy integration",
-    "without_proxy_integration": {
+    "integration_sentence": {
       "integration_is_not_complete": "Integration is not complete.",
       "proceed_with_the_following_integration_procedure": "Proceed with the following integration procedure."
     }

--- a/resource/locales/en_US/admin/admin.json
+++ b/resource/locales/en_US/admin/admin.json
@@ -302,7 +302,8 @@
     "integration_sentence": {
       "integration_is_not_complete": "Integration is not complete.",
       "proceed_with_the_following_integration_procedure": "Proceed with the following integration procedure."
-    }
+    },
+    "custom_bot_with_proxy_integration": "Custom bot with proxy integration"
   },
   "user_management": {
     "invite_users": "Temporarily issue a new user",

--- a/resource/locales/en_US/admin/admin.json
+++ b/resource/locales/en_US/admin/admin.json
@@ -297,7 +297,8 @@
       "register_secret_and_token": "Set Signing Secret and Bot Token",
       "test_connection": "Test Connection",
       "how_to_create_a_bot": "How to create a bot"
-    }
+    },
+    "custom_bot_without_proxy_integration": "Custom bot without proxy integration"
   },
   "user_management": {
     "invite_users": "Temporarily issue a new user",

--- a/resource/locales/en_US/admin/admin.json
+++ b/resource/locales/en_US/admin/admin.json
@@ -298,7 +298,11 @@
       "test_connection": "Test Connection",
       "how_to_create_a_bot": "How to create a bot"
     },
-    "custom_bot_without_proxy_integration": "Custom bot without proxy integration"
+    "custom_bot_without_proxy_integration": "Custom bot without proxy integration",
+    "without_proxy_integration": {
+      "integration_is_not_complete": "Integration is not complete.",
+      "proceed_with_the_following_integration_procedure": "Proceed with the following integration procedure."
+    }
   },
   "user_management": {
     "invite_users": "Temporarily issue a new user",

--- a/resource/locales/ja_JP/admin/admin.json
+++ b/resource/locales/ja_JP/admin/admin.json
@@ -297,7 +297,7 @@
       "how_to_create_a_bot": "作成方法はこちら"
     },
     "custom_bot_without_proxy_integration": "Custom bot without proxy 連携",
-    "without_proxy_integration": {
+    "integration_sentence": {
       "integration_is_not_complete": "連携は完了していません。",
       "proceed_with_the_following_integration_procedure": "下記の連携手順を進めてください。"
     }

--- a/resource/locales/ja_JP/admin/admin.json
+++ b/resource/locales/ja_JP/admin/admin.json
@@ -296,7 +296,11 @@
       "test_connection": "連携状況のテストをする",
       "how_to_create_a_bot": "作成方法はこちら"
     },
-    "custom_bot_without_proxy_integration": "Custom bot without proxy 連携"
+    "custom_bot_without_proxy_integration": "Custom bot without proxy 連携",
+    "without_proxy_integration": {
+      "integration_is_not_complete": "連携は完了していません。",
+      "proceed_with_the_following_integration_procedure": "下記の連携手順を進めてください。"
+    }
   },
   "user_management": {
     "invite_users": "新規ユーザーの仮発行",

--- a/resource/locales/ja_JP/admin/admin.json
+++ b/resource/locales/ja_JP/admin/admin.json
@@ -300,7 +300,8 @@
     "integration_sentence": {
       "integration_is_not_complete": "連携は完了していません。",
       "proceed_with_the_following_integration_procedure": "下記の連携手順を進めてください。"
-    }
+    },
+    "custom_bot_with_proxy_integration": "Custom bot with proxy 連携"
   },
   "user_management": {
     "invite_users": "新規ユーザーの仮発行",

--- a/resource/locales/ja_JP/admin/admin.json
+++ b/resource/locales/ja_JP/admin/admin.json
@@ -295,7 +295,8 @@
       "register_secret_and_token": "Signing Secret と Bot Token を登録する",
       "test_connection": "連携状況のテストをする",
       "how_to_create_a_bot": "作成方法はこちら"
-    }
+    },
+    "custom_bot_without_proxy_integration": "Custom bot without proxy 連携"
   },
   "user_management": {
     "invite_users": "新規ユーザーの仮発行",

--- a/resource/locales/zh_CN/admin/admin.json
+++ b/resource/locales/zh_CN/admin/admin.json
@@ -310,7 +310,8 @@
     "integration_sentence": {
       "integration_is_not_complete": "一体化未完成。",
       "proceed_with_the_following_integration_procedure": "进行以下一体化程序。"
-    }
+    },
+    "custom_bot_with_proxy_integration": "Custom bot with proxy 一体化"
   },
 	"user_management": {
 		"invite_users": "临时发布新用户",

--- a/resource/locales/zh_CN/admin/admin.json
+++ b/resource/locales/zh_CN/admin/admin.json
@@ -306,7 +306,11 @@
       "test_connection": "测试连接",
       "how_to_create_a_bot": "如何创建一个BOT"
     },
-    "custom_bot_without_proxy_integration": "Custom bot without proxy 一体化"
+    "custom_bot_without_proxy_integration": "Custom bot without proxy 一体化",
+    "without_proxy_integration": {
+      "integration_is_not_complete": "一体化未完成。",
+      "proceed_with_the_following_integration_procedure": "进行以下一体化程序。"
+    }
   },
 	"user_management": {
 		"invite_users": "临时发布新用户",

--- a/resource/locales/zh_CN/admin/admin.json
+++ b/resource/locales/zh_CN/admin/admin.json
@@ -305,7 +305,8 @@
       "register_secret_and_token": "设置签名秘密和BOT令牌",
       "test_connection": "测试连接",
       "how_to_create_a_bot": "如何创建一个BOT"
-    }
+    },
+    "custom_bot_without_proxy_integration": "Custom bot without proxy 一体化"
   },
 	"user_management": {
 		"invite_users": "临时发布新用户",

--- a/resource/locales/zh_CN/admin/admin.json
+++ b/resource/locales/zh_CN/admin/admin.json
@@ -307,7 +307,7 @@
       "how_to_create_a_bot": "如何创建一个BOT"
     },
     "custom_bot_without_proxy_integration": "Custom bot without proxy 一体化",
-    "without_proxy_integration": {
+    "integration_sentence": {
       "integration_is_not_complete": "一体化未完成。",
       "proceed_with_the_following_integration_procedure": "进行以下一体化程序。"
     }

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
@@ -1,6 +1,14 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
+import PropTypes from 'prop-types';
+import AppContainer from '../../../services/AppContainer';
+import AdminAppContainer from '../../../services/AdminAppContainer';
+import { withUnstatedContainers } from '../../UnstatedUtils';
 
-const CustomBotWithProxySettings = () => {
+const CustomBotWithProxySettings = (props) => {
+  // eslint-disable-next-line no-unused-vars
+  const { appContainer, adminAppContainer } = props;
+  const { t } = useTranslation();
 
   return (
     <div className="row my-5">
@@ -9,4 +17,12 @@ const CustomBotWithProxySettings = () => {
   );
 };
 
-export default CustomBotWithProxySettings;
+
+const CustomBotWithProxySettingsWrapper = withUnstatedContainers(CustomBotWithProxySettings, [AppContainer, AdminAppContainer]);
+
+CustomBotWithProxySettings.propTypes = {
+  appContainer: PropTypes.instanceOf(AppContainer).isRequired,
+  adminAppContainer: PropTypes.instanceOf(AdminAppContainer).isRequired,
+};
+
+export default CustomBotWithProxySettingsWrapper;

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
@@ -18,57 +18,46 @@ const CustomBotWithProxySettings = (props) => {
       <h2 className="admin-setting-header">{t('admin:slack_integration.custom_bot_with_proxy_integration')}</h2>
 
       <div className="d-flex justify-content-center my-5 bot-integration">
+
+        {/* card-slack */}
         <div className="card rounded shadow border-0 w-50 admin-bot-card">
           <h5 className="card-title font-weight-bold mt-3 ml-4">Slack</h5>
           <div className="card-body p-4"></div>
         </div>
 
-        <div className="text-center w-50 row">
 
-          {/* border */}
-          <hr className="border-danger align-self-center admin-border col"></hr>
+        {/* border */}
+        <hr className="border-danger align-self-center admin-border col"></hr>
 
-          {/* circle */}
-          <div className="align-self-center col">
-            <div className="circle-back">
-              <div className="circle-front mt-3">
-                <p className="text-light font-weight-bold m-0 pt-3 mt-2">Proxy</p>
-                <p className="text-light font-weight-bold">Server</p>
-              </div>
-            </div>
-          </div>
 
-          {/* border */}
-          <hr className="border-danger align-self-center admin-border col"></hr>
+        {/* sentence */}
+        {/* <p className="text-secondary m-0"><small>{t('admin:slack_integration.integration_sentence.integration_is_not_complete')}</small></p> */}
+        {/* <p className="text-secondary"><small>{t('admin:slack_integration.integration_sentence.proceed_with_the_following_integration_procedure')}</small></p> */}
 
-          {/* <p className="text-secondary m-0"><small>{t('admin:slack_integration.integration_sentence.integration_is_not_complete')}</small></p> */}
-          {/* <p className="text-secondary"><small>{t('admin:slack_integration.integration_sentence.proceed_with_the_following_integration_procedure')}</small></p> */}
-        </div>
 
+        {/* card-growi-app */}
         <div className="card rounded-lg shadow border-0 w-50 admin-bot-card">
           <h5 className="card-title font-weight-bold mt-3 ml-4">GROWI App</h5>
           <div className="card-body p-4 text-center">
             <a className="btn btn-primary mb-5">WESEEK Inner Wiki</a>
           </div>
         </div>
+
       </div>
 
-
-
-
+      
       <div className="row text-center bot-integration">
 
+        {/* border */}
         <hr className="border-danger align-self-center admin-border col"></hr>
 
-        <div className="align-self-center col">
-          <div className="circle-back">
-            <div className="circle-front mt-3">
-              <p className="text-light font-weight-bold m-0 pt-3 mt-2">Proxy</p>
-              <p className="text-light font-weight-bold">Server</p>
-            </div>
-          </div>
+        {/* cicle */}
+        <div className="circle text-center">
+          <p className="text-light font-weight-bold m-0 pt-3 mt-2">Proxy</p>
+          <p className="text-light font-weight-bold">Server</p>
         </div>
 
+        {/* border */}
         <hr className="border-danger align-self-center admin-border col"></hr>
       </div>
 

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
@@ -11,9 +11,11 @@ const CustomBotWithProxySettings = (props) => {
   const { t } = useTranslation();
 
   return (
-    <div className="row my-5">
-      <h1>With Proxy Component</h1>
-    </div>
+    <>
+
+      <h2 className="admin-setting-header">{t('admin:slack_integration.custom_bot_with_proxy_integration')}</h2>
+      
+    </>
   );
 };
 

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
@@ -15,6 +15,26 @@ const CustomBotWithProxySettings = (props) => {
 
       <h2 className="admin-setting-header">{t('admin:slack_integration.custom_bot_with_proxy_integration')}</h2>
       
+      <div className="d-flex justify-content-center my-5 bot-integration">
+        <div className="card rounded shadow border-0 w-50 admin-bot-card">
+          <h5 className="card-title font-weight-bold m-3">Slack</h5>
+          <div className="card-body p-4"></div>
+        </div>
+
+        <div className="text-center w-25 mt-4">
+          <p className="text-secondary m-0"><small>{t('admin:slack_integration.integration_sentence.integration_is_not_complete')}</small></p>
+          <p className="text-secondary"><small>{t('admin:slack_integration.integration_sentence.proceed_with_the_following_integration_procedure')}</small></p>
+          <hr className="border-danger align-self-center admin-border"></hr>
+        </div>
+
+        <div className="card rounded-lg shadow border-0 w-50 admin-bot-card">
+          <h5 className="card-title font-weight-bold m-3">GROWI App</h5>
+          <div className="card-body p-4 text-center">
+            <a className="btn btn-primary mb-5">WESEEK Inner Wiki</a>
+          </div>
+        </div>
+      </div>
+
     </>
   );
 };

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
@@ -13,18 +13,28 @@ const CustomBotWithProxySettings = (props) => {
   return (
     <>
 
+      {/* --------------- start ---------------*/}
+
       <h2 className="admin-setting-header">{t('admin:slack_integration.custom_bot_with_proxy_integration')}</h2>
-      
+
       <div className="d-flex justify-content-center my-5 bot-integration">
         <div className="card rounded shadow border-0 w-50 admin-bot-card">
           <h5 className="card-title font-weight-bold m-3">Slack</h5>
           <div className="card-body p-4"></div>
         </div>
 
-        <div className="text-center w-25 mt-4">
-          <p className="text-secondary m-0"><small>{t('admin:slack_integration.integration_sentence.integration_is_not_complete')}</small></p>
+        <div className="text-center align-items-center justify-content-center">
+
+          <div>
+            <div className="circle-back p-1"></div>
+            <div className="circle-front">
+              <p className="text-light">Proxy</p>
+              <p className="text-light">Server</p>
+            </div>
+          </div>
+          {/* <p className="text-secondary m-0"><small>{t('admin:slack_integration.integration_sentence.integration_is_not_complete')}</small></p>
           <p className="text-secondary"><small>{t('admin:slack_integration.integration_sentence.proceed_with_the_following_integration_procedure')}</small></p>
-          <hr className="border-danger align-self-center admin-border"></hr>
+          <hr className="border-danger align-self-center admin-border"></hr> */}
         </div>
 
         <div className="card rounded-lg shadow border-0 w-50 admin-bot-card">
@@ -34,6 +44,8 @@ const CustomBotWithProxySettings = (props) => {
           </div>
         </div>
       </div>
+
+      {/* ---------------  end  ---------------*/}
 
     </>
   );

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
@@ -25,42 +25,40 @@ const CustomBotWithProxySettings = (props) => {
           <div className="card-body p-4"></div>
         </div>
 
+        {/* center-content */}
+        <div className="text-center w-25 mb-5">
 
-        {/* border */}
-        <hr className="border-danger align-self-center admin-border col"></hr>
+          {/* sentence */}
+          <p className="text-secondary m-0"><small>{t('admin:slack_integration.integration_sentence.integration_is_not_complete')}</small></p>
+          <p className="text-secondary"><small>{t('admin:slack_integration.integration_sentence.proceed_with_the_following_integration_procedure')}</small></p>
 
+          <div className="row m-0">
 
-        {/* sentence */}
-        {/* <p className="text-secondary m-0"><small>{t('admin:slack_integration.integration_sentence.integration_is_not_complete')}</small></p> */}
-        {/* <p className="text-secondary"><small>{t('admin:slack_integration.integration_sentence.proceed_with_the_following_integration_procedure')}</small></p> */}
+            {/* border */}
+            <hr className="border-danger align-self-center admin-border col"></hr>
 
+            {/* circle */}
+            <div className="circle text-center">
+              <p className="text-light font-weight-bold m-0 pt-3 mt-2 col">Proxy</p>
+              <p className="text-light font-weight-bold">Server</p>
+            </div>
+
+            {/* border */}
+            <hr className="border-danger align-self-center admin-border col"></hr>
+
+          </div>
+
+        </div>
 
         {/* card-growi-app */}
         <div className="card rounded-lg shadow border-0 w-50 admin-bot-card">
           <h5 className="card-title font-weight-bold mt-3 ml-4">GROWI App</h5>
           <div className="card-body p-4 text-center">
-            <a className="btn btn-primary mb-5">WESEEK Inner Wiki</a>
+            <a className="btn btn-primary mt-3">WESEEK Inner Wiki</a>
           </div>
         </div>
 
       </div>
-
-      
-      <div className="row text-center bot-integration">
-
-        {/* border */}
-        <hr className="border-danger align-self-center admin-border col"></hr>
-
-        {/* cicle */}
-        <div className="circle text-center">
-          <p className="text-light font-weight-bold m-0 pt-3 mt-2">Proxy</p>
-          <p className="text-light font-weight-bold">Server</p>
-        </div>
-
-        {/* border */}
-        <hr className="border-danger align-self-center admin-border col"></hr>
-      </div>
-
 
       {/* ---------------  end  ---------------*/}
 

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
@@ -28,8 +28,8 @@ const CustomBotWithProxySettings = (props) => {
 
           <div className="row m-0">
             <hr className="border-danger align-self-center admin-border col"></hr>
-            <div className="circle text-center">
-              <p className="text-light font-weight-bold m-0 pt-3 mt-2 col">Proxy</p>
+            <div className="circle text-center bg-primary border-light">
+              <p className="text-light font-weight-bold m-0 pt-3">Proxy</p>
               <p className="text-light font-weight-bold">Server</p>
             </div>
             <hr className="border-danger align-self-center admin-border col"></hr>

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
@@ -23,18 +23,26 @@ const CustomBotWithProxySettings = (props) => {
           <div className="card-body p-4"></div>
         </div>
 
-        <div className="text-center align-items-center justify-content-center">
+        <div className="text-center w-50 row">
 
-          <div>
-            <div className="circle-back p-1"></div>
-            <div className="circle-front">
-              <p className="text-light">Proxy</p>
-              <p className="text-light">Server</p>
+          {/* border */}
+          <hr className="border-danger align-self-center admin-border col"></hr>
+
+          {/* circle */}
+          <div className="align-self-center col">
+            <div className="circle-back">
+              <div className="circle-front mt-3">
+                <p className="text-light font-weight-bold m-0 pt-3 mt-2">Proxy</p>
+                <p className="text-light font-weight-bold">Server</p>
+              </div>
             </div>
           </div>
-          {/* <p className="text-secondary m-0"><small>{t('admin:slack_integration.integration_sentence.integration_is_not_complete')}</small></p>
-          <p className="text-secondary"><small>{t('admin:slack_integration.integration_sentence.proceed_with_the_following_integration_procedure')}</small></p>
-          <hr className="border-danger align-self-center admin-border"></hr> */}
+
+          {/* border */}
+          <hr className="border-danger align-self-center admin-border col"></hr>
+
+          {/* <p className="text-secondary m-0"><small>{t('admin:slack_integration.integration_sentence.integration_is_not_complete')}</small></p> */}
+          {/* <p className="text-secondary"><small>{t('admin:slack_integration.integration_sentence.proceed_with_the_following_integration_procedure')}</small></p> */}
         </div>
 
         <div className="card rounded-lg shadow border-0 w-50 admin-bot-card">
@@ -44,6 +52,26 @@ const CustomBotWithProxySettings = (props) => {
           </div>
         </div>
       </div>
+
+
+
+
+      <div className="row text-center bot-integration">
+
+        <hr className="border-danger align-self-center admin-border col"></hr>
+
+        <div className="align-self-center col">
+          <div className="circle-back">
+            <div className="circle-front mt-3">
+              <p className="text-light font-weight-bold m-0 pt-3 mt-2">Proxy</p>
+              <p className="text-light font-weight-bold">Server</p>
+            </div>
+          </div>
+        </div>
+
+        <hr className="border-danger align-self-center admin-border col"></hr>
+      </div>
+
 
       {/* ---------------  end  ---------------*/}
 

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
@@ -13,44 +13,29 @@ const CustomBotWithProxySettings = (props) => {
   return (
     <>
 
-      {/* --------------- start ---------------*/}
-
       <h2 className="admin-setting-header">{t('admin:slack_integration.custom_bot_with_proxy_integration')}</h2>
 
       <div className="d-flex justify-content-center my-5 bot-integration">
 
-        {/* card-slack */}
         <div className="card rounded shadow border-0 w-50 admin-bot-card">
           <h5 className="card-title font-weight-bold mt-3 ml-4">Slack</h5>
           <div className="card-body p-4"></div>
         </div>
 
-        {/* center-content */}
         <div className="text-center w-25 mb-5">
-
-          {/* sentence */}
           <p className="text-secondary m-0"><small>{t('admin:slack_integration.integration_sentence.integration_is_not_complete')}</small></p>
           <p className="text-secondary"><small>{t('admin:slack_integration.integration_sentence.proceed_with_the_following_integration_procedure')}</small></p>
 
           <div className="row m-0">
-
-            {/* border */}
             <hr className="border-danger align-self-center admin-border col"></hr>
-
-            {/* circle */}
             <div className="circle text-center">
               <p className="text-light font-weight-bold m-0 pt-3 mt-2 col">Proxy</p>
               <p className="text-light font-weight-bold">Server</p>
             </div>
-
-            {/* border */}
             <hr className="border-danger align-self-center admin-border col"></hr>
-
           </div>
-
         </div>
 
-        {/* card-growi-app */}
         <div className="card rounded-lg shadow border-0 w-50 admin-bot-card">
           <h5 className="card-title font-weight-bold mt-3 ml-4">GROWI App</h5>
           <div className="card-body p-4 text-center">
@@ -59,8 +44,6 @@ const CustomBotWithProxySettings = (props) => {
         </div>
 
       </div>
-
-      {/* ---------------  end  ---------------*/}
 
     </>
   );

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
@@ -19,7 +19,7 @@ const CustomBotWithProxySettings = (props) => {
 
       <div className="d-flex justify-content-center my-5 bot-integration">
         <div className="card rounded shadow border-0 w-50 admin-bot-card">
-          <h5 className="card-title font-weight-bold m-3">Slack</h5>
+          <h5 className="card-title font-weight-bold mt-3 ml-4">Slack</h5>
           <div className="card-body p-4"></div>
         </div>
 
@@ -46,7 +46,7 @@ const CustomBotWithProxySettings = (props) => {
         </div>
 
         <div className="card rounded-lg shadow border-0 w-50 admin-bot-card">
-          <h5 className="card-title font-weight-bold m-3">GROWI App</h5>
+          <h5 className="card-title font-weight-bold mt-3 ml-4">GROWI App</h5>
           <div className="card-body p-4 text-center">
             <a className="btn btn-primary mb-5">WESEEK Inner Wiki</a>
           </div>

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
@@ -37,7 +37,12 @@ const CustomBotWithProxySettings = (props) => {
         </div>
 
         <div className="card rounded-lg shadow border-0 w-50 admin-bot-card">
-          <h5 className="card-title font-weight-bold mt-3 ml-4">GROWI App</h5>
+          <div className="row m-0">
+            <h5 className="card-title font-weight-bold mt-3 ml-4 col">GROWI App</h5>
+            <div className="pull-right mt-3">
+              <a className="icon-fw fa fa-repeat fa-2x"></a>
+            </div>
+          </div>
           <div className="card-body p-4 text-center">
             <a className="btn btn-primary mt-3">WESEEK Inner Wiki</a>
           </div>

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -93,7 +93,7 @@ const CustomBotWithoutProxySettings = (props) => {
 
         {/* カード１ */}
         <div className="card rounded-lg shadow border-0 w-50">
-          <h5 className="card-title m-3">Slack</h5>
+          <h5 className="card-title m-3"><b>Slack</b></h5>
           <div className="card-body p-5"></div>
         </div>
 
@@ -110,7 +110,7 @@ const CustomBotWithoutProxySettings = (props) => {
 
         {/* カード２ */}
         <div className="card rounded-lg shadow border-0 w-50">
-          <h5 className="card-title m-3">GROWI App</h5>
+          <h5 className="card-title m-3"><b>GROWI App</b></h5>
           <div className="card-body p-5 text-center">
             <a className="btn btn-primary">WESEEK Inner brWiki</a>
           </div>

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -87,7 +87,7 @@ const CustomBotWithoutProxySettings = (props) => {
 
       <h2 className="admin-setting-header">{t('admin:slack_integration.custom_bot_without_proxy_integration')}</h2>
 
-      <div className="d-flex justify-content-center my-5">
+      <div className="d-flex justify-content-center mt-3">
         <div className="card rounded-lg shadow border-0 w-50">
           <h5 className="card-title font-weight-bold m-3">Slack</h5>
           <div className="card-body p-5"></div>

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -87,8 +87,8 @@ const CustomBotWithoutProxySettings = (props) => {
 
       <h2 className="admin-setting-header">{t('admin:slack_integration.custom_bot_without_proxy_integration')}</h2>
 
-      <div className="d-flex justify-content-center mt-3">
-        <div className="card rounded-lg shadow border-0 w-50">
+      <div className="d-flex justify-content-center mt-3 bot-integration">
+        <div className="card rounded shadow border-0 w-50 admin-bot-card" style={{ radius: '8px'}}>
           <h5 className="card-title font-weight-bold m-3">Slack</h5>
           <div className="card-body p-5"></div>
         </div>
@@ -96,7 +96,7 @@ const CustomBotWithoutProxySettings = (props) => {
         <div className="text-center w-25 mt-5">
           <p className="text-secondary m-0"><small>{t('admin:slack_integration.integration_sentence.integration_is_not_complete')}</small></p>
           <p className="text-secondary"><small>{t('admin:slack_integration.integration_sentence.proceed_with_the_following_integration_procedure')}</small></p>
-          <hr className="border-danger align-self-center" style={{ border: 'dashed' }}></hr>
+          <hr className="border-danger align-self-center admin-border"></hr>
         </div>
 
         <div className="card rounded-lg shadow border-0 w-50">

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -95,8 +95,8 @@ const CustomBotWithoutProxySettings = (props) => {
         </div>
 
         <div className="text-center w-25 mt-5">
-          <p className="text-secondary m-0"><small>{t('admin:slack_integration.without_proxy_integration.integration_is_not_complete')}</small></p>
-          <p className="text-secondary"><small>{t('admin:slack_integration.without_proxy_integration.proceed_with_the_following_integration_procedure')}</small></p>
+          <p className="text-secondary m-0"><small>{t('admin:slack_integration.integration_sentence.integration_is_not_complete')}</small></p>
+          <p className="text-secondary"><small>{t('admin:slack_integration.integration_sentence.proceed_with_the_following_integration_procedure')}</small></p>
           <hr className="border-danger align-self-center" style={{ border: 'dashed' }}></hr>
         </div>
 

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -103,7 +103,8 @@ const CustomBotWithoutProxySettings = (props) => {
 
         {/* 破線 & 文字 */}
         <div className="text-center w-25">
-          <p className="text-secondary">連携は完了していません。下記の連携手順を進めてください。</p>
+          <p className="text-secondary m-0"><small>連携は完了していません。</small></p>
+          <p className="text-secondary"><small>下記の連携手順を進めてください。</small></p>
           <hr className="border-danger align-self-center" style={{ border: 'dashed' }}></hr>
         </div>
 

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -85,26 +85,21 @@ const CustomBotWithoutProxySettings = (props) => {
   return (
     <>
 
-      {/* ----------------  start --------------- */}
-
       <h2 className="admin-setting-header">{t('admin:slack_integration.custom_bot_without_proxy_integration')}</h2>
 
       <div className="d-flex justify-content-center my-5">
 
-        {/* カード１ */}
         <div className="card rounded-lg shadow border-0 w-50">
           <h5 className="card-title m-3"><b>Slack</b></h5>
           <div className="card-body p-5"></div>
         </div>
 
-        {/* 破線 & 文字 */}
         <div className="text-center w-25 mt-5">
           <p className="text-secondary m-0"><small>連携は完了していません。</small></p>
           <p className="text-secondary"><small>下記の連携手順を進めてください。</small></p>
           <hr className="border-danger align-self-center" style={{ border: 'dashed' }}></hr>
         </div>
 
-        {/* カード２ */}
         <div className="card rounded-lg shadow border-0 w-50">
           <h5 className="card-title m-3"><b>GROWI App</b></h5>
           <div className="card-body p-5 text-center">
@@ -113,8 +108,6 @@ const CustomBotWithoutProxySettings = (props) => {
         </div>
 
       </div>
-
-      {/* ----------------   end  --------------- */}
 
       <h2 className="admin-setting-header">{t('admin:slack_integration.custom_bot_without_proxy_settings')}</h2>
       {/* temporarily put bellow component */}

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -89,7 +89,7 @@ const CustomBotWithoutProxySettings = (props) => {
 
       <div className="d-flex justify-content-center my-5">
         <div className="card rounded-lg shadow border-0 w-50">
-          <h5 className="card-title m-3"><b>Slack</b></h5>
+          <h5 className="card-title font-weight-bold m-3">Slack</h5>
           <div className="card-body p-5"></div>
         </div>
 
@@ -100,7 +100,7 @@ const CustomBotWithoutProxySettings = (props) => {
         </div>
 
         <div className="card rounded-lg shadow border-0 w-50">
-          <h5 className="card-title m-3"><b>GROWI App</b></h5>
+          <h5 className="card-title font-weight-bold m-3">GROWI App</h5>
           <div className="card-body p-5 text-center">
             <a className="btn btn-primary mb-3">WESEEK Inner Wiki</a>
           </div>

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -99,13 +99,19 @@ const CustomBotWithoutProxySettings = (props) => {
 
         {/* 破線 */}
         {/* <div className="w-25 border-danger align-self-center" style={{ border: "dashed" }}></div> */}
-        <hr className="border-danger align-self-center w-25" style={{ border: "dashed" }}></hr>
+        {/* <hr className="border-danger align-self-center w-25" style={{ border: "dashed" }}></hr> */}
+
+        {/* 破線 & 文字 */}
+        <div className="text-center w-25">
+          <p className="text-secondary">連携は完了していません。下記の連携手順を進めてください。</p>
+          <hr className="border-danger align-self-center" style={{ border: "dashed" }}></hr>
+        </div>
 
         {/* カード２ */}
         <div className="card rounded-lg shadow border-0 w-50">
           <h5 className="card-title m-2">GROWI App</h5>
           <div className="card-body p-5 text-center">
-            <a className="btn btn-primary">WESEEK Inner Wiki</a>
+            <a className="btn btn-primary">WESEEK Inner brWiki</a>
           </div>
         </div>
 

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -104,7 +104,7 @@ const CustomBotWithoutProxySettings = (props) => {
         {/* 破線 & 文字 */}
         <div className="text-center w-25">
           <p className="text-secondary">連携は完了していません。下記の連携手順を進めてください。</p>
-          <hr className="border-danger align-self-center" style={{ border: "dashed" }}></hr>
+          <hr className="border-danger align-self-center" style={{ border: 'dashed' }}></hr>
         </div>
 
         {/* カード２ */}

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -93,7 +93,7 @@ const CustomBotWithoutProxySettings = (props) => {
           <div className="card-body p-4"></div>
         </div>
 
-        <div className="text-center w-25 mt-5">
+        <div className="text-center w-25 mt-4">
           <p className="text-secondary m-0"><small>{t('admin:slack_integration.integration_sentence.integration_is_not_complete')}</small></p>
           <p className="text-secondary"><small>{t('admin:slack_integration.integration_sentence.proceed_with_the_following_integration_procedure')}</small></p>
           <hr className="border-danger align-self-center admin-border"></hr>
@@ -102,7 +102,7 @@ const CustomBotWithoutProxySettings = (props) => {
         <div className="card rounded-lg shadow border-0 w-50 admin-bot-card">
           <h5 className="card-title font-weight-bold m-3">GROWI App</h5>
           <div className="card-body p-4 text-center">
-            <a className="btn btn-primary mb-3">WESEEK Inner Wiki</a>
+            <a className="btn btn-primary mb-5">WESEEK Inner Wiki</a>
           </div>
         </div>
       </div>

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -97,10 +97,6 @@ const CustomBotWithoutProxySettings = (props) => {
           <div className="card-body p-5"></div>
         </div>
 
-        {/* 破線 */}
-        {/* <div className="w-25 border-danger align-self-center" style={{ border: "dashed" }}></div> */}
-        {/* <hr className="border-danger align-self-center w-25" style={{ border: "dashed" }}></hr> */}
-
         {/* 破線 & 文字 */}
         <div className="text-center w-25">
           <p className="text-secondary m-0"><small>連携は完了していません。</small></p>
@@ -112,7 +108,7 @@ const CustomBotWithoutProxySettings = (props) => {
         <div className="card rounded-lg shadow border-0 w-50">
           <h5 className="card-title m-3"><b>GROWI App</b></h5>
           <div className="card-body p-5 text-center">
-            <a className="btn btn-primary">WESEEK Inner brWiki</a>
+            <a className="btn btn-primary">WESEEK Inner Wiki</a>
           </div>
         </div>
 

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -93,7 +93,7 @@ const CustomBotWithoutProxySettings = (props) => {
 
         {/* カード１ */}
         <div className="card rounded-lg shadow border-0 w-50">
-          <h5 className="card-title m-2">Slack</h5>
+          <h5 className="card-title m-3">Slack</h5>
           <div className="card-body p-5"></div>
         </div>
 
@@ -110,7 +110,7 @@ const CustomBotWithoutProxySettings = (props) => {
 
         {/* カード２ */}
         <div className="card rounded-lg shadow border-0 w-50">
-          <h5 className="card-title m-2">GROWI App</h5>
+          <h5 className="card-title m-3">GROWI App</h5>
           <div className="card-body p-5 text-center">
             <a className="btn btn-primary">WESEEK Inner brWiki</a>
           </div>

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -90,7 +90,7 @@ const CustomBotWithoutProxySettings = (props) => {
       <div className="d-flex justify-content-center mt-3 bot-integration">
         <div className="card rounded shadow border-0 w-50 admin-bot-card" style={{ radius: '8px'}}>
           <h5 className="card-title font-weight-bold m-3">Slack</h5>
-          <div className="card-body p-5"></div>
+          <div className="card-body p-4"></div>
         </div>
 
         <div className="text-center w-25 mt-5">
@@ -101,7 +101,7 @@ const CustomBotWithoutProxySettings = (props) => {
 
         <div className="card rounded-lg shadow border-0 w-50">
           <h5 className="card-title font-weight-bold m-3">GROWI App</h5>
-          <div className="card-body p-5 text-center">
+          <div className="card-body p-4 text-center">
             <a className="btn btn-primary mb-3">WESEEK Inner Wiki</a>
           </div>
         </div>

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -98,7 +98,7 @@ const CustomBotWithoutProxySettings = (props) => {
         </div>
 
         {/* 破線 & 文字 */}
-        <div className="text-center w-25">
+        <div className="text-center w-25 mt-5">
           <p className="text-secondary m-0"><small>連携は完了していません。</small></p>
           <p className="text-secondary"><small>下記の連携手順を進めてください。</small></p>
           <hr className="border-danger align-self-center" style={{ border: 'dashed' }}></hr>
@@ -108,7 +108,7 @@ const CustomBotWithoutProxySettings = (props) => {
         <div className="card rounded-lg shadow border-0 w-50">
           <h5 className="card-title m-3"><b>GROWI App</b></h5>
           <div className="card-body p-5 text-center">
-            <a className="btn btn-primary">WESEEK Inner Wiki</a>
+            <a className="btn btn-primary mb-3">WESEEK Inner Wiki</a>
           </div>
         </div>
 

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -88,7 +88,6 @@ const CustomBotWithoutProxySettings = (props) => {
       <h2 className="admin-setting-header">{t('admin:slack_integration.custom_bot_without_proxy_integration')}</h2>
 
       <div className="d-flex justify-content-center my-5">
-
         <div className="card rounded-lg shadow border-0 w-50">
           <h5 className="card-title m-3"><b>Slack</b></h5>
           <div className="card-body p-5"></div>
@@ -106,7 +105,6 @@ const CustomBotWithoutProxySettings = (props) => {
             <a className="btn btn-primary mb-3">WESEEK Inner Wiki</a>
           </div>
         </div>
-
       </div>
 
       <h2 className="admin-setting-header">{t('admin:slack_integration.custom_bot_without_proxy_settings')}</h2>

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -89,7 +89,7 @@ const CustomBotWithoutProxySettings = (props) => {
 
       <h2 className="admin-setting-header">{t('admin:slack_integration.custom_bot_without_proxy_integration')}</h2>
 
-      <div className="d-flex justify-content-center my-4">
+      <div className="d-flex justify-content-center my-5">
 
         {/* カード１ */}
         <div className="card rounded-lg shadow border-0 w-50">

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -84,6 +84,32 @@ const CustomBotWithoutProxySettings = (props) => {
 
   return (
     <>
+
+      {/* ----------------  start --------------- */}
+
+      <h2 className="admin-setting-header">{t('admin:slack_integration.custom_bot_without_proxy_integration')}</h2>
+
+      <div className="d-flex justify-content-center my-4">
+
+        {/* カード１ */}
+        <div className="card rounded-lg shadow border-0 w-50">
+          <h5 className="card-title m-2">Slack</h5>
+          <div className="card-body p-5"></div>
+        </div>
+
+        {/* 破線 */}
+        <div className="w-25 border-danger align-self-center" style={{ border: "dashed" }}></div>
+
+        {/* カード２ */}
+        <div className="card rounded-lg shadow border-0 w-50">
+          <h5 className="card-title m-2">GROWI App</h5>
+          <div className="card-body p-5"></div>
+        </div>
+
+      </div>
+
+      {/* ----------------   end  --------------- */}
+
       <h2 className="admin-setting-header">{t('admin:slack_integration.custom_bot_without_proxy_settings')}</h2>
       {/* temporarily put bellow component */}
       <SlackGrowiBridging

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -88,7 +88,7 @@ const CustomBotWithoutProxySettings = (props) => {
       <h2 className="admin-setting-header">{t('admin:slack_integration.custom_bot_without_proxy_integration')}</h2>
 
       <div className="d-flex justify-content-center mt-3 bot-integration">
-        <div className="card rounded shadow border-0 w-50 admin-bot-card" style={{ radius: '8px'}}>
+        <div className="card rounded shadow border-0 w-50 admin-bot-card">
           <h5 className="card-title font-weight-bold m-3">Slack</h5>
           <div className="card-body p-4"></div>
         </div>
@@ -99,7 +99,7 @@ const CustomBotWithoutProxySettings = (props) => {
           <hr className="border-danger align-self-center admin-border"></hr>
         </div>
 
-        <div className="card rounded-lg shadow border-0 w-50">
+        <div className="card rounded-lg shadow border-0 w-50 admin-bot-card">
           <h5 className="card-title font-weight-bold m-3">GROWI App</h5>
           <div className="card-body p-4 text-center">
             <a className="btn btn-primary mb-3">WESEEK Inner Wiki</a>

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -98,13 +98,15 @@ const CustomBotWithoutProxySettings = (props) => {
         </div>
 
         {/* 破線 */}
-        {/* <div className="w-25 border-danger align-self-center" style={{ border: "dashed" }}></?div> */}
+        {/* <div className="w-25 border-danger align-self-center" style={{ border: "dashed" }}></div> */}
         <hr className="border-danger align-self-center w-25" style={{ border: "dashed" }}></hr>
 
         {/* カード２ */}
         <div className="card rounded-lg shadow border-0 w-50">
           <h5 className="card-title m-2">GROWI App</h5>
-          <div className="card-body p-5"></div>
+          <div className="card-body p-5 text-center">
+            <a className="btn btn-primary">WESEEK Inner Wiki</a>
+          </div>
         </div>
 
       </div>

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -95,8 +95,8 @@ const CustomBotWithoutProxySettings = (props) => {
         </div>
 
         <div className="text-center w-25 mt-5">
-          <p className="text-secondary m-0"><small>連携は完了していません。</small></p>
-          <p className="text-secondary"><small>下記の連携手順を進めてください。</small></p>
+          <p className="text-secondary m-0"><small>{t('admin:slack_integration.without_proxy_integration.integration_is_not_complete')}</small></p>
+          <p className="text-secondary"><small>{t('admin:slack_integration.without_proxy_integration.proceed_with_the_following_integration_procedure')}</small></p>
           <hr className="border-danger align-self-center" style={{ border: 'dashed' }}></hr>
         </div>
 

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -98,7 +98,8 @@ const CustomBotWithoutProxySettings = (props) => {
         </div>
 
         {/* 破線 */}
-        <div className="w-25 border-danger align-self-center" style={{ border: "dashed" }}></div>
+        {/* <div className="w-25 border-danger align-self-center" style={{ border: "dashed" }}></?div> */}
+        <hr className="border-danger align-self-center w-25" style={{ border: "dashed" }}></hr>
 
         {/* カード２ */}
         <div className="card rounded-lg shadow border-0 w-50">

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -87,7 +87,7 @@ const CustomBotWithoutProxySettings = (props) => {
 
       <h2 className="admin-setting-header">{t('admin:slack_integration.custom_bot_without_proxy_integration')}</h2>
 
-      <div className="d-flex justify-content-center mt-3 bot-integration">
+      <div className="d-flex justify-content-center my-5 bot-integration">
         <div className="card rounded shadow border-0 w-50 admin-bot-card">
           <h5 className="card-title font-weight-bold m-3">Slack</h5>
           <div className="card-body p-4"></div>

--- a/src/client/styles/scss/_admin.scss
+++ b/src/client/styles/scss/_admin.scss
@@ -105,6 +105,16 @@
     }
   }
 
+  .bot-integration {
+    .admin-bot-card {
+      border-radius: 8px !important;
+    }
+    .admin-border {
+      border-style : dashed;
+      border-width : 2px;
+    }
+  }
+
   //// TODO: migrate to Bootstrap 4
   //// omit all .btn-toggle and use Switches
   //// https://getbootstrap.com/docs/4.2/components/forms/#switches

--- a/src/client/styles/scss/_admin.scss
+++ b/src/client/styles/scss/_admin.scss
@@ -113,6 +113,20 @@
       border-style : dashed;
       border-width : 2px;
     }
+    .circle-front {
+      position: relative;
+      width: 60px;
+      height: 60px;
+      background: #092c58;
+      border-radius: 50%;
+    }
+    .circle-back {
+      position: absolute;
+      width: 70px;
+      height: 70px;
+      background: #d0d6de;
+      border-radius: 50%;
+    }
   }
 
   //// TODO: migrate to Bootstrap 4

--- a/src/client/styles/scss/_admin.scss
+++ b/src/client/styles/scss/_admin.scss
@@ -114,18 +114,24 @@
       border-width : 2px;
     }
     .circle-front {
-      position: relative;
-      width: 60px;
-      height: 60px;
+      // position: relative;
+      width: 74px;
+      height: 74px;
+      margin: 0 auto;
       background: #092c58;
       border-radius: 50%;
     }
     .circle-back {
-      position: absolute;
-      width: 70px;
-      height: 70px;
+      // position: absolute;
+      width: 100px;
+      height: 100px;
       background: #d0d6de;
       border-radius: 50%;
+    }
+    .circle{
+      width: 100px;
+      height: 100px;
+      
     }
   }
 

--- a/src/client/styles/scss/_admin.scss
+++ b/src/client/styles/scss/_admin.scss
@@ -116,8 +116,8 @@
     .circle{
       width: 100px;
       height: 100px;
-      background: #092c58;
-      border: 13px solid #d0d6de;
+      // background: #092c58;
+      border: 13px solid;
       border-radius: 50%;
     }
   }

--- a/src/client/styles/scss/_admin.scss
+++ b/src/client/styles/scss/_admin.scss
@@ -117,7 +117,7 @@
       width: 100px;
       height: 100px;
       background: #092c58;
-      border: 10px solid #d0d6de;
+      border: 13px solid #d0d6de;
       border-radius: 50%;
     }
   }

--- a/src/client/styles/scss/_admin.scss
+++ b/src/client/styles/scss/_admin.scss
@@ -113,25 +113,12 @@
       border-style : dashed;
       border-width : 2px;
     }
-    .circle-front {
-      // position: relative;
-      width: 74px;
-      height: 74px;
-      margin: 0 auto;
-      background: #092c58;
-      border-radius: 50%;
-    }
-    .circle-back {
-      // position: absolute;
-      width: 100px;
-      height: 100px;
-      background: #d0d6de;
-      border-radius: 50%;
-    }
     .circle{
       width: 100px;
       height: 100px;
-      
+      background: #092c58;
+      border: 10px solid #d0d6de;
+      border-radius: 50%;
     }
   }
 


### PR DESCRIPTION
[XD](https://xd.adobe.com/view/e239e247-2784-4066-b2ff-15558ddc0dff-b76a/screen/f1c18420-788d-4e30-a669-ecd4ad0d292a/)を参考に admin/slack-integration の Custom bot with proxy に以下の図を作成しました。

【日本語】
<img width="1432" alt="スクリーンショット 2021-04-16 18 14 03" src="https://user-images.githubusercontent.com/34241526/115002431-b4042c00-9edf-11eb-966b-58be9dac941f.png">

【英語】
<img width="1409" alt="スクリーンショット 2021-04-16 18 14 23" src="https://user-images.githubusercontent.com/34241526/115002454-ba92a380-9edf-11eb-98bc-4443cf856b3b.png">

【中国語】
<img width="1416" alt="スクリーンショット 2021-04-16 18 14 42" src="https://user-images.githubusercontent.com/34241526/115002479-c1b9b180-9edf-11eb-9b97-bded73e83f32.png">
