### PR TITLE
Fix/gw 6174 fix text color

### DIFF
--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxyIntegrationCard.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxyIntegrationCard.jsx
@@ -24,7 +24,7 @@ const CustomBotWithProxyIntegrationCard = (props) => {
         </div>
       </div>
 
-      <div className="text-center w-25 mt-5">
+      <div className="text-center w-25 mt-3">
         {props.isSlackScopeSet && (
           <p className="text-success small">
             <i className="fa fa-check mr-1" />

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxyIntegrationCard.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxyIntegrationCard.jsx
@@ -33,7 +33,7 @@ const CustomBotWithProxyIntegrationCard = (props) => {
         )}
         {!props.isSlackScopeSet && (
           <small
-            className="text-secondary"
+            className="text-danger"
             // eslint-disable-next-line react/no-danger
             dangerouslySetInnerHTML={{ __html: t('admin:slack_integration.integration_sentence.integration_is_not_complete') }}
           />


### PR DESCRIPTION
## 概要
withProxy の未接続時の連携図の文言の色を secondary から danger に変更しました。

<img width="436" alt="スクリーンショット 2021-05-28 18 41 12" src="https://user-images.githubusercontent.com/34241526/119964553-4b32c800-bfe4-11eb-9742-b21bbf24c6fe.png">
