### PR TITLE
Imprv/numbering each accordion and display words at error

### DIFF
--- a/resource/locales/en_US/admin/admin.json
+++ b/resource/locales/en_US/admin/admin.json
@@ -296,6 +296,7 @@
     "delete": "Delete",
     "integration_procedure": "Integration Procedure",
     "custom_bot_without_proxy_settings": "Custom Bot without proxy Settings",
+    "integration_failed":"Integration failed",
     "official_bot_settings": "Official bot Settings",
     "reset": "Reset",
     "reset_all_settings": "Reset all settings",

--- a/resource/locales/ja_JP/admin/admin.json
+++ b/resource/locales/ja_JP/admin/admin.json
@@ -294,6 +294,7 @@
     "delete": "削除",
     "integration_procedure": "連携手順",
     "custom_bot_without_proxy_settings": "Custom Bot (Without-Proxy) 設定",
+    "integration_failed":"連携に失敗しました",
     "reset": "リセット",
     "reset_all_settings": "全ての設定をリセット",
     "delete_slackbot_settings": "Slack Bot 設定をリセットする",

--- a/resource/locales/zh_CN/admin/admin.json
+++ b/resource/locales/zh_CN/admin/admin.json
@@ -304,6 +304,7 @@
     "delete": "取消",
     "integration_procedure": "协作程序",
     "custom_bot_without_proxy_settings": "Custom Bot (Without-Proxy) 设置",
