### PR TITLE
Changed modal color

### DIFF
--- a/src/client/js/components/Admin/SlackIntegration/ConfirmBotChangeModal.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/ConfirmBotChangeModal.jsx
@@ -22,7 +22,10 @@ const ConfirmBotChangeModal = (props) => {
 
   return (
     <Modal isOpen={props.isOpen} centered>
-      <ModalHeader toggle={handleCancelButton}>
+      <ModalHeader
+        toggle={handleCancelButton}
+        className="bg-danger"
+      >
         {t('slack_integration.modal.warning')}
       </ModalHeader>
       <ModalBody>
@@ -37,7 +40,7 @@ const ConfirmBotChangeModal = (props) => {
         <button type="button" className="btn btn-secondary" onClick={handleCancelButton}>
           {t('slack_integration.modal.cancel')}
         </button>
-        <button type="button" className="btn btn-primary" onClick={handleChangeButton}>
+        <button type="button" className="btn btn-danger" onClick={handleChangeButton}>
           {t('slack_integration.modal.change')}
         </button>
       </ModalFooter>


### PR DESCRIPTION
Bot変更時のModalの色を変更しました。
<img width="509" alt="Screen Shot 2021-04-27 at 13 43 26" src="https://user-images.githubusercontent.com/66785624/116187329-4ae2ab00-a760-11eb-9509-eda845936c06.png">
<img width="511" alt="Screen Shot 2021-04-27 at 13 43 44" src="https://user-images.githubusercontent.com/66785624/116187332-4cac6e80-a760-11eb-9443-2fe607a3e85c.png">
<img width="508" alt="Screen Shot 2021-04-27 at 13 44 18" src="https://user-images.githubusercontent.com/66785624/116187334-4d450500-a760-11eb-97f8-c7fab73b2a56.png">
<img width="510" alt="Screen Shot 2021-04-27 at 13 44 31" src="https://user-images.githubusercontent.com/66785624/116187336-4ddd9b80-a760-11eb-99f4-50d9475fa414.png">
