### PR TITLE
delete all slackAppIntegration documents

### DIFF
--- a/src/server/routes/apiv3/slack-integration-settings.js
+++ b/src/server/routes/apiv3/slack-integration-settings.js
@@ -73,6 +73,8 @@ module.exports = (crowi) => {
   };
 
   async function resetAllBotSettings() {
+    await SlackAppIntegration.collection.deleteMany();
+
     const params = {
       'slackbot:currentBotType': null,
       'slackbot:signingSecret': null,

--- a/src/server/routes/apiv3/slack-integration-settings.js
+++ b/src/server/routes/apiv3/slack-integration-settings.js
@@ -73,7 +73,7 @@ module.exports = (crowi) => {
   };
 
   async function resetAllBotSettings() {
-    await SlackAppIntegration.collection.deleteMany();
+    await SlackAppIntegration.deleteMany();
 
     const params = {
       'slackbot:currentBotType': null,


### PR DESCRIPTION
GW-6106 bot type変更時に、slackAppIntegraitonの値も破棄させる