### PR TITLE
Imprv/switch display by passing test

### DIFF
--- a/packages/slack/src/utils/check-communicable.ts
+++ b/packages/slack/src/utils/check-communicable.ts
@@ -49,7 +49,7 @@ const checkSlackScopes = (resultTestSlackApiServer: any) => {
   const isPassedScopeCheck = correctScopes.every(e => slackScopes.includes(e));
 
   if (!isPassedScopeCheck) {
-    throw new Error('Scope error');
+    throw new Error('The scopes is not appropriate. Required scopes is [Rcommands], [team:read], and [chat:write].');
   }
 };
 

--- a/packages/slack/src/utils/check-communicable.ts
+++ b/packages/slack/src/utils/check-communicable.ts
@@ -46,12 +46,11 @@ const testSlackApiServer = async(client: WebClient): Promise<any> => {
 const checkSlackScopes = (resultTestSlackApiServer: any) => {
   const slackScopes = resultTestSlackApiServer.response_metadata.scopes;
   const correctScopes = ['commands', 'team:read', 'chat:write'];
+  const isPassedScopeCheck = correctScopes.every(e => slackScopes.includes(e));
 
-  if (correctScopes.every(e => slackScopes.includes(e))) {
-    return;
+  if (!isPassedScopeCheck) {
+    throw new Error('Scope error');
   }
-
-  throw new Error('Scope error');
 };
 
 /**

--- a/packages/slack/src/utils/check-communicable.ts
+++ b/packages/slack/src/utils/check-communicable.ts
@@ -94,8 +94,17 @@ export const getConnectionStatuses = async(tokens: string[]): Promise<{[key: str
  * @param token bot OAuth token
  * @returns
  */
-export const relationTestToSlack = async(token:string): Promise<void> => {
+export const testToSlack = async(token:string, channel:string): Promise<void> => {
   const client = generateWebClient(token);
-  // TODO GW-6002 fire chat.postMessage
-  await testSlackApiServer(client);
+  try {
+    await testSlackApiServer(client);
+    await client.chat.postMessage({
+      channel,
+      text: 'Your test was successful!',
+    });
+  }
+  catch (error) {
+    console.log(error);
+  }
+
 };

--- a/packages/slack/src/utils/check-communicable.ts
+++ b/packages/slack/src/utils/check-communicable.ts
@@ -111,3 +111,11 @@ export const testToSlack = async(token:string): Promise<void> => {
   const res = await testSlackApiServer(client);
   await checkSlackScopes(res);
 };
+
+export const sendSuccessMessage = async(token:string, channel:string, appSiteUrl:string): Promise<void> => {
+  const client = generateWebClient(token);
+  await client.chat.postMessage({
+    channel,
+    text: `Successfully tested with ${appSiteUrl}.`,
+  });
+};

--- a/packages/slack/src/utils/check-communicable.ts
+++ b/packages/slack/src/utils/check-communicable.ts
@@ -43,12 +43,15 @@ const testSlackApiServer = async(client: WebClient): Promise<any> => {
   return result;
 };
 
-const checkSlackScope = (result: any) => {
-  const slackScope = result.response_metadata.scopes;
+const checkSlackScopes = (result: any) => {
+  const slackScopes = result.response_metadata.scopes;
+  const correctScopes = ['commands', 'team:read', 'chat:write'];
 
-  if (!slackScope.includes('commands', 'team:read', 'chat:write')) {
-    throw new Error('Scope error');
+  if (correctScopes.every(e => slackScopes.includes(e))) {
+    return;
   }
+
+  throw new Error('Scope error');
 };
 
 /**
@@ -79,8 +82,7 @@ export const getConnectionStatuses = async(tokens: string[]): Promise<{[key: str
         const status: ConnectionStatus = {};
         try {
           // try to connect
-          const res = await testSlackApiServer(client);
-          await checkSlackScope(res);
+          await testSlackApiServer(client);
           // retrieve workspace name
           status.workspaceName = await retrieveWorkspaceName(client);
         }
@@ -108,5 +110,5 @@ export const getConnectionStatuses = async(tokens: string[]): Promise<{[key: str
 export const testToSlack = async(token:string): Promise<void> => {
   const client = generateWebClient(token);
   const res = await testSlackApiServer(client);
-  await checkSlackScope(res);
+  await checkSlackScopes(res);
 };

--- a/packages/slack/src/utils/check-communicable.ts
+++ b/packages/slack/src/utils/check-communicable.ts
@@ -43,8 +43,8 @@ const testSlackApiServer = async(client: WebClient): Promise<any> => {
   return result;
 };
 
-const checkSlackScopes = (result: any) => {
-  const slackScopes = result.response_metadata.scopes;
+const checkSlackScopes = (resultTestSlackApiServer: any) => {
+  const slackScopes = resultTestSlackApiServer.response_metadata.scopes;
   const correctScopes = ['commands', 'team:read', 'chat:write'];
 
   if (correctScopes.every(e => slackScopes.includes(e))) {

--- a/packages/slack/src/utils/check-communicable.ts
+++ b/packages/slack/src/utils/check-communicable.ts
@@ -49,7 +49,7 @@ const checkSlackScopes = (resultTestSlackApiServer: any) => {
   const isPassedScopeCheck = correctScopes.every(e => slackScopes.includes(e));
 
   if (!isPassedScopeCheck) {
-    throw new Error('The scopes is not appropriate. Required scopes is [Rcommands], [team:read], and [chat:write].');
+    throw new Error('The scopes is not appropriate. Required scopes is [\'commands\', \'team:read\', \'chat:write\']');
   }
 };
 

--- a/packages/slack/src/utils/check-communicable.ts
+++ b/packages/slack/src/utils/check-communicable.ts
@@ -39,6 +39,7 @@ const testSlackApiServer = async(client: WebClient): Promise<void> => {
   if (!result.ok) {
     throw new Error(result.error);
   }
+  console.log(result);
 };
 
 /**
@@ -94,14 +95,10 @@ export const getConnectionStatuses = async(tokens: string[]): Promise<{[key: str
  * @param token bot OAuth token
  * @returns
  */
-export const testToSlack = async(token:string, channel:string): Promise<void> => {
+export const testToSlack = async(token:string): Promise<void> => {
   const client = generateWebClient(token);
   try {
     await testSlackApiServer(client);
-    await client.chat.postMessage({
-      channel,
-      text: 'Your test was successful!',
-    });
   }
   catch (error) {
     console.log(error);

--- a/packages/slackbot-proxy/src/controllers/growi-to-slack.ts
+++ b/packages/slackbot-proxy/src/controllers/growi-to-slack.ts
@@ -104,7 +104,15 @@ export class GrowiToSlackCtrl {
         logger.error(err);
         return res.status(400).send({ message: `failed to request to GROWI. err: ${err.message}` });
       }
-      await testToSlack(token);
+
+      try {
+        await testToSlack(token);
+      }
+      catch (err) {
+        logger.error(err);
+        return res.status(400).send({ message: `failed to test. err: ${err.message}` });
+      }
+
       return res.send({ relation });
     }
 
@@ -135,7 +143,13 @@ export class GrowiToSlackCtrl {
       return res.status(400).send({ message: 'installation is invalid' });
     }
 
-    await testToSlack(token);
+    try {
+      await testToSlack(token);
+    }
+    catch (err) {
+      logger.error(err);
+      return res.status(400).send({ message: `failed to test. err: ${err.message}` });
+    }
 
     logger.debug('relation test is success', order);
 

--- a/packages/slackbot-proxy/src/controllers/growi-to-slack.ts
+++ b/packages/slackbot-proxy/src/controllers/growi-to-slack.ts
@@ -5,7 +5,7 @@ import axios from 'axios';
 
 import { WebAPICallResult } from '@slack/web-api';
 
-import { verifyGrowiToSlackRequest, getConnectionStatuses, relationTestToSlack } from '@growi/slack';
+import { verifyGrowiToSlackRequest, getConnectionStatuses, testToSlack } from '@growi/slack';
 
 import { GrowiReq } from '~/interfaces/growi-to-slack/growi-req';
 import { InstallationRepository } from '~/repositories/installation';
@@ -84,7 +84,7 @@ export class GrowiToSlackCtrl {
         return res.status(400).send({ message: 'installation is invalid' });
       }
 
-      await relationTestToSlack(token);
+      await testToSlack(token);
       return res.send({ relation });
     }
 
@@ -119,7 +119,7 @@ export class GrowiToSlackCtrl {
       return res.status(400).send({ message: 'installation is invalid' });
     }
 
-    await relationTestToSlack(token);
+    await testToSlack(token);
 
     logger.debug('relation test is success', order);
 

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
@@ -11,7 +11,7 @@ const CustomBotWithoutProxyIntegrationCard = (props) => {
       <div className="card rounded shadow border-0 w-50 admin-bot-card mb-0">
         <h5 className="card-title font-weight-bold mt-3 ml-4">Slack</h5>
         <div className="card-body p-2 w-50 mx-auto">
-          {props.slackWSNameInWithoutProxy != null && (
+          {props.isIntegrationSuccess && props.slackWSNameInWithoutProxy != null && (
             <div className="card slack-work-space-name-card">
               <div className="m-2 text-center">
                 <h5 className="font-weight-bold">{props.slackWSNameInWithoutProxy}</h5>

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
@@ -72,48 +72,6 @@ const CustomBotWithoutProxyIntegrationCard = (props) => {
            </>
          )
         }
-
-
-        {/* <div className="d-none d-lg-block">
-          {props.isIntegrationSuccess ? (
-            <>
-              <p className="text-success small mt-5">
-                <i className="fa fa-check mr-1" />
-                {t('admin:slack_integration.integration_sentence.integration_successful')}
-              </p>
-              <hr className="align-self-center admin-border-success border-success"></hr>
-            </>
-          )
-          : (
-            <>
-              <p className="mt-4">
-                <small
-                  className="text-danger m-0"
-            // eslint-disable-next-line react/no-danger
-                  dangerouslySetInnerHTML={{ __html: t('admin:slack_integration.integration_sentence.integration_is_not_complete') }}
-                />
-              </p>
-              <hr className="align-self-center admin-border-danger border-danger"></hr>
-            </>
-            )
-          }
-        </div> */}
-
-        {/* <div id="integration-line-for-tooltip" className="d-block d-lg-none mt-5">
-          {props.isIntegrationSuccess ? (
-            <>
-              <i className="fa fa-check mr-1 text-success" />
-              <hr className="align-self-center admin-border-success border-success"></hr>
-            </>
-            )
-            : (
-              <>
-                <i className="icon-info text-danger" />
-                <hr className="align-self-center admin-border-danger border-danger"></hr>
-              </>
-            )
-          }
-        </div> */}
       </div>
 
       <div className="card rounded-lg shadow border-0 w-50 admin-bot-card mb-0">
@@ -122,22 +80,6 @@ const CustomBotWithoutProxyIntegrationCard = (props) => {
           <div className="btn btn-primary">{ props.siteName }</div>
         </div>
       </div>
-
-      {/* <UncontrolledTooltip placement="top" fade={false} target="integration-line-for-tooltip">
-        {props.isIntegrationSuccess ? (
-          <small>
-            {t('admin:slack_integration.integration_sentence.integration_successful')}
-          </small>
-          )
-          : (
-            <small
-              className="m-0"
-              // eslint-disable-next-line react/no-danger
-              dangerouslySetInnerHTML={{ __html: t('admin:slack_integration.integration_sentence.integration_is_not_complete') }}
-            />
-          )
-        }
-      </UncontrolledTooltip> */}
     </div>
   );
 };

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
@@ -25,7 +25,6 @@ const CustomBotWithoutProxyIntegrationCard = (props) => {
       </div>
 
       <div className="text-center w-25">
-
         <div className="d-none d-lg-block">
           {props.isIntegrationSuccess ? (
             <>
@@ -89,8 +88,6 @@ const CustomBotWithoutProxyIntegrationCard = (props) => {
             />
           )
         }
-
-
       </UncontrolledTooltip>
     </div>
   );

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
@@ -23,23 +23,27 @@ const CustomBotWithoutProxyIntegrationCard = (props) => {
       </div>
 
       <div className="text-center w-25">
-        {/* TODO apply correct condition GW-5895 */}
-        <div className="mt-4">
-          <small
-            className="text-secondary m-0"
-                // eslint-disable-next-line react/no-danger
-            dangerouslySetInnerHTML={{ __html: t('admin:slack_integration.integration_sentence.integration_is_not_complete') }}
-          />
-          <hr className="align-self-center admin-border-danger border-danger"></hr>
-        </div>
-
-        <div className="mt-5">
-          <p className="text-success small">
-            <i className="fa fa-check mr-1" />
-            {t('admin:slack_integration.integration_sentence.integration_successful')}
-          </p>
-          <hr className="align-self-center admin-border-success border-success"></hr>
-        </div>
+        {props.isIntegrationSuccess
+          ? (
+            <div className="mt-5">
+              <p className="text-success small">
+                <i className="fa fa-check mr-1" />
+                {t('admin:slack_integration.integration_sentence.integration_successful')}
+              </p>
+              <hr className="align-self-center admin-border-success border-success"></hr>
+            </div>
+          )
+          : (
+            <div className="mt-4">
+              <small
+                className="text-secondary m-0"
+                  // eslint-disable-next-line react/no-danger
+                dangerouslySetInnerHTML={{ __html: t('admin:slack_integration.integration_sentence.integration_is_not_complete') }}
+              />
+              <hr className="align-self-center admin-border-danger border-danger"></hr>
+            </div>
+          )
+        }
 
       </div>
 
@@ -56,6 +60,7 @@ const CustomBotWithoutProxyIntegrationCard = (props) => {
 CustomBotWithoutProxyIntegrationCard.propTypes = {
   siteName: PropTypes.string.isRequired,
   slackWSNameInWithoutProxy: PropTypes.string,
+  isIntegrationSuccess: PropTypes.bool,
 };
 
 export default CustomBotWithoutProxyIntegrationCard;

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
@@ -4,9 +4,63 @@ import PropTypes from 'prop-types';
 
 import { UncontrolledTooltip } from 'reactstrap';
 
-const CustomBotWithoutProxyIntegrationCard = (props) => {
-
+const IntegrationSuccess = () => {
   const { t } = useTranslation();
+
+  return (
+    <>
+      <div className="d-none d-lg-block">
+        <p className="text-success small mt-5">
+          <i className="fa fa-check mr-1" />
+          {t('admin:slack_integration.integration_sentence.integration_successful')}
+        </p>
+        <hr className="align-self-center admin-border-success border-success"></hr>
+      </div>
+      <div id="integration-line-for-tooltip" className="d-block d-lg-none mt-5">
+        <i className="fa fa-check mr-1 text-success" />
+        <hr className="align-self-center admin-border-success border-success"></hr>
+      </div>
+      <UncontrolledTooltip placement="top" fade={false} target="integration-line-for-tooltip">
+        <small>
+          {t('admin:slack_integration.integration_sentence.integration_successful')}
+        </small>
+      </UncontrolledTooltip>
+    </>
+  );
+};
+
+const IntegrationFailed = () => {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <div className="d-none d-lg-block">
+        <p className="mt-4">
+          <small
+            className="text-danger m-0"
+          // eslint-disable-next-line react/no-danger
+            dangerouslySetInnerHTML={{ __html: t('admin:slack_integration.integration_sentence.integration_is_not_complete') }}
+          />
+        </p>
+        <hr className="align-self-center admin-border-danger border-danger"></hr>
+
+      </div>
+      <div id="integration-line-for-tooltip" className="d-block d-lg-none mt-5">
+        <i className="icon-info text-danger" />
+        <hr className="align-self-center admin-border-danger border-danger"></hr>
+      </div>
+      <UncontrolledTooltip placement="top" fade={false} target="integration-line-for-tooltip">
+        <small
+          className="m-0"
+        // eslint-disable-next-line react/no-danger
+          dangerouslySetInnerHTML={{ __html: t('admin:slack_integration.integration_sentence.integration_is_not_complete') }}
+        />
+      </UncontrolledTooltip>
+    </>
+  );
+};
+
+const CustomBotWithoutProxyIntegrationCard = (props) => {
 
   return (
     <div className="d-flex justify-content-center my-5 bot-integration">
@@ -25,53 +79,7 @@ const CustomBotWithoutProxyIntegrationCard = (props) => {
       </div>
 
       <div className="text-center w-25">
-
-        {props.isIntegrationSuccess ? (
-          <>
-            <div className="d-none d-lg-block">
-              <p className="text-success small mt-5">
-                <i className="fa fa-check mr-1" />
-                {t('admin:slack_integration.integration_sentence.integration_successful')}
-              </p>
-              <hr className="align-self-center admin-border-success border-success"></hr>
-            </div>
-            <div id="integration-line-for-tooltip" className="d-block d-lg-none mt-5">
-              <i className="fa fa-check mr-1 text-success" />
-              <hr className="align-self-center admin-border-success border-success"></hr>
-            </div>
-            <UncontrolledTooltip placement="top" fade={false} target="integration-line-for-tooltip">
-              <small>
-                {t('admin:slack_integration.integration_sentence.integration_successful')}
-              </small>
-            </UncontrolledTooltip>
-          </>
-         ) : (
-           <>
-             <div className="d-none d-lg-block">
-               <p className="mt-4">
-                 <small
-                   className="text-danger m-0"
-                   // eslint-disable-next-line react/no-danger
-                   dangerouslySetInnerHTML={{ __html: t('admin:slack_integration.integration_sentence.integration_is_not_complete') }}
-                 />
-               </p>
-               <hr className="align-self-center admin-border-danger border-danger"></hr>
-
-             </div>
-             <div id="integration-line-for-tooltip" className="d-block d-lg-none mt-5">
-               <i className="icon-info text-danger" />
-               <hr className="align-self-center admin-border-danger border-danger"></hr>
-             </div>
-             <UncontrolledTooltip placement="top" fade={false} target="integration-line-for-tooltip">
-               <small
-                 className="m-0"
-                 // eslint-disable-next-line react/no-danger
-                 dangerouslySetInnerHTML={{ __html: t('admin:slack_integration.integration_sentence.integration_is_not_complete') }}
-               />
-             </UncontrolledTooltip>
-           </>
-         )
-        }
+        {props.isIntegrationSuccess ? <IntegrationSuccess /> : <IntegrationFailed />}
       </div>
 
       <div className="card rounded-lg shadow border-0 w-50 admin-bot-card mb-0">

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
@@ -44,7 +44,6 @@ const CustomBotWithoutProxyIntegrationCard = (props) => {
             </div>
           )
         }
-
       </div>
 
       <div className="card rounded-lg shadow border-0 w-50 admin-bot-card mb-0">

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
@@ -25,7 +25,56 @@ const CustomBotWithoutProxyIntegrationCard = (props) => {
       </div>
 
       <div className="text-center w-25">
-        <div className="d-none d-lg-block">
+
+        {props.isIntegrationSuccess ? (
+          <>
+            <div className="d-none d-lg-block">
+              <p className="text-success small mt-5">
+                <i className="fa fa-check mr-1" />
+                {t('admin:slack_integration.integration_sentence.integration_successful')}
+              </p>
+              <hr className="align-self-center admin-border-success border-success"></hr>
+            </div>
+            <div id="integration-line-for-tooltip" className="d-block d-lg-none mt-5">
+              <i className="fa fa-check mr-1 text-success" />
+              <hr className="align-self-center admin-border-success border-success"></hr>
+            </div>
+            <UncontrolledTooltip placement="top" fade={false} target="integration-line-for-tooltip">
+              <small>
+                {t('admin:slack_integration.integration_sentence.integration_successful')}
+              </small>
+            </UncontrolledTooltip>
+          </>
+         ) : (
+           <>
+             <div className="d-none d-lg-block">
+               <p className="mt-4">
+                 <small
+                   className="text-danger m-0"
+                   // eslint-disable-next-line react/no-danger
+                   dangerouslySetInnerHTML={{ __html: t('admin:slack_integration.integration_sentence.integration_is_not_complete') }}
+                 />
+               </p>
+               <hr className="align-self-center admin-border-danger border-danger"></hr>
+
+             </div>
+             <div id="integration-line-for-tooltip" className="d-block d-lg-none mt-5">
+               <i className="icon-info text-danger" />
+               <hr className="align-self-center admin-border-danger border-danger"></hr>
+             </div>
+             <UncontrolledTooltip placement="top" fade={false} target="integration-line-for-tooltip">
+               <small
+                 className="m-0"
+                 // eslint-disable-next-line react/no-danger
+                 dangerouslySetInnerHTML={{ __html: t('admin:slack_integration.integration_sentence.integration_is_not_complete') }}
+               />
+             </UncontrolledTooltip>
+           </>
+         )
+        }
+
+
+        {/* <div className="d-none d-lg-block">
           {props.isIntegrationSuccess ? (
             <>
               <p className="text-success small mt-5">
@@ -48,9 +97,9 @@ const CustomBotWithoutProxyIntegrationCard = (props) => {
             </>
             )
           }
-        </div>
+        </div> */}
 
-        <div id="integration-line-for-tooltip" className="d-block d-lg-none mt-5">
+        {/* <div id="integration-line-for-tooltip" className="d-block d-lg-none mt-5">
           {props.isIntegrationSuccess ? (
             <>
               <i className="fa fa-check mr-1 text-success" />
@@ -64,7 +113,7 @@ const CustomBotWithoutProxyIntegrationCard = (props) => {
               </>
             )
           }
-        </div>
+        </div> */}
       </div>
 
       <div className="card rounded-lg shadow border-0 w-50 admin-bot-card mb-0">
@@ -74,7 +123,7 @@ const CustomBotWithoutProxyIntegrationCard = (props) => {
         </div>
       </div>
 
-      <UncontrolledTooltip placement="top" fade={false} target="integration-line-for-tooltip">
+      {/* <UncontrolledTooltip placement="top" fade={false} target="integration-line-for-tooltip">
         {props.isIntegrationSuccess ? (
           <small>
             {t('admin:slack_integration.integration_sentence.integration_successful')}
@@ -88,7 +137,7 @@ const CustomBotWithoutProxyIntegrationCard = (props) => {
             />
           )
         }
-      </UncontrolledTooltip>
+      </UncontrolledTooltip> */}
     </div>
   );
 };

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -15,7 +15,7 @@ const CustomBotWithoutProxySettings = (props) => {
   const [siteName, setSiteName] = useState('');
   const [isDeleteConfirmModalShown, setIsDeleteConfirmModalShown] = useState(false);
   const [isIntegrationSuccess, setIsIntegrationSuccess] = useState(false);
-  const [connectionMessage, setConnectionMessage] = useState(null);
+  const [connectionMessage, setConnectionMessage] = useState('');
   const [connectionErrorCode, setConnectionErrorCode] = useState(null);
   const [testChannel, setTestChannel] = useState('');
 

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -9,12 +9,15 @@ import CustomBotWithoutProxyIntegrationCard from './CustomBotWithoutProxyIntegra
 import DeleteSlackBotSettingsModal from './DeleteSlackBotSettingsModal';
 
 const CustomBotWithoutProxySettings = (props) => {
-  const { appContainer, onResetSettings } = props;
+  const { appContainer, onResetSettings, onSetIsSendTestMessage } = props;
   const { t } = useTranslation();
 
   const [siteName, setSiteName] = useState('');
   const [isDeleteConfirmModalShown, setIsDeleteConfirmModalShown] = useState(false);
   const [isIntegrationSuccess, setIsIntegrationSuccess] = useState(false);
+  const [connectionMessage, setConnectionMessage] = useState(null);
+  const [connectionErrorCode, setConnectionErrorCode] = useState(null);
+  const [testChannel, setTestChannel] = useState('');
 
   const resetSettings = async() => {
     if (onResetSettings == null) {
@@ -25,20 +28,23 @@ const CustomBotWithoutProxySettings = (props) => {
 
   const testConnection = async() => {
     setConnectionErrorCode(null);
-    setConnectionErrorMessage(null);
-    setConnectionSuccessMessage(null);
+    setConnectionMessage(null);
     try {
       await appContainer.apiv3.post('/slack-integration-settings/without-proxy/test', { channel: testChannel });
-      setConnectionSuccessMessage('Send to message to slack ws.');
+      setConnectionMessage('Send message to slack ws.');
       onSetIsSendTestMessage(true);
-      onSetIsIntegrationSuccess(true);
+      setIsIntegrationSuccess(true);
     }
     catch (err) {
       setConnectionErrorCode(err[0].code);
-      setConnectionErrorMessage(err[0].message);
+      setConnectionMessage(err[0].message);
       onSetIsSendTestMessage(false);
-      onSetIsIntegrationSuccess(false);
+      setIsIntegrationSuccess(false);
     }
+  };
+
+  const inputTestChannelHandler = (channel) => {
+    setTestChannel(channel);
   };
 
   useEffect(() => {
@@ -71,6 +77,11 @@ const CustomBotWithoutProxySettings = (props) => {
         <CustomBotWithoutProxySettingsAccordion
           {...props}
           activeStep={botInstallationStep.CREATE_BOT}
+          onTestConnection={testConnection}
+          onInputTestChannelHandler={inputTestChannelHandler}
+          connectionMessage={connectionMessage}
+          connectionErrorCode={connectionErrorCode}
+          testChannel={testChannel}
         />
       </div>
       <DeleteSlackBotSettingsModal
@@ -96,6 +107,7 @@ CustomBotWithoutProxySettings.propTypes = {
   isIntegrationSuccess: PropTypes.bool,
   slackWSNameInWithoutProxy: PropTypes.string,
   onResetSettings: PropTypes.func,
+  onSetIsSendTestMessage: PropTypes.func,
 };
 
 export default CustomBotWithoutProxySettingsWrapper;

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -79,7 +79,7 @@ const CustomBotWithoutProxySettings = (props) => {
           connectionErrorCode={connectionErrorCode}
           isIntegrationSuccess={isIntegrationSuccess}
           testChannel={testChannel}
-          testConnection={testConnection}
+          onTestFormSubmitted={testConnection}
           inputTestChannelHandler={inputTestChannelHandler}
 
         />

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -9,7 +9,7 @@ import CustomBotWithoutProxyIntegrationCard from './CustomBotWithoutProxyIntegra
 import DeleteSlackBotSettingsModal from './DeleteSlackBotSettingsModal';
 
 const CustomBotWithoutProxySettings = (props) => {
-  const { appContainer, onResetSettings, onSetIsSendTestMessage } = props;
+  const { appContainer, onResetSettings } = props;
   const { t } = useTranslation();
 
   const [siteName, setSiteName] = useState('');
@@ -32,13 +32,11 @@ const CustomBotWithoutProxySettings = (props) => {
     try {
       await appContainer.apiv3.post('/slack-integration-settings/without-proxy/test', { channel: testChannel });
       setConnectionMessage('Send the message to slack work space.');
-      onSetIsSendTestMessage(true);
       setIsIntegrationSuccess(true);
     }
     catch (err) {
       setConnectionErrorCode(err[0].code);
       setConnectionMessage(err[0].message);
-      onSetIsSendTestMessage(false);
       setIsIntegrationSuccess(false);
     }
   };
@@ -79,6 +77,7 @@ const CustomBotWithoutProxySettings = (props) => {
           activeStep={botInstallationStep.CREATE_BOT}
           connectionMessage={connectionMessage}
           connectionErrorCode={connectionErrorCode}
+          isIntegrationSuccess={isIntegrationSuccess}
           testChannel={testChannel}
           testConnection={testConnection}
           inputTestChannelHandler={inputTestChannelHandler}
@@ -108,7 +107,6 @@ CustomBotWithoutProxySettings.propTypes = {
   isIntegrationSuccess: PropTypes.bool,
   slackWSNameInWithoutProxy: PropTypes.string,
   onResetSettings: PropTypes.func,
-  onSetIsSendTestMessage: PropTypes.func,
 };
 
 export default CustomBotWithoutProxySettingsWrapper;

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -43,10 +43,6 @@ const CustomBotWithoutProxySettings = (props) => {
     }
   };
 
-  const inputTestChannelHandler = (channel) => {
-    setTestChannel(channel);
-  };
-
   useEffect(() => {
     const siteName = appContainer.config.crowi.title;
     setSiteName(siteName);
@@ -77,11 +73,12 @@ const CustomBotWithoutProxySettings = (props) => {
         <CustomBotWithoutProxySettingsAccordion
           {...props}
           activeStep={botInstallationStep.CREATE_BOT}
-          onTestConnection={testConnection}
-          onInputTestChannelHandler={inputTestChannelHandler}
           connectionMessage={connectionMessage}
           connectionErrorCode={connectionErrorCode}
           testChannel={testChannel}
+          onTestConnection={testConnection}
+          onSetTestChannel={setTestChannel}
+
         />
       </div>
       <DeleteSlackBotSettingsModal

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -14,6 +14,7 @@ const CustomBotWithoutProxySettings = (props) => {
 
   const [siteName, setSiteName] = useState('');
   const [isDeleteConfirmModalShown, setIsDeleteConfirmModalShown] = useState(false);
+  const [isIntegrationSuccess, setIsIntegrationSuccess] = useState(false);
 
   const resetSettings = async() => {
     if (onResetSettings == null) {

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -27,8 +27,8 @@ const CustomBotWithoutProxySettings = (props) => {
   };
 
   const testConnection = async() => {
-    setConnectionMessage(null);
     setConnectionErrorCode(null);
+    setConnectionMessage(null);
     try {
       await appContainer.apiv3.post('/slack-integration-settings/without-proxy/test', { channel: testChannel });
       setConnectionMessage('Send the message to slack ws.');

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -31,7 +31,7 @@ const CustomBotWithoutProxySettings = (props) => {
     setConnectionMessage(null);
     try {
       await appContainer.apiv3.post('/slack-integration-settings/without-proxy/test', { channel: testChannel });
-      setConnectionMessage('Send the message to slack ws.');
+      setConnectionMessage('Send the message to slack work space.');
       onSetIsSendTestMessage(true);
       setIsIntegrationSuccess(true);
     }

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -43,6 +43,10 @@ const CustomBotWithoutProxySettings = (props) => {
     }
   };
 
+  const inputTestChannelHandler = (channel) => {
+    setTestChannel(channel);
+  };
+
   useEffect(() => {
     const siteName = appContainer.config.crowi.title;
     setSiteName(siteName);
@@ -77,7 +81,7 @@ const CustomBotWithoutProxySettings = (props) => {
           connectionErrorCode={connectionErrorCode}
           testChannel={testChannel}
           testConnection={testConnection}
-          onSetTestChannel={setTestChannel}
+          inputTestChannelHandler={inputTestChannelHandler}
 
         />
       </div>

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -9,7 +9,7 @@ import CustomBotWithoutProxyIntegrationCard from './CustomBotWithoutProxyIntegra
 import DeleteSlackBotSettingsModal from './DeleteSlackBotSettingsModal';
 
 const CustomBotWithoutProxySettings = (props) => {
-  const { appContainer, onResetSettings, isIntegrationSuccess } = props;
+  const { appContainer, onResetSettings } = props;
   const { t } = useTranslation();
 
   const [siteName, setSiteName] = useState('');
@@ -21,6 +21,24 @@ const CustomBotWithoutProxySettings = (props) => {
       return;
     }
     onResetSettings();
+  };
+
+  const testConnection = async() => {
+    setConnectionErrorCode(null);
+    setConnectionErrorMessage(null);
+    setConnectionSuccessMessage(null);
+    try {
+      await appContainer.apiv3.post('/slack-integration-settings/without-proxy/test', { channel: testChannel });
+      setConnectionSuccessMessage('Send to message to slack ws.');
+      onSetIsSendTestMessage(true);
+      onSetIsIntegrationSuccess(true);
+    }
+    catch (err) {
+      setConnectionErrorCode(err[0].code);
+      setConnectionErrorMessage(err[0].message);
+      onSetIsSendTestMessage(false);
+      onSetIsIntegrationSuccess(false);
+    }
   };
 
   useEffect(() => {

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -76,7 +76,7 @@ const CustomBotWithoutProxySettings = (props) => {
           connectionMessage={connectionMessage}
           connectionErrorCode={connectionErrorCode}
           testChannel={testChannel}
-          onTestConnection={testConnection}
+          testConnection={testConnection}
           onSetTestChannel={setTestChannel}
 
         />

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -27,11 +27,11 @@ const CustomBotWithoutProxySettings = (props) => {
   };
 
   const testConnection = async() => {
-    setConnectionErrorCode(null);
     setConnectionMessage(null);
+    setConnectionErrorCode(null);
     try {
       await appContainer.apiv3.post('/slack-integration-settings/without-proxy/test', { channel: testChannel });
-      setConnectionMessage('Send message to slack ws.');
+      setConnectionMessage('Send the message to slack ws.');
       onSetIsSendTestMessage(true);
       setIsIntegrationSuccess(true);
     }

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -9,7 +9,7 @@ import CustomBotWithoutProxyIntegrationCard from './CustomBotWithoutProxyIntegra
 import DeleteSlackBotSettingsModal from './DeleteSlackBotSettingsModal';
 
 const CustomBotWithoutProxySettings = (props) => {
-  const { appContainer, onResetSettings } = props;
+  const { appContainer, onResetSettings, isIntegrationSuccess } = props;
   const { t } = useTranslation();
 
   const [siteName, setSiteName] = useState('');
@@ -34,6 +34,7 @@ const CustomBotWithoutProxySettings = (props) => {
       <CustomBotWithoutProxyIntegrationCard
         siteName={siteName}
         slackWSNameInWithoutProxy={props.slackWSNameInWithoutProxy}
+        isIntegrationSuccess={isIntegrationSuccess}
       />
 
       <h2 className="admin-setting-header">{t('admin:slack_integration.custom_bot_without_proxy_settings')}</h2>
@@ -73,6 +74,7 @@ CustomBotWithoutProxySettings.propTypes = {
   slackBotToken: PropTypes.string,
   slackBotTokenEnv: PropTypes.string,
   isRgisterSlackCredentials: PropTypes.bool,
+  isIntegrationSuccess: PropTypes.bool,
   slackWSNameInWithoutProxy: PropTypes.string,
   onResetSettings: PropTypes.func,
 };

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
@@ -16,19 +16,15 @@ export const botInstallationStep = {
 };
 
 const CustomBotWithoutProxySettingsAccordion = ({
-  appContainer, activeStep, fetchSlackIntegrationData,
+  appContainer, activeStep, fetchSlackIntegrationData, connectionMessage, connectionErrorCode, testChannel,
   slackSigningSecret, slackSigningSecretEnv, slackBotToken, slackBotTokenEnv,
   isRegisterSlackCredentials, isSendTestMessage,
-  onSetSlackSigningSecret, onSetSlackBotToken, onSetIsSendTestMessage, onSetIsIntegrationSuccess,
+  onSetSlackSigningSecret, onSetSlackBotToken, onTestConnection, onInputTestChannelHandler,
 }) => {
   const { t } = useTranslation();
   // TODO: GW-5644 Store default open accordion
   // eslint-disable-next-line no-unused-vars
   const [defaultOpenAccordionKeys, setDefaultOpenAccordionKeys] = useState(new Set([activeStep]));
-  const [connectionErrorCode, setConnectionErrorCode] = useState(null);
-  const [connectionErrorMessage, setConnectionErrorMessage] = useState(null);
-  const [connectionSuccessMessage, setConnectionSuccessMessage] = useState(null);
-  const [testChannel, setTestChannel] = useState('');
   const currentBotType = 'customBotWithoutProxy';
 
 
@@ -63,39 +59,19 @@ const CustomBotWithoutProxySettingsAccordion = ({
     }
   };
 
-  const testConnection = async() => {
-    setConnectionErrorCode(null);
-    setConnectionErrorMessage(null);
-    setConnectionSuccessMessage(null);
-    try {
-      await appContainer.apiv3.post('/slack-integration-settings/without-proxy/test', { channel: testChannel });
-      setConnectionSuccessMessage('Send to message to slack ws.');
-      onSetIsSendTestMessage(true);
-      onSetIsIntegrationSuccess(true);
-    }
-    catch (err) {
-      setConnectionErrorCode(err[0].code);
-      setConnectionErrorMessage(err[0].message);
-      onSetIsSendTestMessage(false);
-      onSetIsIntegrationSuccess(false);
-    }
-  };
 
   const submitForm = (e) => {
     e.preventDefault();
-    testConnection();
+    onTestConnection();
   };
 
-  const inputTestChannelHandler = (channel) => {
-    setTestChannel(channel);
-  };
 
   let value = '';
-  if (connectionErrorMessage != null) {
-    value = [connectionErrorCode, connectionErrorMessage];
+  if (connectionMessage === 'Send message to slack ws.' || connectionMessage == null) {
+    value = connectionMessage;
   }
-  if (connectionSuccessMessage != null) {
-    value = connectionSuccessMessage;
+  else {
+    value = [connectionErrorCode, connectionMessage];
   }
 
   return (
@@ -170,7 +146,7 @@ const CustomBotWithoutProxySettingsAccordion = ({
                 type="text"
                 value={testChannel}
                 placeholder="Slack Channel"
-                onChange={e => inputTestChannelHandler(e.target.value)}
+                onChange={e => onInputTestChannelHandler(e.target.value)}
               />
             </div>
             <button
@@ -181,10 +157,17 @@ const CustomBotWithoutProxySettingsAccordion = ({
             </button>
           </form>
         </div>
-        {connectionErrorMessage != null
-          && <p className="text-danger text-center my-4">{t('admin:slack_integration.accordion.error_check_logs_below')}</p>}
-        {connectionSuccessMessage != null
-          && <p className="text-info text-center my-4">{t('admin:slack_integration.accordion.send_message_to_slack_work_space')}</p>}
+        {connectionMessage == null
+          ? <p></p>
+          : (
+            <>
+              {connectionMessage === 'Send message to slack ws.'
+                ? <p className="text-info text-center my-4">{t('admin:slack_integration.accordion.send_message_to_slack_work_space')}</p>
+                : <p className="text-danger text-center my-4">{t('admin:slack_integration.accordion.error_check_logs_below')}</p>
+              }
+            </>
+          )
+        }
         <form>
           <div className="row my-3 justify-content-center">
             <div className="form-group slack-connection-log col-md-4">
@@ -211,16 +194,17 @@ CustomBotWithoutProxySettingsAccordion.propTypes = {
   slackSigningSecretEnv: PropTypes.string,
   slackBotToken: PropTypes.string,
   slackBotTokenEnv: PropTypes.string,
+  testChannel: PropTypes.string,
   isRegisterSlackCredentials: PropTypes.bool,
   isSendTestMessage: PropTypes.bool,
   fetchSlackIntegrationData: PropTypes.func,
   onSetSlackSigningSecret: PropTypes.func,
   onSetSlackBotToken: PropTypes.func,
-  onSetIsSendTestMessage: PropTypes.func,
   onSetIsRegisterSlackCredentials: PropTypes.func,
-  setSlackWSNameInWithoutProxy: PropTypes.func,
-  onSetIsIntegrationSuccess: PropTypes.func,
-
+  onInputTestChannelHandler: PropTypes.func,
+  onTestConnection: PropTypes.func,
+  connectionMessage: PropTypes.string,
+  connectionErrorCode: PropTypes.string,
   adminAppContainer: PropTypes.instanceOf(AdminAppContainer).isRequired,
   activeStep: PropTypes.oneOf(Object.values(botInstallationStep)).isRequired,
 };

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
@@ -77,7 +77,7 @@ const CustomBotWithoutProxySettingsAccordion = ({
 
 
   let value = '';
-  if (connectionMessage === 'Send the message to slack work space.' || connectionMessage == null) {
+  if (connectionMessage === 'Send the message to slack work space.' || connectionMessage === '') {
     value = connectionMessage;
   }
   else {

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
@@ -19,7 +19,7 @@ const CustomBotWithoutProxySettingsAccordion = ({
   appContainer, activeStep, fetchSlackIntegrationData,
   slackSigningSecret, slackSigningSecretEnv, slackBotToken, slackBotTokenEnv,
   isRegisterSlackCredentials, isSendTestMessage,
-  onSetSlackSigningSecret, onSetSlackBotToken, onSetIsSendTestMessage,
+  onSetSlackSigningSecret, onSetSlackBotToken, onSetIsSendTestMessage, onSetIsIntegrationSuccess,
 }) => {
   const { t } = useTranslation();
   // TODO: GW-5644 Store default open accordion
@@ -73,11 +73,13 @@ const CustomBotWithoutProxySettingsAccordion = ({
       });
       setConnectionSuccessMessage('Send to message to slack ws.');
       onSetIsSendTestMessage(true);
+      onSetIsIntegrationSuccess(true);
     }
     catch (err) {
-      onSetIsSendTestMessage(false);
       setConnectionErrorCode(err[0].code);
       setConnectionErrorMessage(err[0].message);
+      onSetIsSendTestMessage(false);
+      onSetIsIntegrationSuccess(false);
     }
   };
 
@@ -219,6 +221,7 @@ CustomBotWithoutProxySettingsAccordion.propTypes = {
   onSetIsSendTestMessage: PropTypes.func,
   onSetIsRegisterSlackCredentials: PropTypes.func,
   setSlackWSNameInWithoutProxy: PropTypes.func,
+  onSetIsIntegrationSuccess: PropTypes.func,
 
   adminAppContainer: PropTypes.instanceOf(AdminAppContainer).isRequired,
   activeStep: PropTypes.oneOf(Object.values(botInstallationStep)).isRequired,

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
@@ -18,7 +18,7 @@ export const botInstallationStep = {
 const CustomBotWithoutProxySettingsAccordion = ({
   appContainer, activeStep,
   connectionMessage, connectionErrorCode, testChannel, slackSigningSecret, slackSigningSecretEnv, slackBotToken, slackBotTokenEnv,
-  isRegisterSlackCredentials, isSendTestMessage,
+  isRegisterSlackCredentials, isIntegrationSuccess,
   fetchSlackIntegrationData, testConnection, inputTestChannelHandler,
   onSetSlackSigningSecret, onSetSlackBotToken,
 }) => {
@@ -136,7 +136,7 @@ const CustomBotWithoutProxySettingsAccordion = ({
       <Accordion
         defaultIsActive={defaultOpenAccordionKeys.has(botInstallationStep.CONNECTION_TEST)}
         // eslint-disable-next-line max-len
-        title={<><span className="mr-2">④</span>{t('admin:slack_integration.accordion.test_connection')}{isSendTestMessage && <i className="ml-3 text-success fa fa-check"></i>}</>}
+        title={<><span className="mr-2">④</span>{t('admin:slack_integration.accordion.test_connection')}{isIntegrationSuccess && <i className="ml-3 text-success fa fa-check"></i>}</>}
       >
         <p className="text-center m-4">{t('admin:slack_integration.accordion.test_connection_by_pressing_button')}</p>
         <div className="d-flex justify-content-center">
@@ -200,7 +200,7 @@ CustomBotWithoutProxySettingsAccordion.propTypes = {
   slackBotTokenEnv: PropTypes.string,
   testChannel: PropTypes.string,
   isRegisterSlackCredentials: PropTypes.bool,
-  isSendTestMessage: PropTypes.bool,
+  isIntegrationSuccess: PropTypes.bool,
   fetchSlackIntegrationData: PropTypes.func,
   testConnection: PropTypes.func,
   inputTestChannelHandler: PropTypes.func,

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
@@ -19,8 +19,7 @@ const CustomBotWithoutProxySettingsAccordion = ({
   appContainer, activeStep,
   connectionMessage, connectionErrorCode, testChannel, slackSigningSecret, slackSigningSecretEnv, slackBotToken, slackBotTokenEnv,
   isRegisterSlackCredentials, isIntegrationSuccess,
-  fetchSlackIntegrationData, testConnection, inputTestChannelHandler,
-  onSetSlackSigningSecret, onSetSlackBotToken,
+  fetchSlackIntegrationData, inputTestChannelHandler, onTestFormSubmitted, onSetSlackSigningSecret, onSetSlackBotToken,
 }) => {
   const { t } = useTranslation();
   // TODO: GW-5644 Store default open accordion
@@ -63,10 +62,10 @@ const CustomBotWithoutProxySettingsAccordion = ({
   const submitForm = (e) => {
     e.preventDefault();
 
-    if (testConnection == null) {
+    if (onTestFormSubmitted == null) {
       return;
     }
-    testConnection();
+    onTestFormSubmitted();
   };
 
 
@@ -202,8 +201,8 @@ CustomBotWithoutProxySettingsAccordion.propTypes = {
   isRegisterSlackCredentials: PropTypes.bool,
   isIntegrationSuccess: PropTypes.bool,
   fetchSlackIntegrationData: PropTypes.func,
-  testConnection: PropTypes.func,
   inputTestChannelHandler: PropTypes.func,
+  onTestFormSubmitted: PropTypes.func,
   onSetSlackSigningSecret: PropTypes.func,
   onSetSlackBotToken: PropTypes.func,
   connectionMessage: PropTypes.string,

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
@@ -161,7 +161,7 @@ const CustomBotWithoutProxySettingsAccordion = ({
             </button>
           </form>
         </div>
-        {connectionMessage == null
+        {connectionMessage === ''
           ? <p></p>
           : (
             <>

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
@@ -67,7 +67,7 @@ const CustomBotWithoutProxySettingsAccordion = ({
 
 
   let value = '';
-  if (connectionMessage === 'Send message to slack ws.' || connectionMessage == null) {
+  if (connectionMessage === 'Send a message to slack ws.' || connectionMessage == null) {
     value = connectionMessage;
   }
   else {
@@ -161,7 +161,7 @@ const CustomBotWithoutProxySettingsAccordion = ({
           ? <p></p>
           : (
             <>
-              {connectionMessage === 'Send message to slack ws.'
+              {connectionMessage === 'Send a message to slack ws.'
                 ? <p className="text-info text-center my-4">{t('admin:slack_integration.accordion.send_message_to_slack_work_space')}</p>
                 : <p className="text-danger text-center my-4">{t('admin:slack_integration.accordion.error_check_logs_below')}</p>
               }

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
@@ -209,7 +209,6 @@ CustomBotWithoutProxySettingsAccordion.propTypes = {
   fetchSlackIntegrationData: PropTypes.func,
   onSetSlackSigningSecret: PropTypes.func,
   onSetSlackBotToken: PropTypes.func,
-  onSetIsRegisterSlackCredentials: PropTypes.func,
   onTestConnection: PropTypes.func,
   onSetTestChannel:  PropTypes.func,
   connectionMessage: PropTypes.string,

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
@@ -69,7 +69,7 @@ const CustomBotWithoutProxySettingsAccordion = ({
     setConnectionSuccessMessage(null);
     // TODO: 5921 Add new Test endpoint
     try {
-      const res = await appContainer.apiv3.post('/slack-integration-settings//without-proxy/test', {
+      const res = await appContainer.apiv3.post('/slack-integration-settings/without-proxy/test', {
         channel: testChannel,
       });
       setConnectionSuccessMessage(res.data.message);

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
@@ -67,7 +67,6 @@ const CustomBotWithoutProxySettingsAccordion = ({
     setConnectionErrorCode(null);
     setConnectionErrorMessage(null);
     setConnectionSuccessMessage(null);
-    // TODO: 5921 Add new Test endpoint
     try {
       await appContainer.apiv3.post('/slack-integration-settings/without-proxy/test', {
         channel: testChannel,

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
@@ -16,10 +16,11 @@ export const botInstallationStep = {
 };
 
 const CustomBotWithoutProxySettingsAccordion = ({
-  appContainer, activeStep, fetchSlackIntegrationData, connectionMessage, connectionErrorCode, testChannel,
-  slackSigningSecret, slackSigningSecretEnv, slackBotToken, slackBotTokenEnv,
+  appContainer, activeStep,
+  connectionMessage, connectionErrorCode, testChannel, slackSigningSecret, slackSigningSecretEnv, slackBotToken, slackBotTokenEnv,
   isRegisterSlackCredentials, isSendTestMessage,
-  onSetSlackSigningSecret, onSetSlackBotToken, onTestConnection, onSetTestChannel,
+  fetchSlackIntegrationData, testConnection,
+  onSetSlackSigningSecret, onSetSlackBotToken, onSetTestChannel,
 }) => {
   const { t } = useTranslation();
   // TODO: GW-5644 Store default open accordion
@@ -68,10 +69,10 @@ const CustomBotWithoutProxySettingsAccordion = ({
   const submitForm = (e) => {
     e.preventDefault();
 
-    if (onTestConnection == null) {
+    if (testConnection == null) {
       return;
     }
-    onTestConnection();
+    testConnection();
   };
 
 
@@ -207,9 +208,9 @@ CustomBotWithoutProxySettingsAccordion.propTypes = {
   isRegisterSlackCredentials: PropTypes.bool,
   isSendTestMessage: PropTypes.bool,
   fetchSlackIntegrationData: PropTypes.func,
+  testConnection: PropTypes.func,
   onSetSlackSigningSecret: PropTypes.func,
   onSetSlackBotToken: PropTypes.func,
-  onTestConnection: PropTypes.func,
   onSetTestChannel:  PropTypes.func,
   connectionMessage: PropTypes.string,
   connectionErrorCode: PropTypes.string,

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
@@ -19,7 +19,7 @@ const CustomBotWithoutProxySettingsAccordion = ({
   appContainer, activeStep, fetchSlackIntegrationData, connectionMessage, connectionErrorCode, testChannel,
   slackSigningSecret, slackSigningSecretEnv, slackBotToken, slackBotTokenEnv,
   isRegisterSlackCredentials, isSendTestMessage,
-  onSetSlackSigningSecret, onSetSlackBotToken, onTestConnection, onInputTestChannelHandler,
+  onSetSlackSigningSecret, onSetSlackBotToken, onTestConnection, onSetTestChannel,
 }) => {
   const { t } = useTranslation();
   // TODO: GW-5644 Store default open accordion
@@ -59,9 +59,18 @@ const CustomBotWithoutProxySettingsAccordion = ({
     }
   };
 
+  const inputTestChannelHandler = (channel) => {
+    if (onSetTestChannel != null) {
+      onSetTestChannel(channel);
+    }
+  };
 
   const submitForm = (e) => {
     e.preventDefault();
+
+    if (onTestConnection == null) {
+      return;
+    }
     onTestConnection();
   };
 
@@ -146,7 +155,7 @@ const CustomBotWithoutProxySettingsAccordion = ({
                 type="text"
                 value={testChannel}
                 placeholder="Slack Channel"
-                onChange={e => onInputTestChannelHandler(e.target.value)}
+                onChange={e => inputTestChannelHandler(e.target.value)}
               />
             </div>
             <button
@@ -201,8 +210,8 @@ CustomBotWithoutProxySettingsAccordion.propTypes = {
   onSetSlackSigningSecret: PropTypes.func,
   onSetSlackBotToken: PropTypes.func,
   onSetIsRegisterSlackCredentials: PropTypes.func,
-  onInputTestChannelHandler: PropTypes.func,
   onTestConnection: PropTypes.func,
+  onSetTestChannel:  PropTypes.func,
   connectionMessage: PropTypes.string,
   connectionErrorCode: PropTypes.string,
   adminAppContainer: PropTypes.instanceOf(AdminAppContainer).isRequired,

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
@@ -69,13 +69,11 @@ const CustomBotWithoutProxySettingsAccordion = ({
     setConnectionSuccessMessage(null);
     // TODO: 5921 Add new Test endpoint
     try {
-      // eslint-disable-next-line no-console
-      console.log('Test');
-      // const res = await appContainer.apiv3.post('/slack-integration-settings//without-proxy/test', {
-      //   channel: testChannel,
-      // });
-      // setConnectionSuccessMessage(res.data.message);
-      // onSetIsSendTestMessage(true);
+      const res = await appContainer.apiv3.post('/slack-integration-settings//without-proxy/test', {
+        channel: testChannel,
+      });
+      setConnectionSuccessMessage(res.data.message);
+      onSetIsSendTestMessage(true);
     }
     catch (err) {
       onSetIsSendTestMessage(false);

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
@@ -19,8 +19,8 @@ const CustomBotWithoutProxySettingsAccordion = ({
   appContainer, activeStep,
   connectionMessage, connectionErrorCode, testChannel, slackSigningSecret, slackSigningSecretEnv, slackBotToken, slackBotTokenEnv,
   isRegisterSlackCredentials, isSendTestMessage,
-  fetchSlackIntegrationData, testConnection,
-  onSetSlackSigningSecret, onSetSlackBotToken, onSetTestChannel,
+  fetchSlackIntegrationData, testConnection, inputTestChannelHandler,
+  onSetSlackSigningSecret, onSetSlackBotToken,
 }) => {
   const { t } = useTranslation();
   // TODO: GW-5644 Store default open accordion
@@ -57,12 +57,6 @@ const CustomBotWithoutProxySettingsAccordion = ({
   const onChangeBotTokenHandler = (botTokenInput) => {
     if (onSetSlackBotToken != null) {
       onSetSlackBotToken(botTokenInput);
-    }
-  };
-
-  const inputTestChannelHandler = (channel) => {
-    if (onSetTestChannel != null) {
-      onSetTestChannel(channel);
     }
   };
 
@@ -209,9 +203,9 @@ CustomBotWithoutProxySettingsAccordion.propTypes = {
   isSendTestMessage: PropTypes.bool,
   fetchSlackIntegrationData: PropTypes.func,
   testConnection: PropTypes.func,
+  inputTestChannelHandler: PropTypes.func,
   onSetSlackSigningSecret: PropTypes.func,
   onSetSlackBotToken: PropTypes.func,
-  onSetTestChannel:  PropTypes.func,
   connectionMessage: PropTypes.string,
   connectionErrorCode: PropTypes.string,
   adminAppContainer: PropTypes.instanceOf(AdminAppContainer).isRequired,

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
@@ -69,16 +69,16 @@ const CustomBotWithoutProxySettingsAccordion = ({
     setConnectionSuccessMessage(null);
     // TODO: 5921 Add new Test endpoint
     try {
-      const res = await appContainer.apiv3.post('/slack-integration-settings/without-proxy/test', {
+      await appContainer.apiv3.post('/slack-integration-settings/without-proxy/test', {
         channel: testChannel,
       });
-      setConnectionSuccessMessage(res.data.message);
+      setConnectionSuccessMessage('Send to message to slack ws.');
       onSetIsSendTestMessage(true);
     }
     catch (err) {
       onSetIsSendTestMessage(false);
-      setConnectionErrorCode('dummy-error-code');
-      setConnectionErrorMessage('This is a sample error message');
+      setConnectionErrorCode(err[0].code);
+      setConnectionErrorMessage(err[0].message);
     }
   };
 

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
@@ -68,9 +68,7 @@ const CustomBotWithoutProxySettingsAccordion = ({
     setConnectionErrorMessage(null);
     setConnectionSuccessMessage(null);
     try {
-      await appContainer.apiv3.post('/slack-integration-settings/without-proxy/test', {
-        channel: testChannel,
-      });
+      await appContainer.apiv3.post('/slack-integration-settings/without-proxy/test', { channel: testChannel });
       setConnectionSuccessMessage('Send to message to slack ws.');
       onSetIsSendTestMessage(true);
       onSetIsIntegrationSuccess(true);

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
@@ -67,7 +67,7 @@ const CustomBotWithoutProxySettingsAccordion = ({
 
 
   let value = '';
-  if (connectionMessage === 'Send a message to slack ws.' || connectionMessage == null) {
+  if (connectionMessage === 'Send the message to slack ws.' || connectionMessage == null) {
     value = connectionMessage;
   }
   else {
@@ -161,7 +161,7 @@ const CustomBotWithoutProxySettingsAccordion = ({
           ? <p></p>
           : (
             <>
-              {connectionMessage === 'Send a message to slack ws.'
+              {connectionMessage === 'Send the message to slack ws.'
                 ? <p className="text-info text-center my-4">{t('admin:slack_integration.accordion.send_message_to_slack_work_space')}</p>
                 : <p className="text-danger text-center my-4">{t('admin:slack_integration.accordion.error_check_logs_below')}</p>
               }

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
@@ -67,7 +67,7 @@ const CustomBotWithoutProxySettingsAccordion = ({
 
 
   let value = '';
-  if (connectionMessage === 'Send the message to slack ws.' || connectionMessage == null) {
+  if (connectionMessage === 'Send the message to slack work space.' || connectionMessage == null) {
     value = connectionMessage;
   }
   else {
@@ -161,7 +161,7 @@ const CustomBotWithoutProxySettingsAccordion = ({
           ? <p></p>
           : (
             <>
-              {connectionMessage === 'Send the message to slack ws.'
+              {connectionMessage === 'Send the message to slack work space.'
                 ? <p className="text-info text-center my-4">{t('admin:slack_integration.accordion.send_message_to_slack_work_space')}</p>
                 : <p className="text-danger text-center my-4">{t('admin:slack_integration.accordion.error_check_logs_below')}</p>
               }

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -25,6 +25,7 @@ const SlackIntegration = (props) => {
   const [slackBotTokenEnv, setSlackBotTokenEnv] = useState('');
   const [isRegisterSlackCredentials, setIsRegisterSlackCredentials] = useState(false);
   const [isSendTestMessage, setIsSendTestMessage] = useState(false);
+  const [isIntegrationSuccess, setIsIntegrationSuccess] = useState(false);
   const [slackWSNameInWithoutProxy, setSlackWSNameInWithoutProxy] = useState(null);
   const [isDeleteConfirmModalShown, setIsDeleteConfirmModalShown] = useState(false);
 
@@ -136,6 +137,8 @@ const SlackIntegration = (props) => {
           onSetIsSendTestMessage={setIsSendTestMessage}
           onResetSettings={resetWithOutSettings}
           fetchSlackIntegrationData={fetchSlackIntegrationData}
+          isIntegrationSuccess={isIntegrationSuccess}
+          onSetIsIntegrationSuccess={setIsIntegrationSuccess}
         />
       );
       break;

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -24,7 +24,6 @@ const SlackIntegration = (props) => {
   const [slackSigningSecretEnv, setSlackSigningSecretEnv] = useState('');
   const [slackBotTokenEnv, setSlackBotTokenEnv] = useState('');
   const [isRegisterSlackCredentials, setIsRegisterSlackCredentials] = useState(false);
-  const [isSendTestMessage, setIsSendTestMessage] = useState(false);
   const [slackWSNameInWithoutProxy, setSlackWSNameInWithoutProxy] = useState(null);
   const [isDeleteConfirmModalShown, setIsDeleteConfirmModalShown] = useState(false);
   const [slackAppIntegrations, setSlackAppIntegrations] = useState();
@@ -93,7 +92,6 @@ const SlackIntegration = (props) => {
       setIsRegisterSlackCredentials(false);
       setSlackSigningSecret(null);
       setSlackBotToken(null);
-      setIsSendTestMessage(false);
       setSlackWSNameInWithoutProxy(null);
     }
     catch (err) {
@@ -129,7 +127,6 @@ const SlackIntegration = (props) => {
     case 'customBotWithoutProxy':
       settingsComponent = (
         <CustomBotWithoutProxySettings
-          isSendTestMessage={isSendTestMessage}
           isRegisterSlackCredentials={isRegisterSlackCredentials}
           slackBotTokenEnv={slackBotTokenEnv}
           slackBotToken={slackBotToken}
@@ -138,7 +135,6 @@ const SlackIntegration = (props) => {
           slackWSNameInWithoutProxy={slackWSNameInWithoutProxy}
           onSetSlackSigningSecret={setSlackSigningSecret}
           onSetSlackBotToken={setSlackBotToken}
-          onSetIsSendTestMessage={setIsSendTestMessage}
           onResetSettings={resetWithOutSettings}
           fetchSlackIntegrationData={fetchSlackIntegrationData}
         />

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -25,7 +25,6 @@ const SlackIntegration = (props) => {
   const [slackBotTokenEnv, setSlackBotTokenEnv] = useState('');
   const [isRegisterSlackCredentials, setIsRegisterSlackCredentials] = useState(false);
   const [isSendTestMessage, setIsSendTestMessage] = useState(false);
-  const [isIntegrationSuccess, setIsIntegrationSuccess] = useState(false);
   const [slackWSNameInWithoutProxy, setSlackWSNameInWithoutProxy] = useState(null);
   const [isDeleteConfirmModalShown, setIsDeleteConfirmModalShown] = useState(false);
   const [slackAppIntegrations, setSlackAppIntegrations] = useState();
@@ -142,8 +141,6 @@ const SlackIntegration = (props) => {
           onSetIsSendTestMessage={setIsSendTestMessage}
           onResetSettings={resetWithOutSettings}
           fetchSlackIntegrationData={fetchSlackIntegrationData}
-          isIntegrationSuccess={isIntegrationSuccess}
-          onSetIsIntegrationSuccess={setIsIntegrationSuccess}
         />
       );
       break;

--- a/src/server/routes/apiv3/slack-integration-settings.js
+++ b/src/server/routes/apiv3/slack-integration-settings.js
@@ -5,7 +5,7 @@ const axios = require('axios');
 const urljoin = require('url-join');
 const loggerFactory = require('@alias/logger');
 
-const { getConnectionStatuses, testToSlack, generateWebClient } = require('@growi/slack');
+const { getConnectionStatuses, testToSlack, sendSuccessMessage } = require('@growi/slack');
 
 const ErrorV3 = require('../../models/vo/error-apiv3');
 
@@ -502,7 +502,7 @@ module.exports = (crowi) => {
    */
   router.post('/without-proxy/test', loginRequiredStrictly, adminRequired, csrf, validator.SlackChannel, apiV3FormValidator, async(req, res) => {
     const currentBotType = crowi.configManager.getConfig('crowi', 'slackbot:currentBotType');
-    // const appSiteURL = crowi.configManager.getConfig('crowi', 'app:siteUrl');
+    const appSiteURL = crowi.configManager.getConfig('crowi', 'app:siteUrl');
 
     if (currentBotType !== 'customBotWithoutProxy') {
       const msg = 'Select Without Proxy Type';
@@ -512,11 +512,7 @@ module.exports = (crowi) => {
     const slackBotToken = crowi.configManager.getConfig('crowi', 'slackbot:token');
     try {
       await testToSlack(slackBotToken);
-      const client = generateWebClient(slackBotToken);
-      await client.chat.postMessage({
-        channel,
-        text: 'Your test was successful!',
-      });
+      await sendSuccessMessage(slackBotToken, channel, appSiteURL);
       return res.apiv3();
     }
     catch (error) {

--- a/src/server/routes/apiv3/slack-integration-settings.js
+++ b/src/server/routes/apiv3/slack-integration-settings.js
@@ -502,6 +502,8 @@ module.exports = (crowi) => {
    */
   router.post('/without-proxy/test', loginRequiredStrictly, adminRequired, csrf, validator.SlackChannel, apiV3FormValidator, async(req, res) => {
     const currentBotType = crowi.configManager.getConfig('crowi', 'slackbot:currentBotType');
+    // const appSiteURL = crowi.configManager.getConfig('crowi', 'app:siteUrl');
+
     if (currentBotType !== 'customBotWithoutProxy') {
       const msg = 'Select Without Proxy Type';
       return res.apiv3Err(new ErrorV3(msg, 'select-not-proxy-type'), 400);

--- a/src/server/routes/apiv3/slack-integration-settings.js
+++ b/src/server/routes/apiv3/slack-integration-settings.js
@@ -510,7 +510,7 @@ module.exports = (crowi) => {
     try {
       await testToSlack(slackBotToken);
       const client = generateWebClient(slackBotToken);
-      client.chat.postMessage({
+      await client.chat.postMessage({
         channel,
         text: 'Your test was successful!',
       });

--- a/src/server/routes/apiv3/slack-integration-settings.js
+++ b/src/server/routes/apiv3/slack-integration-settings.js
@@ -5,7 +5,7 @@ const axios = require('axios');
 const urljoin = require('url-join');
 const loggerFactory = require('@alias/logger');
 
-const { getConnectionStatuses, testToSlack } = require('@growi/slack');
+const { getConnectionStatuses, testToSlack, generateWebClient } = require('@growi/slack');
 
 const ErrorV3 = require('../../models/vo/error-apiv3');
 
@@ -508,8 +508,12 @@ module.exports = (crowi) => {
     const { channel } = req.body;
     const slackBotToken = crowi.configManager.getConfig('crowi', 'slackbot:token');
     try {
-      const res = await testToSlack(slackBotToken);
-      console.log(res);
+      await testToSlack(slackBotToken);
+      const client = generateWebClient(slackBotToken);
+      client.chat.postMessage({
+        channel,
+        text: 'Your test was successful!',
+      });
     }
     catch (error) {
       logger.error('Error', error);

--- a/src/server/routes/apiv3/slack-integration-settings.js
+++ b/src/server/routes/apiv3/slack-integration-settings.js
@@ -515,7 +515,7 @@ module.exports = (crowi) => {
         channel,
         text: 'Your test was successful!',
       });
-      return res.apiv3({ });
+      return res.apiv3();
     }
     catch (error) {
       logger.error('Error', error);

--- a/src/server/routes/apiv3/slack-integration-settings.js
+++ b/src/server/routes/apiv3/slack-integration-settings.js
@@ -508,7 +508,7 @@ module.exports = (crowi) => {
     const { channel } = req.body;
     const slackBotToken = crowi.configManager.getConfig('crowi', 'slackbot:token');
     try {
-      const res = await testToSlack(slackBotToken, channel);
+      const res = await testToSlack(slackBotToken);
       console.log(res);
     }
     catch (error) {

--- a/src/server/routes/apiv3/slack-integration-settings.js
+++ b/src/server/routes/apiv3/slack-integration-settings.js
@@ -5,7 +5,7 @@ const axios = require('axios');
 const urljoin = require('url-join');
 const loggerFactory = require('@alias/logger');
 
-const { getConnectionStatuses, relationTestToSlack } = require('@growi/slack');
+const { getConnectionStatuses, testToSlack } = require('@growi/slack');
 
 const ErrorV3 = require('../../models/vo/error-apiv3');
 
@@ -505,12 +505,11 @@ module.exports = (crowi) => {
       const msg = 'Select Without Proxy Type';
       return res.apiv3Err(new ErrorV3(msg, 'select-not-proxy-type'), 400);
     }
-    // TODO impl req.body at GW-5998
-    // const { channel } = req.body;
+    const { channel } = req.body;
     const slackBotToken = crowi.configManager.getConfig('crowi', 'slackbot:token');
     try {
-      await relationTestToSlack(slackBotToken);
-      // TODO impl return response after imple 5996, 6002
+      const res = await testToSlack(slackBotToken, channel);
+      console.log(res);
     }
     catch (error) {
       logger.error('Error', error);

--- a/src/server/routes/apiv3/slack-integration-settings.js
+++ b/src/server/routes/apiv3/slack-integration-settings.js
@@ -514,6 +514,7 @@ module.exports = (crowi) => {
         channel,
         text: 'Your test was successful!',
       });
+      return res.apiv3({ });
     }
     catch (error) {
       logger.error('Error', error);


### PR DESCRIPTION
 ## 概要
テストボタンを押したときに、導通の成否を適切に表示できるようにしています。

- リセットボタンを押したときの挙動は実装していません。
- 実装しない理由は以下です。
  - リセットボタンを押すとデータを消去した後に fetchSlackIntegration() が走ります。
  - この処理は `管理画面 > Slack 連携` にアクセスしたときに webClient を作成して 都度データを取得する処理です。
  - この後のタスクで `管理画面 > Slack 連携` にアクセスしたときの処理を実装すれば解決すると考えたからです。

- 現在 test button を実行したときに workspace 名を 取得してきません。 
  - 理由は、以下をコメントアウトしているからです。(動画で取得しているように見えるのは コメントアウトを外しています。)
  SlackIntegration.jsx
  ```:SlackIntegration.jsx
   if (data.connectionStatuses != null) {
        // TODO fix
        // const { workspaceName } = data.connectionStatuses[slackBotToken];
        // setSlackWSNameInWithoutProxy(workspaceName);
      } ``` 
  - この部分の実装は また別タスクで行います。
  - 現状 この部分は without proxy 用になっていて、with proxy を考慮していないため TODO になっております。