### PR TITLE
Fix/5693 cards responsive

### DIFF
--- a/src/client/js/components/Admin/SlackIntegration/BotTypeCard.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/BotTypeCard.jsx
@@ -51,15 +51,15 @@ const BotTypeCard = (props) => {
 
           {/*  A recommended badge is shown on official bot card, supplementary names are shown on Custom bot cards   */}
           {props.botType === 'officialBot'
-            ? (
-              <span className="badge badge-info mr-2">
-                {t('admin:slack_integration.selecting_bot_types.recommended')}
-              </span>
-            ) : (
-              <span className="supplementary-bot-name mr-2">
-                {t(`admin:slack_integration.selecting_bot_types.${botDetails[props.botType].supplementaryBotName}`)}
-              </span>
-            )}
+          ? (
+            <span className="badge badge-info mr-2">
+              {t('admin:slack_integration.selecting_bot_types.recommended')}
+            </span>
+          ) : (
+            <span className="supplementary-bot-name mr-2">
+              {t(`admin:slack_integration.selecting_bot_types.${botDetails[props.botType].supplementaryBotName}`)}
+            </span>
+          )}
 
           {/* TODO: add an appropriate links by GW-5614 */}
           <i className={`fa fa-external-link btn-link ${props.isActive ? 'bg-primary text-light' : ''}`} aria-hidden="true"></i>
@@ -81,8 +81,6 @@ const BotTypeCard = (props) => {
         </div>
       </div>
     </div>
-
-
   );
 
 };

