### PR TITLE
Imprv/get ws name when access admin management if scope is correct

### DIFF
--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
@@ -62,13 +62,13 @@ const IntegrationFailed = () => {
 
 const CustomBotWithoutProxyIntegrationCard = (props) => {
 
-  const { isIntegrationSuccess, slackWSNameInWithoutProxy, siteName } = props;
+  const { slackWSNameInWithoutProxy, siteName } = props;
   return (
     <div className="d-flex justify-content-center my-5 bot-integration">
       <div className="card rounded shadow border-0 w-50 admin-bot-card mb-0">
         <h5 className="card-title font-weight-bold mt-3 ml-4">Slack</h5>
         <div className="card-body p-2 w-50 mx-auto">
-          {isIntegrationSuccess && slackWSNameInWithoutProxy != null && (
+          {slackWSNameInWithoutProxy != null && (
             <div className="card slack-work-space-name-card">
               <div className="m-2 text-center">
                 <h5 className="font-weight-bold">{slackWSNameInWithoutProxy}</h5>
@@ -80,7 +80,7 @@ const CustomBotWithoutProxyIntegrationCard = (props) => {
       </div>
 
       <div className="text-center w-25">
-        {isIntegrationSuccess ? <IntegrationSuccess /> : <IntegrationFailed />}
+        {(slackWSNameInWithoutProxy != null) ? <IntegrationSuccess /> : <IntegrationFailed />}
       </div>
 
       <div className="card rounded-lg shadow border-0 w-50 admin-bot-card mb-0">
@@ -96,7 +96,6 @@ const CustomBotWithoutProxyIntegrationCard = (props) => {
 CustomBotWithoutProxyIntegrationCard.propTypes = {
   siteName: PropTypes.string.isRequired,
   slackWSNameInWithoutProxy: PropTypes.string,
-  isIntegrationSuccess: PropTypes.bool,
 };
 
 export default CustomBotWithoutProxyIntegrationCard;

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
@@ -62,15 +62,16 @@ const IntegrationFailed = () => {
 
 const CustomBotWithoutProxyIntegrationCard = (props) => {
 
+  const { isIntegrationSuccess, slackWSNameInWithoutProxy, siteName } = props;
   return (
     <div className="d-flex justify-content-center my-5 bot-integration">
       <div className="card rounded shadow border-0 w-50 admin-bot-card mb-0">
         <h5 className="card-title font-weight-bold mt-3 ml-4">Slack</h5>
         <div className="card-body p-2 w-50 mx-auto">
-          {props.isIntegrationSuccess && props.slackWSNameInWithoutProxy != null && (
+          {isIntegrationSuccess && slackWSNameInWithoutProxy != null && (
             <div className="card slack-work-space-name-card">
               <div className="m-2 text-center">
-                <h5 className="font-weight-bold">{props.slackWSNameInWithoutProxy}</h5>
+                <h5 className="font-weight-bold">{slackWSNameInWithoutProxy}</h5>
                 <img width={20} height={20} src="/images/slack-integration/growi-bot-kun-icon.png" />
               </div>
             </div>
@@ -79,13 +80,13 @@ const CustomBotWithoutProxyIntegrationCard = (props) => {
       </div>
 
       <div className="text-center w-25">
-        {props.isIntegrationSuccess ? <IntegrationSuccess /> : <IntegrationFailed />}
+        {isIntegrationSuccess ? <IntegrationSuccess /> : <IntegrationFailed />}
       </div>
 
       <div className="card rounded-lg shadow border-0 w-50 admin-bot-card mb-0">
         <h5 className="card-title font-weight-bold mt-3 ml-4">GROWI App</h5>
         <div className="card-body p-4 mb-5 text-center">
-          <div className="btn btn-primary">{ props.siteName }</div>
+          <div className="btn btn-primary">{ siteName }</div>
         </div>
       </div>
     </div>

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -12,7 +12,7 @@ import { toastSuccess, toastError } from '../../../util/apiNotification';
 
 const CustomBotWithoutProxySettings = (props) => {
   const {
-    appContainer, slackWSNameInWithoutProxy, fetchSlackIntegrationData, isIntegrationSuccess,
+    appContainer, slackWSNameInWithoutProxy, fetchSlackIntegrationData,
   } = props;
   const { t } = useTranslation();
 
@@ -66,7 +66,6 @@ const CustomBotWithoutProxySettings = (props) => {
       <CustomBotWithoutProxyIntegrationCard
         siteName={siteName}
         slackWSNameInWithoutProxy={slackWSNameInWithoutProxy}
-        isIntegrationSuccess={isIntegrationSuccess}
       />
 
       <h2 className="admin-setting-header">{t('admin:slack_integration.integration_procedure')}</h2>
@@ -113,7 +112,6 @@ CustomBotWithoutProxySettings.propTypes = {
   slackBotToken: PropTypes.string,
   slackBotTokenEnv: PropTypes.string,
   isRgisterSlackCredentials: PropTypes.bool,
-  isIntegrationSuccess: PropTypes.bool,
   slackWSNameInWithoutProxy: PropTypes.string,
   onResetSettings: PropTypes.func,
   fetchSlackIntegrationData: PropTypes.func,

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -7,6 +7,8 @@ import { withUnstatedContainers } from '../../UnstatedUtils';
 import CustomBotWithoutProxySettingsAccordion, { botInstallationStep } from './CustomBotWithoutProxySettingsAccordion';
 import CustomBotWithoutProxyIntegrationCard from './CustomBotWithoutProxyIntegrationCard';
 import DeleteSlackBotSettingsModal from './DeleteSlackBotSettingsModal';
+import { toastSuccess, toastError } from '../../../util/apiNotification';
+
 
 const CustomBotWithoutProxySettings = (props) => {
   const {
@@ -19,6 +21,7 @@ const CustomBotWithoutProxySettings = (props) => {
   const [connectionMessage, setConnectionMessage] = useState('');
   const [connectionErrorCode, setConnectionErrorCode] = useState(null);
   const [testChannel, setTestChannel] = useState('');
+  const [isCheckIntegrationTest, setIsCheckIntegrationTest] = useState(false);
 
   const resetSettings = async() => {
     try {
@@ -26,19 +29,19 @@ const CustomBotWithoutProxySettings = (props) => {
       setTestChannel('');
       setConnectionMessage('');
       fetchSlackIntegrationData();
-      // toastSuccess(t('admin:slack_integration.bot_reset_successful'));
+      toastSuccess(t('admin:slack_integration.bot_reset_successful'));
     }
     catch (error) {
-      // toastError(error);
+      toastError(error);
     }
   };
 
   const testConnection = async() => {
-    setConnectionErrorCode(null);
-    setConnectionMessage(null);
     try {
       await appContainer.apiv3.post('/slack-integration-settings/without-proxy/test', { channel: testChannel });
       setConnectionMessage('Send the message to slack work space.');
+      setIsCheckIntegrationTest(true);
+
       fetchSlackIntegrationData();
     }
     catch (err) {
@@ -83,7 +86,7 @@ const CustomBotWithoutProxySettings = (props) => {
           activeStep={botInstallationStep.CREATE_BOT}
           connectionMessage={connectionMessage}
           connectionErrorCode={connectionErrorCode}
-          isIntegrationSuccess={isIntegrationSuccess}
+          isCheckIntegrationTest={isCheckIntegrationTest}
           testChannel={testChannel}
           onTestFormSubmitted={testConnection}
           inputTestChannelHandler={inputTestChannelHandler}

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -9,7 +9,7 @@ import CustomBotWithoutProxyIntegrationCard from './CustomBotWithoutProxyIntegra
 import DeleteSlackBotSettingsModal from './DeleteSlackBotSettingsModal';
 
 const CustomBotWithoutProxySettings = (props) => {
-  const { appContainer, onResetSettings, slackWSNameInWithoutProxy } = props;
+  const { appContainer, slackWSNameInWithoutProxy, fetchSlackIntegrationData } = props;
   const { t } = useTranslation();
 
   const [siteName, setSiteName] = useState('');
@@ -20,10 +20,17 @@ const CustomBotWithoutProxySettings = (props) => {
   const [testChannel, setTestChannel] = useState('');
 
   const resetSettings = async() => {
-    if (onResetSettings == null) {
-      return;
+    try {
+      await appContainer.apiv3.put('/slack-integration-settings/bot-type', { currentBotType: 'customBotWithoutProxy' });
+      setTestChannel('');
+      setIsIntegrationSuccess(false);
+      setConnectionMessage('');
+      fetchSlackIntegrationData();
+      // toastSuccess(t('admin:slack_integration.bot_reset_successful'));
     }
-    onResetSettings();
+    catch (error) {
+      // toastError(error);
+    }
   };
 
   const testConnection = async() => {

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -9,7 +9,7 @@ import CustomBotWithoutProxyIntegrationCard from './CustomBotWithoutProxyIntegra
 import DeleteSlackBotSettingsModal from './DeleteSlackBotSettingsModal';
 
 const CustomBotWithoutProxySettings = (props) => {
-  const { appContainer, onResetSettings } = props;
+  const { appContainer, onResetSettings, slackWSNameInWithoutProxy } = props;
   const { t } = useTranslation();
 
   const [siteName, setSiteName] = useState('');
@@ -56,7 +56,7 @@ const CustomBotWithoutProxySettings = (props) => {
 
       <CustomBotWithoutProxyIntegrationCard
         siteName={siteName}
-        slackWSNameInWithoutProxy={props.slackWSNameInWithoutProxy}
+        slackWSNameInWithoutProxy={slackWSNameInWithoutProxy}
         isIntegrationSuccess={isIntegrationSuccess}
       />
 

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -28,6 +28,7 @@ const CustomBotWithoutProxySettings = (props) => {
       await appContainer.apiv3.put('/slack-integration-settings/bot-type', { currentBotType: 'customBotWithoutProxy' });
       setTestChannel('');
       setConnectionMessage('');
+      setIsCheckIntegrationTest(false);
       fetchSlackIntegrationData();
       toastSuccess(t('admin:slack_integration.bot_reset_successful'));
     }

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -9,12 +9,13 @@ import CustomBotWithoutProxyIntegrationCard from './CustomBotWithoutProxyIntegra
 import DeleteSlackBotSettingsModal from './DeleteSlackBotSettingsModal';
 
 const CustomBotWithoutProxySettings = (props) => {
-  const { appContainer, slackWSNameInWithoutProxy, fetchSlackIntegrationData } = props;
+  const {
+    appContainer, slackWSNameInWithoutProxy, fetchSlackIntegrationData, isIntegrationSuccess,
+  } = props;
   const { t } = useTranslation();
 
   const [siteName, setSiteName] = useState('');
   const [isDeleteConfirmModalShown, setIsDeleteConfirmModalShown] = useState(false);
-  const [isIntegrationSuccess, setIsIntegrationSuccess] = useState(false);
   const [connectionMessage, setConnectionMessage] = useState('');
   const [connectionErrorCode, setConnectionErrorCode] = useState(null);
   const [testChannel, setTestChannel] = useState('');
@@ -23,7 +24,6 @@ const CustomBotWithoutProxySettings = (props) => {
     try {
       await appContainer.apiv3.put('/slack-integration-settings/bot-type', { currentBotType: 'customBotWithoutProxy' });
       setTestChannel('');
-      setIsIntegrationSuccess(false);
       setConnectionMessage('');
       fetchSlackIntegrationData();
       // toastSuccess(t('admin:slack_integration.bot_reset_successful'));
@@ -39,12 +39,11 @@ const CustomBotWithoutProxySettings = (props) => {
     try {
       await appContainer.apiv3.post('/slack-integration-settings/without-proxy/test', { channel: testChannel });
       setConnectionMessage('Send the message to slack work space.');
-      setIsIntegrationSuccess(true);
+      fetchSlackIntegrationData();
     }
     catch (err) {
       setConnectionErrorCode(err[0].code);
       setConnectionMessage(err[0].message);
-      setIsIntegrationSuccess(false);
     }
   };
 
@@ -114,6 +113,7 @@ CustomBotWithoutProxySettings.propTypes = {
   isIntegrationSuccess: PropTypes.bool,
   slackWSNameInWithoutProxy: PropTypes.string,
   onResetSettings: PropTypes.func,
+  fetchSlackIntegrationData: PropTypes.func,
 };
 
 export default CustomBotWithoutProxySettingsWrapper;

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
@@ -19,14 +19,13 @@ const CustomBotWithoutProxySettingsAccordion = ({
   appContainer, activeStep,
   connectionMessage, connectionErrorCode, testChannel, slackSigningSecret, slackSigningSecretEnv, slackBotToken, slackBotTokenEnv,
   isRegisterSlackCredentials, isCheckIntegrationTest,
-  fetchSlackIntegrationData, inputTestChannelHandler, onTestFormSubmitted, onSetSlackSigningSecret, onSetSlackBotToken,
+  inputTestChannelHandler, onTestFormSubmitted, onSetSlackSigningSecret, onSetSlackBotToken, onUpdateSecretTokenHandlerInvoked,
 }) => {
   const { t } = useTranslation();
   // TODO: GW-5644 Store default open accordion
   // eslint-disable-next-line no-unused-vars
   const [defaultOpenAccordionKeys, setDefaultOpenAccordionKeys] = useState(new Set([activeStep]));
   const currentBotType = 'customBotWithoutProxy';
-
 
   const updateSecretTokenHandler = async() => {
     try {
@@ -36,9 +35,11 @@ const CustomBotWithoutProxySettingsAccordion = ({
         currentBotType,
       });
 
-      if (fetchSlackIntegrationData == null) {
+      if (onUpdateSecretTokenHandlerInvoked == null) {
         return null;
       }
+      onUpdateSecretTokenHandlerInvoked(true);
+
       toastSuccess(t('toaster.update_successed', { target: t('admin:slack_integration.custom_bot_without_proxy_settings') }));
     }
     catch (err) {
@@ -199,9 +200,9 @@ CustomBotWithoutProxySettingsAccordion.propTypes = {
   testChannel: PropTypes.string,
   isRegisterSlackCredentials: PropTypes.bool,
   isCheckIntegrationTest: PropTypes.bool,
-  fetchSlackIntegrationData: PropTypes.func,
   inputTestChannelHandler: PropTypes.func,
   onTestFormSubmitted: PropTypes.func,
+  onUpdateSecretTokenHandlerInvoked: PropTypes.func,
   onSetSlackSigningSecret: PropTypes.func,
   onSetSlackBotToken: PropTypes.func,
   connectionMessage: PropTypes.string,

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
@@ -39,7 +39,6 @@ const CustomBotWithoutProxySettingsAccordion = ({
       if (fetchSlackIntegrationData == null) {
         return null;
       }
-      fetchSlackIntegrationData();
       toastSuccess(t('toaster.update_successed', { target: t('admin:slack_integration.custom_bot_without_proxy_settings') }));
     }
     catch (err) {

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
@@ -161,7 +161,7 @@ const CustomBotWithoutProxySettingsAccordion = ({
             </button>
           </form>
         </div>
-        {connectionMessage == null
+        {connectionMessage === ''
           ? <p></p>
           : (
             <>

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
@@ -18,7 +18,7 @@ export const botInstallationStep = {
 const CustomBotWithoutProxySettingsAccordion = ({
   appContainer, activeStep,
   connectionMessage, connectionErrorCode, testChannel, slackSigningSecret, slackSigningSecretEnv, slackBotToken, slackBotTokenEnv,
-  isRegisterSlackCredentials, isIntegrationSuccess,
+  isRegisterSlackCredentials, isCheckIntegrationTest,
   fetchSlackIntegrationData, inputTestChannelHandler, onTestFormSubmitted, onSetSlackSigningSecret, onSetSlackBotToken,
 }) => {
   const { t } = useTranslation();
@@ -135,7 +135,7 @@ const CustomBotWithoutProxySettingsAccordion = ({
       <Accordion
         defaultIsActive={defaultOpenAccordionKeys.has(botInstallationStep.CONNECTION_TEST)}
         // eslint-disable-next-line max-len
-        title={<><span className="mr-2">④</span>{t('admin:slack_integration.accordion.test_connection')}{isIntegrationSuccess && <i className="ml-3 text-success fa fa-check"></i>}</>}
+        title={<><span className="mr-2">④</span>{t('admin:slack_integration.accordion.test_connection')}{isCheckIntegrationTest && <i className="ml-3 text-success fa fa-check"></i>}</>}
       >
         <p className="text-center m-4">{t('admin:slack_integration.accordion.test_connection_by_pressing_button')}</p>
         <div className="d-flex justify-content-center">
@@ -199,7 +199,7 @@ CustomBotWithoutProxySettingsAccordion.propTypes = {
   slackBotTokenEnv: PropTypes.string,
   testChannel: PropTypes.string,
   isRegisterSlackCredentials: PropTypes.bool,
-  isIntegrationSuccess: PropTypes.bool,
+  isCheckIntegrationTest: PropTypes.bool,
   fetchSlackIntegrationData: PropTypes.func,
   inputTestChannelHandler: PropTypes.func,
   onTestFormSubmitted: PropTypes.func,

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -37,12 +37,13 @@ const SlackIntegration = (props) => {
       const {
         slackSigningSecret, slackBotToken, slackSigningSecretEnvVars, slackBotTokenEnvVars, slackAppIntegrations, proxyServerUri, isIntegrationToSlack,
       } = data.settings;
-      setIsIntegrationSuccess(isIntegrationToSlack);
 
       if (data.connectionStatuses != null) {
         // TODO fix
-        const { workspaceName } = data.connectionStatuses[slackBotToken];
-        setSlackWSNameInWithoutProxy(workspaceName);
+        if (data.currentBotType === 'customBotWithoutProxy') {
+          const { workspaceName } = data.connectionStatuses[slackBotToken];
+          setSlackWSNameInWithoutProxy(workspaceName);
+        }
       }
       setCurrentBotType(data.currentBotType);
       setSlackSigningSecret(slackSigningSecret);
@@ -51,6 +52,8 @@ const SlackIntegration = (props) => {
       setSlackBotTokenEnv(slackBotTokenEnvVars);
       setSlackAppIntegrations(slackAppIntegrations);
       setProxyServerUri(proxyServerUri);
+      setIsIntegrationSuccess(isIntegrationToSlack);
+
 
       setIsRegisterSlackCredentials(false);
       if ((slackSigningSecret != null && slackBotToken != null) || (slackBotTokenEnvVars != null && slackSigningSecretEnvVars != null)) {
@@ -84,9 +87,7 @@ const SlackIntegration = (props) => {
       });
       setCurrentBotType(res.data.slackBotTypeParam.slackBotType);
       setSelectedBotType(null);
-      setIsRegisterSlackCredentials(false);
-      setSlackSigningSecret(null);
-      setSlackBotToken(null);
+      fetchSlackIntegrationData();
     }
     catch (err) {
       toastError(err);

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -28,23 +28,22 @@ const SlackIntegration = (props) => {
   const [isDeleteConfirmModalShown, setIsDeleteConfirmModalShown] = useState(false);
   const [slackAppIntegrations, setSlackAppIntegrations] = useState();
   const [proxyServerUri, setProxyServerUri] = useState();
+  const [isIntegrationSuccess, setIsIntegrationSuccess] = useState(false);
 
 
   const fetchSlackIntegrationData = useCallback(async() => {
-    console.log('nka');
     try {
       const { data } = await appContainer.apiv3.get('/slack-integration-settings');
       const {
-        slackSigningSecret, slackBotToken, slackSigningSecretEnvVars, slackBotTokenEnvVars, slackAppIntegrations, proxyServerUri,
+        slackSigningSecret, slackBotToken, slackSigningSecretEnvVars, slackBotTokenEnvVars, slackAppIntegrations, proxyServerUri, isIntegrationToSlack,
       } = data.settings;
+      setIsIntegrationSuccess(isIntegrationToSlack);
 
       if (data.connectionStatuses != null) {
         // TODO fix
         const { workspaceName } = data.connectionStatuses[slackBotToken];
-        console.log(workspaceName);
         setSlackWSNameInWithoutProxy(workspaceName);
       }
-
       setCurrentBotType(data.currentBotType);
       setSlackSigningSecret(slackSigningSecret);
       setSlackBotToken(slackBotToken);
@@ -68,17 +67,6 @@ const SlackIntegration = (props) => {
       toastError(error);
     }
   };
-
-  // const resetWithoutSettings = async() => {
-  //   try {
-  //     await appContainer.apiv3.put('/slack-integration-settings/bot-type', { currentBotType: 'customBotWithoutProxy' });
-  //     fetchSlackIntegrationData();
-  //     toastSuccess(t('admin:slack_integration.bot_reset_successful'));
-  //   }
-  //   catch (error) {
-  //     toastError(error);
-  //   }
-  // };
 
   useEffect(() => {
     fetchSlackIntegrationData();
@@ -137,8 +125,8 @@ const SlackIntegration = (props) => {
           slackWSNameInWithoutProxy={slackWSNameInWithoutProxy}
           onSetSlackSigningSecret={setSlackSigningSecret}
           onSetSlackBotToken={setSlackBotToken}
-          // onResetSettings={resetWithoutSettings}
           fetchSlackIntegrationData={fetchSlackIntegrationData}
+          isIntegrationSuccess={isIntegrationSuccess}
         />
       );
       break;

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -32,6 +32,7 @@ const SlackIntegration = (props) => {
 
 
   const fetchSlackIntegrationData = useCallback(async() => {
+    console.log('nka');
     try {
       const { data } = await appContainer.apiv3.get('/slack-integration-settings');
       const {
@@ -40,8 +41,9 @@ const SlackIntegration = (props) => {
 
       if (data.connectionStatuses != null) {
         // TODO fix
-        // const { workspaceName } = data.connectionStatuses[slackBotToken];
-        // setSlackWSNameInWithoutProxy(workspaceName);
+        const { workspaceName } = data.connectionStatuses[slackBotToken];
+        console.log(workspaceName);
+        setSlackWSNameInWithoutProxy(workspaceName);
       }
 
       setCurrentBotType(data.currentBotType);

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -69,16 +69,16 @@ const SlackIntegration = (props) => {
     }
   };
 
-  const resetWithoutSettings = async() => {
-    try {
-      await appContainer.apiv3.put('/slack-integration-settings/bot-type', { currentBotType: 'customBotWithoutProxy' });
-      fetchSlackIntegrationData();
-      toastSuccess(t('admin:slack_integration.bot_reset_successful'));
-    }
-    catch (error) {
-      toastError(error);
-    }
-  };
+  // const resetWithoutSettings = async() => {
+  //   try {
+  //     await appContainer.apiv3.put('/slack-integration-settings/bot-type', { currentBotType: 'customBotWithoutProxy' });
+  //     fetchSlackIntegrationData();
+  //     toastSuccess(t('admin:slack_integration.bot_reset_successful'));
+  //   }
+  //   catch (error) {
+  //     toastError(error);
+  //   }
+  // };
 
   useEffect(() => {
     fetchSlackIntegrationData();
@@ -137,7 +137,7 @@ const SlackIntegration = (props) => {
           slackWSNameInWithoutProxy={slackWSNameInWithoutProxy}
           onSetSlackSigningSecret={setSlackSigningSecret}
           onSetSlackBotToken={setSlackBotToken}
-          onResetSettings={resetWithoutSettings}
+          // onResetSettings={resetWithoutSettings}
           fetchSlackIntegrationData={fetchSlackIntegrationData}
         />
       );

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -21,8 +21,8 @@ const SlackIntegration = (props) => {
   const [selectedBotType, setSelectedBotType] = useState(null);
   const [slackSigningSecret, setSlackSigningSecret] = useState(null);
   const [slackBotToken, setSlackBotToken] = useState(null);
-  const [slackSigningSecretEnv, setSlackSigningSecretEnv] = useState('');
-  const [slackBotTokenEnv, setSlackBotTokenEnv] = useState('');
+  const [slackSigningSecretEnv, setSlackSigningSecretEnv] = useState(null);
+  const [slackBotTokenEnv, setSlackBotTokenEnv] = useState(null);
   const [isRegisterSlackCredentials, setIsRegisterSlackCredentials] = useState(false);
   const [slackWSNameInWithoutProxy, setSlackWSNameInWithoutProxy] = useState(null);
   const [isDeleteConfirmModalShown, setIsDeleteConfirmModalShown] = useState(false);
@@ -51,6 +51,11 @@ const SlackIntegration = (props) => {
       setSlackBotTokenEnv(slackBotTokenEnvVars);
       setSlackAppIntegrations(slackAppIntegrations);
       setProxyServerUri(proxyServerUri);
+
+      setIsRegisterSlackCredentials(false);
+      if ((slackSigningSecret != null && slackBotToken != null) || (slackBotTokenEnvVars != null && slackSigningSecretEnvVars != null)) {
+        setIsRegisterSlackCredentials(true);
+      }
     }
     catch (err) {
       toastError(err);
@@ -82,7 +87,6 @@ const SlackIntegration = (props) => {
       setIsRegisterSlackCredentials(false);
       setSlackSigningSecret(null);
       setSlackBotToken(null);
-      setSlackWSNameInWithoutProxy(null);
     }
     catch (err) {
       toastError(err);

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -129,6 +129,7 @@ const SlackIntegration = (props) => {
           onSetSlackSigningSecret={setSlackSigningSecret}
           onSetSlackBotToken={setSlackBotToken}
           fetchSlackIntegrationData={fetchSlackIntegrationData}
+          onUpdateSecretTokenHandlerInvoked={setIsRegisterSlackCredentials}
         />
       );
       break;

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -28,16 +28,16 @@ const SlackIntegration = (props) => {
   const [isDeleteConfirmModalShown, setIsDeleteConfirmModalShown] = useState(false);
   const [slackAppIntegrations, setSlackAppIntegrations] = useState();
   const [proxyServerUri, setProxyServerUri] = useState();
-  const [isIntegrationSuccess, setIsIntegrationSuccess] = useState(false);
 
 
   const fetchSlackIntegrationData = useCallback(async() => {
     try {
       const { data } = await appContainer.apiv3.get('/slack-integration-settings');
       const {
-        slackSigningSecret, slackBotToken, slackSigningSecretEnvVars, slackBotTokenEnvVars, slackAppIntegrations, proxyServerUri, isIntegrationToSlack,
+        slackSigningSecret, slackBotToken, slackSigningSecretEnvVars, slackBotTokenEnvVars, slackAppIntegrations, proxyServerUri,
       } = data.settings;
 
+      setSlackWSNameInWithoutProxy(null);
       if (data.connectionStatuses != null) {
         // TODO fix
         if (data.currentBotType === 'customBotWithoutProxy') {
@@ -52,8 +52,6 @@ const SlackIntegration = (props) => {
       setSlackBotTokenEnv(slackBotTokenEnvVars);
       setSlackAppIntegrations(slackAppIntegrations);
       setProxyServerUri(proxyServerUri);
-      setIsIntegrationSuccess(isIntegrationToSlack);
-
 
       setIsRegisterSlackCredentials(false);
       if ((slackSigningSecret != null && slackBotToken != null) || (slackBotTokenEnvVars != null && slackSigningSecretEnvVars != null)) {
@@ -131,7 +129,6 @@ const SlackIntegration = (props) => {
           onSetSlackSigningSecret={setSlackSigningSecret}
           onSetSlackBotToken={setSlackBotToken}
           fetchSlackIntegrationData={fetchSlackIntegrationData}
-          isIntegrationSuccess={isIntegrationSuccess}
         />
       );
       break;

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -69,7 +69,7 @@ const SlackIntegration = (props) => {
     }
   };
 
-  const resetWithOutSettings = async() => {
+  const resetWithoutSettings = async() => {
     try {
       await appContainer.apiv3.put('/slack-integration-settings/bot-type', { currentBotType: 'customBotWithoutProxy' });
       fetchSlackIntegrationData();
@@ -137,7 +137,7 @@ const SlackIntegration = (props) => {
           slackWSNameInWithoutProxy={slackWSNameInWithoutProxy}
           onSetSlackSigningSecret={setSlackSigningSecret}
           onSetSlackBotToken={setSlackBotToken}
-          onResetSettings={resetWithOutSettings}
+          onResetSettings={resetWithoutSettings}
           fetchSlackIntegrationData={fetchSlackIntegrationData}
         />
       );

--- a/src/server/routes/apiv3/slack-integration-settings.js
+++ b/src/server/routes/apiv3/slack-integration-settings.js
@@ -178,6 +178,9 @@ module.exports = (crowi) => {
           logger.error('Error', error);
           return res.apiv3Err(new ErrorV3(`Error occured while testing. Cause: ${error.message}`, 'test-failed', error.stack));
         }
+
+        await updateSlackBotSettings({ 'slackbot:isIntegration': true });
+        crowi.slackBotService.publishUpdatedMessage();
       }
     }
     else {

--- a/src/server/routes/apiv3/slack-integration-settings.js
+++ b/src/server/routes/apiv3/slack-integration-settings.js
@@ -82,7 +82,6 @@ module.exports = (crowi) => {
       'slackbot:signingSecret': null,
       'slackbot:token': null,
       'slackbot:proxyServerUri': null,
-      'slackbot:isIntegration': null,
     };
     const { configManager } = crowi;
     // update config without publishing S2sMessage
@@ -150,7 +149,6 @@ module.exports = (crowi) => {
       settings.proxyServerUri = crowi.configManager.getConfig('crowi', 'slackbot:proxyServerUri');
       settings.proxyUriEnvVars = configManager.getConfigFromEnvVars('crowi', 'slackbot:proxyServerUri');
     }
-    settings.isIntegrationToSlack = configManager.getConfig('crowi', 'slackbot:isIntegration');
 
     // retrieve connection statuses
     let connectionStatuses;
@@ -178,9 +176,6 @@ module.exports = (crowi) => {
           logger.error('Error', error);
           return res.apiv3Err(new ErrorV3(`Error occured while testing. Cause: ${error.message}`, 'test-failed', error.stack));
         }
-
-        await updateSlackBotSettings({ 'slackbot:isIntegration': true });
-        crowi.slackBotService.publishUpdatedMessage();
       }
     }
     else {
@@ -542,8 +537,7 @@ module.exports = (crowi) => {
     catch (error) {
       return res.apiv3Err(new ErrorV3(`Error occured while sending message. Cause: ${error.message}`, 'send-message-failed', error.stack));
     }
-    await updateSlackBotSettings({ 'slackbot:isIntegration': true });
-    crowi.slackBotService.publishUpdatedMessage();
+
     return res.apiv3();
   });
 

--- a/src/server/routes/apiv3/slack-integration-settings.js
+++ b/src/server/routes/apiv3/slack-integration-settings.js
@@ -156,9 +156,12 @@ module.exports = (crowi) => {
       // TODO imple null action
     }
     else if (currentBotType === 'customBotWithoutProxy') {
+      connectionStatuses = null;
       const token = settings.slackBotToken;
+      console.log(token);
       // check the token is not null
       if (token != null) {
+        console.log('token 存在');
         try {
           connectionStatuses = await getConnectionStatuses([token]);
         }
@@ -167,7 +170,16 @@ module.exports = (crowi) => {
           logger.error('Error', error);
           return res.apiv3Err(new ErrorV3(msg, 'get-connection-failed'), 500);
         }
+
+        try {
+          await testToSlack(token);
+        }
+        catch (error) {
+          logger.error('Error', error);
+          return res.apiv3Err(new ErrorV3(`Error occured while testing. Cause: ${error.message}`, 'test-failed', error.stack));
+        }
       }
+      console.log(connectionStatuses);
     }
     else {
       const proxyServerUri = settings.proxyServerUri;

--- a/src/server/routes/apiv3/slack-integration-settings.js
+++ b/src/server/routes/apiv3/slack-integration-settings.js
@@ -82,6 +82,7 @@ module.exports = (crowi) => {
       'slackbot:signingSecret': null,
       'slackbot:token': null,
       'slackbot:proxyServerUri': null,
+      'slackbot:isIntegration': null,
     };
     const { configManager } = crowi;
     // update config without publishing S2sMessage
@@ -149,6 +150,7 @@ module.exports = (crowi) => {
       settings.proxyServerUri = crowi.configManager.getConfig('crowi', 'slackbot:proxyServerUri');
       settings.proxyUriEnvVars = configManager.getConfigFromEnvVars('crowi', 'slackbot:proxyServerUri');
     }
+    settings.isIntegrationToSlack = configManager.getConfig('crowi', 'slackbot:isIntegration');
 
     // retrieve connection statuses
     let connectionStatuses;
@@ -158,10 +160,8 @@ module.exports = (crowi) => {
     else if (currentBotType === 'customBotWithoutProxy') {
       connectionStatuses = null;
       const token = settings.slackBotToken;
-      console.log(token);
       // check the token is not null
       if (token != null) {
-        console.log('token 存在');
         try {
           connectionStatuses = await getConnectionStatuses([token]);
         }
@@ -179,7 +179,6 @@ module.exports = (crowi) => {
           return res.apiv3Err(new ErrorV3(`Error occured while testing. Cause: ${error.message}`, 'test-failed', error.stack));
         }
       }
-      console.log(connectionStatuses);
     }
     else {
       const proxyServerUri = settings.proxyServerUri;
@@ -540,7 +539,8 @@ module.exports = (crowi) => {
     catch (error) {
       return res.apiv3Err(new ErrorV3(`Error occured while sending message. Cause: ${error.message}`, 'send-message-failed', error.stack));
     }
-
+    await updateSlackBotSettings({ 'slackbot:isIntegration': true });
+    crowi.slackBotService.publishUpdatedMessage();
     return res.apiv3();
   });
 

--- a/src/server/service/config-loader.js
+++ b/src/server/service/config-loader.js
@@ -422,12 +422,6 @@ const ENV_VAR_NAME_TO_CONFIG_INFO = {
     type:    TYPES.STRING,
     default: null,
   },
-  SLACK_IS_INTEGRATION: {
-    ns:      'crowi',
-    key:     'slackbot:isIntegration',
-    type:    TYPES.BOOLEAN,
-    default: null,
-  },
   DEFAULT_EMAIL_PUBLISHED: {
     ns:      'crowi',
     key:     'customize:isEmailPublishedForNewUser',

--- a/src/server/service/config-loader.js
+++ b/src/server/service/config-loader.js
@@ -422,6 +422,12 @@ const ENV_VAR_NAME_TO_CONFIG_INFO = {
     type:    TYPES.STRING,
     default: null,
   },
+  SLACK_IS_INTEGRATION: {
+    ns:      'crowi',
+    key:     'slackbot:isIntegration',
+    type:    TYPES.BOOLEAN,
+    default: null,
+  },
   DEFAULT_EMAIL_PUBLISHED: {
     ns:      'crowi',
     key:     'customize:isEmailPublishedForNewUser',


### PR DESCRIPTION
## 概要
slack 連携のページにアクセスするたびに、
情報が正しければ、slack work space 名を取得できるようにしています。

without に関して言えば、 test を実行しなくても reload すると testボタンと似たような処理が走るので ws 名を取得できてしまいますが、これは使用上どうしようもないと思っています。