### PR TITLE
Fix/error when official bot selected

### DIFF
--- a/src/client/js/components/Admin/SlackIntegration/OfficialBotSettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/OfficialBotSettings.jsx
@@ -13,13 +13,18 @@ const logger = loggerFactory('growi:SlackBotSettings');
 
 const OfficialBotSettings = (props) => {
   const {
-    appContainer, slackAppIntegrations, proxyServerUri, onClickAddSlackWorkspaceBtn,
+    appContainer, slackAppIntegrations, proxyServerUri, onClickAddSlackWorkspaceBtn, connectionStatuses,
   } = props;
   const [siteName, setSiteName] = useState('');
   const [isDeleteConfirmModalShown, setIsDeleteConfirmModalShown] = useState(false);
   const { t } = useTranslation();
 
   const [newProxyServerUri, setNewProxyServerUri] = useState();
+
+  const workspaceNameObjects = Object.values(connectionStatuses);
+  const workspaceNames = workspaceNameObjects.map((w) => {
+    return w.workspaceName;
+  });
 
   useEffect(() => {
     if (proxyServerUri != null) {
@@ -95,7 +100,7 @@ const OfficialBotSettings = (props) => {
             { name: 'wsName2', active: false },
           ]
         }
-        isSlackScopeSet
+        workspaceNames={workspaceNames}
       />
 
       <div className="form-group row my-4">
@@ -174,6 +179,8 @@ OfficialBotSettings.propTypes = {
   slackAppIntegrations: PropTypes.array,
   proxyServerUri: PropTypes.string,
   onClickAddSlackWorkspaceBtn: PropTypes.func,
+  connectionStatuses: PropTypes.object.isRequired,
+
 };
 
 export default OfficialBotSettingsWrapper;

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -143,6 +143,7 @@ const SlackIntegration = (props) => {
           slackAppIntegrations={slackAppIntegrations}
           proxyServerUri={proxyServerUri}
           onClickAddSlackWorkspaceBtn={createSlackIntegrationData}
+          connectionStatuses={connectionStatuses}
         />
       );
       break;


### PR DESCRIPTION
## 概要

official bot も `<CustomBotWithProxyIntegrationCard />` を使っています。
このコンポーネントは connectionStatuses を props として受け取らなければ error になります。
なので official bot にも connectionStatuses を渡して一旦 error を解消しています。