### PR TITLE
Feat/show site name

### DIFF
--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -82,7 +82,7 @@ const CustomBotWithoutProxySettings = (props) => {
         <div className="card rounded-lg shadow border-0 w-50 admin-bot-card">
           <h5 className="card-title font-weight-bold mt-3 ml-4">GROWI App</h5>
           <div className="card-body p-4 mb-5 text-center">
-            <div className="btn btn-primary">WESEEK Inner Wiki</div>
+            <div className="btn btn-primary">{ siteName }</div>
           </div>
         </div>
       </div>

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -29,7 +29,18 @@ const CustomBotWithoutProxySettings = (props) => {
     }
   };
 
+  const fetchSiteName = async() => {
+    try {
+      await adminAppContainer.retrieveAppSettingsData()
+      setSiteName(adminAppContainer.state.title);
+    }
+    catch (err) {
+      toastError(err);
+    }
+  }
+
   useEffect(() => {
+    fetchSiteName();
     setSlackWSNameInWithoutProxy(null);
     if (props.isSetupSlackBot) {
       fetchSlackWorkSpaceName();

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -10,7 +10,7 @@ import CustomBotWithoutProxySettingsAccordion, { botInstallationStep } from './C
 import GrowiLogo from '../../Icons/GrowiLogo';
 
 const CustomBotWithoutProxySettings = (props) => {
-  const { appContainer } = props;
+  const { appContainer, adminAppContainer } = props;
   const { t } = useTranslation();
 
   const [slackWSNameInWithoutProxy, setSlackWSNameInWithoutProxy] = useState(null);


### PR DESCRIPTION
## 概要

admin/slack-integration の Custom bot without proxy 連携 の図においてサイト名を表示するようにしました。

<img width="1105" alt="スクリーンショット 2021-04-20 20 09 39" src="https://user-images.githubusercontent.com/34241526/115386772-cdc1ae00-a214-11eb-8793-44f482ac6a8d.png">
