### PR TITLE
Imprv/5770 secret token responsive

### DIFF
--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySecretTokenSection.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySecretTokenSection.jsx
@@ -25,7 +25,7 @@ const CustomBotWithoutProxySecretTokenSection = (props) => {
   };
 
   return (
-    <div className="w-75 d-flex">
+    <div className="w-75 d-flex flex-column">
 
       <h3>Signing Secret</h3>
       <div className="row">

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySecretTokenSection.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySecretTokenSection.jsx
@@ -26,64 +26,66 @@ const CustomBotWithoutProxySecretTokenSection = (props) => {
 
   return (
     <div className="card-body">
-      <table className="table settings-table">
-        <colgroup>
-          <col className="item-name" />
-          <col className="from-db" />
-          <col className="from-env-vars" />
-        </colgroup>
-        <thead>
-          <tr><th className="border-top-0"></th><th className="border-top-0">Database</th><th className="border-top-0">Environment variables</th></tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th>Signing Secret</th>
-            <td>
-              <input
-                className="form-control"
-                type="text"
-                value={props.slackSigningSecret || ''}
-                onChange={e => onChangeSigningSecretHandler(e.target.value)}
-              />
-            </td>
-            <td>
-              <input
-                className="form-control"
-                type="text"
-                value={props.slackSigningSecretEnv || ''}
-                readOnly
-              />
-              <p className="form-text text-muted">
-                {/* eslint-disable-next-line react/no-danger */}
-                <small dangerouslySetInnerHTML={{ __html: t('admin:slack_integration.use_env_var_if_empty', { variable: 'SLACK_SIGNING_SECRET' }) }} />
-              </p>
-            </td>
-          </tr>
-          <tr>
-            <th>Bot User OAuth Token</th>
-            <td>
-              <input
-                className="form-control"
-                type="text"
-                value={props.slackBotToken || ''}
-                onChange={e => onChangeBotTokenHandler(e.target.value)}
-              />
-            </td>
-            <td>
-              <input
-                className="form-control"
-                type="text"
-                value={props.slackBotTokenEnv || ''}
-                readOnly
-              />
-              <p className="form-text text-muted">
-                {/* eslint-disable-next-line react/no-danger */}
-                <small dangerouslySetInnerHTML={{ __html: t('admin:slack_integration.use_env_var_if_empty', { variable: 'SLACK_BOT_TOKEN' }) }} />
-              </p>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+      <div className="table-responsive">
+        <table className="table settings-table">
+          <colgroup>
+            <col className="item-name" />
+            <col className="from-db" />
+            <col className="from-env-vars" />
+          </colgroup>
+          <thead>
+            <tr><th className="border-top-0"></th><th className="border-top-0">Database</th><th className="border-top-0">Environment variables</th></tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th>Signing Secret</th>
+              <td>
+                <input
+                  className="form-control"
+                  type="text"
+                  value={props.slackSigningSecret || ''}
+                  onChange={e => onChangeSigningSecretHandler(e.target.value)}
+                />
+              </td>
+              <td>
+                <input
+                  className="form-control"
+                  type="text"
+                  value={props.slackSigningSecretEnv || ''}
+                  readOnly
+                />
+                <p className="form-text text-muted">
+                  {/* eslint-disable-next-line react/no-danger */}
+                  <small dangerouslySetInnerHTML={{ __html: t('admin:slack_integration.use_env_var_if_empty', { variable: 'SLACK_SIGNING_SECRET' }) }} />
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <th>Bot User OAuth Token</th>
+              <td>
+                <input
+                  className="form-control"
+                  type="text"
+                  value={props.slackBotToken || ''}
+                  onChange={e => onChangeBotTokenHandler(e.target.value)}
+                />
+              </td>
+              <td>
+                <input
+                  className="form-control"
+                  type="text"
+                  value={props.slackBotTokenEnv || ''}
+                  readOnly
+                />
+                <p className="form-text text-muted">
+                  {/* eslint-disable-next-line react/no-danger */}
+                  <small dangerouslySetInnerHTML={{ __html: t('admin:slack_integration.use_env_var_if_empty', { variable: 'SLACK_BOT_TOKEN' }) }} />
+                </p>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
 
       <AdminUpdateButtonRow onClick={updateSecretTokenHandler} disabled={false} />
     </div>

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySecretTokenSection.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySecretTokenSection.jsx
@@ -27,84 +27,62 @@ const CustomBotWithoutProxySecretTokenSection = (props) => {
   return (
     <>
       <h3>Signing Secret</h3>
-      <div className="table-responsive">
-        <table className="table settings-table">
-          <colgroup>
-            <col className="from-db" />
-            <col className="from-env-vars" />
-          </colgroup>
-          <thead>
-            <tr>
-              <th className="border-top-0">Database</th>
-              <th className="border-top-0">Environment variables</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>
-                <input
-                  className="form-control"
-                  type="text"
-                  value={props.slackSigningSecret || ''}
-                  onChange={e => onChangeSigningSecretHandler(e.target.value)}
-                />
-              </td>
-              <td>
-                <input
-                  className="form-control"
-                  type="text"
-                  value={props.slackSigningSecretEnv || ''}
-                  readOnly
-                />
-                <p className="form-text text-muted">
-                  {/* eslint-disable-next-line react/no-danger */}
-                  <small dangerouslySetInnerHTML={{ __html: t('admin:slack_integration.use_env_var_if_empty', { variable: 'SLACK_SIGNING_SECRET' }) }} />
-                </p>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-      <h3>Bot User OAuth Token</h3>
-      <div className="table-responsive">
-        <table className="table settings-table">
-          <colgroup>
-            <col className="from-db" />
-            <col className="from-env-vars" />
-          </colgroup>
-          <thead>
-            <tr>
-              <th className="border-top-0">Database</th>
-              <th className="border-top-0">Environment variables</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>
-                <input
-                  className="form-control"
-                  type="text"
-                  value={props.slackBotToken || ''}
-                  onChange={e => onChangeBotTokenHandler(e.target.value)}
-                />
-              </td>
-              <td>
-                <input
-                  className="form-control"
-                  type="text"
-                  value={props.slackBotTokenEnv || ''}
-                  readOnly
-                />
-                <p className="form-text text-muted">
-                  {/* eslint-disable-next-line react/no-danger */}
-                  <small dangerouslySetInnerHTML={{ __html: t('admin:slack_integration.use_env_var_if_empty', { variable: 'SLACK_BOT_TOKEN' }) }} />
-                </p>
-              </td>
-            </tr>
-          </tbody>
-        </table>
+      <div className="row row-cols-2">
+
+        <div className="col">
+          <p className="border-top-0">Database</p>
+          <input
+            className="form-control"
+            type="text"
+            value={props.slackSigningSecret || ''}
+            onChange={e => onChangeSigningSecretHandler(e.target.value)}
+          />
+        </div>
+
+        <div className="col">
+          <p className="border-top-0">Environment variables</p>
+          <input
+            className="form-control"
+            type="text"
+            value={props.slackSigningSecretEnv || ''}
+            readOnly
+          />
+          <p className="form-text text-muted">
+            {/* eslint-disable-next-line react/no-danger */}
+            <small dangerouslySetInnerHTML={{ __html: t('admin:slack_integration.use_env_var_if_empty', { variable: 'SLACK_SIGNING_SECRET' }) }} />
+          </p>
+        </div>
+
       </div>
 
+      <h3>Bot User OAuth Token</h3>
+      <div className="row row-cols-2">
+
+        <div className="col">
+          <p className="border-top-0">Database</p>
+          <input
+            className="form-control"
+            type="text"
+            value={props.slackBotToken || ''}
+            onChange={e => onChangeBotTokenHandler(e.target.value)}
+          />
+        </div>
+
+        <div className="col">
+          <p className="border-top-0">Environment variables</p>
+          <input
+            className="form-control"
+            type="text"
+            value={props.slackBotTokenEnv || ''}
+            readOnly
+          />
+          <p className="form-text text-muted">
+            {/* eslint-disable-next-line react/no-danger */}
+            <small dangerouslySetInnerHTML={{ __html: t('admin:slack_integration.use_env_var_if_empty', { variable: 'SLACK_BOT_TOKEN' }) }} />
+          </p>
+        </div>
+
+      </div>
 
       <AdminUpdateButtonRow onClick={updateSecretTokenHandler} disabled={false} />
     </>

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySecretTokenSection.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySecretTokenSection.jsx
@@ -27,9 +27,9 @@ const CustomBotWithoutProxySecretTokenSection = (props) => {
   return (
     <>
       <h3>Signing Secret</h3>
-      <div className="row row-cols-2">
+      <div className="row">
 
-        <div className="col">
+        <div className="col-sm">
           <p className="border-top-0">Database</p>
           <input
             className="form-control"
@@ -39,7 +39,7 @@ const CustomBotWithoutProxySecretTokenSection = (props) => {
           />
         </div>
 
-        <div className="col">
+        <div className="col-sm">
           <p className="border-top-0">Environment variables</p>
           <input
             className="form-control"
@@ -56,9 +56,9 @@ const CustomBotWithoutProxySecretTokenSection = (props) => {
       </div>
 
       <h3>Bot User OAuth Token</h3>
-      <div className="row row-cols-2">
+      <div className="row">
 
-        <div className="col">
+        <div className="col-sm">
           <p className="border-top-0">Database</p>
           <input
             className="form-control"
@@ -68,7 +68,7 @@ const CustomBotWithoutProxySecretTokenSection = (props) => {
           />
         </div>
 
-        <div className="col">
+        <div className="col-sm">
           <p className="border-top-0">Environment variables</p>
           <input
             className="form-control"

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySecretTokenSection.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySecretTokenSection.jsx
@@ -25,12 +25,13 @@ const CustomBotWithoutProxySecretTokenSection = (props) => {
   };
 
   return (
-    <>
+    <div className="w-75 d-flex">
+
       <h3>Signing Secret</h3>
       <div className="row">
 
         <div className="col-sm">
-          <p className="border-top-0">Database</p>
+          <p>Database</p>
           <input
             className="form-control"
             type="text"
@@ -40,7 +41,7 @@ const CustomBotWithoutProxySecretTokenSection = (props) => {
         </div>
 
         <div className="col-sm">
-          <p className="border-top-0">Environment variables</p>
+          <p>Environment variables</p>
           <input
             className="form-control"
             type="text"
@@ -59,7 +60,7 @@ const CustomBotWithoutProxySecretTokenSection = (props) => {
       <div className="row">
 
         <div className="col-sm">
-          <p className="border-top-0">Database</p>
+          <p>Database</p>
           <input
             className="form-control"
             type="text"
@@ -69,7 +70,7 @@ const CustomBotWithoutProxySecretTokenSection = (props) => {
         </div>
 
         <div className="col-sm">
-          <p className="border-top-0">Environment variables</p>
+          <p>Environment variables</p>
           <input
             className="form-control"
             type="text"
@@ -85,7 +86,8 @@ const CustomBotWithoutProxySecretTokenSection = (props) => {
       </div>
 
       <AdminUpdateButtonRow onClick={updateSecretTokenHandler} disabled={false} />
-    </>
+
+    </div>
   );
 };
 

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySecretTokenSection.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySecretTokenSection.jsx
@@ -25,67 +25,66 @@ const CustomBotWithoutProxySecretTokenSection = (props) => {
   };
 
   return (
-    <div className="card-body">
-      <div className="table-responsive">
-        <table className="table settings-table">
-          <colgroup>
-            <col className="item-name" />
-            <col className="from-db" />
-            <col className="from-env-vars" />
-          </colgroup>
-          <thead>
-            <tr><th className="border-top-0"></th><th className="border-top-0">Database</th><th className="border-top-0">Environment variables</th></tr>
-          </thead>
-          <tbody>
-            <tr>
-              <th>Signing Secret</th>
-              <td>
-                <input
-                  className="form-control"
-                  type="text"
-                  value={props.slackSigningSecret || ''}
-                  onChange={e => onChangeSigningSecretHandler(e.target.value)}
-                />
-              </td>
-              <td>
-                <input
-                  className="form-control"
-                  type="text"
-                  value={props.slackSigningSecretEnv || ''}
-                  readOnly
-                />
-                <p className="form-text text-muted">
-                  {/* eslint-disable-next-line react/no-danger */}
-                  <small dangerouslySetInnerHTML={{ __html: t('admin:slack_integration.use_env_var_if_empty', { variable: 'SLACK_SIGNING_SECRET' }) }} />
-                </p>
-              </td>
-            </tr>
-            <tr>
-              <th>Bot User OAuth Token</th>
-              <td>
-                <input
-                  className="form-control"
-                  type="text"
-                  value={props.slackBotToken || ''}
-                  onChange={e => onChangeBotTokenHandler(e.target.value)}
-                />
-              </td>
-              <td>
-                <input
-                  className="form-control"
-                  type="text"
-                  value={props.slackBotTokenEnv || ''}
-                  readOnly
-                />
-                <p className="form-text text-muted">
-                  {/* eslint-disable-next-line react/no-danger */}
-                  <small dangerouslySetInnerHTML={{ __html: t('admin:slack_integration.use_env_var_if_empty', { variable: 'SLACK_BOT_TOKEN' }) }} />
-                </p>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
+    <div className="table-responsive">
+      <table className="table settings-table">
+        <colgroup>
+          <col className="item-name" />
+          <col className="from-db" />
+          <col className="from-env-vars" />
+        </colgroup>
+        <thead>
+          <tr><th className="border-top-0"></th><th className="border-top-0">Database</th><th className="border-top-0">Environment variables</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th>Signing Secret</th>
+            <td>
+              <input
+                className="form-control"
+                type="text"
+                value={props.slackSigningSecret || ''}
+                onChange={e => onChangeSigningSecretHandler(e.target.value)}
+              />
+            </td>
+            <td>
+              <input
+                className="form-control"
+                type="text"
+                value={props.slackSigningSecretEnv || ''}
+                readOnly
+              />
+              <p className="form-text text-muted">
+                {/* eslint-disable-next-line react/no-danger */}
+                <small dangerouslySetInnerHTML={{ __html: t('admin:slack_integration.use_env_var_if_empty', { variable: 'SLACK_SIGNING_SECRET' }) }} />
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th>Bot User OAuth Token</th>
+            <td>
+              <input
+                className="form-control"
+                type="text"
+                value={props.slackBotToken || ''}
+                onChange={e => onChangeBotTokenHandler(e.target.value)}
+              />
+            </td>
+            <td>
+              <input
+                className="form-control"
+                type="text"
+                value={props.slackBotTokenEnv || ''}
+                readOnly
+              />
+              <p className="form-text text-muted">
+                {/* eslint-disable-next-line react/no-danger */}
+                <small dangerouslySetInnerHTML={{ __html: t('admin:slack_integration.use_env_var_if_empty', { variable: 'SLACK_BOT_TOKEN' }) }} />
+              </p>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
 
       <AdminUpdateButtonRow onClick={updateSecretTokenHandler} disabled={false} />
     </div>

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySecretTokenSection.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySecretTokenSection.jsx
@@ -25,7 +25,7 @@ const CustomBotWithoutProxySecretTokenSection = (props) => {
   };
 
   return (
-    <div className="w-75 d-flex flex-column">
+    <div className="w-75 mx-auto">
 
       <h3>Signing Secret</h3>
       <div className="row">

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySecretTokenSection.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySecretTokenSection.jsx
@@ -25,69 +25,89 @@ const CustomBotWithoutProxySecretTokenSection = (props) => {
   };
 
   return (
-    <div className="table-responsive">
-      <table className="table settings-table">
-        <colgroup>
-          <col className="item-name" />
-          <col className="from-db" />
-          <col className="from-env-vars" />
-        </colgroup>
-        <thead>
-          <tr><th className="border-top-0"></th><th className="border-top-0">Database</th><th className="border-top-0">Environment variables</th></tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th>Signing Secret</th>
-            <td>
-              <input
-                className="form-control"
-                type="text"
-                value={props.slackSigningSecret || ''}
-                onChange={e => onChangeSigningSecretHandler(e.target.value)}
-              />
-            </td>
-            <td>
-              <input
-                className="form-control"
-                type="text"
-                value={props.slackSigningSecretEnv || ''}
-                readOnly
-              />
-              <p className="form-text text-muted">
-                {/* eslint-disable-next-line react/no-danger */}
-                <small dangerouslySetInnerHTML={{ __html: t('admin:slack_integration.use_env_var_if_empty', { variable: 'SLACK_SIGNING_SECRET' }) }} />
-              </p>
-            </td>
-          </tr>
-          <tr>
-            <th>Bot User OAuth Token</th>
-            <td>
-              <input
-                className="form-control"
-                type="text"
-                value={props.slackBotToken || ''}
-                onChange={e => onChangeBotTokenHandler(e.target.value)}
-              />
-            </td>
-            <td>
-              <input
-                className="form-control"
-                type="text"
-                value={props.slackBotTokenEnv || ''}
-                readOnly
-              />
-              <p className="form-text text-muted">
-                {/* eslint-disable-next-line react/no-danger */}
-                <small dangerouslySetInnerHTML={{ __html: t('admin:slack_integration.use_env_var_if_empty', { variable: 'SLACK_BOT_TOKEN' }) }} />
-              </p>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+    <>
+      <h3>Signing Secret</h3>
+      <div className="table-responsive">
+        <table className="table settings-table">
+          <colgroup>
+            <col className="from-db" />
+            <col className="from-env-vars" />
+          </colgroup>
+          <thead>
+            <tr>
+              <th className="border-top-0">Database</th>
+              <th className="border-top-0">Environment variables</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <input
+                  className="form-control"
+                  type="text"
+                  value={props.slackSigningSecret || ''}
+                  onChange={e => onChangeSigningSecretHandler(e.target.value)}
+                />
+              </td>
+              <td>
+                <input
+                  className="form-control"
+                  type="text"
+                  value={props.slackSigningSecretEnv || ''}
+                  readOnly
+                />
+                <p className="form-text text-muted">
+                  {/* eslint-disable-next-line react/no-danger */}
+                  <small dangerouslySetInnerHTML={{ __html: t('admin:slack_integration.use_env_var_if_empty', { variable: 'SLACK_SIGNING_SECRET' }) }} />
+                </p>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <h3>Bot User OAuth Token</h3>
+      <div className="table-responsive">
+        <table className="table settings-table">
+          <colgroup>
+            <col className="from-db" />
+            <col className="from-env-vars" />
+          </colgroup>
+          <thead>
+            <tr>
+              <th className="border-top-0">Database</th>
+              <th className="border-top-0">Environment variables</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <input
+                  className="form-control"
+                  type="text"
+                  value={props.slackBotToken || ''}
+                  onChange={e => onChangeBotTokenHandler(e.target.value)}
+                />
+              </td>
+              <td>
+                <input
+                  className="form-control"
+                  type="text"
+                  value={props.slackBotTokenEnv || ''}
+                  readOnly
+                />
+                <p className="form-text text-muted">
+                  {/* eslint-disable-next-line react/no-danger */}
+                  <small dangerouslySetInnerHTML={{ __html: t('admin:slack_integration.use_env_var_if_empty', { variable: 'SLACK_BOT_TOKEN' }) }} />
+                </p>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
 
 
       <AdminUpdateButtonRow onClick={updateSecretTokenHandler} disabled={false} />
-    </div>
+    </>
   );
 };
 


### PR DESCRIPTION
 Without Proxy設定画面内アコーディオンのSigning Secret/OAth Tokenセクションをレスポンシブ対応させました。

<img width="1661" alt="Screen Shot 2021-04-23 at 20 38 56" src="https://user-images.githubusercontent.com/66785624/115866189-4bcfc000-a474-11eb-9811-7215391c111f.png">
