### PR TITLE
Imprv/gw5824 add accordion contents 1 4

### DIFF
--- a/src/client/js/components/Admin/SlackIntegration/OfficialbotSettingsAccordion.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/OfficialbotSettingsAccordion.jsx
@@ -30,7 +30,7 @@ const OfficialBotSettingsAccordion = () => {
       <Accordion
         title={<><span className="mr-2">②</span>{t('admin:slack_integration.accordion.register_official_bot_proxy_service')}</>}
       >
-
+        {/* TODO: GW-5824 add accordion contents  */}
         hoge
       </Accordion>
       <Accordion
@@ -42,8 +42,37 @@ const OfficialBotSettingsAccordion = () => {
       <Accordion
         title={<><span className="mr-2">④</span>{t('admin:slack_integration.accordion.test_connection')}</>}
       >
-        {/* TODO: GW-5824 add accordion contents  */}
-        hoge
+        <p className="text-center m-4">{t('admin:slack_integration.accordion.test_connection_by_pressing_button')}</p>
+        <div className="d-flex justify-content-center">
+          <form className="form-row align-items-center w-25">
+            <div className="col-8 input-group-prepend">
+              <span className="input-group-text" id="slack-channel-addon"><i className="fa fa-hashtag" /></span>
+              <input
+                className="form-control w-100"
+                type="text"
+                placeholder="Slack Channel"
+              />
+            </div>
+            <div className="col-4">
+              <button
+                type="submit"
+                className="btn btn-info mx-3 font-weight-bold"
+              >Test
+              </button>
+            </div>
+          </form>
+        </div>
+        <form>
+          <div className="row my-3 justify-content-center">
+            <div className="form-group slack-connection-log w-25">
+              <label className="mb-1"><p className="border-info slack-connection-log-title pl-2">Logs</p></label>
+              <textarea
+                className="form-control card border-info slack-connection-log-body rounded-lg"
+                readOnly
+              />
+            </div>
+          </div>
+        </form>
       </Accordion>
     </div>
   );

--- a/src/client/js/components/Admin/SlackIntegration/OfficialbotSettingsAccordion.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/OfficialbotSettingsAccordion.jsx
@@ -10,13 +10,27 @@ const OfficialBotSettingsAccordion = () => {
       <Accordion
         title={<><span className="mr-2">①</span>{t('admin:slack_integration.accordion.install_bot_to_slack')}</>}
       >
-        {/* TODO: GW-5824 add accordion contents  */}
-        hoge
+        <div className="my-5 d-flex flex-column align-items-center">
+          {/* TODO: Insert install link */}
+          <button type="button" className="btn btn-primary text-nowrap" onClick={() => window.open('https://api.slack.com/apps', '_blank', 'noreferrer')}>
+            {t('admin:slack_integration.accordion.install_now')}
+            <i className="fa fa-external-link ml-2" aria-hidden="true" />
+          </button>
+          {/* TODO: Insert DOCS link */}
+          <a href="#">
+            <p className="text-center mt-1">
+              <small>
+                {t('admin:slack_integration.accordion.how_to_install')}
+                <i className="fa fa-external-link ml-2" aria-hidden="true" />
+              </small>
+            </p>
+          </a>
+        </div>
       </Accordion>
       <Accordion
         title={<><span className="mr-2">②</span>{t('admin:slack_integration.accordion.register_official_bot_proxy_service')}</>}
       >
-        {/* TODO: GW-5824 add accordion contents  */}
+
         hoge
       </Accordion>
       <Accordion


### PR DESCRIPTION
## Task
GW-5824 [Official bot]アコーディオン の中身を追加①と④

- 見た目のみです
- スティーブンさんの[ブランチ](https://github.com/weseek/growi/pull/3686)から切りました。i18nは確認済みです。
- ↑がマージされている場合は、マージ先を` feat/growi-bot`に変更する必要があります。
## View

### [XD](https://xd.adobe.com/view/c941b01b-2761-4e52-bfb7-bffab973cb8a-9c12/screen/b2703ecc-050b-4d7a-810a-6e52aaf7f0a5)

<img width="627" alt="Screen Shot 2021-05-06 at 12 49 31" src="https://user-images.githubusercontent.com/59536731/117239434-b405a500-ae69-11eb-9eb4-82f36dc63e73.png">

- test formのinputはXDに反映されていません。
<img width="754" alt="Screen Shot 2021-05-06 at 12 50 25" src="https://user-images.githubusercontent.com/59536731/117239437-b536d200-ae69-11eb-9586-766a693d59cb.png">


###  実装後
<img width="999" alt="Screen Shot 2021-05-06 at 12 40 25" src="https://user-images.githubusercontent.com/59536731/117238763-73595c00-ae68-11eb-86d0-119770e18dcd.png">
