### PR TITLE
Fix/5707 accordion proptypes fix

### DIFF
--- a/src/client/js/components/Admin/Common/Accordion.jsx
+++ b/src/client/js/components/Admin/Common/Accordion.jsx
@@ -30,7 +30,6 @@ Accordion.propTypes = {
   title: PropTypes.node.isRequired,
   children: PropTypes.node.isRequired,
   isOpenDefault: PropTypes.bool,
-
 };
 
 Accordion.defaultProps = {

--- a/src/client/js/components/Admin/Common/Accordion.jsx
+++ b/src/client/js/components/Admin/Common/Accordion.jsx
@@ -29,7 +29,12 @@ const Accordion = (props) => {
 Accordion.propTypes = {
   title: PropTypes.node.isRequired,
   children: PropTypes.node.isRequired,
-  isOpenDefault: PropTypes.bool.isRequired,
+  isOpenDefault: PropTypes.bool,
+
+};
+
+Accordion.defaultProps = {
+  isOpenDefault: false,
 };
 
 export default Accordion;


### PR DESCRIPTION
# GW-5707 [bug]アコーディオン読み込み時にPropTypesのエラーが出る

## やったこと
Without Proxy画面読み込み時に下記エラーが出るのを修正しました。
`Warning: Failed prop type: The prop isOpenDefault is marked as required in Accordion, but its value is undefined.`

## できるようになること
`isOpenDefault`をpropsとして渡さなくてもAccordionが使えるようになりました。