### PR TITLE
fix/gw 6176 delete button element

### DIFF
--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyIntegrationCard.jsx
@@ -85,7 +85,9 @@ const CustomBotWithoutProxyIntegrationCard = (props) => {
       <div className="card rounded-lg shadow border-0 w-50 admin-bot-card mb-0">
         <h5 className="card-title font-weight-bold mt-3 ml-4">GROWI App</h5>
         <div className="card-body p-4 mb-5 text-center">
-          <div className="btn btn-primary">{ props.siteName }</div>
+          <div className="border p-2 bg-primary text-light mx-5">
+            {props.siteName}
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 概要
withoutProxy 連携図の GROWI APP から button 要素を外しました。

<img width="378" alt="スクリーンショット 2021-05-28 18 52 25" src="https://user-images.githubusercontent.com/34241526/119966129-f4c68900-bfe5-11eb-8e36-0076eda9f207.png">
