### PR TITLE
Imprv/gw5866 forward to growi server

### DIFF
--- a/packages/slackbot-proxy/src/controllers/slack.ts
+++ b/packages/slackbot-proxy/src/controllers/slack.ts
@@ -170,7 +170,6 @@ export class SlackCtrl {
       return axios.post(url.toString(), {
         ...body,
         tokenPtoG: relation.tokenPtoG,
-        payload,
       });
     });
 

--- a/packages/slackbot-proxy/src/controllers/slack.ts
+++ b/packages/slackbot-proxy/src/controllers/slack.ts
@@ -164,15 +164,6 @@ export class SlackCtrl {
      */
     const relations = await this.relationRepository.find({ installation: installation?.id });
 
-    if (relations.length === 0) {
-      return res.json({
-        blocks: [
-          generateMarkdownSectionBlock('*No relation found.*'),
-          generateMarkdownSectionBlock('Run `/growi register` first.'),
-        ],
-      });
-    }
-
     const promises = relations.map((relation: Relation) => {
       // generate API URL
       const url = new URL('/_api/v3/slack-integration/proxied/interactions', relation.growiUri);


### PR DESCRIPTION
## Task
GW-5866 GROWI本体に forward する処理の実装

## Description

- GROWI本体のapiを叩くことに成功しました。
※  registerの処理の部分を一時的にコメントアウトして、 `forward to GROWI server`の処理が動くかどうかを確かめました。
```
// register
    if (growiCommand.growiCommandType === 'register') {
      // Send response immediately to avoid opelation_timeout error
      // See https://api.slack.com/apis/connections/events-api#the-events-api__responding-to-events
      res.send();

      return this.registerService.process(growiCommand, authorizeResult, body as {[key:string]:string});
    }
 ```
<img width="545" alt="Screen Shot 2021-05-10 at 21 25 54" src="https://user-images.githubusercontent.com/59536731/117658964-527d6780-b1d6-11eb-8e9a-ac8da2a095a7.png">
