### PR TITLE
fix server uri error

### DIFF
--- a/packages/slackbot-proxy/src/Server.ts
+++ b/packages/slackbot-proxy/src/Server.ts
@@ -75,7 +75,7 @@ export class Server {
   @Inject()
   injector: InjectorService;
 
-  $onInit(): Promise<any> | void {
+  $beforeInit(): Promise<any> | void {
     const serverUri = process.env.SERVER_URI;
 
     if (serverUri === undefined) {


### PR DESCRIPTION
## Task
GW-5938 SERVER_URIがセットされていない場合、サーバーが起動できてしまうのを修正

<img width="956" alt="Screen Shot 2021-05-14 at 11 36 16" src="https://user-images.githubusercontent.com/59536731/118213301-a030f300-b4a8-11eb-8510-591fc51d4c3b.png">


## Reference
- https://tsed.io/docs/services.html#lifecycle-hooks
<img width="443" alt="Screen Shot 2021-05-14 at 11 34 25" src="https://user-images.githubusercontent.com/59536731/118213162-5d6f1b00-b4a8-11eb-8072-4a68a0e16685.png">