+    "integration_failed":"联动失败",
     "reset":"重置",
     "reset_all_settings": "重置所有设置",
     "delete_slackbot_settings": "重置 Slack Bot 设置",

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
@@ -12,7 +12,9 @@ import DeleteSlackBotSettingsModal from './DeleteSlackBotSettingsModal';
 const logger = loggerFactory('growi:SlackBotSettings');
 
 const CustomBotWithProxySettings = (props) => {
-  const { appContainer, slackAppIntegrations, proxyServerUri } = props;
+  const {
+    appContainer, slackAppIntegrations, proxyServerUri, connectionStatuses,
+  } = props;
   const [newProxyServerUri, setNewProxyServerUri] = useState();
   const [integrationIdToDelete, setIntegrationIdToDelete] = useState(null);
   const { t } = useTranslation();
@@ -110,7 +112,7 @@ const CustomBotWithProxySettings = (props) => {
 
       <h2 className="admin-setting-header">{t('admin:slack_integration.integration_procedure')}</h2>
       <div className="mx-3">
-        {slackAppIntegrations.map((slackAppIntegration) => {
+        {slackAppIntegrations.map((slackAppIntegration, i) => {
           const { tokenGtoP, tokenPtoG } = slackAppIntegration;
           return (
             <React.Fragment key={slackAppIntegration._id}>
@@ -124,6 +126,7 @@ const CustomBotWithProxySettings = (props) => {
                   {t('admin:slack_integration.delete')}
                 </button>
               </div>
+              <div>No.{i + 1}</div>
               <WithProxyAccordions
                 botType="customBotWithProxy"
                 slackAppIntegrationId={slackAppIntegration._id}

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
@@ -19,10 +19,13 @@ const CustomBotWithProxySettings = (props) => {
   const [integrationIdToDelete, setIntegrationIdToDelete] = useState(null);
   const { t } = useTranslation();
 
-  const workspaceNameObjects = Object.values(connectionStatuses);
-  const workspaceNames = workspaceNameObjects.map((w) => {
-    return w.workspaceName;
-  });
+  let workspaceNames;
+  if (connectionStatuses != null) {
+    const workspaceNameObjects = Object.values(connectionStatuses);
+    workspaceNames = workspaceNameObjects.map((w) => {
+      return w.workspaceName;
+    });
+  }
 
   useEffect(() => {
     if (proxyServerUri != null) {
@@ -132,7 +135,7 @@ const CustomBotWithProxySettings = (props) => {
                   {t('admin:slack_integration.delete')}
                 </button>
               </div>
-              <div>No.{i + 1} {workspaceNames[i] == null && <span className="text-danger">{t('admin:slack_integration.integration_failed')}</span>}</div>
+              {workspaceNames[i] == null && (<>Settings #{i + 1} <span className="text-danger">{t('admin:slack_integration.integration_failed')}</span></>)}
               <WithProxyAccordions
                 botType="customBotWithProxy"
                 slackAppIntegrationId={slackAppIntegration._id}
@@ -167,6 +170,7 @@ const CustomBotWithProxySettingsWrapper = withUnstatedContainers(CustomBotWithPr
 
 CustomBotWithProxySettings.defaultProps = {
   slackAppIntegrations: [],
+  connectionStatuses: null,
 };
 
 CustomBotWithProxySettings.propTypes = {

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
@@ -19,6 +19,11 @@ const CustomBotWithProxySettings = (props) => {
   const [integrationIdToDelete, setIntegrationIdToDelete] = useState(null);
   const { t } = useTranslation();
 
+  const workspaceNamesArray = Object.values(connectionStatuses);
+  const workspaceNames = workspaceNamesArray.map((w) => {
+    return w.workspaceName;
+  });
+
   useEffect(() => {
     if (proxyServerUri != null) {
       setNewProxyServerUri(proxyServerUri);
@@ -126,7 +131,7 @@ const CustomBotWithProxySettings = (props) => {
                   {t('admin:slack_integration.delete')}
                 </button>
               </div>
-              <div>No.{i + 1}</div>
+              <div>No.{i + 1} {workspaceNames[i] == null && <span className="text-danger">連携に失敗しました</span>}</div>
               <WithProxyAccordions
                 botType="customBotWithProxy"
                 slackAppIntegrationId={slackAppIntegration._id}
@@ -168,6 +173,7 @@ CustomBotWithProxySettings.propTypes = {
   slackAppIntegrations: PropTypes.array,
   proxyServerUri: PropTypes.string,
   fetchSlackIntegrationData: PropTypes.func,
+  connectionStatuses: PropTypes.object,
 };
 
 export default CustomBotWithProxySettingsWrapper;

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
@@ -19,8 +19,8 @@ const CustomBotWithProxySettings = (props) => {
   const [integrationIdToDelete, setIntegrationIdToDelete] = useState(null);
   const { t } = useTranslation();
 
-  const workspaceNamesArray = Object.values(connectionStatuses);
-  const workspaceNames = workspaceNamesArray.map((w) => {
+  const workspaceNameObjects = Object.values(connectionStatuses);
+  const workspaceNames = workspaceNameObjects.map((w) => {
     return w.workspaceName;
   });
 

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
@@ -131,7 +131,7 @@ const CustomBotWithProxySettings = (props) => {
                   {t('admin:slack_integration.delete')}
                 </button>
               </div>
-              <div>No.{i + 1} {workspaceNames[i] == null && <span className="text-danger">連携に失敗しました</span>}</div>
+              <div>No.{i + 1} {workspaceNames[i] == null && <span className="text-danger">{t('admin:slack_integration.integration_failed')}</span>}</div>
               <WithProxyAccordions
                 botType="customBotWithProxy"
                 slackAppIntegrationId={slackAppIntegration._id}

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -28,6 +28,7 @@ const SlackIntegration = (props) => {
   const [isDeleteConfirmModalShown, setIsDeleteConfirmModalShown] = useState(false);
   const [slackAppIntegrations, setSlackAppIntegrations] = useState();
   const [proxyServerUri, setProxyServerUri] = useState();
+  const [connectionStatuses, setConnectionStatuses] = useState(null);
 
 
   const fetchSlackIntegrationData = useCallback(async() => {
@@ -41,6 +42,8 @@ const SlackIntegration = (props) => {
         // TODO fix
         // const { workspaceName } = data.connectionStatuses[slackBotToken];
         // setSlackWSNameInWithoutProxy(workspaceName);
+        setConnectionStatuses(data.connectionStatuses);
+
       }
 
       setCurrentBotType(data.currentBotType);
@@ -146,6 +149,7 @@ const SlackIntegration = (props) => {
           slackAppIntegrations={slackAppIntegrations}
           proxyServerUri={proxyServerUri}
           fetchSlackIntegrationData={fetchSlackIntegrationData}
+          connectionStatuses={connectionStatuses}
         />
       );
       break;


### PR DESCRIPTION
## 概要
- with proxy にて 各アコーディオンに ナンバリングを施しました。
これは、導通しなかった workspace に対して付与するものです。
- 導通が失敗した ws に対応するアコーディオンの横に **導通が失敗しました** を表示させました。