### PR TITLE
reset modal

### DIFF
--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
@@ -97,6 +97,7 @@ const CustomBotWithProxySettings = (props) => {
         </div>
       </div>
       <DeleteSlackBotSettingsModal
+        resetAll={false}
         isOpen={isDeleteConfirmModalShown}
         onClose={() => setIsDeleteConfirmModalShown(false)}
         onClickDeleteButton={deleteSlackSettingsHandler}

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
@@ -97,7 +97,7 @@ const CustomBotWithProxySettings = (props) => {
         </div>
       </div>
       <DeleteSlackBotSettingsModal
-        resetAll={false}
+        isResetAll={false}
         isOpen={isDeleteConfirmModalShown}
         onClose={() => setIsDeleteConfirmModalShown(false)}
         onClickDeleteButton={deleteSlackSettingsHandler}

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -60,6 +60,7 @@ const CustomBotWithoutProxySettings = (props) => {
         />
       </div>
       <DeleteSlackBotSettingsModal
+        resetAll={false}
         isOpen={isDeleteConfirmModalShown}
         onClose={() => setIsDeleteConfirmModalShown(false)}
         onClickDeleteButton={deleteSlackSettingsHandler}

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -60,7 +60,7 @@ const CustomBotWithoutProxySettings = (props) => {
         />
       </div>
       <DeleteSlackBotSettingsModal
-        resetAll={false}
+        isResetAll={false}
         isOpen={isDeleteConfirmModalShown}
         onClose={() => setIsDeleteConfirmModalShown(false)}
         onClickDeleteButton={deleteSlackSettingsHandler}

--- a/src/client/js/components/Admin/SlackIntegration/DeleteSlackBotSettingsModal.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/DeleteSlackBotSettingsModal.jsx
@@ -65,7 +65,7 @@ const DeleteSlackBotSettingsModal = React.memo((props) => {
 
 DeleteSlackBotSettingsModal.propTypes = {
   t: PropTypes.func.isRequired, // i18next
-  resetAll: PropTypes.bool,
+  resetAll: PropTypes.bool.isRequired,
   isOpen: PropTypes.bool.isRequired,
   onClose: PropTypes.func,
   onClickDeleteButton: PropTypes.func,

--- a/src/client/js/components/Admin/SlackIntegration/DeleteSlackBotSettingsModal.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/DeleteSlackBotSettingsModal.jsx
@@ -56,7 +56,7 @@ const DeleteSlackBotSettingsModal = React.memo((props) => {
 
 DeleteSlackBotSettingsModal.propTypes = {
   t: PropTypes.func.isRequired, // i18next
-
+  resetAll: PropTypes.bool,
   isOpen: PropTypes.bool.isRequired,
   onClose: PropTypes.func,
   onClickDeleteButton: PropTypes.func,

--- a/src/client/js/components/Admin/SlackIntegration/DeleteSlackBotSettingsModal.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/DeleteSlackBotSettingsModal.jsx
@@ -36,12 +36,12 @@ const DeleteSlackBotSettingsModal = React.memo((props) => {
       <ModalHeader tag="h4" toggle={closeButtonHandler} className="bg-danger text-light">
         <span>
           <i className="icon-fw icon-fire"></i>
-          {props.resetAll && (
+          {props.isResetAll && (
             <>
               {t('admin:slack_integration.reset_all_settings')}
             </>
           )}
-          {!props.resetAll && (
+          {!props.isResetAll && (
             <>
               {t('admin:slack_integration.delete_slackbot_settings')}
             </>

--- a/src/client/js/components/Admin/SlackIntegration/DeleteSlackBotSettingsModal.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/DeleteSlackBotSettingsModal.jsx
@@ -65,7 +65,7 @@ const DeleteSlackBotSettingsModal = React.memo((props) => {
 
 DeleteSlackBotSettingsModal.propTypes = {
   t: PropTypes.func.isRequired, // i18next
-  resetAll: PropTypes.bool.isRequired,
+  isResetAll: PropTypes.bool.isRequired,
   isOpen: PropTypes.bool.isRequired,
   onClose: PropTypes.func,
   onClickDeleteButton: PropTypes.func,

--- a/src/client/js/components/Admin/SlackIntegration/DeleteSlackBotSettingsModal.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/DeleteSlackBotSettingsModal.jsx
@@ -36,7 +36,16 @@ const DeleteSlackBotSettingsModal = React.memo((props) => {
       <ModalHeader tag="h4" toggle={closeButtonHandler} className="bg-danger text-light">
         <span>
           <i className="icon-fw icon-fire"></i>
-          {t('admin:slack_integration.delete_slackbot_settings')}
+          {props.resetAll && (
+            <>
+              {t('admin:slack_integration.reset_all_settings')}
+            </>
+          )}
+          {!props.resetAll && (
+            <>
+              {t('admin:slack_integration.delete_slackbot_settings')}
+            </>
+          )}
         </span>
       </ModalHeader>
       <ModalBody>

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -126,6 +126,7 @@ const SlackIntegration = (props) => {
         onCancelClick={cancelBotChangeHandler}
       />
 
+      {/* TODO add onClickDeleteButton */}
       <DeleteSlackBotSettingsModal
         resetAll
         isOpen={isDeleteConfirmModalShown}

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -10,6 +10,7 @@ import CustomBotWithoutProxySettings from './CustomBotWithoutProxySettings';
 import CustomBotWithProxySettings from './CustomBotWithProxySettings';
 import ConfirmBotChangeModal from './ConfirmBotChangeModal';
 import BotTypeCard from './BotTypeCard';
+import DeleteSlackBotSettingsModal from './DeleteSlackBotSettingsModal';
 
 const botTypes = ['officialBot', 'customBotWithoutProxy', 'customBotWithProxy'];
 
@@ -122,6 +123,10 @@ const SlackIntegration = (props) => {
         isOpen={selectedBotType != null}
         onConfirmClick={changeCurrentBotSettingsHandler}
         onCancelClick={cancelBotChangeHandler}
+      />
+
+      <DeleteSlackBotSettingsModal
+        isOpen
       />
 
       <div className="selecting-bot-type mb-5">

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -128,7 +128,7 @@ const SlackIntegration = (props) => {
 
       {/* TODO add onClickDeleteButton */}
       <DeleteSlackBotSettingsModal
-        resetAll
+        isResetAll
         isOpen={isDeleteConfirmModalShown}
         onClose={() => setIsDeleteConfirmModalShown(false)}
       />

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -127,6 +127,7 @@ const SlackIntegration = (props) => {
       />
 
       <DeleteSlackBotSettingsModal
+        resetAll
         isOpen={isDeleteConfirmModalShown}
         onClose={() => setIsDeleteConfirmModalShown(false)}
       />

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -150,6 +150,7 @@ const SlackIntegration = (props) => {
             <button
               className="mx-3 btn btn-outline-danger flex-end"
               type="button"
+              onClick={() => setIsDeleteConfirmModalShown(true)}
             >{t('admin:slack_integration.reset_all_settings')}
             </button>
           )}

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -26,6 +26,7 @@ const SlackIntegration = (props) => {
   const [isRegisterSlackCredentials, setIsRegisterSlackCredentials] = useState(false);
   const [isSendTestMessage, setIsSendTestMessage] = useState(false);
   const [slackWSNameInWithoutProxy, setSlackWSNameInWithoutProxy] = useState(null);
+  const [isDeleteConfirmModalShown, setIsDeleteConfirmModalShown] = useState(false);
 
   const fetchSlackIntegrationData = useCallback(async() => {
     try {
@@ -126,7 +127,8 @@ const SlackIntegration = (props) => {
       />
 
       <DeleteSlackBotSettingsModal
-        isOpen
+        isOpen={isDeleteConfirmModalShown}
+        onClose={() => setIsDeleteConfirmModalShown(false)}
       />
 
       <div className="selecting-bot-type mb-5">


### PR DESCRIPTION
## 概要
全ての設定をリセット のボタンを押した際にモーダルを表示させるようにしました。

<img width="501" alt="スクリーンショット 2021-05-13 21 34 34" src="https://user-images.githubusercontent.com/34241526/118126585-7f7a8600-b433-11eb-9ac9-cfab9bf55d34.png">

## メモ
- DeleteSkackBotSettingsModal.jsx に resetAll props を持たせてモーダルの文言を変更するようにした。
- リセットボタンを押した際のロジックは後続タスクで行う。