### PR TITLE
Fix/5711 Bug: 再起的な操作を行うと子供のページがサイドバーの最新の変更に表示されない GW-5710 

### DIFF
--- a/src/server/service/page.js
+++ b/src/server/service/page.js
@@ -635,9 +635,9 @@ class PageService {
       const toPath = Page.getRevertDeletedPageName(page.path);
 
       if (pathToPageMapping[toPath] != null) {
-        // When the page is deleted, it will always be created with "redirectTo" in the path of the original page.
-        // So, it's ok to delete the page
-        // However, If a page exists that is not "redirectTo", something is wrong. (Data correction is needed).
+      // When the page is deleted, it will always be created with "redirectTo" in the path of the original page.
+      // So, it's ok to delete the page
+      // However, If a page exists that is not "redirectTo", something is wrong. (Data correction is needed).
         if (pathToPageMapping[toPath].redirectTo === page.path) {
           removePageBulkOp.find({ path: toPath }).remove();
         }
@@ -669,9 +669,9 @@ class PageService {
     const newPath = Page.getRevertDeletedPageName(page.path);
     const originPage = await Page.findByPath(newPath);
     if (originPage != null) {
-    // When the page is deleted, it will always be created with "redirectTo" in the path of the original page.
-    // So, it's ok to delete the page
-    // However, If a page exists that is not "redirectTo", something is wrong. (Data correction is needed).
+      // When the page is deleted, it will always be created with "redirectTo" in the path of the original page.
+      // So, it's ok to delete the page
+      // However, If a page exists that is not "redirectTo", something is wrong. (Data correction is needed).
       if (originPage.redirectTo !== page.path) {
         throw new Error('The new page of to revert is exists and the redirect path of the page is not the deleted page.');
       }

--- a/src/server/service/page.js
+++ b/src/server/service/page.js
@@ -105,7 +105,7 @@ class PageService {
       if (updateMetadata) {
         unorderedBulkOp
           .find({ _id: page._id })
-          .update({ $set: { path: newPagePath, lastUpdateUser: user._id, updatedAt: { $dateFromString: { dateString: Date.now() } } } });
+          .update({ $set: { path: newPagePath, lastUpdateUser: user._id, updatedAt: Date.now().toISOString() } });
       }
       else {
         unorderedBulkOp.find({ _id: page._id }).update({ $set: { path: newPagePath } });
@@ -635,9 +635,9 @@ class PageService {
       const toPath = Page.getRevertDeletedPageName(page.path);
 
       if (pathToPageMapping[toPath] != null) {
-      // When the page is deleted, it will always be created with "redirectTo" in the path of the original page.
-      // So, it's ok to delete the page
-      // However, If a page exists that is not "redirectTo", something is wrong. (Data correction is needed).
+        // When the page is deleted, it will always be created with "redirectTo" in the path of the original page.
+        // So, it's ok to delete the page
+        // However, If a page exists that is not "redirectTo", something is wrong. (Data correction is needed).
         if (pathToPageMapping[toPath].redirectTo === page.path) {
           removePageBulkOp.find({ path: toPath }).remove();
         }

--- a/src/server/service/page.js
+++ b/src/server/service/page.js
@@ -103,7 +103,7 @@ class PageService {
       const revisionId = new mongoose.Types.ObjectId();
 
       if (updateMetadata) {
-        unorderedBulkOp.find({ _id: page._id }).update({ $set: { path: newPagePath, lastUpdateUser: user._id, updatedAt:  Date.now() } });
+        unorderedBulkOp.find({ _id: page._id }).update({ $set: { path: newPagePath, lastUpdateUser: user._id, updatedAt:  Date.now().toISOString() } });
       }
       else {
         unorderedBulkOp.find({ _id: page._id }).update({ $set: { path: newPagePath } });

--- a/src/server/service/page.js
+++ b/src/server/service/page.js
@@ -103,7 +103,9 @@ class PageService {
       const revisionId = new mongoose.Types.ObjectId();
 
       if (updateMetadata) {
-        unorderedBulkOp.find({ _id: page._id }).update({ $set: { path: newPagePath, lastUpdateUser: user._id, updatedAt: { $dateFromString: { dateString: Date.now() } } } });
+        unorderedBulkOp
+          .find({ _id: page._id })
+          .update({ $set: { path: newPagePath, lastUpdateUser: user._id, updatedAt: { $dateFromString: { dateString: Date.now() } } } });
       }
       else {
         unorderedBulkOp.find({ _id: page._id }).update({ $set: { path: newPagePath } });

--- a/src/server/service/page.js
+++ b/src/server/service/page.js
@@ -103,7 +103,7 @@ class PageService {
       const revisionId = new mongoose.Types.ObjectId();
 
       if (updateMetadata) {
-        unorderedBulkOp.find({ _id: page._id }).update({ $set: { path: newPagePath, lastUpdateUser: user._id, updatedAt: new Date() } });
+        unorderedBulkOp.find({ _id: page._id }).update({ $set: { path: newPagePath, lastUpdateUser: user._id, updatedAt: { $dateFromString: { dateString: Date.now() } } } });
       }
       else {
         unorderedBulkOp.find({ _id: page._id }).update({ $set: { path: newPagePath } });

--- a/src/server/service/page.js
+++ b/src/server/service/page.js
@@ -103,7 +103,7 @@ class PageService {
       const revisionId = new mongoose.Types.ObjectId();
 
       if (updateMetadata) {
-        unorderedBulkOp.find({ _id: page._id }).update({ $set: { path: newPagePath, lastUpdateUser: user._id, updatedAt:  Date.now().toISOString() } });
+        unorderedBulkOp.find({ _id: page._id }).update({ $set: { path: newPagePath, lastUpdateUser: user._id, updatedAt: new Date() } });
       }
       else {
         unorderedBulkOp.find({ _id: page._id }).update({ $set: { path: newPagePath } });

--- a/src/server/service/page.js
+++ b/src/server/service/page.js
@@ -669,9 +669,9 @@ class PageService {
     const newPath = Page.getRevertDeletedPageName(page.path);
     const originPage = await Page.findByPath(newPath);
     if (originPage != null) {
-      // When the page is deleted, it will always be created with "redirectTo" in the path of the original page.
-      // So, it's ok to delete the page
-      // However, If a page exists that is not "redirectTo", something is wrong. (Data correction is needed).
+    // When the page is deleted, it will always be created with "redirectTo" in the path of the original page.
+    // So, it's ok to delete the page
+    // However, If a page exists that is not "redirectTo", something is wrong. (Data correction is needed).
       if (originPage.redirectTo !== page.path) {
         throw new Error('The new page of to revert is exists and the redirect path of the page is not the deleted page.');
       }


### PR DESCRIPTION
# 再起的な操作を行うと子供のページがサイドバーの最新の変更に表示されない

## 再現方法
- `/page` と `/page/child` にページを作成する
- `/page`を`/pages`等に名前変更し、子ページを含めて再起的に移動を行う

## 症状
- サイドバーの「最新の変更」に `/pages/child` が表示されない

## 想定される動作
- 「最新の変更」に `/pages/child` が表示される

## 原因
- 子ページの`updatedAt`がDateではなくDouble型としてDBに記録されてしまったため
<img width="535" alt="Screen Shot 2021-04-20 at 12 20 11" src="https://user-images.githubusercontent.com/66785624/115336985-283e1880-a1db-11eb-90d2-775020a35c11.png">

## やったこと
`Date.now`を`Date.now().toISOString()`に変更しました。

## やっていないこと
他に`Date.now()`を用いているところはバグが出ていないので変更することはしませんでした。

## 他に試したこと
### `new Date()`
`updatedAt: new Date()`
→CI でエラーが出ます。

### mongodbの`$dateFromString`
`updatedAt: { $dateFromString: { dateString: Date.now() } }`
→CI でエラーが出ます。

## 動作確認
済
<img width="338" alt="Screen Shot 2021-04-20 at 13 30 52" src="https://user-images.githubusercontent.com/66785624/115337884-c383bd80-a1dc-11eb-8b8a-f4a18444b704.png">
<img width="555" alt="Screen Shot 2021-04-20 at 13 31 18" src="https://user-images.githubusercontent.com/66785624/115337885-c4b4ea80-a1dc-11eb-81f0-c7b2c86a8267.png">