### PR TITLE
add token salt to env

### DIFF
--- a/config/env.dev.js
+++ b/config/env.dev.js
@@ -24,4 +24,6 @@ module.exports = {
   // PROMSTER_ENABLED: true,
   // SLACK_SIGNING_SECRET: '',
   // SLACK_BOT_TOKEN: '',
+  SALT_FOR_GTOP_TOKEN: 'proxy',
+  SALT_FOR_PTOG_TOKEN: 'growi',
 };

--- a/src/server/models/slack-app-integration.js
+++ b/src/server/models/slack-app-integration.js
@@ -10,9 +10,9 @@ class SlackAppIntegration {
   static generateAccessToken() {
     const hasher1 = crypto.createHash('sha512');
     const hasher2 = crypto.createHash('sha512');
-    const tokenGtoP = hasher1.update(`${new Date().getTime().toString()}proxy`).digest('base64');
-    const tokenPtoG = hasher2.update(`${new Date().getTime().toString()}growi`).digest('base64');
-    return [tokenGtoP, tokenPtoG];
+    const tokenGtoP = hasher1.update(new Date().getTime().toString() + process.env.SALT_FOR_GTOP_TOKEN);
+    const tokenPtoG = hasher2.update(new Date().getTime().toString() + process.env.SALT_FOR_PTOG_TOKEN);
+    return [tokenGtoP.digest('base64'), tokenPtoG.digest('base64')];
   }
 
 }


### PR DESCRIPTION
## 概要
環境変数に ```SALT_FOR_GTOP_TOKEN``` と ```SALT_FOR_PTOG_TOKEN```  を作成し、slack-app-integration.js 内でアクセストークンを作成する際の salt として利用できるようにした。