### PR TITLE
FIx/5751 fix group select error

### DIFF
--- a/src/client/js/components/SavePageControls/GrantSelector.jsx
+++ b/src/client/js/components/SavePageControls/GrantSelector.jsx
@@ -203,7 +203,6 @@ class GrantSelector extends React.Component {
     return (
       <Modal
         className="select-grant-group"
-        container={this}
         isOpen={this.state.isSelectGroupModalShown}
         toggle={this.hideSelectGroupModal}
       >


### PR DESCRIPTION
## 概要
v4.2.15 で 任意のページを新規作成または編集し、公開範囲を特定のグループのみにした場合エラーが発生する問題の修正を行いました。fix #3655 