### PR TITLE
Imprv/gw 5728 remove reload icon

### DIFF
--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -43,13 +43,7 @@ const CustomBotWithoutProxySettings = (props) => {
 
       <div className="d-flex justify-content-center my-5 bot-integration">
         <div className="card rounded shadow border-0 w-50 admin-bot-card">
-          <div className="row">
-            <h5 className="card-title font-weight-bold mt-3 ml-4 col">Slack</h5>
-            <div className="pull-right mt-3 mr-3">
-              <div className="icon-fw fa fa-repeat fa-2x" onClick={fetchSlackWorkSpaceName}></div>
-            </div>
-          </div>
-
+          <h5 className="card-title font-weight-bold mt-3 ml-4">Slack</h5>
           <div className="card-body p-2 w-50 mx-auto">
             {slackWSNameInWithoutProxy && (
               <div className="card p-20 slack-work-space-name-card">


### PR DESCRIPTION
## 概要

リロードボタンのアイコンを削除しました。

【before】
<img width="1051" alt="スクリーンショット 2021-04-21 1 01 11" src="https://user-images.githubusercontent.com/34241526/115428621-8996d380-a23d-11eb-9333-8b922d389836.png">

【after】
<img width="1057" alt="スクリーンショット 2021-04-21 1 02 46" src="https://user-images.githubusercontent.com/34241526/115428658-9287a500-a23d-11eb-8e52-c9bc4d0fc667.png">

