### PR TITLE
Imprv/gw6038 growi register description

### DIFF
--- a/resource/locales/en_US/admin/admin.json
+++ b/resource/locales/en_US/admin/admin.json
@@ -310,7 +310,7 @@
       "install_now": "Install now",
       "generate_access_token": "Generate Access Token",
       "register_for_growi_official_bot_proxy_service": "Register for GROWI Official Bot Proxy Service",
-      "enter_growi_register_on_slack": "Enter `/growi register` on slack",
+      "enter_growi_register_on_slack": "Enter <b>/growi register</b> on slack",
       "paste_growi_url": "Since a modal is displayed, enter the following URL in <b>GROWI URL</b>.",
       "enter_access_token_for_growi_and_proxy": "Enter <b>Access Token for GROWI</b> and <b>Access Token for Proxy</b>",
       "set_proxy_url_on_growi": "Set Proxy URL on GROWI",

--- a/resource/locales/ja_JP/admin/admin.json
+++ b/resource/locales/ja_JP/admin/admin.json
@@ -307,7 +307,7 @@
       "install_now": "今すぐインストール",
       "generate_access_token": "Access Tokenの発行",
       "register_for_growi_official_bot_proxy_service": "GROWI Official Bot Proxy サービスへの登録",
-      "enter_growi_register_on_slack": "Slack上で <b>/growi register</b> と打つ",
+      "enter_growi_register_on_slack": "Slack上で <b>/growi register</b> と打ちます。",
       "paste_growi_url": "モーダルが表示されるので、<b>GROWI URL</b> には下記のURLを入力します。",
       "enter_access_token_for_growi_and_proxy": "上記で発行した<b>Access Token for GROWI</b> と <b>Access Token for Proxy</b>を入れる",
       "set_proxy_url_on_growi": "ProxyのURLをGROWIに登録する",

--- a/resource/locales/ja_JP/admin/admin.json
+++ b/resource/locales/ja_JP/admin/admin.json
@@ -307,7 +307,7 @@
       "install_now": "今すぐインストール",
       "generate_access_token": "Access Tokenの発行",
       "register_for_growi_official_bot_proxy_service": "GROWI Official Bot Proxy サービスへの登録",
-      "enter_growi_register_on_slack": "Slack上で `/growi register` と打つ",
+      "enter_growi_register_on_slack": "Slack上で <b>/growi register</b> と打つ",
       "paste_growi_url": "モーダルが表示されるので、<b>GROWI URL</b> には下記のURLを入力します。",
       "enter_access_token_for_growi_and_proxy": "上記で発行した<b>Access Token for GROWI</b> と <b>Access Token for Proxy</b>を入れる",
       "set_proxy_url_on_growi": "ProxyのURLをGROWIに登録する",

--- a/resource/locales/zh_CN/admin/admin.json
+++ b/resource/locales/zh_CN/admin/admin.json
@@ -317,7 +317,7 @@
       "install_now": "现在安装",
       "generate_access_token": "生成Access Token",
       "register_for_growi_official_bot_proxy_service": "注册 GROWI Official Bot Proxy Service",
-      "enter_growi_register_on_slack": "在Slack中，输入`/growi register`。",
+      "enter_growi_register_on_slack": "在Slack中，输入 <b>/growi register</b>",
       "paste_growi_url": "由于显示了模式，请在 <b>GROWI URL</b> 中输入以下URL",
       "enter_access_token_for_growi_and_proxy": "插入上面发出的 <b>Access Token for GROWI</b> 和 <b>Access Token for Proxy</b>。",
       "set_proxy_url_on_growi": "向GROWI注册Proxy的URL",

--- a/src/client/js/components/Admin/SlackIntegration/WithProxyAccordions.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/WithProxyAccordions.jsx
@@ -125,12 +125,17 @@ export const GenelatingTokensAndRegisteringProxyServiceProcess = withUnstatedCon
       <p className="font-weight-bold">2. {t('admin:slack_integration.accordion.register_for_growi_official_bot_proxy_service')}</p>
       <div className="d-flex flex-column align-items-center">
         <ol className="p-0">
-          <li><p className="ml-2">{t('admin:slack_integration.accordion.enter_growi_register_on_slack')}</p></li>
+          <li>
+            <p
+              className="ml-2"
+                // eslint-disable-next-line react/no-danger
+              dangerouslySetInnerHTML={{ __html: t('admin:slack_integration.accordion.enter_growi_register_on_slack') }}
+            />
+          </li>
           <li>
             <p
               className="ml-2"
                 // TODO: Add dynamic link
-                // TODO: Copy to clipboard on click
                 // TODO: Add logo
                 // eslint-disable-next-line react/no-danger
               dangerouslySetInnerHTML={{ __html: t('admin:slack_integration.accordion.paste_growi_url') }}


### PR DESCRIPTION
## Task
GW-6038 /growi registerをボールドにし、余分な記号を削除

## 補足
XDでは、背景色をつける予定でしたが、これだけのためにi18nを分離する必要もないかなと考えたのでボールドに変更しました。
後ほどXDも修正します。


## 変更前
<img width="744" alt="Screen Shot 2021-05-24 at 14 12 37" src="https://user-images.githubusercontent.com/59536731/119299594-282dae80-bc9a-11eb-819b-43f57340d52c.png">

## 変更後
<img width="652" alt="Screen Shot 2021-05-24 at 14 12 08" src="https://user-images.githubusercontent.com/59536731/119299581-2237cd80-bc9a-11eb-96b4-b1638bd79f2a.png">

## XD
<img width="743" alt="Screen Shot 2021-05-24 at 14 16 29" src="https://user-images.githubusercontent.com/59536731/119299828-a8541400-bc9a-11eb-90ed-1b129e11fa2c.png">

