### PR TITLE
Imprv/gw5856 be able to copy a url

### DIFF
--- a/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/AccessTokenSettings.jsx
@@ -33,7 +33,7 @@ const AccessTokenSettings = (props) => {
             {accessToken.length === 0 ? (
               <input className="form-control" type="text" value={accessToken} readOnly />
             ) : (
-              <CopyToClipboard text={accessToken} onCopy={() => toastSuccess(t('slack_integration.copied_to_clipboard'))}>
+              <CopyToClipboard text={accessToken} onCopy={() => toastSuccess(t('admin:slack_integration.copied_to_clipboard'))}>
                 <input className="form-control" type="text" value={accessToken} readOnly />
               </CopyToClipboard>
             )}

--- a/src/client/js/components/Admin/SlackIntegration/OfficialbotSettingsAccordion.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/OfficialbotSettingsAccordion.jsx
@@ -1,11 +1,14 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { CopyToClipboard } from 'react-copy-to-clipboard';
 import Accordion from '../Common/Accordion';
 import AdminUpdateButtonRow from '../Common/AdminUpdateButtonRow';
+import { toastSuccess } from '../../../util/apiNotification';
 
 const growiUrl = window.location.host;
 
 const OfficialBotSettingsAccordion = () => {
+  // TODO: apply i18n by GW-5878
   const { t } = useTranslation();
 
   return (
@@ -63,12 +66,19 @@ const OfficialBotSettingsAccordion = () => {
           <div className="d-flex flex-column align-items-center">
             <ol className="p-0">
               <li><p className="ml-2">Slack上で`/growi register`と打つ</p></li>
-              {/* TODO: Copy to clipboard on click by GW5856 */}
               <li>
-                <p className="ml-2"><b>GROWI URL</b>には{growiUrl}
-                  <i className="fa fa-clipboard mx-1 text-secondary" aria-hidden="true"></i>
-                  を貼り付ける
-                </p>
+                <div className="input-group">
+                  <b>GROWI URL</b>には
+                  <div className="input-group-prepend mx-1">
+                    <input className="form-control" type="text" value={growiUrl} readOnly />
+                    <CopyToClipboard text={growiUrl} onCopy={() => toastSuccess(t('slack_integration.copied_to_clipboard'))}>
+                      <div className="btn input-group-text">
+                        <i className="fa fa-clipboard mx-1" aria-hidden="true"></i>
+                      </div>
+                    </CopyToClipboard>
+                  </div>
+                    を貼り付ける
+                </div>
               </li>
               <li><p className="ml-2">上記で発行した<b>Access Token for GROWI と Access Token for Proxy</b>を入れる</p></li>
             </ol>

--- a/src/client/js/components/Admin/SlackIntegration/OfficialbotSettingsAccordion.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/OfficialbotSettingsAccordion.jsx
@@ -67,8 +67,8 @@ const OfficialBotSettingsAccordion = () => {
             <ol className="p-0">
               <li><p className="ml-2">Slack上で`/growi register`と打つ</p></li>
               <li>
-                <div className="input-group">
-                  <b>GROWI URL</b>には
+                <div className="input-group align-items-center ml-2 mb-3">
+                  <b> GROWI URL</b>には
                   <div className="input-group-prepend mx-1">
                     <input className="form-control" type="text" value={growiUrl} readOnly />
                     <CopyToClipboard text={growiUrl} onCopy={() => toastSuccess(t('slack_integration.copied_to_clipboard'))}>

--- a/src/client/js/components/Admin/SlackIntegration/OfficialbotSettingsAccordion.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/OfficialbotSettingsAccordion.jsx
@@ -71,7 +71,7 @@ const OfficialBotSettingsAccordion = () => {
                   <b> GROWI URL</b>には
                   <div className="input-group-prepend mx-1">
                     <input className="form-control" type="text" value={growiUrl} readOnly />
-                    <CopyToClipboard text={growiUrl} onCopy={() => toastSuccess(t('slack_integration.copied_to_clipboard'))}>
+                    <CopyToClipboard text={growiUrl} onCopy={() => toastSuccess(t('admin:slack_integration.copied_to_clipboard'))}>
                       <div className="btn input-group-text">
                         <i className="fa fa-clipboard mx-1" aria-hidden="true"></i>
                       </div>


### PR DESCRIPTION
## Task
GW-5856 コピーボタンを押したらGROWI URLをコピーできるようにする

XDの見た目と違うんですけど、GitHubなどはこの見た目でClipboardにコピーしているんで真似しました。

## View
### XD
<img width="920" alt="Screen Shot 2021-05-10 at 16 47 54" src="https://user-images.githubusercontent.com/59536731/117624087-7da09080-b1af-11eb-83ae-61f0f53d0215.png">


### 実装後

<img width="895" alt="Screen Shot 2021-05-10 at 16 35 26" src="https://user-images.githubusercontent.com/59536731/117624223-a759b780-b1af-11eb-8ed9-a9b199095f47.png">


- ボタンを押すとトーストサクセスが表示される。

<img width="350" alt="Screen Shot 2021-05-10 at 16 45 59" src="https://user-images.githubusercontent.com/59536731/117623811-374b3180-b1af-11eb-96ca-e0ce618483dd.png">
