### PR TITLE
Imprv/gw5556 show proxy url

### DIFF
--- a/packages/slackbot-proxy/src/controllers/slack.ts
+++ b/packages/slackbot-proxy/src/controllers/slack.ts
@@ -171,7 +171,7 @@ export class SlackCtrl {
       if (type === 'view_submission') {
         switch (payload.response_urls[0].action_id) {
           case 'show_proxy_url':
-            await this.registerService.upsertOrderRecord(payload, this.orderRepository, installation);
+            await this.registerService.upsertOrderRecord(this.orderRepository, installation, payload);
             await this.registerService.showProxyURL(authorizeResult, payload);
             break;
           default:

--- a/packages/slackbot-proxy/src/controllers/slack.ts
+++ b/packages/slackbot-proxy/src/controllers/slack.ts
@@ -138,8 +138,9 @@ export class SlackCtrl {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const installation = await this.installationRepository.findByTeamIdOrEnterpriseId(installationId!);
 
-    const handleViewSubmission = async(inputValues) => {
+    const handleViewSubmission = async(payload) => {
 
+      const inputValues = payload.view.state.values;
       const inputGrowiUrl = inputValues.growiDomain.contents_input.value;
       const inputGrowiAccessToken = inputValues.growiAccessToken.contents_input.value;
       const inputProxyAccessToken = inputValues.proxyToken.contents_input.value;
@@ -165,12 +166,11 @@ export class SlackCtrl {
 
     const payload = JSON.parse(body.payload);
     const { type } = payload;
-    const inputValues = payload.view.state.values;
 
     try {
       switch (type) {
         case 'view_submission':
-          await handleViewSubmission(inputValues);
+          await handleViewSubmission(payload);
           break;
         default:
           break;

--- a/packages/slackbot-proxy/src/controllers/slack.ts
+++ b/packages/slackbot-proxy/src/controllers/slack.ts
@@ -158,7 +158,7 @@ export class SlackCtrl {
         });
       }
 
-      await this.registerService.sendProxyURL(authorizeResult, payload);
+      await this.registerService.showProxyURL(authorizeResult, payload);
 
 
       res.send();

--- a/packages/slackbot-proxy/src/controllers/slack.ts
+++ b/packages/slackbot-proxy/src/controllers/slack.ts
@@ -156,6 +156,11 @@ export class SlackCtrl {
           installation: installation?.id, growiUrl: inputGrowiUrl, growiAccessToken: inputGrowiAccessToken, proxyAccessToken: inputProxyAccessToken,
         });
       }
+
+      await this.registerService.sendProxyURL(authorizeResult, body as {[key:string]:string});
+
+
+      res.send();
     };
 
     const payload = JSON.parse(body.payload);

--- a/packages/slackbot-proxy/src/controllers/slack.ts
+++ b/packages/slackbot-proxy/src/controllers/slack.ts
@@ -167,21 +167,16 @@ export class SlackCtrl {
     const payload = JSON.parse(body.payload);
     const { type } = payload;
 
-    try {
-      if (type === 'view_submission') {
-        switch (payload.response_urls[0].action_id) {
-          case 'show_proxy_url':
-            await this.registerService.upsertOrderRecord(this.orderRepository, installation, payload);
-            await this.registerService.showProxyURL(authorizeResult, payload);
-            break;
-          default:
-            break;
-        }
-      }
+    // register
+    if (type === 'view_submission' && payload.response_urls[0].action_id === 'show_proxy_url') {
+      await this.registerService.upsertOrderRecord(authorizeResult, this.orderRepository, installation, payload);
+      return;
     }
-    catch (error) {
-      logger.error(error);
-    }
+
+    /*
+     * forward to GROWI server
+     */
+    // TODO: forward to GROWI server by GW-5866
 
   }
 

--- a/packages/slackbot-proxy/src/controllers/slack.ts
+++ b/packages/slackbot-proxy/src/controllers/slack.ts
@@ -160,7 +160,6 @@ export class SlackCtrl {
 
       await this.registerService.showProxyURL(authorizeResult, payload);
 
-
       res.send();
     };
 

--- a/packages/slackbot-proxy/src/controllers/slack.ts
+++ b/packages/slackbot-proxy/src/controllers/slack.ts
@@ -185,8 +185,6 @@ export class SlackCtrl {
       }
 
       await this.registerService.showProxyURL(authorizeResult, payload);
-
-      res.send();
     };
 
     const payload = JSON.parse(body.payload);

--- a/packages/slackbot-proxy/src/controllers/slack.ts
+++ b/packages/slackbot-proxy/src/controllers/slack.ts
@@ -168,8 +168,9 @@ export class SlackCtrl {
     const { type } = payload;
 
     // register
-    if (type === 'view_submission' && payload.response_urls[0].action_id === 'show_proxy_url') {
-      await this.registerService.upsertOrderRecord(authorizeResult, this.orderRepository, installation, payload);
+    if (type === 'view_submission' && payload.response_urls[0].action_id === 'submit_growi_url_and_access_tokens') {
+      await this.registerService.upsertOrderRecord(this.orderRepository, installation, payload);
+      await this.registerService.showProxyUrl(authorizeResult, payload);
       return;
     }
 

--- a/packages/slackbot-proxy/src/controllers/slack.ts
+++ b/packages/slackbot-proxy/src/controllers/slack.ts
@@ -158,7 +158,7 @@ export class SlackCtrl {
         });
       }
 
-      await this.registerService.sendProxyURL(authorizeResult, body as {[key:string]:string});
+      await this.registerService.sendProxyURL(authorizeResult, payload);
 
 
       res.send();

--- a/packages/slackbot-proxy/src/controllers/slack.ts
+++ b/packages/slackbot-proxy/src/controllers/slack.ts
@@ -191,12 +191,14 @@ export class SlackCtrl {
     const { type } = payload;
 
     try {
-      switch (type) {
-        case 'view_submission':
-          await handleViewSubmission(payload);
-          break;
-        default:
-          break;
+      if (type === 'view_submission') {
+        switch (payload.response_urls[0].action_id) {
+          case 'show_proxy_url':
+            await handleViewSubmission(payload);
+            break;
+          default:
+            break;
+        }
       }
     }
     catch (error) {

--- a/packages/slackbot-proxy/src/services/RegisterService.ts
+++ b/packages/slackbot-proxy/src/services/RegisterService.ts
@@ -70,7 +70,7 @@ export class RegisterService implements GrowiCommandProcessor {
       user: payload.user.id,
       text: 'Hello world',
       blocks: [
-        generateMarkdownSectionBlock('Please enter and update the following Proxy URL to Slack Bot Setting form in your GROWI'),
+        generateMarkdownSectionBlock('Please enter and update the following Proxy URL to slack bot setting form in your GROWI'),
         generateMarkdownSectionBlock(`Proxy URL: ${proxyURL}`),
       ],
     });

--- a/packages/slackbot-proxy/src/services/RegisterService.ts
+++ b/packages/slackbot-proxy/src/services/RegisterService.ts
@@ -70,7 +70,7 @@ export class RegisterService implements GrowiCommandProcessor {
       user: payload.user.id,
       text: 'Hello world',
       blocks: [
-        generateMarkdownSectionBlock('Please enter and update the following Proxy URL to your GROWI slack bot setting form'),
+        generateMarkdownSectionBlock('Please enter and update the following Proxy URL to Slack Bot Setting form in your GROWI'),
         generateMarkdownSectionBlock(`Proxy URL: ${proxyURL}`),
       ],
     });

--- a/packages/slackbot-proxy/src/services/RegisterService.ts
+++ b/packages/slackbot-proxy/src/services/RegisterService.ts
@@ -67,8 +67,8 @@ export class RegisterService implements GrowiCommandProcessor {
     await client.chat.postEphemeral({
       channel: payload.response_urls[0].channel_id,
       user: payload.user.id,
-      // Recommended to include text to provide a fallback when using blocks
-      // https://api.slack.com/methods/chat.postEphemeral#text_usage
+      // Recommended including 'text' to provide a fallback when using blocks
+      // refer to https://api.slack.com/methods/chat.postEphemeral#text_usage
       text: 'Proxy URL',
       blocks: [
         generateMarkdownSectionBlock('Please enter and update the following Proxy URL to slack bot setting form in your GROWI'),

--- a/packages/slackbot-proxy/src/services/RegisterService.ts
+++ b/packages/slackbot-proxy/src/services/RegisterService.ts
@@ -43,7 +43,7 @@ export class RegisterService implements GrowiCommandProcessor {
               text: 'Select a channel to post the proxy URL on',
             },
             element: {
-              action_id: 'post_proxy_url_id',
+              action_id: 'show_proxy_url',
               type: 'conversations_select',
               response_url_enabled: true,
               default_to_current_conversation: true,

--- a/packages/slackbot-proxy/src/services/RegisterService.ts
+++ b/packages/slackbot-proxy/src/services/RegisterService.ts
@@ -62,13 +62,14 @@ export class RegisterService implements GrowiCommandProcessor {
 
     const { botToken } = authorizeResult;
 
-    // tmp use process.env
     const client = new WebClient(botToken, { logLevel: isProduction ? LogLevel.DEBUG : LogLevel.INFO });
 
     await client.chat.postEphemeral({
       channel: payload.response_urls[0].channel_id,
       user: payload.user.id,
-      text: 'Hello world',
+      // Recommended to include text to provide a fallback when using blocks
+      // https://api.slack.com/methods/chat.postEphemeral#text_usage
+      text: 'Proxy URL',
       blocks: [
         generateMarkdownSectionBlock('Please enter and update the following Proxy URL to slack bot setting form in your GROWI'),
         generateMarkdownSectionBlock(`Proxy URL: ${proxyURL}`),

--- a/packages/slackbot-proxy/src/services/RegisterService.ts
+++ b/packages/slackbot-proxy/src/services/RegisterService.ts
@@ -56,6 +56,7 @@ export class RegisterService implements GrowiCommandProcessor {
 
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   async showProxyURL(authorizeResult: AuthorizeResult, payload: any): Promise<void> {
+    // TODO: implement for when proxy URL is undefined by GW-5834
     let proxyURL;
     if (process.env.PROXY_URL != null) {
       proxyURL = process.env.PROXY_URL;

--- a/packages/slackbot-proxy/src/services/RegisterService.ts
+++ b/packages/slackbot-proxy/src/services/RegisterService.ts
@@ -56,8 +56,10 @@ export class RegisterService implements GrowiCommandProcessor {
     });
   }
 
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-  async upsertOrderRecord(orderRepository: OrderRepository, installation: Installation | undefined, payload: any): Promise<void> {
+  async upsertOrderRecord(
+      // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+      authorizeResult:AuthorizeResult, orderRepository: OrderRepository, installation: Installation | undefined, payload: any,
+  ): Promise<void> {
     const inputValues = payload.view.state.values;
     const inputGrowiUrl = inputValues.growiDomain.contents_input.value;
     const inputGrowiAccessToken = inputValues.growiAccessToken.contents_input.value;
@@ -75,10 +77,6 @@ export class RegisterService implements GrowiCommandProcessor {
         installation: installation?.id, growiUrl: inputGrowiUrl, growiAccessToken: inputGrowiAccessToken, proxyAccessToken: inputProxyAccessToken,
       });
     }
-  }
-
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-  async showProxyURL(authorizeResult: AuthorizeResult, payload: any): Promise<void> {
 
     // TODO: implement for when proxy URL is undefined by GW-5834
     let proxyURL;

--- a/packages/slackbot-proxy/src/services/RegisterService.ts
+++ b/packages/slackbot-proxy/src/services/RegisterService.ts
@@ -2,7 +2,6 @@ import { Service } from '@tsed/di';
 import { WebClient, LogLevel } from '@slack/web-api';
 import { generateInputSectionBlock, GrowiCommand, generateMarkdownSectionBlock } from '@growi/slack';
 import { AuthorizeResult } from '@slack/oauth';
-
 import { GrowiCommandProcessor } from '~/interfaces/growi-command-processor';
 
 
@@ -12,7 +11,6 @@ const isProduction = process.env.NODE_ENV === 'production';
 export class RegisterService implements GrowiCommandProcessor {
 
   async process(growiCommand: GrowiCommand, authorizeResult: AuthorizeResult, body: {[key:string]:string}): Promise<void> {
-
     const { botToken } = authorizeResult;
 
     // tmp use process.env
@@ -56,20 +54,24 @@ export class RegisterService implements GrowiCommandProcessor {
     });
   }
 
-  async sendProxyURL(authorizeResult: AuthorizeResult, body: any): Promise<void> {
+  async sendProxyURL(authorizeResult: AuthorizeResult, payload :any): Promise<void> {
+    let proxyURL;
+    if (process.env.PROXY_URL != null) {
+      proxyURL = process.env.PROXY_URL;
+    }
 
     const { botToken } = authorizeResult;
-    console.log('body', body);
 
     // tmp use process.env
     const client = new WebClient(botToken, { logLevel: isProduction ? LogLevel.DEBUG : LogLevel.INFO });
+
     await client.chat.postEphemeral({
-      channel: body.channel_id,
-      user: body.user.id,
+      channel: payload.response_urls[0].channel_id,
+      user: payload.user.id,
       text: 'Hello world',
       blocks: [
-        generateMarkdownSectionBlock('hoge1'),
-        generateMarkdownSectionBlock('hoge2'),
+        generateMarkdownSectionBlock('Please enter the following Proxy URL to your GROWI slack bot setting form'),
+        generateMarkdownSectionBlock(`Proxy URL: ${proxyURL}`),
       ],
     });
     return;

--- a/packages/slackbot-proxy/src/services/RegisterService.ts
+++ b/packages/slackbot-proxy/src/services/RegisterService.ts
@@ -54,7 +54,7 @@ export class RegisterService implements GrowiCommandProcessor {
     });
   }
 
-  async sendProxyURL(authorizeResult: AuthorizeResult, payload :any): Promise<void> {
+  async showProxyURL(authorizeResult: AuthorizeResult, payload: any): Promise<void> {
     let proxyURL;
     if (process.env.PROXY_URL != null) {
       proxyURL = process.env.PROXY_URL;

--- a/packages/slackbot-proxy/src/services/RegisterService.ts
+++ b/packages/slackbot-proxy/src/services/RegisterService.ts
@@ -55,6 +55,27 @@ export class RegisterService implements GrowiCommandProcessor {
   }
 
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+  async upsertOrderRecord(payload: any, orderRepository, installation): Promise<void> {
+    const inputValues = payload.view.state.values;
+    const inputGrowiUrl = inputValues.growiDomain.contents_input.value;
+    const inputGrowiAccessToken = inputValues.growiAccessToken.contents_input.value;
+    const inputProxyAccessToken = inputValues.proxyToken.contents_input.value;
+
+    const order = await orderRepository.findOne({ installation: installation?.id, growiUrl: inputGrowiUrl });
+    if (order != null) {
+      orderRepository.update(
+        { installation: installation?.id, growiUrl: inputGrowiUrl },
+        { growiAccessToken: inputGrowiAccessToken, proxyAccessToken: inputProxyAccessToken },
+      );
+    }
+    else {
+      orderRepository.save({
+        installation: installation?.id, growiUrl: inputGrowiUrl, growiAccessToken: inputGrowiAccessToken, proxyAccessToken: inputProxyAccessToken,
+      });
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   async showProxyURL(authorizeResult: AuthorizeResult, payload: any): Promise<void> {
     // TODO: implement for when proxy URL is undefined by GW-5834
     let proxyURL;

--- a/packages/slackbot-proxy/src/services/RegisterService.ts
+++ b/packages/slackbot-proxy/src/services/RegisterService.ts
@@ -37,20 +37,35 @@ export class RegisterService implements GrowiCommandProcessor {
           generateInputSectionBlock('growiDomain', 'GROWI domain', 'contents_input', false, 'https://example.com'),
           generateInputSectionBlock('growiAccessToken', 'GROWI ACCESS_TOKEN', 'contents_input', false, 'jBMZvpk.....'),
           generateInputSectionBlock('proxyToken', 'PROXY ACCESS_TOKEN', 'contents_input', false, 'jBMZvpk.....'),
+          {
+            type: 'input',
+            block_id: 'current_channel',
+            element: {
+              type: 'conversations_select',
+              action_id: 'input',
+              response_url_enabled: true,
+              default_to_current_conversation: true,
+            },
+            label: {
+              type: 'plain_text',
+              text: '起動したチャンネル',
+            },
+          },
         ],
       },
     });
   }
 
-  async sendProxyURL(authorizeResult: AuthorizeResult, body: {[key:string]:string}): Promise<void> {
+  async sendProxyURL(authorizeResult: AuthorizeResult, body: any): Promise<void> {
 
     const { botToken } = authorizeResult;
+    console.log('body', body);
 
     // tmp use process.env
     const client = new WebClient(botToken, { logLevel: isProduction ? LogLevel.DEBUG : LogLevel.INFO });
     await client.chat.postEphemeral({
       channel: body.channel_id,
-      user: body.user_id,
+      user: body.user.id,
       text: 'Hello world',
       blocks: [
         generateMarkdownSectionBlock('hoge1'),

--- a/packages/slackbot-proxy/src/services/RegisterService.ts
+++ b/packages/slackbot-proxy/src/services/RegisterService.ts
@@ -48,14 +48,16 @@ export class RegisterService implements GrowiCommandProcessor {
 
     // tmp use process.env
     const client = new WebClient(botToken, { logLevel: isProduction ? LogLevel.DEBUG : LogLevel.INFO });
-    // await client.chat.postEphemeral({
-    //   channel: body.channel_id,
-    //   user: body.user_id,
-    //   blocks: [
-    //     this.generateMarkdownSectionBlock('*No command.*\n Hint\n `/growi [command] [keyword]`'),
-    //   ],
-    // });
-    // return;
+    await client.chat.postEphemeral({
+      channel: body.channel_id,
+      user: body.user_id,
+      text: 'Hello world',
+      blocks: [
+        generateMarkdownSectionBlock('hoge1'),
+        generateMarkdownSectionBlock('hoge2'),
+      ],
+    });
+    return;
   }
 
 }

--- a/packages/slackbot-proxy/src/services/RegisterService.ts
+++ b/packages/slackbot-proxy/src/services/RegisterService.ts
@@ -70,7 +70,7 @@ export class RegisterService implements GrowiCommandProcessor {
       user: payload.user.id,
       text: 'Hello world',
       blocks: [
-        generateMarkdownSectionBlock('Please enter the following Proxy URL to your GROWI slack bot setting form'),
+        generateMarkdownSectionBlock('Please enter and update the following Proxy URL to your GROWI slack bot setting form'),
         generateMarkdownSectionBlock(`Proxy URL: ${proxyURL}`),
       ],
     });

--- a/packages/slackbot-proxy/src/services/RegisterService.ts
+++ b/packages/slackbot-proxy/src/services/RegisterService.ts
@@ -54,6 +54,7 @@ export class RegisterService implements GrowiCommandProcessor {
     });
   }
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   async showProxyURL(authorizeResult: AuthorizeResult, payload: any): Promise<void> {
     let proxyURL;
     if (process.env.PROXY_URL != null) {

--- a/packages/slackbot-proxy/src/services/RegisterService.ts
+++ b/packages/slackbot-proxy/src/services/RegisterService.ts
@@ -3,6 +3,8 @@ import { WebClient, LogLevel } from '@slack/web-api';
 import { generateInputSectionBlock, GrowiCommand, generateMarkdownSectionBlock } from '@growi/slack';
 import { AuthorizeResult } from '@slack/oauth';
 import { GrowiCommandProcessor } from '~/interfaces/growi-command-processor';
+import { OrderRepository } from '~/repositories/order';
+import { Installation } from '~/entities/installation';
 
 
 const isProduction = process.env.NODE_ENV === 'production';
@@ -55,7 +57,7 @@ export class RegisterService implements GrowiCommandProcessor {
   }
 
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-  async upsertOrderRecord(payload: any, orderRepository, installation): Promise<void> {
+  async upsertOrderRecord(orderRepository: OrderRepository, installation: Installation | undefined, payload: any): Promise<void> {
     const inputValues = payload.view.state.values;
     const inputGrowiUrl = inputValues.growiDomain.contents_input.value;
     const inputGrowiAccessToken = inputValues.growiAccessToken.contents_input.value;
@@ -77,6 +79,7 @@ export class RegisterService implements GrowiCommandProcessor {
 
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   async showProxyURL(authorizeResult: AuthorizeResult, payload: any): Promise<void> {
+
     // TODO: implement for when proxy URL is undefined by GW-5834
     let proxyURL;
     if (process.env.PROXY_URL != null) {

--- a/packages/slackbot-proxy/src/services/RegisterService.ts
+++ b/packages/slackbot-proxy/src/services/RegisterService.ts
@@ -45,7 +45,7 @@ export class RegisterService implements GrowiCommandProcessor {
               text: 'Select a channel to post the proxy URL on',
             },
             element: {
-              action_id: 'show_proxy_url',
+              action_id: 'submit_growi_url_and_access_tokens',
               type: 'conversations_select',
               response_url_enabled: true,
               default_to_current_conversation: true,
@@ -58,7 +58,7 @@ export class RegisterService implements GrowiCommandProcessor {
 
   async upsertOrderRecord(
       // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-      authorizeResult:AuthorizeResult, orderRepository: OrderRepository, installation: Installation | undefined, payload: any,
+      orderRepository: OrderRepository, installation: Installation | undefined, payload: any,
   ): Promise<void> {
     const inputValues = payload.view.state.values;
     const inputGrowiUrl = inputValues.growiDomain.contents_input.value;
@@ -77,6 +77,12 @@ export class RegisterService implements GrowiCommandProcessor {
         installation: installation?.id, growiUrl: inputGrowiUrl, growiAccessToken: inputGrowiAccessToken, proxyAccessToken: inputProxyAccessToken,
       });
     }
+  }
+
+  async showProxyUrl(
+      // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+      authorizeResult:AuthorizeResult, payload: any,
+  ): Promise<void> {
 
     // TODO: implement for when proxy URL is undefined by GW-5834
     let proxyURL;

--- a/packages/slackbot-proxy/src/services/RegisterService.ts
+++ b/packages/slackbot-proxy/src/services/RegisterService.ts
@@ -38,17 +38,17 @@ export class RegisterService implements GrowiCommandProcessor {
           generateInputSectionBlock('growiAccessToken', 'GROWI ACCESS_TOKEN', 'contents_input', false, 'jBMZvpk.....'),
           generateInputSectionBlock('proxyToken', 'PROXY ACCESS_TOKEN', 'contents_input', false, 'jBMZvpk.....'),
           {
+            block_id: 'channel_to_post_proxy_url',
             type: 'input',
-            block_id: 'current_channel',
-            element: {
-              type: 'conversations_select',
-              action_id: 'input',
-              response_url_enabled: true,
-              default_to_current_conversation: true,
-            },
             label: {
               type: 'plain_text',
-              text: '起動したチャンネル',
+              text: 'Select a channel to post the proxy URL on',
+            },
+            element: {
+              action_id: 'post_proxy_url_id',
+              type: 'conversations_select',
+              response_url_enabled: true,
+              default_to_current_conversation: true,
             },
           },
         ],

--- a/packages/slackbot-proxy/src/services/RegisterService.ts
+++ b/packages/slackbot-proxy/src/services/RegisterService.ts
@@ -1,6 +1,6 @@
 import { Service } from '@tsed/di';
 import { WebClient, LogLevel } from '@slack/web-api';
-import { generateInputSectionBlock, GrowiCommand } from '@growi/slack';
+import { generateInputSectionBlock, GrowiCommand, generateMarkdownSectionBlock } from '@growi/slack';
 import { AuthorizeResult } from '@slack/oauth';
 
 import { GrowiCommandProcessor } from '~/interfaces/growi-command-processor';
@@ -40,6 +40,22 @@ export class RegisterService implements GrowiCommandProcessor {
         ],
       },
     });
+  }
+
+  async sendProxyURL(authorizeResult: AuthorizeResult, body: {[key:string]:string}): Promise<void> {
+
+    const { botToken } = authorizeResult;
+
+    // tmp use process.env
+    const client = new WebClient(botToken, { logLevel: isProduction ? LogLevel.DEBUG : LogLevel.INFO });
+    // await client.chat.postEphemeral({
+    //   channel: body.channel_id,
+    //   user: body.user_id,
+    //   blocks: [
+    //     this.generateMarkdownSectionBlock('*No command.*\n Hint\n `/growi [command] [keyword]`'),
+    //   ],
+    // });
+    // return;
   }
 
 }


### PR DESCRIPTION
## Task
GW-5556 Modal の Submit を押した後 Proxy-url を表示してGROWI管理画面での操作を促す

## View
- proxyURLの表示に必要なchannelを指定するinputを新たに追加しました。
- defaultでcommandをうった時のchannelが表示されるように指定しています
<img width="507" alt="Screen Shot 2021-05-06 at 15 06 12" src="https://user-images.githubusercontent.com/59536731/117249502-a0176e80-ae7c-11eb-8eab-3ec5cc769149.png">



<img width="777" alt="Screen Shot 2021-05-06 at 14 46 12" src="https://user-images.githubusercontent.com/59536731/117247759-d56e8d00-ae79-11eb-8942-27669f4a4a18.png">


## 参考
- https://api.slack.com/surfaces/modals/using#modal_response_url
- [Slack ペイロードに含まれる response_url を完全に理解する](https://qiita.com/seratch/items/ed29acd565af36e65072)