--- a/src/client/js/components/Admin/SlackIntegration/BotTypeCard.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/BotTypeCard.jsx
@@ -33,57 +33,57 @@ const BotTypeCard = (props) => {
   const { t } = useTranslation('admin');
 
   return (
-    <div className="card-deck">
-      <div
-        className={`card admin-bot-card rounded border-radius-sm shadow ${props.isActive ? 'border-primary' : ''}`}
-        onClick={() => props.handleBotTypeSelect(botDetails[props.botType].botType)}
-        role="button"
-        key={props.botType}
-      >
-        <div>
-          <h3 className={`card-header mb-0 py-3
+
+    <div
+      className={`card m-3 admin-bot-card rounded border-radius-sm shadow ${props.isActive ? 'border-primary' : ''}`}
+      onClick={() => props.handleBotTypeSelect(botDetails[props.botType].botType)}
+      role="button"
+      key={props.botType}
+    >
+      <div>
+        <h3 className={`card-header mb-0 py-3
               ${props.botType === 'officialBot' ? 'd-flex align-items-center justify-content-center' : 'text-center'}
               ${props.isActive ? 'bg-primary text-light' : ''}`}
-          >
-            <span className="mr-2">
-              {t(`admin:slack_integration.selecting_bot_types.${botDetails[props.botType].botTypeCategory}`)}
-            </span>
+        >
+          <span className="mr-2">
+            {t(`admin:slack_integration.selecting_bot_types.${botDetails[props.botType].botTypeCategory}`)}
+          </span>
 
-            {/*  A recommended badge is shown on official bot card, supplementary names are shown on Custom bot cards   */}
-            {props.botType === 'officialBot'
-              ? (
-                <span className="badge badge-info mr-2">
-                  {t('admin:slack_integration.selecting_bot_types.recommended')}
-                </span>
-              ) : (
-                <span className="supplementary-bot-name mr-2">
-                  {t(`admin:slack_integration.selecting_bot_types.${botDetails[props.botType].supplementaryBotName}`)}
-                </span>
-              )}
+          {/*  A recommended badge is shown on official bot card, supplementary names are shown on Custom bot cards   */}
+          {props.botType === 'officialBot'
+            ? (
+              <span className="badge badge-info mr-2">
+                {t('admin:slack_integration.selecting_bot_types.recommended')}
+              </span>
+            ) : (
+              <span className="supplementary-bot-name mr-2">
+                {t(`admin:slack_integration.selecting_bot_types.${botDetails[props.botType].supplementaryBotName}`)}
+              </span>
+            )}
 
-            {/* TODO: add an appropriate links by GW-5614 */}
-            <i className={`fa fa-external-link btn-link ${props.isActive ? 'bg-primary text-light' : ''}`} aria-hidden="true"></i>
-          </h3>
-        </div>
-        <div className="card-body p-4">
-          <div className="card-text">
-            <div className="my-2">
-              <img className="d-block mx-auto mb-4" src={`/images/slack-integration/slackbot-difficulty-level-${botDetails[props.botType].setUp}.svg`}></img>
-              <div className="d-flex justify-content-between mb-3">
-                <span>{t('admin:slack_integration.selecting_bot_types.multiple_workspaces_integration')}</span>
-                <img className="bot-type-disc" src={`/images/slack-integration/${botDetails[props.botType].multiWSIntegration}.png`} alt="" />
-              </div>
-              <div className="d-flex justify-content-between">
-                <span>{t('admin:slack_integration.selecting_bot_types.security_control')}</span>
-                <img className="bot-type-disc" src={`/images/slack-integration/${botDetails[props.botType].securityControl}.png`} alt="" />
-              </div>
+          {/* TODO: add an appropriate links by GW-5614 */}
+          <i className={`fa fa-external-link btn-link ${props.isActive ? 'bg-primary text-light' : ''}`} aria-hidden="true"></i>
+        </h3>
+      </div>
+      <div className="card-body p-4">
+        <div className="card-text">
+          <div className="my-2">
+            <img className="d-block mx-auto mb-4" src={`/images/slack-integration/slackbot-difficulty-level-${botDetails[props.botType].setUp}.svg`}></img>
+            <div className="d-flex justify-content-between mb-3">
+              <span>{t('admin:slack_integration.selecting_bot_types.multiple_workspaces_integration')}</span>
+              <img className="bot-type-disc" src={`/images/slack-integration/${botDetails[props.botType].multiWSIntegration}.png`} alt="" />
+            </div>
+            <div className="d-flex justify-content-between">
+              <span>{t('admin:slack_integration.selecting_bot_types.security_control')}</span>
+              <img className="bot-type-disc" src={`/images/slack-integration/${botDetails[props.botType].securityControl}.png`} alt="" />
             </div>
           </div>
         </div>
       </div>
-
     </div>
-);
+
+
+  );
 
 };
 

--- a/src/client/js/components/Admin/SlackIntegration/BotTypeCard.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/BotTypeCard.jsx
@@ -33,7 +33,6 @@ const BotTypeCard = (props) => {
   const { t } = useTranslation('admin');
 
   return (
-
     <div
       className={`card m-3 admin-bot-card rounded border-radius-sm shadow ${props.isActive ? 'border-primary' : ''}`}
       onClick={() => props.handleBotTypeSelect(botDetails[props.botType].botType)}

--- a/src/client/js/components/Admin/SlackIntegration/BotTypeCard.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/BotTypeCard.jsx
@@ -33,54 +33,57 @@ const BotTypeCard = (props) => {
   const { t } = useTranslation('admin');
 
   return (
-    <div
-      className={`card admin-bot-card rounded border-radius-sm shadow ${props.isActive ? 'border-primary' : ''}`}
-      onClick={() => props.handleBotTypeSelect(botDetails[props.botType].botType)}
-      role="button"
-      key={props.botType}
-    >
-      <div>
-        <h3 className={`card-header mb-0 py-3
+    <div className="card-deck">
+      <div
+        className={`card admin-bot-card rounded border-radius-sm shadow ${props.isActive ? 'border-primary' : ''}`}
+        onClick={() => props.handleBotTypeSelect(botDetails[props.botType].botType)}
+        role="button"
+        key={props.botType}
+      >
+        <div>
+          <h3 className={`card-header mb-0 py-3
               ${props.botType === 'officialBot' ? 'd-flex align-items-center justify-content-center' : 'text-center'}
               ${props.isActive ? 'bg-primary text-light' : ''}`}
-        >
-          <span className="mr-2">
-            {t(`admin:slack_integration.selecting_bot_types.${botDetails[props.botType].botTypeCategory}`)}
-          </span>
-
-          {/*  A recommended badge is shown on official bot card, supplementary names are shown on Custom bot cards   */}
-          {props.botType === 'officialBot'
-          ? (
-            <span className="badge badge-info mr-2">
-              {t('admin:slack_integration.selecting_bot_types.recommended')}
+          >
+            <span className="mr-2">
+              {t(`admin:slack_integration.selecting_bot_types.${botDetails[props.botType].botTypeCategory}`)}
             </span>
-          ) : (
-            <span className="supplementary-bot-name mr-2">
-              {t(`admin:slack_integration.selecting_bot_types.${botDetails[props.botType].supplementaryBotName}`)}
-            </span>
-          )}
 
-          {/* TODO: add an appropriate links by GW-5614 */}
-          <i className={`fa fa-external-link btn-link ${props.isActive ? 'bg-primary text-light' : ''}`} aria-hidden="true"></i>
-        </h3>
-      </div>
-      <div className="card-body p-4">
-        <div className="card-text">
-          <div className="my-2">
-            <img className="d-block mx-auto mb-4" src={`/images/slack-integration/slackbot-difficulty-level-${botDetails[props.botType].setUp}.svg`}></img>
-            <div className="d-flex justify-content-between mb-3">
-              <span>{t('admin:slack_integration.selecting_bot_types.multiple_workspaces_integration')}</span>
-              <img className="bot-type-disc" src={`/images/slack-integration/${botDetails[props.botType].multiWSIntegration}.png`} alt="" />
-            </div>
-            <div className="d-flex justify-content-between">
-              <span>{t('admin:slack_integration.selecting_bot_types.security_control')}</span>
-              <img className="bot-type-disc" src={`/images/slack-integration/${botDetails[props.botType].securityControl}.png`} alt="" />
+            {/*  A recommended badge is shown on official bot card, supplementary names are shown on Custom bot cards   */}
+            {props.botType === 'officialBot'
+              ? (
+                <span className="badge badge-info mr-2">
+                  {t('admin:slack_integration.selecting_bot_types.recommended')}
+                </span>
+              ) : (
+                <span className="supplementary-bot-name mr-2">
+                  {t(`admin:slack_integration.selecting_bot_types.${botDetails[props.botType].supplementaryBotName}`)}
+                </span>
+              )}
+
+            {/* TODO: add an appropriate links by GW-5614 */}
+            <i className={`fa fa-external-link btn-link ${props.isActive ? 'bg-primary text-light' : ''}`} aria-hidden="true"></i>
+          </h3>
+        </div>
+        <div className="card-body p-4">
+          <div className="card-text">
+            <div className="my-2">
+              <img className="d-block mx-auto mb-4" src={`/images/slack-integration/slackbot-difficulty-level-${botDetails[props.botType].setUp}.svg`}></img>
+              <div className="d-flex justify-content-between mb-3">
+                <span>{t('admin:slack_integration.selecting_bot_types.multiple_workspaces_integration')}</span>
+                <img className="bot-type-disc" src={`/images/slack-integration/${botDetails[props.botType].multiWSIntegration}.png`} alt="" />
+              </div>
+              <div className="d-flex justify-content-between">
+                <span>{t('admin:slack_integration.selecting_bot_types.security_control')}</span>
+                <img className="bot-type-disc" src={`/images/slack-integration/${botDetails[props.botType].securityControl}.png`} alt="" />
+              </div>
             </div>
           </div>
         </div>
       </div>
+
     </div>
-  );
+);
 
 };
 

