### PR TITLE
Feat/create endpoint without proxy relation test

### DIFF
--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
@@ -71,7 +71,7 @@ const CustomBotWithoutProxySettingsAccordion = ({
     try {
       // eslint-disable-next-line no-console
       console.log('Test');
-      // const res = await appContainer.apiv3.post('/slack-integration-settings/notification-test-to-slack-work-space', {
+      // const res = await appContainer.apiv3.post('/slack-integration-settings//without-proxy/relation-test', {
       //   channel: testChannel,
       // });
       // setConnectionSuccessMessage(res.data.message);

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
@@ -71,7 +71,7 @@ const CustomBotWithoutProxySettingsAccordion = ({
     try {
       // eslint-disable-next-line no-console
       console.log('Test');
-      // const res = await appContainer.apiv3.post('/slack-integration-settings//without-proxy/relation-test', {
+      // const res = await appContainer.apiv3.post('/slack-integration-settings//without-proxy/test', {
       //   channel: testChannel,
       // });
       // setConnectionSuccessMessage(res.data.message);

--- a/src/server/routes/apiv3/slack-integration-settings.js
+++ b/src/server/routes/apiv3/slack-integration-settings.js
@@ -55,10 +55,6 @@ module.exports = (crowi) => {
       body('currentBotType')
         .isIn(['officialBot', 'customBotWithoutProxy', 'customBotWithProxy']),
     ],
-    NotificationTestToSlackWorkSpace: [
-      body('channel').trim().not().isEmpty()
-        .isString(),
-    ],
     AccessTokens: [
       body('tokenGtoP').trim().not().isEmpty()
         .isString()
@@ -69,6 +65,10 @@ module.exports = (crowi) => {
     ],
     RelationTest: [
       body('slackappintegrationsId').isMongoId(),
+    ],
+    Channel: [
+      body('channel').trim().not().isEmpty()
+        .isString(),
     ],
   };
 
@@ -498,7 +498,7 @@ module.exports = (crowi) => {
    *           200:
    *             description: Succeeded to connect to slack work space.
    */
-  router.post('/without-proxy/relation-test', loginRequiredStrictly, adminRequired, csrf, async(req, res) => {
+  router.post('/without-proxy/relation-test', loginRequiredStrictly, adminRequired, csrf, validator.Channel, apiV3FormValidator, async(req, res) => {
     const currentBotType = crowi.configManager.getConfig('crowi', 'slackbot:currentBotType');
     if (currentBotType !== 'customBotWithoutProxy') {
       const msg = 'Select Without Proxy Type';

--- a/src/server/routes/apiv3/slack-integration-settings.js
+++ b/src/server/routes/apiv3/slack-integration-settings.js
@@ -487,7 +487,7 @@ module.exports = (crowi) => {
     const slackBotToken = crowi.configManager.getConfig('crowi', 'slackbot:token');
     try {
       await relationTestToSlack(slackBotToken);
-      // TODO impl return response after imple  5996 6002
+      // TODO impl return response after imple 5996, 6002
     }
     catch (error) {
       const msg = 'Error occured in sending test message';

--- a/src/server/routes/apiv3/slack-integration-settings.js
+++ b/src/server/routes/apiv3/slack-integration-settings.js
@@ -513,7 +513,7 @@ module.exports = (crowi) => {
     }
     catch (error) {
       logger.error('Error', error);
-      return res.apiv3Err(new ErrorV3(error.message, 'test-failed'));
+      return res.apiv3Err(new ErrorV3(`Error occured while testing. Cause: ${error.message}`, 'test-failed', error.stack));
     }
   });
 

--- a/src/server/routes/apiv3/slack-integration-settings.js
+++ b/src/server/routes/apiv3/slack-integration-settings.js
@@ -438,7 +438,7 @@ module.exports = (crowi) => {
    *    /slack-integration-settings/with-proxy/relation-test:
    *      post:
    *        tags: [botType]
-   *        operationId: postRelationTestWithProxy
+   *        operationId: postRelationTest
    *        summary: /slack-integration/bot-type
    *        description: Delete botType setting.
    *        requestBody:
@@ -481,10 +481,10 @@ module.exports = (crowi) => {
   /**
    * @swagger
    *
-   *    /slack-integration-settings/without-proxy/relation-test:
+   *    /slack-integration-settings/without-proxy/test:
    *      post:
    *        tags: [botType]
-   *        operationId: postRelationTestWithoutProxy
+   *        operationId: postTest
    *        summary: test the connection
    *        description: Test the connection with slack work space.
    *        requestBody:
@@ -498,7 +498,7 @@ module.exports = (crowi) => {
    *           200:
    *             description: Succeeded to connect to slack work space.
    */
-  router.post('/without-proxy/relation-test', loginRequiredStrictly, adminRequired, csrf, validator.SlackChannel, apiV3FormValidator, async(req, res) => {
+  router.post('/without-proxy/test', loginRequiredStrictly, adminRequired, csrf, validator.SlackChannel, apiV3FormValidator, async(req, res) => {
     const currentBotType = crowi.configManager.getConfig('crowi', 'slackbot:currentBotType');
     if (currentBotType !== 'customBotWithoutProxy') {
       const msg = 'Select Without Proxy Type';

--- a/src/server/routes/apiv3/slack-integration-settings.js
+++ b/src/server/routes/apiv3/slack-integration-settings.js
@@ -484,10 +484,10 @@ module.exports = (crowi) => {
       const msg = 'Select Without Proxy Type';
       return res.apiv3Err(new ErrorV3(msg, 'select-not-proxy-type'), 400);
     }
-
     const slackBotToken = crowi.configManager.getConfig('crowi', 'slackbot:token');
     try {
       await relationTestToSlack(slackBotToken);
+      // TODO impl return response after imple  5996 6002
     }
     catch (error) {
       const msg = 'Error occured in sending test message';

--- a/src/server/routes/apiv3/slack-integration-settings.js
+++ b/src/server/routes/apiv3/slack-integration-settings.js
@@ -512,9 +512,8 @@ module.exports = (crowi) => {
       // TODO impl return response after imple 5996, 6002
     }
     catch (error) {
-      const msg = 'Error occured while sending a test message';
       logger.error('Error', error);
-      return res.apiv3Err(new ErrorV3(msg, 'send-message-to-slack-failed'), 500);
+      return res.apiv3Err(new ErrorV3(error, 'send-message-to-slack-failed'));
     }
   });
 

--- a/src/server/routes/apiv3/slack-integration-settings.js
+++ b/src/server/routes/apiv3/slack-integration-settings.js
@@ -504,7 +504,7 @@ module.exports = (crowi) => {
       const msg = 'Select Without Proxy Type';
       return res.apiv3Err(new ErrorV3(msg, 'select-not-proxy-type'), 400);
     }
-    // TODO impl bellow GW-5998
+    // TODO impl req.body at GW-5998
     // const { channel } = req.body;
     const slackBotToken = crowi.configManager.getConfig('crowi', 'slackbot:token');
     try {

--- a/src/server/routes/apiv3/slack-integration-settings.js
+++ b/src/server/routes/apiv3/slack-integration-settings.js
@@ -512,7 +512,7 @@ module.exports = (crowi) => {
       // TODO impl return response after imple 5996, 6002
     }
     catch (error) {
-      const msg = 'Error occured in sending test message';
+      const msg = 'Error occured while sending a test message';
       logger.error('Error', error);
       return res.apiv3Err(new ErrorV3(msg, 'send-message-to-slack-failed'), 500);
     }

--- a/src/server/routes/apiv3/slack-integration-settings.js
+++ b/src/server/routes/apiv3/slack-integration-settings.js
@@ -513,7 +513,7 @@ module.exports = (crowi) => {
     }
     catch (error) {
       logger.error('Error', error);
-      return res.apiv3Err(new ErrorV3(error.message, 'send-message-to-slack-failed'));
+      return res.apiv3Err(new ErrorV3(error.message, 'test-failed'));
     }
   });
 

--- a/src/server/routes/apiv3/slack-integration-settings.js
+++ b/src/server/routes/apiv3/slack-integration-settings.js
@@ -438,7 +438,7 @@ module.exports = (crowi) => {
    *    /slack-integration-settings/with-proxy/relation-test:
    *      post:
    *        tags: [botType]
-   *        operationId: postRelationTest
+   *        operationId: postRelationTestWithProxy
    *        summary: /slack-integration/bot-type
    *        description: Delete botType setting.
    *        requestBody:
@@ -484,7 +484,7 @@ module.exports = (crowi) => {
    *    /slack-integration-settings/without-proxy/relation-test:
    *      post:
    *        tags: [botType]
-   *        operationId: postRelationTest
+   *        operationId: postRelationTestWithoutProxy
    *        summary: test the connection
    *        description: Test the connection with slack work space.
    *        requestBody:

--- a/src/server/routes/apiv3/slack-integration-settings.js
+++ b/src/server/routes/apiv3/slack-integration-settings.js
@@ -478,12 +478,33 @@ module.exports = (crowi) => {
     }
   });
 
+  /**
+   * @swagger
+   *
+   *    /slack-integration-settings/without-proxy/relation-test:
+   *      post:
+   *        tags: [botType]
+   *        operationId: postRelationTest
+   *        summary: test the connection
+   *        description: Test the connection with slack work space.
+   *        requestBody:
+   *          content:
+   *            application/json:
+   *              schema:
+   *                properties:
+   *                  testChannel:
+   *                    type: string
+   *        responses:
+   *           200:
+   *             description: Succeeded to connect to slack work space.
+   */
   router.post('/without-proxy/relation-test', loginRequiredStrictly, adminRequired, csrf, async(req, res) => {
     const currentBotType = crowi.configManager.getConfig('crowi', 'slackbot:currentBotType');
     if (currentBotType !== 'customBotWithoutProxy') {
       const msg = 'Select Without Proxy Type';
       return res.apiv3Err(new ErrorV3(msg, 'select-not-proxy-type'), 400);
     }
+
     const slackBotToken = crowi.configManager.getConfig('crowi', 'slackbot:token');
     try {
       await relationTestToSlack(slackBotToken);

--- a/src/server/routes/apiv3/slack-integration-settings.js
+++ b/src/server/routes/apiv3/slack-integration-settings.js
@@ -504,7 +504,8 @@ module.exports = (crowi) => {
       const msg = 'Select Without Proxy Type';
       return res.apiv3Err(new ErrorV3(msg, 'select-not-proxy-type'), 400);
     }
-
+    // TODO impl bellow GW-5998
+    // const { channel } = req.body;
     const slackBotToken = crowi.configManager.getConfig('crowi', 'slackbot:token');
     try {
       await relationTestToSlack(slackBotToken);

--- a/src/server/routes/apiv3/slack-integration-settings.js
+++ b/src/server/routes/apiv3/slack-integration-settings.js
@@ -5,7 +5,7 @@ const axios = require('axios');
 const urljoin = require('url-join');
 const loggerFactory = require('@alias/logger');
 
-const { getConnectionStatuses } = require('@growi/slack');
+const { getConnectionStatuses, relationTestToSlack } = require('@growi/slack');
 
 const ErrorV3 = require('../../models/vo/error-apiv3');
 
@@ -483,6 +483,16 @@ module.exports = (crowi) => {
     if (currentBotType !== 'customBotWithoutProxy') {
       const msg = 'Select Without Proxy Type';
       return res.apiv3Err(new ErrorV3(msg, 'select-not-proxy-type'), 400);
+    }
+
+    const slackBotToken = crowi.configManager.getConfig('crowi', 'slackbot:token');
+    try {
+      await relationTestToSlack(slackBotToken);
+    }
+    catch (error) {
+      const msg = 'Error occured in sending test message';
+      logger.error('Error', error);
+      return res.apiv3Err(new ErrorV3(msg, 'send-message-to-slack-failed'), 500);
     }
   });
 

--- a/src/server/routes/apiv3/slack-integration-settings.js
+++ b/src/server/routes/apiv3/slack-integration-settings.js
@@ -66,7 +66,7 @@ module.exports = (crowi) => {
     RelationTest: [
       body('slackappintegrationsId').isMongoId(),
     ],
-    Channel: [
+    SlackChannel: [
       body('channel').trim().not().isEmpty()
         .isString(),
     ],
@@ -498,7 +498,7 @@ module.exports = (crowi) => {
    *           200:
    *             description: Succeeded to connect to slack work space.
    */
-  router.post('/without-proxy/relation-test', loginRequiredStrictly, adminRequired, csrf, validator.Channel, apiV3FormValidator, async(req, res) => {
+  router.post('/without-proxy/relation-test', loginRequiredStrictly, adminRequired, csrf, validator.SlackChannel, apiV3FormValidator, async(req, res) => {
     const currentBotType = crowi.configManager.getConfig('crowi', 'slackbot:currentBotType');
     if (currentBotType !== 'customBotWithoutProxy') {
       const msg = 'Select Without Proxy Type';

--- a/src/server/routes/apiv3/slack-integration-settings.js
+++ b/src/server/routes/apiv3/slack-integration-settings.js
@@ -513,7 +513,7 @@ module.exports = (crowi) => {
     }
     catch (error) {
       logger.error('Error', error);
-      return res.apiv3Err(new ErrorV3(error, 'send-message-to-slack-failed'));
+      return res.apiv3Err(new ErrorV3(error.message, 'send-message-to-slack-failed'));
     }
   });
 

--- a/src/server/routes/apiv3/slack-integration-settings.js
+++ b/src/server/routes/apiv3/slack-integration-settings.js
@@ -478,5 +478,13 @@ module.exports = (crowi) => {
     }
   });
 
+  router.post('/without-proxy/relation-test', loginRequiredStrictly, adminRequired, csrf, async(req, res) => {
+    const currentBotType = crowi.configManager.getConfig('crowi', 'slackbot:currentBotType');
+    if (currentBotType !== 'customBotWithoutProxy') {
+      const msg = 'Select Without Proxy Type';
+      return res.apiv3Err(new ErrorV3(msg, 'select-not-proxy-type'), 400);
+    }
+  });
+
   return router;
 };


### PR DESCRIPTION
## 概要
Test ボタンを押したときのエンドポイントを実装しました。
return の処理は GW 5996 と GW 6002 が実装された後に実装する予定です。