### PR TITLE
Feat/gw 5715 show site name

### DIFF
--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -10,7 +10,7 @@ import CustomBotWithoutProxySettingsAccordion, { botInstallationStep } from './C
 import GrowiLogo from '../../Icons/GrowiLogo';
 
 const CustomBotWithoutProxySettings = (props) => {
-  const { appContainer, adminAppContainer } = props;
+  const { appContainer } = props;
   const { t } = useTranslation();
 
   const [slackWSNameInWithoutProxy, setSlackWSNameInWithoutProxy] = useState(null);

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -15,8 +15,6 @@ const CustomBotWithoutProxySettings = (props) => {
 
   const [slackWSNameInWithoutProxy, setSlackWSNameInWithoutProxy] = useState(null);
 
-  // get site name from this GROWI
-  // eslint-disable-next-line no-unused-vars
   const [siteName, setSiteName] = useState('');
 
   const fetchSlackWorkSpaceName = async() => {

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -27,14 +27,9 @@ const CustomBotWithoutProxySettings = (props) => {
     }
   };
 
-  const fetchSiteName = async() => {
-    try {
-      await adminAppContainer.retrieveAppSettingsData();
-      setSiteName(adminAppContainer.state.title);
-    }
-    catch (err) {
-      toastError(err);
-    }
+  const fetchSiteName = () => {
+    const siteName = appContainer.getConfig().crowi.title;
+    setSiteName(siteName);
   };
 
   useEffect(() => {

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -82,7 +82,7 @@ const CustomBotWithoutProxySettings = (props) => {
         <div className="card rounded-lg shadow border-0 w-50 admin-bot-card">
           <h5 className="card-title font-weight-bold mt-3 ml-4">GROWI App</h5>
           <div className="card-body p-4 mb-5 text-center">
-            <div className="btn btn-primary">WESEEK Inner Wiki</div>
+            <div className="btn btn-primary">{ siteName }</div>
           </div>
         </div>
       </div>

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -39,7 +39,6 @@ const CustomBotWithoutProxySettings = (props) => {
 
   useEffect(() => {
     fetchSiteName();
-    setSlackWSNameInWithoutProxy(null);
     if (props.isSetupSlackBot) {
       fetchSlackWorkSpaceName();
     }

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -29,6 +29,16 @@ const CustomBotWithoutProxySettings = (props) => {
     }
   };
 
+  const fetchSiteName = async() => {
+    try {
+      await adminAppContainer.retrieveAppSettingsData()
+      setSiteName(adminAppContainer.state.title);
+    }
+    catch (err) {
+      toastError(err);
+    }
+  };
+
   useEffect(() => {
     setSlackWSNameInWithoutProxy(null);
     if (props.isSetupSlackBot) {

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -28,7 +28,7 @@ const CustomBotWithoutProxySettings = (props) => {
   };
 
   const fetchSiteName = () => {
-    const siteName = appContainer.getConfig().crowi.title;
+    const siteName = appContainer.config.crowi.title;
     setSiteName(siteName);
   };
 

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -10,7 +10,7 @@ import CustomBotWithoutProxySettingsAccordion, { botInstallationStep } from './C
 import GrowiLogo from '../../Icons/GrowiLogo';
 
 const CustomBotWithoutProxySettings = (props) => {
-  const { appContainer } = props;
+  const { appContainer, adminAppContainer } = props;
   const { t } = useTranslation();
 
   const [slackWSNameInWithoutProxy, setSlackWSNameInWithoutProxy] = useState(null);

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -31,7 +31,7 @@ const CustomBotWithoutProxySettings = (props) => {
 
   const fetchSiteName = async() => {
     try {
-      await adminAppContainer.retrieveAppSettingsData()
+      await adminAppContainer.retrieveAppSettingsData();
       setSiteName(adminAppContainer.state.title);
     }
     catch (err) {

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -40,6 +40,7 @@ const CustomBotWithoutProxySettings = (props) => {
   };
 
   useEffect(() => {
+    fetchSiteName();
     setSlackWSNameInWithoutProxy(null);
     if (props.isSetupSlackBot) {
       fetchSlackWorkSpaceName();


### PR DESCRIPTION
## 概要
admin/slack-integration の Custom bot without proxy 連携 の図においてサイト名を表示するようにしました。

<img width="1055" alt="スクリーンショット 2021-04-21 0 15 59" src="https://user-images.githubusercontent.com/34241526/115421965-6a954300-a237-11eb-91e6-6f161f064739.png">

## メモ
* ~~siteName が null の時（サイト名が無い時）どうするか~~　サイト名が未設定で .getConfig().crowi.title でサイト名を取得すると GROWI になる