### PR TITLE
fix

### DIFF
--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyConnectionStatus.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxyConnectionStatus.jsx
@@ -20,7 +20,7 @@ const CustomBotWithoutProxyConnectionStatus = (props) => {
       <div className="card rounded shadow border-0 w-50 admin-bot-card mb-0">
         <h5 className="card-title font-weight-bold mt-3 ml-4">Slack</h5>
         <div className="card-body p-2 w-50 mx-auto">
-          {totalCount > 0 ? '' : (
+          {totalCount > 0 ? (
             <div className="card slack-work-space-name-card">
               <div className="m-2 text-center">
                 <h5 className="font-weight-bold">
@@ -29,7 +29,7 @@ const CustomBotWithoutProxyConnectionStatus = (props) => {
                 <img width={20} height={20} src="/images/slack-integration/growi-bot-kun-icon.png" />
               </div>
             </div>
-         )}
+         ) : ''}
         </div>
       </div>
 


### PR DESCRIPTION
## 概要
- without
  - totalCount > 0 以上の時に workspace もしくは Settings #1 を表示します。 

## 修正前
- Settings #1 が表示されるのはおかしい

<img width="1064" alt="Screen Shot 2021-05-31 at 16 52 44" src="https://user-images.githubusercontent.com/57100766/120159916-ae189f00-c230-11eb-9a86-8c8c3ac8b79c.png">

- ws 名が表示できていない
<img width="1093" alt="Screen Shot 2021-05-31 at 16 53 04" src="https://user-images.githubusercontent.com/57100766/120159929-afe26280-c230-11eb-9fc0-1d1024be1dfa.png">

## 修正後
<img width="1055" alt="Screen Shot 2021-05-31 at 16 54 24" src="https://user-images.githubusercontent.com/57100766/120160132-df916a80-c230-11eb-8a2c-67d92558726f.png">

<img width="1055" alt="Screen Shot 2021-05-31 at 16 43 05" src="https://user-images.githubusercontent.com/57100766/120159534-482c1780-c230-11eb-8193-5f09d7ff3023.png">
