### PR TITLE
integration success ui

### DIFF
--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxyIntegrationCard.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxyIntegrationCard.jsx
@@ -26,7 +26,12 @@ const CustomBotWithProxyIntegrationCard = (props) => {
               <div className="circle position-absolute bg-primary border-light">
                 <p className="circle-inner text-light font-weight-bold">Proxy Server</p>
               </div>
-              <hr className="align-self-center admin-border-danger border-danger"></hr>
+              {props.isSlackScopeSet && (
+                <hr className="align-self-center border-success admin-border-success"></hr>
+              )}
+              {!props.isSlackScopeSet && (
+                <hr className="align-self-center border-danger admin-border-danger"></hr>
+              )}
             </div>
           </div>
         </div>

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxyIntegrationCard.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxyIntegrationCard.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import PropTypes from 'prop-types';
 
-const CustomBotWithProxyIntegrationCard = () => {
-
+const CustomBotWithProxyIntegrationCard = (props) => {
   const { t } = useTranslation();
 
   return (
@@ -47,6 +47,10 @@ const CustomBotWithProxyIntegrationCard = () => {
 
     </>
   );
+};
+
+CustomBotWithProxyIntegrationCard.propTypes = {
+  isSlackScopeSet: PropTypes.bool.isRequired,
 };
 
 export default CustomBotWithProxyIntegrationCard;

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxyIntegrationCard.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxyIntegrationCard.jsx
@@ -16,11 +16,19 @@ const CustomBotWithProxyIntegrationCard = (props) => {
         </div>
 
         <div className="text-center w-25">
-          <small
-            className="text-secondary"
-            // eslint-disable-next-line react/no-danger
-            dangerouslySetInnerHTML={{ __html: t('admin:slack_integration.integration_sentence.integration_is_not_complete') }}
-          />
+          {props.isSlackScopeSet && (
+            <p className="text-success small">
+              <i className="fa fa-check mr-1" />
+              {t('admin:slack_integration.integration_sentence.integration_successful')}
+            </p>
+          )}
+          {!props.isSlackScopeSet && (
+            <small
+              className="text-secondary"
+              // eslint-disable-next-line react/no-danger
+              dangerouslySetInnerHTML={{ __html: t('admin:slack_integration.integration_sentence.integration_is_not_complete') }}
+            />
+          )}
           <div className="pt-2">
             <div className="position-relative mt-5">
               <div className="circle position-absolute bg-primary border-light">

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
@@ -18,7 +18,7 @@ const CustomBotWithProxySettings = (props) => {
       <h2 className="admin-setting-header">{t('admin:slack_integration.custom_bot_with_proxy_integration')}</h2>
 
       <CustomBotWithProxyIntegrationCard
-        isSlackScopeSet={true}
+        isSlackScopeSet
       />
 
       <div className="my-5 mx-3">

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
@@ -15,7 +15,6 @@ const CustomBotWithProxySettings = (props) => {
   return (
     <>
 
-      {/* TODO: GW-5768 */}
       <h2 className="admin-setting-header">{t('admin:slack_integration.custom_bot_with_proxy_integration')}</h2>
 
       <CustomBotWithProxyIntegrationCard />

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
@@ -17,7 +17,9 @@ const CustomBotWithProxySettings = (props) => {
 
       <h2 className="admin-setting-header">{t('admin:slack_integration.custom_bot_with_proxy_integration')}</h2>
 
-      <CustomBotWithProxyIntegrationCard />
+      <CustomBotWithProxyIntegrationCard
+        isSlackScopeSet={true}
+      />
 
       <div className="my-5 mx-3">
         <CustomBotWithProxySettingsAccordion />


### PR DESCRIPTION
## 概要
CustomBotWithouProxy の連携成功時の UI を作成しました。

<img width="1063" alt="スクリーンショット 2021-05-06 12 22 31" src="https://user-images.githubusercontent.com/34241526/117237619-4c9a2600-ae66-11eb-8ad5-74859884628d.png">

## メモ
連携成功の判断は一時的に isSlackScopeSet という props を用意して行っています。
