### PR TITLE
5775 5773 5781 

### DIFF
--- a/resource/locales/en_US/admin/admin.json
+++ b/resource/locales/en_US/admin/admin.json
@@ -275,6 +275,7 @@
     },
     "bot_reset_successful": "Bot settings have been reset.",
     "copied_to_clipboard": "Copied to clipboard",
+    "set_scope": "Please set up Bot Token Scopes from Slack settings",
     "modal": {
       "warning": "Warning",
       "sure_change_bot_type": "Are you sure you want to change the bot type?",

--- a/resource/locales/ja_JP/admin/admin.json
+++ b/resource/locales/ja_JP/admin/admin.json
@@ -273,6 +273,7 @@
     },
     "bot_reset_successful": "Botの設定を消去しました。",
     "copied_to_clipboard": "クリップボードにコピーされました。",
+    "set_scope": "Slackの設定画面からBot Token Scopeを設定してください",
     "modal": {
       "warning": "注意",
       "sure_change_bot_type": "Botの種類を変更しますか?",

--- a/resource/locales/zh_CN/admin/admin.json
+++ b/resource/locales/zh_CN/admin/admin.json
@@ -283,6 +283,7 @@
     },
     "bot_reset_successful": "删除了BOT设置。",
     "copied_to_clipboard": "它已复制到剪贴板。",
+    "set_scope": "在Slack设置页面中配置Bot Token Scope。",
     "modal": {
       "warning": "警告",
       "sure_change_bot_type": "您确定要更改设置吗？",

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -44,7 +44,7 @@ const SlackIntegration = (props) => {
         toastError(err);
       }
     }
-  }, [appContainer.apiv3, isConnectedToSlack]);
+  }, [appContainer.apiv3, isConnectedToSlack, t]);
 
   const fetchSlackIntegrationData = useCallback(async() => {
     try {

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -37,8 +37,8 @@ const SlackIntegration = (props) => {
       setSlackWSNameInWithoutProxy(res.data.slackWorkSpaceName);
     }
     catch (err) {
-      if (err === 'missing_scope') {
-        toastError(t('admin: slack_integration.set_scope'));
+      if (err[0].message === 'missing_scope') {
+        toastError(err, t('admin:slack_integration.set_scope'));
       }
       else {
         toastError(err);

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -36,6 +36,7 @@ const SlackIntegration = (props) => {
     try {
       const res = await appContainer.apiv3.get('/slack-integration/custom-bot-without-proxy/slack-workspace-name');
       setSlackWSNameInWithoutProxy(res.data.slackWorkSpaceName);
+      isSlackScopeSet(true);
     }
     catch (err) {
       if (err[0].message === 'missing_scope') {
@@ -46,7 +47,7 @@ const SlackIntegration = (props) => {
         toastError(err);
       }
     }
-  }, [appContainer.apiv3, isConnectedToSlack, t]);
+  }, [appContainer.apiv3, isConnectedToSlack, isSlackScopeSet, t]);
 
   const fetchSlackIntegrationData = useCallback(async() => {
     try {

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -37,7 +37,12 @@ const SlackIntegration = (props) => {
       setSlackWSNameInWithoutProxy(res.data.slackWorkSpaceName);
     }
     catch (err) {
-      toastError(err);
+      if (err === 'missing_scope') {
+        toastError(t('admin: slack_integration.set_scope'));
+      }
+      else {
+        toastError(err);
+      }
     }
   }, [appContainer.apiv3, isConnectedToSlack]);
 

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -27,6 +27,7 @@ const SlackIntegration = (props) => {
   const [isSendTestMessage, setIsSendTestMessage] = useState(false);
   const [isSetupSlackBot, setIsSetupSlackBot] = useState(false);
   const [slackWSNameInWithoutProxy, setSlackWSNameInWithoutProxy] = useState(null);
+  const [isSlackScopeSet, setIsSlackScopeSet] = useState(false);
 
   const fetchSlackWorkSpaceNameInWithoutProxy = useCallback(async() => {
     if (!isConnectedToSlack) {
@@ -38,6 +39,7 @@ const SlackIntegration = (props) => {
     }
     catch (err) {
       if (err[0].message === 'missing_scope') {
+        setIsSlackScopeSet(false);
         toastError(err, t('admin:slack_integration.set_scope'));
       }
       else {

--- a/src/server/routes/apiv3/slack-integration.js
+++ b/src/server/routes/apiv3/slack-integration.js
@@ -234,7 +234,7 @@ module.exports = (crowi) => {
     catch (error) {
       let msg = 'Error occured in slack_bot_token';
       if (error.data.ok === false && error.data.error === 'missing_scope') {
-        msg = 'Please set Scope for Slack';
+        msg = 'missing_scope';
       }
       logger.error('Error', error);
       return res.apiv3Err(new ErrorV3(msg, 'get-SlackWorkSpaceName-failed'), 500);

--- a/src/server/routes/apiv3/slack-integration.js
+++ b/src/server/routes/apiv3/slack-integration.js
@@ -232,7 +232,10 @@ module.exports = (crowi) => {
       return res.apiv3({ slackWorkSpaceName });
     }
     catch (error) {
-      const msg = 'Error occured in slack_bot_token';
+      let msg = 'Error occured in slack_bot_token';
+      if (error.data.ok === false && error.data.error === 'missing_scope') {
+        msg = 'Please set Scope for Slack';
+      }
       logger.error('Error', error);
       return res.apiv3Err(new ErrorV3(msg, 'get-SlackWorkSpaceName-failed'), 500);
     }

--- a/src/server/routes/apiv3/slack-integration.js
+++ b/src/server/routes/apiv3/slack-integration.js
@@ -233,7 +233,7 @@ module.exports = (crowi) => {
     }
     catch (error) {
       let msg = 'Error occured in slack_bot_token';
-      if (error.data.ok === false && error.data.error === 'missing_scope') {
+      if (error.data.error === 'missing_scope') {
         msg = 'missing_scope';
       }
       logger.error('Error', error);


### PR DESCRIPTION
## 5775 TokenとSecretを更新した時にScopeが設定されてない場合はリロードせずErrorのToasterを出す
こちら、問題なく作動しました。

https://user-images.githubusercontent.com/66785624/116038455-6ab49900-a6a4-11eb-9b6e-58bd7524562c.mov

## 5773 Scope が適切に設定されていない場合、Toasterの文言をScopeが設定されてないことが分かる文言にする
3言語に対応させました。

<img width="311" alt="Screen Shot 2021-04-26 at 15 22 11" src="https://user-images.githubusercontent.com/66785624/116038572-959eed00-a6a4-11eb-93e1-825c42842c36.png">
<img width="311" alt="Screen Shot 2021-04-26 at 15 22 59" src="https://user-images.githubusercontent.com/66785624/116038578-96378380-a6a4-11eb-9267-446aee05a875.png">
<img width="308" alt="Screen Shot 2021-04-26 at 15 33 02" src="https://user-images.githubusercontent.com/66785624/116038702-c0894100-a6a4-11eb-8f3b-9e0554f838fb.png">

## 5781 Slack APIを叩いてScopeを取得する
こちら、後続の『5774 TokenとSecretが正しくても、Scopeが間違っていたら連携図は赤いままにする』に必要で、
調査の結果scopeを取得するためのAPIがEnterprise専用だったりDeprecatedだったりするので、代替案として、帰ってくるエラーによってScopeのStateを切り替えるという対処をしました。