### PR TITLE
add slack scope test at get('/')

### DIFF
--- a/src/server/routes/apiv3/slack-integration-settings.js
+++ b/src/server/routes/apiv3/slack-integration-settings.js
@@ -151,6 +151,7 @@ module.exports = (crowi) => {
       // TODO imple null action
     }
     else if (currentBotType === 'customBotWithoutProxy') {
+      connectionStatuses = null;
       const token = settings.slackBotToken;
       // check the token is not null
       if (token != null) {
@@ -163,6 +164,15 @@ module.exports = (crowi) => {
           return res.apiv3Err(new ErrorV3(msg, 'get-connection-failed'), 500);
         }
       }
+
+      try {
+        await testToSlack(token);
+      }
+      catch (error) {
+        logger.error('Error', error);
+        return res.apiv3Err(new ErrorV3(`Error occured while testing. Cause: ${error.message}`, 'test-failed', error.stack));
+      }
+
     }
     else {
       try {


### PR DESCRIPTION
## 概要
api を修正しています。[slack-integration-settings.js]

slack 連携にアクセスしたときにその都度、get アクションを行い情報を取得します。
その時に testToSlack  を行うように改修しました。

この処理が必要な理由は以下です。
初回は secret と token  を入力したあと test ボタンを実行して ws 名を取得します。
しかし、2回目以降は secret と token が入っているので、それを元に data を取得してきます。
この時に scope も正しい必要があり(testToSlack を実行する必要があり)、正しければ 導通しているマークを出します。