--- a/src/client/js/components/Admin/SlackIntegration/BotTypeCard.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/BotTypeCard.jsx
@@ -35,7 +35,7 @@ const BotTypeCard = (props) => {
   return (
 
     <div
-      className={`card m-3 col-sm b-0 admin-bot-card rounded border-radius-sm shadow ${props.isActive ? 'border-primary' : ''}`}
+      className={`card m-3 admin-bot-card rounded border-radius-sm shadow ${props.isActive ? 'border-primary' : ''}`}
       onClick={() => props.handleBotTypeSelect(botDetails[props.botType].botType)}
       role="button"
       key={props.botType}

--- a/src/client/js/components/Admin/SlackIntegration/BotTypeCard.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/BotTypeCard.jsx
@@ -35,7 +35,7 @@ const BotTypeCard = (props) => {
   return (
 
     <div
-      className={`card m-3 admin-bot-card rounded border-radius-sm shadow ${props.isActive ? 'border-primary' : ''}`}
+      className={`card m-3 col-sm b-0 admin-bot-card rounded border-radius-sm shadow ${props.isActive ? 'border-primary' : ''}`}
       onClick={() => props.handleBotTypeSelect(botDetails[props.botType].botType)}
       role="button"
       key={props.botType}

--- a/src/client/js/components/Admin/SlackIntegration/BotTypeCard.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/BotTypeCard.jsx
@@ -34,7 +34,7 @@ const BotTypeCard = (props) => {
 
   return (
     <div
-      className={`card m-3 admin-bot-card rounded border-radius-sm shadow ${props.isActive ? 'border-primary' : ''}`}
+      className={`card admin-bot-card rounded border-radius-sm shadow ${props.isActive ? 'border-primary' : ''}`}
       onClick={() => props.handleBotTypeSelect(botDetails[props.botType].botType)}
       role="button"
       key={props.botType}

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -143,8 +143,8 @@ const SlackIntegration = (props) => {
 
         {t('admin:slack_integration.selecting_bot_types.selecting_bot_type')}
 
-        <div className="row my-4">
-          <div className="card-deck mx-auto justify-content-center">
+        <div className="my-4">
+          <div className="row mx-auto justify-content-center">
             {botTypes.map((botType) => {
               return (
                 <BotTypeCard

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -144,7 +144,7 @@ const SlackIntegration = (props) => {
         {t('admin:slack_integration.selecting_bot_types.selecting_bot_type')}
 
         <div className="my-4">
-          <div className="row mx-auto justify-content-center">
+          <div className="row align-content-end justify-content-center">
             {botTypes.map((botType) => {
               return (
                 <BotTypeCard

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -28,7 +28,7 @@ const SlackIntegration = (props) => {
   const [isSetupSlackBot, setIsSetupSlackBot] = useState(false);
 
 
-  const fetchData = useCallback(async() => {
+  const fetchData = useCallback(async () => {
     try {
       const response = await appContainer.apiv3.get('slack-integration/');
       const { currentBotType, customBotWithoutProxySettings } = response.data.slackBotSettingParams;
@@ -73,7 +73,7 @@ const SlackIntegration = (props) => {
     setSelectedBotType(null);
   };
 
-  const changeCurrentBotSettingsHandler = async() => {
+  const changeCurrentBotSettingsHandler = async () => {
     try {
       const res = await appContainer.apiv3.put('slack-integration/custom-bot-without-proxy', {
         slackSigningSecret: '',
@@ -147,19 +147,21 @@ const SlackIntegration = (props) => {
           <div className="row flex-wrap-reverse justify-content-center">
             {botTypes.map((botType) => {
               return (
-                <BotTypeCard
-                  key={botType}
-                  botType={botType}
-                  isActive={currentBotType === botType}
-                  handleBotTypeSelect={handleBotTypeSelect}
-                />
+                <div className="m-3">
+                  <BotTypeCard
+                    key={botType}
+                    botType={botType}
+                    isActive={currentBotType === botType}
+                    handleBotTypeSelect={handleBotTypeSelect}
+                  />
+                </div>
               );
             })}
           </div>
         </div>
       </div>
 
-      {settingsComponent}
+      { settingsComponent}
     </>
   );
 };

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -28,7 +28,7 @@ const SlackIntegration = (props) => {
   const [isSetupSlackBot, setIsSetupSlackBot] = useState(false);
 
 
-  const fetchData = useCallback(async () => {
+  const fetchData = useCallback(async() => {
     try {
       const response = await appContainer.apiv3.get('slack-integration/');
       const { currentBotType, customBotWithoutProxySettings } = response.data.slackBotSettingParams;
@@ -73,7 +73,7 @@ const SlackIntegration = (props) => {
     setSelectedBotType(null);
   };
 
-  const changeCurrentBotSettingsHandler = async () => {
+  const changeCurrentBotSettingsHandler = async() => {
     try {
       const res = await appContainer.apiv3.put('slack-integration/custom-bot-without-proxy', {
         slackSigningSecret: '',
@@ -121,7 +121,6 @@ const SlackIntegration = (props) => {
       settingsComponent = <CustomBotWithProxySettings />;
       break;
   }
-
 
   return (
     <>

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -143,8 +143,8 @@ const SlackIntegration = (props) => {
 
         {t('admin:slack_integration.selecting_bot_types.selecting_bot_type')}
 
-        <div className="row my-4">
-          <div className="flex-wrap-reverse justify-content-center">
+        <div className="my-4">
+          <div className="row flex-wrap-reverse justify-content-center">
             {botTypes.map((botType) => {
               return (
                 <BotTypeCard

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -143,8 +143,8 @@ const SlackIntegration = (props) => {
 
         {t('admin:slack_integration.selecting_bot_types.selecting_bot_type')}
 
-        <div className="my-4">
-          <div className="row flex-wrap-reverse justify-content-center">
+        <div className="row my-4">
+          <div className="flex-wrap-reverse justify-content-center">
             {botTypes.map((botType) => {
               return (
                 <BotTypeCard

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -28,7 +28,7 @@ const SlackIntegration = (props) => {
   const [isSetupSlackBot, setIsSetupSlackBot] = useState(false);
 
 
-  const fetchData = useCallback(async() => {
+  const fetchData = useCallback(async () => {
     try {
       const response = await appContainer.apiv3.get('slack-integration/');
       const { currentBotType, customBotWithoutProxySettings } = response.data.slackBotSettingParams;
@@ -73,7 +73,7 @@ const SlackIntegration = (props) => {
     setSelectedBotType(null);
   };
 
-  const changeCurrentBotSettingsHandler = async() => {
+  const changeCurrentBotSettingsHandler = async () => {
     try {
       const res = await appContainer.apiv3.put('slack-integration/custom-bot-without-proxy', {
         slackSigningSecret: '',
@@ -143,20 +143,19 @@ const SlackIntegration = (props) => {
 
         {t('admin:slack_integration.selecting_bot_types.selecting_bot_type')}
 
-          <div className="row my-4 flex-wrap-reverse justify-content-center">
-            {botTypes.map((botType) => {
-              return (
-                <div className="m-3">
-                  <BotTypeCard
-                    key={botType}
-                    botType={botType}
-                    isActive={currentBotType === botType}
-                    handleBotTypeSelect={handleBotTypeSelect}
-                  />
-                </div>
-              );
-            })}
-          </div>
+        <div className="row my-4 flex-wrap-reverse justify-content-center">
+          {botTypes.map((botType) => {
+            return (
+              <div className="m-3">
+                <BotTypeCard
+                  key={botType}
+                  botType={botType}
+                  isActive={currentBotType === botType}
+                  handleBotTypeSelect={handleBotTypeSelect}
+                />
+              </div>
+            );
+          })}
         </div>
       </div>
 

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -143,8 +143,7 @@ const SlackIntegration = (props) => {
 
         {t('admin:slack_integration.selecting_bot_types.selecting_bot_type')}
 
-        <div className="my-4">
-          <div className="row flex-wrap-reverse justify-content-center">
+          <div className="row my-4 flex-wrap-reverse justify-content-center">
             {botTypes.map((botType) => {
               return (
                 <div className="m-3">

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -144,7 +144,7 @@ const SlackIntegration = (props) => {
         {t('admin:slack_integration.selecting_bot_types.selecting_bot_type')}
 
         <div className="my-4">
-          <div className="row align-content-end justify-content-center">
+          <div className="row flex-wrap-reverse justify-content-center">
             {botTypes.map((botType) => {
               return (
                 <BotTypeCard

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -28,7 +28,7 @@ const SlackIntegration = (props) => {
   const [isSetupSlackBot, setIsSetupSlackBot] = useState(false);
 
 
-  const fetchData = useCallback(async () => {
+  const fetchData = useCallback(async() => {
     try {
       const response = await appContainer.apiv3.get('slack-integration/');
       const { currentBotType, customBotWithoutProxySettings } = response.data.slackBotSettingParams;
@@ -73,7 +73,7 @@ const SlackIntegration = (props) => {
     setSelectedBotType(null);
   };
 
-  const changeCurrentBotSettingsHandler = async () => {
+  const changeCurrentBotSettingsHandler = async() => {
     try {
       const res = await appContainer.apiv3.put('slack-integration/custom-bot-without-proxy', {
         slackSigningSecret: '',

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -161,7 +161,7 @@ const SlackIntegration = (props) => {
         </div>
       </div>
 
-      { settingsComponent}
+      {settingsComponent}
     </>
   );
 };

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -144,7 +144,7 @@ const SlackIntegration = (props) => {
         {t('admin:slack_integration.selecting_bot_types.selecting_bot_type')}
 
         <div className="row my-4">
-          <div className="card-deck mx-auto">
+          <div className="card-deck mx-auto justify-content-center">
             {botTypes.map((botType) => {
               return (
                 <BotTypeCard

--- a/src/client/styles/scss/_admin.scss
+++ b/src/client/styles/scss/_admin.scss
@@ -101,6 +101,7 @@ $slack-work-space-name-card-border: #efc1f6;
     }
     .admin-bot-card {
       min-width: 280px;
+      max-width: 400px;
       border-radius: 8px !important;
     }
     .border-primary {
@@ -123,13 +124,13 @@ $slack-work-space-name-card-border: #efc1f6;
       border-radius: 8px !important;
     }
     .admin-border-danger {
-      border-style : dashed;
-      border-width : 2px;
+      border-style: dashed;
+      border-width: 2px;
     }
     .admin-border-success {
-      border-width : 3px;
+      border-width: 3px;
     }
-    .circle{
+    .circle {
       width: 100px;
       height: 100px;
       // background: #092c58;

--- a/src/client/styles/scss/_admin.scss
+++ b/src/client/styles/scss/_admin.scss
@@ -101,7 +101,7 @@ $slack-work-space-name-card-border: #efc1f6;
     }
     .admin-bot-card {
       min-width: 280px;
-      max-width: 400px;
+      max-width: 500px;
       border-radius: 8px !important;
     }
     .border-primary {


### PR DESCRIPTION
Bot選択画面の3つのカードが、小さい画面で見たときにサイズがおかしくなってしまうのを直しました。

<img width="1659" alt="Screen Shot 2021-04-23 at 16 30 12" src="https://user-images.githubusercontent.com/66785624/115836302-48c3d800-a452-11eb-8ff1-1733a602bb04.png">
