### PR TITLE
Imprv/gw5694 bot types design for each theme

### DIFF
--- a/src/client/js/components/Admin/SlackIntegration/BotTypeCard.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/BotTypeCard.jsx
@@ -42,7 +42,7 @@ const BotTypeCard = (props) => {
       <div>
         <h3 className={`card-header mb-0 py-3
               ${props.botType === 'officialBot' ? 'd-flex align-items-center justify-content-center' : 'text-center'}
-              ${props.isActive ? 'bg-primary text-light' : ''}`}
+              ${props.isActive ? 'bg-primary grw-botcard-title-active' : ''}`}
         >
           <span className="mr-2">
             {t(`admin:slack_integration.selecting_bot_types.${botDetails[props.botType].botTypeCategory}`)}
@@ -61,7 +61,7 @@ const BotTypeCard = (props) => {
           )}
 
           {/* TODO: add an appropriate links by GW-5614 */}
-          <i className={`fa fa-external-link btn-link ${props.isActive ? 'bg-primary text-light' : ''}`} aria-hidden="true"></i>
+          <i className={`fa fa-external-link btn-link ${props.isActive ? 'bg-primary grw-botcard-title-active' : ''}`} aria-hidden="true"></i>
         </h3>
       </div>
       <div className="card-body p-4">

--- a/src/client/js/components/Admin/SlackIntegration/BotTypeCard.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/BotTypeCard.jsx
@@ -61,7 +61,7 @@ const BotTypeCard = (props) => {
           )}
 
           {/* TODO: add an appropriate links by GW-5614 */}
-          <i className={`fa fa-external-link btn-link ${props.isActive ? 'bg-primary grw-botcard-title-active' : ''}`} aria-hidden="true"></i>
+          <i className={`fa fa-external-link btn-link ${props.isActive ? 'grw-botcard-title-active' : ''}`} aria-hidden="true"></i>
         </h3>
       </div>
       <div className="card-body p-4">

--- a/src/client/styles/scss/theme/_apply-colors.scss
+++ b/src/client/styles/scss/theme/_apply-colors.scss
@@ -364,6 +364,12 @@ ul.pagination {
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05);
 }
 
+.admin-bot-card {
+  .grw-botcard-title-active {
+    color: $gray-200;
+  }
+}
+
 /*
  * Form Slider
  */

--- a/src/client/styles/scss/theme/christmas.scss
+++ b/src/client/styles/scss/theme/christmas.scss
@@ -170,12 +170,6 @@ html[dark] {
     }
   }
 
-  .admin-bot-card {
-    .fa.fa-external-link {
-      background-color: transparent !important;
-    }
-  }
-
   .grw-navbar {
     background-image: url('/images/themes/christmas/christmas-navbar.jpg');
   }

--- a/src/client/styles/scss/theme/christmas.scss
+++ b/src/client/styles/scss/theme/christmas.scss
@@ -170,6 +170,12 @@ html[dark] {
     }
   }
 
+  .admin-bot-card {
+    .fa.fa-external-link {
+      background-color: transparent !important;
+    }
+  }
+
   .grw-navbar {
     background-image: url('/images/themes/christmas/christmas-navbar.jpg');
   }

--- a/src/client/styles/scss/theme/island.scss
+++ b/src/client/styles/scss/theme/island.scss
@@ -110,4 +110,11 @@ html[dark] {
       @include btn-page-editor-mode-manager(darken($primary, 50%), lighten($primary, 5%), darken($primary, 5%));
     }
   }
+
+  // Cards
+  .admin-bot-card {
+    .grw-botcard-title-active {
+      color: $color-reversal;
+    }
+  }
 }

--- a/src/client/styles/scss/theme/spring.scss
+++ b/src/client/styles/scss/theme/spring.scss
@@ -144,8 +144,17 @@ html[dark] {
     background-color: $bgcolor-global;
   }
 
+  /*
+    Cards
+  */
   .card-timeline > .card-header {
     background-color: $third-main-color;
+  }
+
+  .admin-bot-card {
+    .grw-botcard-title-active {
+      color: $color-reversal;
+    }
   }
 
   h1,


### PR DESCRIPTION
## Task
- GW-5694 [bot types]各テーマのデザインチェック & 修正

Christmasは、bot typesのcardnに`bg-color: $primary`が適用されてしまっているのを修正
islandとspringはカードタイトルのテキストが暗いと感じたために明るい色を適用することで修正しました。

## 変更前
- Christmas

![Screen Shot 2021-04-26 at 10 31 53](https://user-images.githubusercontent.com/59536731/116021121-88710680-a682-11eb-9575-e9c1fd46fa3e.png)
- island
![Screen Shot 2021-04-26 at 10 31 34](https://user-images.githubusercontent.com/59536731/116021123-8ad36080-a682-11eb-8c4f-3a6019103b71.png)
- spring
![Screen Shot 2021-04-26 at 10 32 48](https://user-images.githubusercontent.com/59536731/116021125-8c9d2400-a682-11eb-9bf3-be46bcd54c26.png)

## 変更後
- Christmas
![Screen Shot 2021-04-26 at 11 31 32](https://user-images.githubusercontent.com/59536731/116021448-2cf34880-a683-11eb-9e06-c04f61291e2b.png)

- spring
![Screen Shot 2021-04-26 at 11 32 26](https://user-images.githubusercontent.com/59536731/116021428-22d14a00-a683-11eb-94a5-a18122e8f305.png)

- island
![Screen Shot 2021-04-26 at 11 32 10](https://user-images.githubusercontent.com/59536731/116021435-2664d100-a683-11eb-99cb-0d4822f62aa1.png)

