### PR TITLE
reset button

### DIFF
--- a/resource/locales/en_US/admin/admin.json
+++ b/resource/locales/en_US/admin/admin.json
@@ -293,6 +293,7 @@
     "official_bot_settings": "Official bot Settings",
     "custom_bot_without_proxy_settings": "Custom Bot without proxy Settings",
     "reset": "Reset",
+    "reset_all_settings": "Reset all settings",
     "delete_slackbot_settings": "Reset Slack Bot settings",
     "slackbot_settings_notice": "Reset",
     "accordion": {

--- a/resource/locales/ja_JP/admin/admin.json
+++ b/resource/locales/ja_JP/admin/admin.json
@@ -290,6 +290,7 @@
     "cooperation_procedure": "連携手順",
     "custom_bot_without_proxy_settings": "Custom Bot (Without-Proxy) 設定",
     "reset": "リセット",
+    "reset_all_settings": "全ての設定をリセット",
     "delete_slackbot_settings": "Slack Bot 設定をリセットする",
     "slackbot_settings_notice": "リセットします",
     "accordion": {

--- a/resource/locales/zh_CN/admin/admin.json
+++ b/resource/locales/zh_CN/admin/admin.json
@@ -300,6 +300,7 @@
     "cooperation_procedure": "协作程序",
     "custom_bot_without_proxy_settings": "Custom Bot (Without-Proxy) 设置",
     "reset":"重置",
+    "reset_all_settings": "重置所有设置",
     "delete_slackbot_settings": "重置 Slack Bot 设置",
     "slackbot_settings_notice": "重置",
     "accordion": {

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -136,7 +136,7 @@ const SlackIntegration = (props) => {
 
         {(currentBotType === 'officialBot' || currentBotType === 'customBotWithProxy') && (
           <button
-            className="mx-3 pull-right btn text-danger border-danger"
+            className="mx-3 btn text-danger border-danger"
             type="button"
           >{t('admin:slack_integration.reset_all_settings')}
           </button>

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -134,6 +134,8 @@ const SlackIntegration = (props) => {
           </a>
         </h2>
 
+        {t('admin:slack_integration.selecting_bot_types.selecting_bot_type')}
+
         {(currentBotType === 'officialBot' || currentBotType === 'customBotWithProxy') && (
           <button
             className="mx-3 btn text-danger border-danger"
@@ -141,8 +143,6 @@ const SlackIntegration = (props) => {
           >{t('admin:slack_integration.reset_all_settings')}
           </button>
         )}
-
-        {t('admin:slack_integration.selecting_bot_types.selecting_bot_type')}
 
         <div className="row my-5 flex-wrap-reverse justify-content-center">
           {botTypes.map((botType) => {

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -134,7 +134,7 @@ const SlackIntegration = (props) => {
           </a>
         </h2>
 
-        <div>
+        <div className="d-flex">
           {t('admin:slack_integration.selecting_bot_types.selecting_bot_type')}
 
           {(currentBotType === 'officialBot' || currentBotType === 'customBotWithProxy') && (

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -124,6 +124,12 @@ const SlackIntegration = (props) => {
         onCancelClick={cancelBotChangeHandler}
       />
 
+      <button
+        className="mx-3 pull-right btn text-danger border-danger"
+        type="button"
+      >{t('admin:slack_integration.reset_all_settings')}
+      </button>
+
       <div className="selecting-bot-type mb-5">
         <h2 className="admin-setting-header mb-4">
           {t('admin:slack_integration.selecting_bot_types.slack_bot')}

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -124,14 +124,6 @@ const SlackIntegration = (props) => {
         onCancelClick={cancelBotChangeHandler}
       />
 
-      {(currentBotType === 'officialBot' || currentBotType === 'customBotWithProxy') && (
-        <button
-          className="mx-3 pull-right btn text-danger border-danger"
-          type="button"
-        >{t('admin:slack_integration.reset_all_settings')}
-        </button>
-      )}
-
       <div className="selecting-bot-type mb-5">
         <h2 className="admin-setting-header mb-4">
           {t('admin:slack_integration.selecting_bot_types.slack_bot')}
@@ -141,6 +133,14 @@ const SlackIntegration = (props) => {
             <i className="fa fa-external-link ml-1" aria-hidden="true"></i>
           </a>
         </h2>
+
+        {(currentBotType === 'officialBot' || currentBotType === 'customBotWithProxy') && (
+          <button
+            className="mx-3 pull-right btn text-danger border-danger"
+            type="button"
+          >{t('admin:slack_integration.reset_all_settings')}
+          </button>
+        )}
 
         {t('admin:slack_integration.selecting_bot_types.selecting_bot_type')}
 

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -134,15 +134,17 @@ const SlackIntegration = (props) => {
           </a>
         </h2>
 
-        {t('admin:slack_integration.selecting_bot_types.selecting_bot_type')}
+        <div>
+          {t('admin:slack_integration.selecting_bot_types.selecting_bot_type')}
 
-        {(currentBotType === 'officialBot' || currentBotType === 'customBotWithProxy') && (
+          {(currentBotType === 'officialBot' || currentBotType === 'customBotWithProxy') && (
           <button
             className="mx-3 btn text-danger border-danger"
             type="button"
           >{t('admin:slack_integration.reset_all_settings')}
           </button>
-        )}
+          )}
+        </div>
 
         <div className="row my-5 flex-wrap-reverse justify-content-center">
           {botTypes.map((botType) => {

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -134,15 +134,17 @@ const SlackIntegration = (props) => {
           </a>
         </h2>
 
-        <div className="d-flex">
-          {t('admin:slack_integration.selecting_bot_types.selecting_bot_type')}
+        <div className="d-flex justify-content">
+          <div className="mr-auto">
+            {t('admin:slack_integration.selecting_bot_types.selecting_bot_type')}
+          </div>
 
           {(currentBotType === 'officialBot' || currentBotType === 'customBotWithProxy') && (
-          <button
-            className="mx-3 btn text-danger border-danger"
-            type="button"
-          >{t('admin:slack_integration.reset_all_settings')}
-          </button>
+            <button
+              className="mx-3 btn text-danger border-danger flex-end"
+              type="button"
+            >{t('admin:slack_integration.reset_all_settings')}
+            </button>
           )}
         </div>
 

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -141,7 +141,7 @@ const SlackIntegration = (props) => {
 
           {(currentBotType === 'officialBot' || currentBotType === 'customBotWithProxy') && (
             <button
-              className="mx-3 btn text-danger border-danger flex-end"
+              className="mx-3 btn btn-outline-danger flex-end"
               type="button"
             >{t('admin:slack_integration.reset_all_settings')}
             </button>

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -124,11 +124,13 @@ const SlackIntegration = (props) => {
         onCancelClick={cancelBotChangeHandler}
       />
 
-      <button
-        className="mx-3 pull-right btn text-danger border-danger"
-        type="button"
-      >{t('admin:slack_integration.reset_all_settings')}
-      </button>
+      {(currentBotType === 'officialBot' || currentBotType === 'customBotWithProxy') && (
+        <button
+          className="mx-3 pull-right btn text-danger border-danger"
+          type="button"
+        >{t('admin:slack_integration.reset_all_settings')}
+        </button>
+      )}
 
       <div className="selecting-bot-type mb-5">
         <h2 className="admin-setting-header mb-4">


### PR DESCRIPTION
## 概要

currentBotType が officialBot か customBotWithProxy の時に、全ての設定をリセット というボタンを表示させるようにしました。

【officialBot】
<img width="1419" alt="スクリーンショット 2021-05-13 14 35 24" src="https://user-images.githubusercontent.com/34241526/118082664-8c2db880-b3f8-11eb-8c27-9c3f5257aaad.png">

【customBotWithProxy】
<img width="1430" alt="スクリーンショット 2021-05-13 14 35 38" src="https://user-images.githubusercontent.com/34241526/118082672-8df77c00-b3f8-11eb-9402-56c33c9c44ec.png">


