### PR TITLE
prevent browser refresh

### DIFF
--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
@@ -159,7 +159,7 @@ const CustomBotWithoutProxySettingsAccordion = ({
       >
         <p className="text-center m-4">{t('admin:slack_integration.without_proxy.test_connection_by_pressing_button')}</p>
         <div className="d-flex justify-content-center">
-          <form className="form-row align-items-center w-25" onSubmit={e => {e.preventDefault()}} >
+          <form className="form-row align-items-center w-25" onSubmit={e => {e.preventDefault(); onTestConnectionHandler();}} >
             <div className="col-8 input-group-prepend">
               <span className="input-group-text" id="slack-channel-addon"><i className="fa fa-hashtag" /></span>
               <input

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
@@ -159,7 +159,7 @@ const CustomBotWithoutProxySettingsAccordion = ({
       >
         <p className="text-center m-4">{t('admin:slack_integration.without_proxy.test_connection_by_pressing_button')}</p>
         <div className="d-flex justify-content-center">
-          <form className="form-row align-items-center w-25">
+          <form className="form-row align-items-center w-25" onSubmit={e => {e.preventDefault()}} >
             <div className="col-8 input-group-prepend">
               <span className="input-group-text" id="slack-channel-addon"><i className="fa fa-hashtag" /></span>
               <input

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
@@ -159,7 +159,7 @@ const CustomBotWithoutProxySettingsAccordion = ({
       >
         <p className="text-center m-4">{t('admin:slack_integration.without_proxy.test_connection_by_pressing_button')}</p>
         <div className="d-flex justify-content-center">
-          <form className="form-row align-items-center w-25" onSubmit={e => {e.preventDefault(); onTestConnectionHandler();}} >
+          <form className="form-row align-items-center w-25" onSubmit={(e) => { e.preventDefault(); onTestConnectionHandler() }}>
             <div className="col-8 input-group-prepend">
               <span className="input-group-text" id="slack-channel-addon"><i className="fa fa-hashtag" /></span>
               <input

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
@@ -63,7 +63,7 @@ const CustomBotWithoutProxySettingsAccordion = ({
     }
   };
 
-  const onTestConnectionHandler = async() => {
+  const testConnection = async() => {
     setConnectionErrorCode(null);
     setConnectionErrorMessage(null);
     setConnectionSuccessMessage(null);
@@ -83,7 +83,7 @@ const CustomBotWithoutProxySettingsAccordion = ({
 
   const submitForm = (e) => {
     e.preventDefault();
-    onTestConnectionHandler();
+    testConnection();
   };
 
   const inputTestChannelHandler = (channel) => {

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
@@ -177,10 +177,9 @@ const CustomBotWithoutProxySettingsAccordion = ({
             </div>
             <div className="col-4">
               <button
-                type="button"
+                type="submit"
                 className="btn btn-info mx-3 font-weight-bold"
                 disabled={testChannel.trim() === ''}
-                onClick={onTestConnectionHandler}
               >Test
               </button>
             </div>

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
@@ -63,11 +63,6 @@ const CustomBotWithoutProxySettingsAccordion = ({
     }
   };
 
-  const submitForm = (e)=> {
-    e.preventDefault();
-    onTestConnectionHandler();
-  };
-
   const onTestConnectionHandler = async() => {
     setConnectionErrorCode(null);
     setConnectionErrorMessage(null);
@@ -84,6 +79,11 @@ const CustomBotWithoutProxySettingsAccordion = ({
       setConnectionErrorCode(err[0].code);
       setConnectionErrorMessage(err[0].message);
     }
+  };
+
+  const submitForm = (e) => {
+    e.preventDefault();
+    onTestConnectionHandler();
   };
 
   const inputTestChannelHandler = (channel) => {
@@ -164,7 +164,7 @@ const CustomBotWithoutProxySettingsAccordion = ({
       >
         <p className="text-center m-4">{t('admin:slack_integration.without_proxy.test_connection_by_pressing_button')}</p>
         <div className="d-flex justify-content-center">
-          <form className="form-row align-items-center w-25" onSubmit={ e => { submitForm(e) }}>
+          <form className="form-row align-items-center w-25" onSubmit={e => submitForm(e)}>
             <div className="col-8 input-group-prepend">
               <span className="input-group-text" id="slack-channel-addon"><i className="fa fa-hashtag" /></span>
               <input

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
@@ -63,6 +63,11 @@ const CustomBotWithoutProxySettingsAccordion = ({
     }
   };
 
+  const submitForm = (e)=> {
+    e.preventDefault();
+    onTestConnectionHandler();
+  };
+
   const onTestConnectionHandler = async() => {
     setConnectionErrorCode(null);
     setConnectionErrorMessage(null);
@@ -159,7 +164,7 @@ const CustomBotWithoutProxySettingsAccordion = ({
       >
         <p className="text-center m-4">{t('admin:slack_integration.without_proxy.test_connection_by_pressing_button')}</p>
         <div className="d-flex justify-content-center">
-          <form className="form-row align-items-center w-25" onSubmit={(e) => { e.preventDefault(); onTestConnectionHandler() }}>
+          <form className="form-row align-items-center w-25" onSubmit={ e => { submitForm(e) }}>
             <div className="col-8 input-group-prepend">
               <span className="input-group-text" id="slack-channel-addon"><i className="fa fa-hashtag" /></span>
               <input


### PR DESCRIPTION
## 概要
Custom Bot (Without-Proxy) 設定 の 連携手順4のinput要素にカーソルを合わせてenterを押した時にreloadさせないかつテストを走らせるようにする処理の実装を行いました。