### PR TITLE
add slack:botserverUri null

### DIFF
--- a/src/server/routes/apiv3/slack-integration-settings.js
+++ b/src/server/routes/apiv3/slack-integration-settings.js
@@ -77,6 +77,7 @@ module.exports = (crowi) => {
       'slackbot:currentBotType': null,
       'slackbot:signingSecret': null,
       'slackbot:token': null,
+      'slackbot:serverUri': null,
     };
     const { configManager } = crowi;
     // update config without publishing S2sMessage


### PR DESCRIPTION
## 概要
- 考慮漏れです
proxy型 の botType から他の botType に移行するときに、proxy uri を削除する必要がありました。
追加で削除しています。