### PR TITLE
enable display workspace name and growi app name

### DIFF
--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxyIntegrationCard.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxyIntegrationCard.jsx
@@ -61,7 +61,7 @@ const CustomBotWithProxyIntegrationCard = (props) => {
             </div>
           </div>
           <div className="card-body p-4 mb-5 text-center">
-            <a className="btn btn-primary">WESEEK Inner Wiki</a>
+            <a className="btn btn-primary">{props.siteName}</a>
           </div>
         </div>
 

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxyIntegrationCard.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxyIntegrationCard.jsx
@@ -63,6 +63,8 @@ const CustomBotWithProxyIntegrationCard = (props) => {
 };
 
 CustomBotWithProxyIntegrationCard.propTypes = {
+  siteName: PropTypes.string.isRequired,
+  slackWSNameInWithProxy: PropTypes.string,
   isSlackScopeSet: PropTypes.bool.isRequired,
 };
 

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxyIntegrationCard.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxyIntegrationCard.jsx
@@ -12,7 +12,7 @@ const CustomBotWithProxyIntegrationCard = (props) => {
 
         <div className="card rounded shadow border-0 w-50 admin-bot-card">
           <h5 className="card-title font-weight-bold mt-3 ml-4">Slack</h5>
-          <div className="card-body p-4">
+          <div className="card-body px-5">
             {props.slackWSNameInWithProxy != null && (
               <div className="card slack-work-space-name-card">
                 <div className="m-2 text-center">

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxyIntegrationCard.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxyIntegrationCard.jsx
@@ -6,68 +6,63 @@ const CustomBotWithProxyIntegrationCard = (props) => {
   const { t } = useTranslation();
 
   return (
-    <>
+    <div className="d-flex justify-content-center my-5 bot-integration">
 
-      <div className="d-flex justify-content-center my-5 bot-integration">
-
-        <div className="card rounded shadow border-0 w-50 admin-bot-card">
-          <h5 className="card-title font-weight-bold mt-3 ml-4">Slack</h5>
-          <div className="card-body px-5">
-            {props.slackWSNameInWithProxy != null && (
-              <div className="card slack-work-space-name-card">
-                <div className="m-2 text-center">
-                  <h5 className="font-weight-bold">{props.slackWSNameInWithProxy}</h5>
-                  <img width={20} height={20} src="/images/slack-integration/growi-bot-kun-icon.png" />
-                </div>
+      <div className="card rounded shadow border-0 w-50 admin-bot-card">
+        <h5 className="card-title font-weight-bold mt-3 ml-4">Slack</h5>
+        <div className="card-body px-5">
+          {props.slackWSNameInWithProxy != null && (
+            <div className="card slack-work-space-name-card">
+              <div className="m-2 text-center">
+                <h5 className="font-weight-bold">{props.slackWSNameInWithProxy}</h5>
+                <img width={20} height={20} src="/images/slack-integration/growi-bot-kun-icon.png" />
               </div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="text-center w-25">
+        {props.isSlackScopeSet && (
+          <p className="text-success small">
+            <i className="fa fa-check mr-1" />
+            {t('admin:slack_integration.integration_sentence.integration_successful')}
+          </p>
+        )}
+        {!props.isSlackScopeSet && (
+          <small
+            className="text-secondary"
+            // eslint-disable-next-line react/no-danger
+            dangerouslySetInnerHTML={{ __html: t('admin:slack_integration.integration_sentence.integration_is_not_complete') }}
+          />
+        )}
+        <div className="pt-2">
+          <div className="position-relative mt-5">
+            <div className="circle position-absolute bg-primary border-light">
+              <p className="circle-inner text-light font-weight-bold">Proxy Server</p>
+            </div>
+            {props.isSlackScopeSet && (
+              <hr className="align-self-center border-success admin-border-success"></hr>
+            )}
+            {!props.isSlackScopeSet && (
+              <hr className="align-self-center border-danger admin-border-danger"></hr>
             )}
           </div>
         </div>
-
-        <div className="text-center w-25">
-          {props.isSlackScopeSet && (
-            <p className="text-success small">
-              <i className="fa fa-check mr-1" />
-              {t('admin:slack_integration.integration_sentence.integration_successful')}
-            </p>
-          )}
-          {!props.isSlackScopeSet && (
-            <small
-              className="text-secondary"
-              // eslint-disable-next-line react/no-danger
-              dangerouslySetInnerHTML={{ __html: t('admin:slack_integration.integration_sentence.integration_is_not_complete') }}
-            />
-          )}
-          <div className="pt-2">
-            <div className="position-relative mt-5">
-              <div className="circle position-absolute bg-primary border-light">
-                <p className="circle-inner text-light font-weight-bold">Proxy Server</p>
-              </div>
-              {props.isSlackScopeSet && (
-                <hr className="align-self-center border-success admin-border-success"></hr>
-              )}
-              {!props.isSlackScopeSet && (
-                <hr className="align-self-center border-danger admin-border-danger"></hr>
-              )}
-            </div>
-          </div>
-        </div>
-
-        <div className="card rounded-lg shadow border-0 w-50 admin-bot-card">
-          <div className="row">
-            <h5 className="card-title font-weight-bold mt-3 ml-4 col">GROWI App</h5>
-            <div className="pull-right mt-3 mr-3">
-              <a className="icon-fw fa fa-repeat fa-2x"></a>
-            </div>
-          </div>
-          <div className="card-body p-4 mb-5 text-center">
-            <a className="btn btn-primary">{props.siteName}</a>
-          </div>
-        </div>
-
       </div>
 
-    </>
+      <div className="card rounded-lg shadow border-0 w-50 admin-bot-card">
+        <div className="row">
+          <h5 className="card-title font-weight-bold mt-3 ml-4 col">GROWI App</h5>
+          <div className="pull-right mt-3 mr-3">
+            <a className="icon-fw fa fa-repeat fa-2x"></a>
+          </div>
+        </div>
+        <div className="card-body p-4 mb-5 text-center">
+          <a className="btn btn-primary">{props.siteName}</a>
+        </div>
+      </div>
+    </div>
   );
 };
 

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxyIntegrationCard.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxyIntegrationCard.jsx
@@ -12,7 +12,16 @@ const CustomBotWithProxyIntegrationCard = (props) => {
 
         <div className="card rounded shadow border-0 w-50 admin-bot-card">
           <h5 className="card-title font-weight-bold mt-3 ml-4">Slack</h5>
-          <div className="card-body p-4"></div>
+          <div className="card-body p-4">
+            {props.slackWSNameInWithProxy != null && (
+              <div className="card slack-work-space-name-card">
+                <div className="m-2 text-center">
+                  <h5 className="font-weight-bold">{props.slackWSNameInWithProxy}</h5>
+                  <img width={20} height={20} src="/images/slack-integration/growi-bot-kun-icon.png" />
+                </div>
+              </div>
+            )}
+          </div>
         </div>
 
         <div className="text-center w-25">

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
@@ -17,6 +17,7 @@ const CustomBotWithProxySettings = (props) => {
 
       <h2 className="admin-setting-header">{t('admin:slack_integration.custom_bot_with_proxy_integration')}</h2>
 
+      {/* TODO delete tmp props */}
       <CustomBotWithProxyIntegrationCard
         siteName="GROWI"
         slackWSNameInWithProxy="SlackWorkSpaceName"

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
@@ -18,6 +18,8 @@ const CustomBotWithProxySettings = (props) => {
       <h2 className="admin-setting-header">{t('admin:slack_integration.custom_bot_with_proxy_integration')}</h2>
 
       <CustomBotWithProxyIntegrationCard
+        siteName="GROWI"
+        slackWSNameInWithProxy="SlackWorkSpaceName"
         isSlackScopeSet
       />
 

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
@@ -12,36 +12,36 @@ const CustomBotWithoutProxyIntegrationCard = (props) => {
         <h5 className="card-title font-weight-bold mt-3 ml-4">Slack</h5>
         <div className="card-body p-2 w-50 mx-auto">
           {props.slackWSNameInWithoutProxy != null && (
-          <div className="card slack-work-space-name-card">
-            <div className="m-2 text-center">
-              <h5 className="font-weight-bold">{props.slackWSNameInWithoutProxy}</h5>
-              <img width={20} height={20} src="/images/slack-integration/growi-bot-kun-icon.png" />
+            <div className="card slack-work-space-name-card">
+              <div className="m-2 text-center">
+                <h5 className="font-weight-bold">{props.slackWSNameInWithoutProxy}</h5>
+                <img width={20} height={20} src="/images/slack-integration/growi-bot-kun-icon.png" />
+              </div>
             </div>
-          </div>
-            )}
+          )}
         </div>
       </div>
 
       <div className="text-center w-25">
         {props.isSlackScopeSet && (
-        <div className="mt-5">
-          <p className="text-success small">
-            <i className="fa fa-check mr-1" />
-            {t('admin:slack_integration.integration_sentence.integration_successful')}
-          </p>
-          <hr className="align-self-center admin-border-success border-success"></hr>
-        </div>
-          )}
+          <div className="mt-5">
+            <p className="text-success small">
+              <i className="fa fa-check mr-1" />
+              {t('admin:slack_integration.integration_sentence.integration_successful')}
+            </p>
+            <hr className="align-self-center admin-border-success border-success"></hr>
+          </div>
+        )}
         {!props.isSlackScopeSet && (
-        <div className="mt-4">
-          <small
-            className="text-secondary m-0"
-                // eslint-disable-next-line react/no-danger
-            dangerouslySetInnerHTML={{ __html: t('admin:slack_integration.integration_sentence.integration_is_not_complete') }}
-          />
-          <hr className="align-self-center admin-border-danger border-danger"></hr>
-        </div>
-          )}
+          <div className="mt-4">
+            <small
+              className="text-secondary m-0"
+                  // eslint-disable-next-line react/no-danger
+              dangerouslySetInnerHTML={{ __html: t('admin:slack_integration.integration_sentence.integration_is_not_complete') }}
+            />
+            <hr className="align-self-center admin-border-danger border-danger"></hr>
+          </div>
+        )}
       </div>
 
       <div className="card rounded-lg shadow border-0 w-50 admin-bot-card mb-0">


### PR DESCRIPTION
## 概要
CustomBotWithProxy の連携図において、ワークスペース名の表示と siteName を表示できるようにしました。

<img width="1062" alt="スクリーンショット 2021-05-06 14 50 43" src="https://user-images.githubusercontent.com/34241526/117248253-9f7dd880-ae7a-11eb-9e06-7961531498e2.png">

## メモ
ワークスペース名と siteName を表示させるために一時的に slackWSNameInWithProxy と siteName の props を作成しました。
