### PR TITLE
Fix/5710 5731 fix error for date now

### DIFF
--- a/package.json
+++ b/package.json
@@ -207,6 +207,7 @@
     "i18next-browser-languagedetector": "^4.0.1",
     "imports-loader": "^0.8.0",
     "jest": "^25.1.0",
+    "jest-date-mock": "^1.0.8",
     "jquery-slimscroll": "^1.3.8",
     "jquery-ui": "^1.12.1",
     "jquery.cookie": "~1.4.1",

--- a/src/server/service/page.js
+++ b/src/server/service/page.js
@@ -105,7 +105,7 @@ class PageService {
       if (updateMetadata) {
         unorderedBulkOp
           .find({ _id: page._id })
-          .update({ $set: { path: newPagePath, lastUpdateUser: user._id, updatedAt: Date.now().toISOString() } });
+          .update({ $set: { path: newPagePath, lastUpdateUser: user._id, updatedAt: new Date() } });
       }
       else {
         unorderedBulkOp.find({ _id: page._id }).update({ $set: { path: newPagePath } });

--- a/src/test/service/page.test.js
+++ b/src/test/service/page.test.js
@@ -1,4 +1,6 @@
 /* eslint-disable no-unused-vars */
+import { advanceTo } from 'jest-date-mock';
+
 const mongoose = require('mongoose');
 
 const { getInstance } = require('../setup-crowi');
@@ -236,11 +238,12 @@ describe('PageService', () => {
   describe('rename page', () => {
     let pageEventSpy;
     let renameDescendantsWithStreamSpy;
-    const dateToUse = new Date('2000-01-01');
+    // mock new Date() and Date.now()
+    advanceTo(new Date(2000, 1, 1, 0, 0, 0));
+    const dateToUse = new Date();
     const socketClientId = null;
 
     beforeEach(async(done) => {
-      jest.spyOn(global.Date, 'now').mockImplementation(() => dateToUse);
       pageEventSpy = jest.spyOn(crowi.pageService.pageEvent, 'emit').mockImplementation();
       renameDescendantsWithStreamSpy = jest.spyOn(crowi.pageService, 'renameDescendantsWithStream').mockImplementation();
       done();

--- a/yarn.lock
+++ b/yarn.lock
@@ -8161,6 +8161,11 @@ jest-config@^25.1.0:
     pretty-format "^25.1.0"
     realpath-native "^1.1.0"
 
+jest-date-mock@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/jest-date-mock/-/jest-date-mock-1.0.8.tgz#13468c0352c5a3614c6b356dbc6b88eb37d9e0b3"
+  integrity sha512-0Lyp+z9xvuNmLbK+5N6FOhSiBeux05Lp5bbveFBmYo40Aggl2wwxFoIrZ+rOWC8nDNcLeBoDd2miQdEDSf3iQw==
+
 jest-diff@^25.1.0:
   version "25.1.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-25.1.0.tgz#58b827e63edea1bc80c1de952b80cec9ac50e1ad"


### PR DESCRIPTION
- new Date() と Date.now() が混在しているテストだと Mock するのが難しいため `jest-date-mock` をインストールして使用しました。
