### PR TITLE
responsive integration diagram

### DIFF
--- a/resource/locales/ja_JP/admin/admin.json
+++ b/resource/locales/ja_JP/admin/admin.json
@@ -331,7 +331,7 @@
     "custom_bot_without_proxy_integration": "Custom bot without proxy 連携",
     "integration_sentence": {
       "integration_is_not_complete": "連携は完了していません。<br>下記の連携手順を進めてください。",
-      "integration_successful": "連携が完了しました。"
+      "integration_successful": "連携が完了しています。"
     },
     "custom_bot_with_proxy_integration": "Custom bot with proxy 連携",
     "official_bot_integration": "Official bot 連携"

--- a/resource/locales/ja_JP/admin/admin.json
+++ b/resource/locales/ja_JP/admin/admin.json
@@ -331,7 +331,7 @@
     "custom_bot_without_proxy_integration": "Custom bot without proxy 連携",
     "integration_sentence": {
       "integration_is_not_complete": "連携は完了していません。<br>下記の連携手順を進めてください。",
-      "integration_successful": "連携が完了しています。"
+      "integration_successful": "連携は完了しています。"
     },
     "custom_bot_with_proxy_integration": "Custom bot with proxy 連携",
     "official_bot_integration": "Official bot 連携"

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
@@ -34,9 +34,9 @@ const CustomBotWithoutProxyIntegrationCard = (props) => {
           />
         </div>
 
-        {/* <div className="d-block d-lg-none">
-          <p>smartPhone size</p>
-        </div> */}
+        <div className="d-block d-lg-none">
+          <i className="fa fa-info-circle text-danger" />
+        </div>
 
         <hr className="align-self-center admin-border-danger border-danger"></hr>
 

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
@@ -57,7 +57,7 @@ const CustomBotWithoutProxyIntegrationCard = (props) => {
         </div>
       </div>
 
-      <UncontrolledTooltip placement="top" fade={false} target="integration-line">
+      <UncontrolledTooltip placement="top" fade={false} target="integration-line-for-tooltip">
         <small
           className="m-0"
           // eslint-disable-next-line react/no-danger

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
@@ -25,7 +25,6 @@ const CustomBotWithoutProxyIntegrationCard = (props) => {
       </div>
 
       <div id="integration-line" className="text-center w-25">
-        {/* TODO apply correct condition GW-5895 */}
         <div className="mt-4">
           <small
             className="text-warning m-0"

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
@@ -52,7 +52,11 @@ const CustomBotWithoutProxyIntegrationCard = (props) => {
       </div>
 
       <UncontrolledTooltip placement="top" fade={false} target="integration-line">
-       Hello Tooltip!!
+        <small
+          className="m-0"
+          // eslint-disable-next-line react/no-danger
+          dangerouslySetInnerHTML={{ __html: t('admin:slack_integration.integration_sentence.integration_is_not_complete') }}
+        />
       </UncontrolledTooltip>
     </div>
   );

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
@@ -26,22 +26,19 @@ const CustomBotWithoutProxyIntegrationCard = (props) => {
 
       <div id="integration-line" className="text-center w-25">
 
-        <div className="d-none d-lg-block">
-          <p>pc-size</p>
-        </div>
-
-        <div className="d-block d-lg-none">
-          <p>smartPhone size</p>
-        </div>
-
-        <div className="mt-4">
+        <div className="d-none d-lg-block mt-4">
           <small
             className="text-warning m-0"
             // eslint-disable-next-line react/no-danger
             dangerouslySetInnerHTML={{ __html: t('admin:slack_integration.integration_sentence.integration_is_not_complete') }}
           />
-          <hr className="align-self-center admin-border-danger border-danger"></hr>
         </div>
+
+        {/* <div className="d-block d-lg-none">
+          <p>smartPhone size</p>
+        </div> */}
+
+        <hr className="align-self-center admin-border-danger border-danger"></hr>
 
         {/* <div className="mt-5">
           <p className="text-success small">

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
@@ -34,7 +34,7 @@ const CustomBotWithoutProxyIntegrationCard = (props) => {
           />
         </div>
 
-        <div className="d-block d-lg-none">
+        <div className="d-block d-lg-none mt-5">
           <i className="fa fa-info-circle text-danger" />
         </div>
 

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
@@ -28,27 +28,27 @@ const CustomBotWithoutProxyIntegrationCard = (props) => {
 
         <div className="d-none d-lg-block">
 
-          <p className="text-success small mt-5">
+          {/* <p className="text-success small mt-5">
             <i className="fa fa-check mr-1" />
             {t('admin:slack_integration.integration_sentence.integration_successful')}
-          </p>
+          </p> */}
 
-          {/* <p className="mt-4">
+          <p className="mt-4">
             <small
               className="text-warning m-0"
               // eslint-disable-next-line react/no-danger
               dangerouslySetInnerHTML={{ __html: t('admin:slack_integration.integration_sentence.integration_is_not_complete') }}
             />
-          </p> */}
+          </p>
         </div>
 
         <div id="integration-line-for-tooltip" className="d-block d-lg-none mt-5">
-          <i className="fa fa-check mr-1 text-success" />
-          {/* <i className="icon-info text-danger" /> */}
+          {/* <i className="fa fa-check mr-1 text-success" /> */}
+          <i className="icon-info text-danger" />
         </div>
 
-        <hr className="align-self-center admin-border-success border-success"></hr>
-        {/* <hr className="align-self-center admin-border-danger border-danger"></hr> */}
+        {/* <hr className="align-self-center admin-border-success border-success"></hr> */}
+        <hr className="align-self-center admin-border-danger border-danger"></hr>
       </div>
 
       <div className="card rounded-lg shadow border-0 w-50 admin-bot-card mb-0">
@@ -59,14 +59,15 @@ const CustomBotWithoutProxyIntegrationCard = (props) => {
       </div>
 
       <UncontrolledTooltip placement="top" fade={false} target="integration-line-for-tooltip">
-        <small>
+        {/* <small>
           {t('admin:slack_integration.integration_sentence.integration_successful')}
-        </small>
-        {/* <small
+        </small> */}
+
+        <small
           className="m-0"
           // eslint-disable-next-line react/no-danger
           dangerouslySetInnerHTML={{ __html: t('admin:slack_integration.integration_sentence.integration_is_not_complete') }}
-        /> */}
+        />
       </UncontrolledTooltip>
     </div>
   );

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
@@ -26,15 +26,15 @@ const CustomBotWithoutProxyIntegrationCard = (props) => {
 
       <div className="text-center w-25">
 
-        <div className="d-none d-lg-block mt-5">
+        <div className="d-none d-lg-block">
 
-          <p className="text-success small">
+          <p className="text-success small mt-5">
             <i className="fa fa-check mr-1" />
             {t('admin:slack_integration.integration_sentence.integration_successful')}
           </p>
 
           {/* <small
-            className="text-warning m-0 mt-5"
+            className="text-warning m-0 mt-4"
             // eslint-disable-next-line react/no-danger
             dangerouslySetInnerHTML={{ __html: t('admin:slack_integration.integration_sentence.integration_is_not_complete') }}
           /> */}

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
@@ -27,7 +27,7 @@ const CustomBotWithoutProxyIntegrationCard = (props) => {
       <div className="text-center w-25">
 
         <div className="d-none d-lg-block">
-
+          {/* TODO GW-6078 switching logic */}
           {/* <p className="text-success small mt-5">
             <i className="fa fa-check mr-1" />
             {t('admin:slack_integration.integration_sentence.integration_successful')}
@@ -42,11 +42,13 @@ const CustomBotWithoutProxyIntegrationCard = (props) => {
           </p>
         </div>
 
+        {/* TODO GW-6078 */}
         <div id="integration-line-for-tooltip" className="d-block d-lg-none mt-5">
           {/* <i className="fa fa-check mr-1 text-success" /> */}
           <i className="icon-info text-danger" />
         </div>
 
+        {/* TODO GW-6078 */}
         {/* <hr className="align-self-center admin-border-success border-success"></hr> */}
         <hr className="align-self-center admin-border-danger border-danger"></hr>
       </div>
@@ -59,10 +61,10 @@ const CustomBotWithoutProxyIntegrationCard = (props) => {
       </div>
 
       <UncontrolledTooltip placement="top" fade={false} target="integration-line-for-tooltip">
+        {/* TODO GW-6078 */}
         {/* <small>
           {t('admin:slack_integration.integration_sentence.integration_successful')}
         </small> */}
-
         <small
           className="m-0"
           // eslint-disable-next-line react/no-danger

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
@@ -27,7 +27,7 @@ const CustomBotWithoutProxyIntegrationCard = (props) => {
       <div className="text-center w-25">
 
         <div className="d-none d-lg-block">
-          {/* TODO GW-6078 switching logic */}
+          {/* TODO GW-5998 switching logic */}
           {/* <p className="text-success small mt-5">
             <i className="fa fa-check mr-1" />
             {t('admin:slack_integration.integration_sentence.integration_successful')}
@@ -42,13 +42,13 @@ const CustomBotWithoutProxyIntegrationCard = (props) => {
           </p>
         </div>
 
-        {/* TODO GW-6078 */}
+        {/* TODO GW-5998  */}
         <div id="integration-line-for-tooltip" className="d-block d-lg-none mt-5">
           {/* <i className="fa fa-check mr-1 text-success" /> */}
           <i className="icon-info text-danger" />
         </div>
 
-        {/* TODO GW-6078 */}
+        {/* TODO GW-5998 */}
         {/* <hr className="align-self-center admin-border-success border-success"></hr> */}
         <hr className="align-self-center admin-border-danger border-danger"></hr>
       </div>
@@ -61,7 +61,7 @@ const CustomBotWithoutProxyIntegrationCard = (props) => {
       </div>
 
       <UncontrolledTooltip placement="top" fade={false} target="integration-line-for-tooltip">
-        {/* TODO GW-6078 */}
+        {/* TODO GW-5998 */}
         {/* <small>
           {t('admin:slack_integration.integration_sentence.integration_successful')}
         </small> */}

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
@@ -26,26 +26,32 @@ const CustomBotWithoutProxyIntegrationCard = (props) => {
 
       <div className="text-center w-25">
 
-        <div className="d-none d-lg-block mt-4">
-          <small
+        <div className="d-none d-lg-block mt-5">
+          {/* <small
             className="text-warning m-0"
             // eslint-disable-next-line react/no-danger
             dangerouslySetInnerHTML={{ __html: t('admin:slack_integration.integration_sentence.integration_is_not_complete') }}
-          />
+          /> */}
+
+          <p className="text-success small">
+            <i className="fa fa-check mr-1" />
+            {t('admin:slack_integration.integration_sentence.integration_successful')}
+          </p>
         </div>
 
         <div id="integration-line-for-tooltip" className="d-block d-lg-none mt-5">
-          <i className="fa fa-info-circle text-danger" />
+          <i className="icon-info text-danger" />
         </div>
 
-        <hr className="align-self-center admin-border-danger border-danger"></hr>
+        {/* <hr className="align-self-center admin-border-danger border-danger"></hr> */}
+        <hr className="align-self-center admin-border-success border-success"></hr>
 
         {/* <div className="mt-5">
           <p className="text-success small">
             <i className="fa fa-check mr-1" />
             {t('admin:slack_integration.integration_sentence.integration_successful')}
           </p>
-          <hr className="align-self-center admin-border-success border-success"></hr>
+
         </div> */}
 
       </div>

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
@@ -28,35 +28,26 @@ const CustomBotWithoutProxyIntegrationCard = (props) => {
 
         <div className="d-none d-lg-block">
 
-          {/* <p className="text-success small mt-5">
+          <p className="text-success small mt-5">
             <i className="fa fa-check mr-1" />
             {t('admin:slack_integration.integration_sentence.integration_successful')}
-          </p> */}
+          </p>
 
-          <p className="mt-4">
+          {/* <p className="mt-4">
             <small
               className="text-warning m-0"
               // eslint-disable-next-line react/no-danger
               dangerouslySetInnerHTML={{ __html: t('admin:slack_integration.integration_sentence.integration_is_not_complete') }}
             />
-          </p>
+          </p> */}
         </div>
 
         <div id="integration-line-for-tooltip" className="d-block d-lg-none mt-5">
-          <i className="icon-info text-danger" />
+          {/* <i className="icon-info text-danger" /> */}
         </div>
 
-        {/* <hr className="align-self-center admin-border-success border-success"></hr> */}
-        <hr className="align-self-center admin-border-danger border-danger"></hr>
-
-        {/* <div className="mt-5">
-          <p className="text-success small">
-            <i className="fa fa-check mr-1" />
-            {t('admin:slack_integration.integration_sentence.integration_successful')}
-          </p>
-
-        </div> */}
-
+        <hr className="align-self-center admin-border-success border-success"></hr>
+        {/* <hr className="align-self-center admin-border-danger border-danger"></hr> */}
       </div>
 
       <div className="card rounded-lg shadow border-0 w-50 admin-bot-card mb-0">
@@ -67,11 +58,11 @@ const CustomBotWithoutProxyIntegrationCard = (props) => {
       </div>
 
       <UncontrolledTooltip placement="top" fade={false} target="integration-line-for-tooltip">
-        <small
+        {/* <small
           className="m-0"
           // eslint-disable-next-line react/no-danger
           dangerouslySetInnerHTML={{ __html: t('admin:slack_integration.integration_sentence.integration_is_not_complete') }}
-        />
+        /> */}
       </UncontrolledTooltip>
     </div>
   );

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
@@ -28,24 +28,26 @@ const CustomBotWithoutProxyIntegrationCard = (props) => {
 
         <div className="d-none d-lg-block">
 
-          <p className="text-success small mt-5">
+          {/* <p className="text-success small mt-5">
             <i className="fa fa-check mr-1" />
             {t('admin:slack_integration.integration_sentence.integration_successful')}
-          </p>
+          </p> */}
 
-          {/* <small
-            className="text-warning m-0 mt-4"
-            // eslint-disable-next-line react/no-danger
-            dangerouslySetInnerHTML={{ __html: t('admin:slack_integration.integration_sentence.integration_is_not_complete') }}
-          /> */}
+          <p className="mt-4">
+            <small
+              className="text-warning m-0"
+              // eslint-disable-next-line react/no-danger
+              dangerouslySetInnerHTML={{ __html: t('admin:slack_integration.integration_sentence.integration_is_not_complete') }}
+            />
+          </p>
         </div>
 
         <div id="integration-line-for-tooltip" className="d-block d-lg-none mt-5">
           <i className="icon-info text-danger" />
         </div>
 
-        {/* <hr className="align-self-center admin-border-danger border-danger"></hr> */}
-        <hr className="align-self-center admin-border-success border-success"></hr>
+        {/* <hr className="align-self-center admin-border-success border-success"></hr> */}
+        <hr className="align-self-center admin-border-danger border-danger"></hr>
 
         {/* <div className="mt-5">
           <p className="text-success small">

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
@@ -43,6 +43,7 @@ const CustomBotWithoutProxyIntegrationCard = (props) => {
         </div>
 
         <div id="integration-line-for-tooltip" className="d-block d-lg-none mt-5">
+          <i className="fa fa-check mr-1 text-success" />
           {/* <i className="icon-info text-danger" /> */}
         </div>
 
@@ -58,6 +59,9 @@ const CustomBotWithoutProxyIntegrationCard = (props) => {
       </div>
 
       <UncontrolledTooltip placement="top" fade={false} target="integration-line-for-tooltip">
+        <small>
+          {t('admin:slack_integration.integration_sentence.integration_successful')}
+        </small>
         {/* <small
           className="m-0"
           // eslint-disable-next-line react/no-danger

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
@@ -25,6 +25,15 @@ const CustomBotWithoutProxyIntegrationCard = (props) => {
       </div>
 
       <div id="integration-line" className="text-center w-25">
+
+        <div className="d-none d-lg-block">
+          <p>pc-size</p>
+        </div>
+
+        <div className="d-block d-lg-none">
+          <p>smartPhone size</p>
+        </div>
+
         <div className="mt-4">
           <small
             className="text-warning m-0"

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
@@ -33,13 +33,13 @@ const CustomBotWithoutProxyIntegrationCard = (props) => {
           <hr className="align-self-center admin-border-danger border-danger"></hr>
         </div>
 
-        <div className="mt-5">
+        {/* <div className="mt-5">
           <p className="text-success small">
             <i className="fa fa-check mr-1" />
             {t('admin:slack_integration.integration_sentence.integration_successful')}
           </p>
           <hr className="align-self-center admin-border-success border-success"></hr>
-        </div>
+        </div> */}
 
       </div>
 

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
@@ -22,7 +22,7 @@ const CustomBotWithoutProxyIntegrationCard = (props) => {
         </div>
       </div>
 
-      <div className="text-center w-25">
+      <div id="integration-line" className="text-center w-25">
         {/* TODO apply correct condition GW-5895 */}
         <div className="mt-4">
           <small

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
@@ -35,7 +35,7 @@ const CustomBotWithoutProxyIntegrationCard = (props) => {
 
           <p className="mt-4">
             <small
-              className="text-warning m-0"
+              className="text-danger m-0"
               // eslint-disable-next-line react/no-danger
               dangerouslySetInnerHTML={{ __html: t('admin:slack_integration.integration_sentence.integration_is_not_complete') }}
             />

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
@@ -27,16 +27,17 @@ const CustomBotWithoutProxyIntegrationCard = (props) => {
       <div className="text-center w-25">
 
         <div className="d-none d-lg-block mt-5">
-          {/* <small
-            className="text-warning m-0"
-            // eslint-disable-next-line react/no-danger
-            dangerouslySetInnerHTML={{ __html: t('admin:slack_integration.integration_sentence.integration_is_not_complete') }}
-          /> */}
 
           <p className="text-success small">
             <i className="fa fa-check mr-1" />
             {t('admin:slack_integration.integration_sentence.integration_successful')}
           </p>
+
+          {/* <small
+            className="text-warning m-0 mt-5"
+            // eslint-disable-next-line react/no-danger
+            dangerouslySetInnerHTML={{ __html: t('admin:slack_integration.integration_sentence.integration_is_not_complete') }}
+          /> */}
         </div>
 
         <div id="integration-line-for-tooltip" className="d-block d-lg-none mt-5">

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
@@ -24,7 +24,7 @@ const CustomBotWithoutProxyIntegrationCard = (props) => {
         </div>
       </div>
 
-      <div id="integration-line" className="text-center w-25">
+      <div className="text-center w-25">
 
         <div className="d-none d-lg-block mt-4">
           <small
@@ -34,7 +34,7 @@ const CustomBotWithoutProxyIntegrationCard = (props) => {
           />
         </div>
 
-        <div className="d-block d-lg-none mt-5">
+        <div id="integration-line-for-tooltip" className="d-block d-lg-none mt-5">
           <i className="fa fa-info-circle text-danger" />
         </div>
 

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import PropTypes from 'prop-types';
 
+import { UncontrolledTooltip } from 'reactstrap';
+
 const CustomBotWithoutProxyIntegrationCard = (props) => {
 
   const { t } = useTranslation();
@@ -49,6 +51,10 @@ const CustomBotWithoutProxyIntegrationCard = (props) => {
           <div className="btn btn-primary">{ props.siteName }</div>
         </div>
       </div>
+
+      <UncontrolledTooltip placement="top" fade={false} target="integration-line">
+       Hello Tooltip!!
+      </UncontrolledTooltip>
     </div>
   );
 };


### PR DESCRIPTION
##  概要
withouProxy の連携図をレスポンシブに対応させました。

- 連携完了時
<img width="494" alt="スクリーンショット 2021-05-25 14 35 01" src="https://user-images.githubusercontent.com/34241526/119446287-241c9200-bd69-11eb-8479-7c719edc3979.png">

- 未完了時
<img width="493" alt="スクリーンショット 2021-05-25 14 34 17" src="https://user-images.githubusercontent.com/34241526/119446292-25e65580-bd69-11eb-98ca-830fdef387d6.png">

## メモ
- 現在は連携未完了の状態で表示させていいます
- 導通の成否によって、表示を切り替える実装は [GW-5998](https://youtrack.weseek.co.jp/agiles/84-39/current?issue=GW-5998) で行っています。
