### PR TITLE
Fix/on change name

### DIFF
--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySecretTokenSection.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySecretTokenSection.jsx
@@ -9,10 +9,11 @@ import { toastSuccess, toastError } from '../../../util/apiNotification';
 
 const CustomBotWithoutProxySecretTokenSection = (props) => {
   const {
-    appContainer, slackSigningSecret, slackBotToken, slackSigningSecretEnv, slackBotTokenEnv,
+    appContainer, slackSigningSecret, slackBotToken, slackSigningSecretEnv, slackBotTokenEnv, onUpdatedSecretToken,
   } = props;
-
-  const [inputSingingSecret, setInputSigningSecret] = useState(slackSigningSecret);
+  console.log('slackSigning', slackSigningSecret);
+  const [inputSigningSecret, setInputSigningSecret] = useState(slackSigningSecret);
+  console.log(inputSigningSecret);
   const [inputBotToken, setBotToken] = useState(slackBotToken);
 
   const { t } = useTranslation();
@@ -25,6 +26,11 @@ const CustomBotWithoutProxySecretTokenSection = (props) => {
         slackBotToken,
         currentBotType,
       });
+
+      if (onUpdatedSecretToken == null) {
+        return;
+      }
+      onUpdatedSecretToken(inputSigningSecret, inputBotToken);
       toastSuccess(t('toaster.update_successed', { target: t('admin:slack_integration.custom_bot_without_proxy_settings') }));
     }
     catch (err) {
@@ -43,7 +49,8 @@ const CustomBotWithoutProxySecretTokenSection = (props) => {
           <input
             className="form-control"
             type="text"
-            value={inputSingingSecret || ''}
+            value={inputSigningSecret || ''}
+            placeholder={slackSigningSecret}
             onChange={(e) => { setInputSigningSecret(e.target.value) }}
           />
         </div>
@@ -103,8 +110,7 @@ const CustomBotWithoutProxySecretTokenSectionWrapper = withUnstatedContainers(Cu
 
 CustomBotWithoutProxySecretTokenSection.propTypes = {
   appContainer: PropTypes.instanceOf(AppContainer).isRequired,
-  onChangeSigningSecretHandler: PropTypes.func,
-  onChangeBotTokenHandler: PropTypes.func,
+  onUpdatedSecretToken: PropTypes.func,
   slackSigningSecret: PropTypes.string,
   slackSigningSecretEnv: PropTypes.string,
   slackBotToken: PropTypes.string,

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySecretTokenSection.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySecretTokenSection.jsx
@@ -19,8 +19,8 @@ const CustomBotWithoutProxySecretTokenSection = (props) => {
   const updatedSecretToken = async() => {
     try {
       await appContainer.apiv3.put('/slack-integration-settings/without-proxy/update-settings', {
-        inputSigningSecret,
-        inputBotToken,
+        slackSigningSecret: inputSigningSecret,
+        slackBotToken: inputBotToken,
         currentBotType,
       });
 

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySecretTokenSection.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySecretTokenSection.jsx
@@ -13,7 +13,6 @@ const CustomBotWithoutProxySecretTokenSection = (props) => {
   } = props;
   const [inputSigningSecret, setInputSigningSecret] = useState(slackSigningSecret);
   const [inputBotToken, setBotToken] = useState(slackBotToken);
-  console.log(slackSigningSecret);
   const { t } = useTranslation();
 
   const currentBotType = 'customBotWithoutProxy';

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySecretTokenSection.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySecretTokenSection.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import PropTypes from 'prop-types';
 import AdminUpdateButtonRow from '../Common/AdminUpdateButtonRow';
@@ -6,25 +6,20 @@ import AdminUpdateButtonRow from '../Common/AdminUpdateButtonRow';
 const CustomBotWithoutProxySecretTokenSection = (props) => {
   const {
     slackSigningSecret, slackSigningSecretEnv, slackBotToken, slackBotTokenEnv,
-    onSigningSecretChanged, onBotTokenChanged,
+    onSigningSecretChanged, onBotTokenChanged, onUpdatedSecretToken,
   } = props;
+  console.log(slackSigningSecret);
+  const [inputSingingSecret, setInputSigningSecret] = useState(slackSigningSecret);
+  const [inputBotToken, setBotToken] = useState(slackBotToken);
+
   const { t } = useTranslation();
 
-  const signingSecretChanged = (signingSecretInput) => {
-    if (onSigningSecretChanged != null) {
-      onSigningSecretChanged(signingSecretInput);
-    }
-  };
 
-  const botTokenChanged = (botTokenInput) => {
-    if (onBotTokenChanged != null) {
-      onBotTokenChanged(botTokenInput);
-    }
-  };
-
-  const updateSecretTokenHandler = () => {
+  const updateSecretTokenHandler = (inputSingingSecret, inputBotToken) => {
     if (props.updateSecretTokenHandler != null) {
       props.updateSecretTokenHandler();
+      props.onUpdatedSecretToken(inputSingingSecret, inputBotToken);
+      console.log(slackSigningSecret);
     }
   };
 
@@ -39,8 +34,8 @@ const CustomBotWithoutProxySecretTokenSection = (props) => {
           <input
             className="form-control"
             type="text"
-            value={slackSigningSecret || ''}
-            onChange={e => signingSecretChanged(e.target.value)}
+            value={inputSingingSecret || ''}
+            onChange={(e) => { setInputSigningSecret(e.target.value) }}
           />
         </div>
 
@@ -68,8 +63,8 @@ const CustomBotWithoutProxySecretTokenSection = (props) => {
           <input
             className="form-control"
             type="text"
-            value={slackBotToken || ''}
-            onChange={e => botTokenChanged(e.target.value)}
+            value={inputBotToken || ''}
+            onChange={(e) => { setBotToken(e.target.value) }}
           />
         </div>
 

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySecretTokenSection.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySecretTokenSection.jsx
@@ -11,8 +11,8 @@ const CustomBotWithoutProxySecretTokenSection = (props) => {
   const {
     appContainer, slackSigningSecret, slackBotToken, slackSigningSecretEnv, slackBotTokenEnv, onUpdatedSecretToken,
   } = props;
-  const [inputSigningSecret, setInputSigningSecret] = useState(slackSigningSecret);
-  const [inputBotToken, setInputBotToken] = useState(slackBotToken);
+  const [inputSigningSecret, setInputSigningSecret] = useState(null);
+  const [inputBotToken, setInputBotToken] = useState(null);
   const { t } = useTranslation();
 
   const updatedSecretToken = async() => {

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySecretTokenSection.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySecretTokenSection.jsx
@@ -12,7 +12,7 @@ const CustomBotWithoutProxySecretTokenSection = (props) => {
     appContainer, slackSigningSecret, slackBotToken, slackSigningSecretEnv, slackBotTokenEnv, onUpdatedSecretToken,
   } = props;
   const [inputSigningSecret, setInputSigningSecret] = useState(slackSigningSecret);
-  const [inputBotToken, setBotToken] = useState(slackBotToken);
+  const [inputBotToken, setInputBotToken] = useState(slackBotToken);
   const { t } = useTranslation();
 
   const updatedSecretToken = async() => {
@@ -35,7 +35,7 @@ const CustomBotWithoutProxySecretTokenSection = (props) => {
 
   useEffect(() => {
     setInputSigningSecret(slackSigningSecret);
-    setBotToken(slackBotToken);
+    setInputBotToken(slackBotToken);
   }, [slackSigningSecret, slackBotToken]);
 
 
@@ -80,7 +80,7 @@ const CustomBotWithoutProxySecretTokenSection = (props) => {
             className="form-control"
             type="text"
             value={inputBotToken || ''}
-            onChange={(e) => { setBotToken(e.target.value) }}
+            onChange={(e) => { setInputBotToken(e.target.value) }}
           />
         </div>
 

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySecretTokenSection.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySecretTokenSection.jsx
@@ -15,13 +15,11 @@ const CustomBotWithoutProxySecretTokenSection = (props) => {
   const [inputBotToken, setBotToken] = useState(slackBotToken);
   const { t } = useTranslation();
 
-  const currentBotType = 'customBotWithoutProxy';
   const updatedSecretToken = async() => {
     try {
       await appContainer.apiv3.put('/slack-integration-settings/without-proxy/update-settings', {
         slackSigningSecret: inputSigningSecret,
         slackBotToken: inputBotToken,
-        currentBotType,
       });
 
       if (onUpdatedSecretToken == null) {
@@ -39,6 +37,8 @@ const CustomBotWithoutProxySecretTokenSection = (props) => {
     setInputSigningSecret(slackSigningSecret);
     setBotToken(slackBotToken);
   }, [slackSigningSecret, slackBotToken]);
+
+
   return (
     <div className="w-75 mx-auto">
 

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySecretTokenSection.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySecretTokenSection.jsx
@@ -4,17 +4,21 @@ import PropTypes from 'prop-types';
 import AdminUpdateButtonRow from '../Common/AdminUpdateButtonRow';
 
 const CustomBotWithoutProxySecretTokenSection = (props) => {
+  const {
+    slackSigningSecret, slackSigningSecretEnv, slackBotToken, slackBotTokenEnv,
+    onSigningSecretChanged, onBotTokenChanged,
+  } = props;
   const { t } = useTranslation();
 
-  const onChangeSigningSecretHandler = (signingSecretInput) => {
-    if (props.onChangeSigningSecretHandler != null) {
-      props.onChangeSigningSecretHandler(signingSecretInput);
+  const signingSecretChanged = (signingSecretInput) => {
+    if (onSigningSecretChanged != null) {
+      onSigningSecretChanged(signingSecretInput);
     }
   };
 
-  const onChangeBotTokenHandler = (botTokenInput) => {
-    if (props.onChangeBotTokenHandler != null) {
-      props.onChangeBotTokenHandler(botTokenInput);
+  const botTokenChanged = (botTokenInput) => {
+    if (onBotTokenChanged != null) {
+      onBotTokenChanged(botTokenInput);
     }
   };
 
@@ -35,8 +39,8 @@ const CustomBotWithoutProxySecretTokenSection = (props) => {
           <input
             className="form-control"
             type="text"
-            value={props.slackSigningSecret || ''}
-            onChange={e => onChangeSigningSecretHandler(e.target.value)}
+            value={slackSigningSecret || ''}
+            onChange={e => signingSecretChanged(e.target.value)}
           />
         </div>
 
@@ -45,7 +49,7 @@ const CustomBotWithoutProxySecretTokenSection = (props) => {
           <input
             className="form-control"
             type="text"
-            value={props.slackSigningSecretEnv || ''}
+            value={slackSigningSecretEnv || ''}
             readOnly
           />
           <p className="form-text text-muted">
@@ -64,8 +68,8 @@ const CustomBotWithoutProxySecretTokenSection = (props) => {
           <input
             className="form-control"
             type="text"
-            value={props.slackBotToken || ''}
-            onChange={e => onChangeBotTokenHandler(e.target.value)}
+            value={slackBotToken || ''}
+            onChange={e => botTokenChanged(e.target.value)}
           />
         </div>
 
@@ -74,7 +78,7 @@ const CustomBotWithoutProxySecretTokenSection = (props) => {
           <input
             className="form-control"
             type="text"
-            value={props.slackBotTokenEnv || ''}
+            value={slackBotTokenEnv || ''}
             readOnly
           />
           <p className="form-text text-muted">
@@ -93,8 +97,8 @@ const CustomBotWithoutProxySecretTokenSection = (props) => {
 
 CustomBotWithoutProxySecretTokenSection.propTypes = {
   updateSecretTokenHandler: PropTypes.func,
-  onChangeSigningSecretHandler: PropTypes.func,
-  onChangeBotTokenHandler: PropTypes.func,
+  onSigningSecretChanged: PropTypes.func,
+  onBotTokenChanged: PropTypes.func,
   slackSigningSecret: PropTypes.string,
   slackSigningSecretEnv: PropTypes.string,
   slackBotToken: PropTypes.string,

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySecretTokenSection.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySecretTokenSection.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import PropTypes from 'prop-types';
 import AdminUpdateButtonRow from '../Common/AdminUpdateButtonRow';
@@ -11,19 +11,17 @@ const CustomBotWithoutProxySecretTokenSection = (props) => {
   const {
     appContainer, slackSigningSecret, slackBotToken, slackSigningSecretEnv, slackBotTokenEnv, onUpdatedSecretToken,
   } = props;
-  console.log('slackSigning', slackSigningSecret);
   const [inputSigningSecret, setInputSigningSecret] = useState(slackSigningSecret);
-  console.log(inputSigningSecret);
   const [inputBotToken, setBotToken] = useState(slackBotToken);
-
+  console.log(slackSigningSecret);
   const { t } = useTranslation();
 
   const currentBotType = 'customBotWithoutProxy';
   const updatedSecretToken = async() => {
     try {
       await appContainer.apiv3.put('/slack-integration-settings/without-proxy/update-settings', {
-        slackSigningSecret,
-        slackBotToken,
+        inputSigningSecret,
+        inputBotToken,
         currentBotType,
       });
 
@@ -38,6 +36,10 @@ const CustomBotWithoutProxySecretTokenSection = (props) => {
     }
   };
 
+  useEffect(() => {
+    setInputSigningSecret(slackSigningSecret);
+    setBotToken(slackBotToken);
+  }, [slackSigningSecret, slackBotToken]);
   return (
     <div className="w-75 mx-auto">
 
@@ -50,7 +52,6 @@ const CustomBotWithoutProxySecretTokenSection = (props) => {
             className="form-control"
             type="text"
             value={inputSigningSecret || ''}
-            placeholder={slackSigningSecret}
             onChange={(e) => { setInputSigningSecret(e.target.value) }}
           />
         </div>

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
@@ -49,18 +49,6 @@ const CustomBotWithoutProxySettingsAccordion = (props) => {
     }
   };
 
-  // const onChangeSigningSecretHandler = (signingSecretInput) => {
-  //   if (onSetSlackSigningSecret != null) {
-  //     onSetSlackSigningSecret(signingSecretInput);
-  //   }
-  // };
-
-  // const onChangeBotTokenHandler = (botTokenInput) => {
-  //   if (onSetSlackBotToken != null) {
-  //     onSetSlackBotToken(botTokenInput);
-  //   }
-  // };
-
   const submitForm = (e) => {
     e.preventDefault();
 
@@ -127,8 +115,6 @@ const CustomBotWithoutProxySettingsAccordion = (props) => {
         <CustomBotWithoutProxySecretTokenSection
           {...props}
           updateSecretTokenHandler={updateSecretTokenHandler}
-          // onChangeSigningSecretHandler={onChangeSigningSecretHandler}
-          // onChangeBotTokenHandler={onChangeBotTokenHandler}
           slackSigningSecret={slackSigningSecret}
           slackSigningSecretEnv={slackSigningSecretEnv}
           slackBotToken={slackBotToken}
@@ -206,8 +192,6 @@ CustomBotWithoutProxySettingsAccordion.propTypes = {
   fetchSlackIntegrationData: PropTypes.func,
   inputTestChannelHandler: PropTypes.func,
   onTestFormSubmitted: PropTypes.func,
-  onSetSlackSigningSecret: PropTypes.func,
-  onSetSlackBotToken: PropTypes.func,
   connectionMessage: PropTypes.string,
   connectionErrorCode: PropTypes.string,
   adminAppContainer: PropTypes.instanceOf(AdminAppContainer).isRequired,

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
@@ -15,12 +15,14 @@ export const botInstallationStep = {
   CONNECTION_TEST: 'connection-test',
 };
 
-const CustomBotWithoutProxySettingsAccordion = ({
-  appContainer, activeStep,
-  connectionMessage, connectionErrorCode, testChannel, slackSigningSecret, slackSigningSecretEnv, slackBotToken, slackBotTokenEnv,
-  isRegisterSlackCredentials, isIntegrationSuccess,
-  fetchSlackIntegrationData, inputTestChannelHandler, onTestFormSubmitted, onSetSlackSigningSecret, onSetSlackBotToken,
-}) => {
+const CustomBotWithoutProxySettingsAccordion = (props) => {
+  const {
+    appContainer, activeStep,
+    connectionMessage, connectionErrorCode, testChannel, slackSigningSecret, slackSigningSecretEnv, slackBotToken, slackBotTokenEnv,
+    isRegisterSlackCredentials, isIntegrationSuccess,
+    fetchSlackIntegrationData, inputTestChannelHandler, onTestFormSubmitted,
+  } = props;
+
   const { t } = useTranslation();
   // TODO: GW-5644 Store default open accordion
   // eslint-disable-next-line no-unused-vars
@@ -47,17 +49,17 @@ const CustomBotWithoutProxySettingsAccordion = ({
     }
   };
 
-  const onChangeSigningSecretHandler = (signingSecretInput) => {
-    if (onSetSlackSigningSecret != null) {
-      onSetSlackSigningSecret(signingSecretInput);
-    }
-  };
+  // const onChangeSigningSecretHandler = (signingSecretInput) => {
+  //   if (onSetSlackSigningSecret != null) {
+  //     onSetSlackSigningSecret(signingSecretInput);
+  //   }
+  // };
 
-  const onChangeBotTokenHandler = (botTokenInput) => {
-    if (onSetSlackBotToken != null) {
-      onSetSlackBotToken(botTokenInput);
-    }
-  };
+  // const onChangeBotTokenHandler = (botTokenInput) => {
+  //   if (onSetSlackBotToken != null) {
+  //     onSetSlackBotToken(botTokenInput);
+  //   }
+  // };
 
   const submitForm = (e) => {
     e.preventDefault();
@@ -123,9 +125,10 @@ const CustomBotWithoutProxySettingsAccordion = ({
         title={<><span className="mr-2">③</span>{t('admin:slack_integration.accordion.register_secret_and_token')}{isRegisterSlackCredentials && <i className="ml-3 text-success fa fa-check"></i>}</>}
       >
         <CustomBotWithoutProxySecretTokenSection
+          {...props}
           updateSecretTokenHandler={updateSecretTokenHandler}
-          onChangeSigningSecretHandler={onChangeSigningSecretHandler}
-          onChangeBotTokenHandler={onChangeBotTokenHandler}
+          // onChangeSigningSecretHandler={onChangeSigningSecretHandler}
+          // onChangeBotTokenHandler={onChangeBotTokenHandler}
           slackSigningSecret={slackSigningSecret}
           slackSigningSecretEnv={slackSigningSecretEnv}
           slackBotToken={slackBotToken}

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
@@ -92,9 +92,7 @@ const CustomBotWithoutProxySettingsAccordion = (props) => {
         // eslint-disable-next-line max-len
         title={<><span className="mr-2">③</span>{t('admin:slack_integration.accordion.register_secret_and_token')}{isEnterdSecretAndToken && <i className="ml-3 text-success fa fa-check"></i>}</>}
       >
-        <CustomBotWithoutProxySecretTokenSection
-          {...props}
-        />
+        <CustomBotWithoutProxySecretTokenSection {...props} />
       </Accordion>
       <Accordion
         defaultIsActive={defaultOpenAccordionKeys.has(botInstallationStep.CONNECTION_TEST)}

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
@@ -14,7 +14,7 @@ export const botInstallationStep = {
 const CustomBotWithoutProxySettingsAccordion = (props) => {
   const {
     activeStep, connectionMessage, connectionErrorCode, testChannel,
-    slackSigningSecret, slackBotToken, /* slackSigningSecretEnv, slackBotTokenEnv, */
+    slackSigningSecret, slackBotToken, slackSigningSecretEnv, slackBotTokenEnv,
     isIntegrationSuccess,
     inputTestChannelHandler, onTestFormSubmitted,
   } = props;
@@ -40,6 +40,11 @@ const CustomBotWithoutProxySettingsAccordion = (props) => {
   }
   else {
     value = [connectionErrorCode, connectionMessage];
+  }
+
+  let isEnterdSecretAndToken = false;
+  if ((slackSigningSecret != null && slackBotToken != null) || (slackSigningSecretEnv != null && slackBotTokenEnv != null)) {
+    isEnterdSecretAndToken = true;
   }
 
   return (
@@ -85,7 +90,7 @@ const CustomBotWithoutProxySettingsAccordion = (props) => {
       <Accordion
         defaultIsActive={defaultOpenAccordionKeys.has(botInstallationStep.REGISTER_SLACK_CONFIGURATION)}
         // eslint-disable-next-line max-len
-        title={<><span className="mr-2">③</span>{t('admin:slack_integration.accordion.register_secret_and_token')}{slackSigningSecret != null && slackBotToken != null && <i className="ml-3 text-success fa fa-check"></i>}</>}
+        title={<><span className="mr-2">③</span>{t('admin:slack_integration.accordion.register_secret_and_token')}{isEnterdSecretAndToken && <i className="ml-3 text-success fa fa-check"></i>}</>}
       >
         <CustomBotWithoutProxySecretTokenSection
           {...props}

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -90,9 +90,7 @@ const SlackIntegration = (props) => {
   };
 
   const changeSecretAndToken = (secret, token) => {
-    console.log(secret); //
     setSlackSigningSecret(secret);
-    console.log(slackSigningSecret); // null
     setSlackBotToken(token);
   };
 

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -89,6 +89,11 @@ const SlackIntegration = (props) => {
     }
   };
 
+  const changeSecretAndToken = (secret, token) => {
+    setSlackSigningSecret(secret);
+    setSlackBotToken(token);
+  };
+
   useEffect(() => {
     fetchSlackIntegrationData();
   }, [fetchSlackIntegrationData]);
@@ -155,6 +160,7 @@ const SlackIntegration = (props) => {
           onBotTokenChanged={setSlackBotToken}
           onResetSettings={resetWithOutSettings}
           fetchSlackIntegrationData={fetchSlackIntegrationData}
+          onUpdatedSecretToken={changeSecretAndToken}
           connectionStatuses={connectionStatuses}
         />
       );

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -151,8 +151,8 @@ const SlackIntegration = (props) => {
           slackSigningSecretEnv={slackSigningSecretEnv}
           slackSigningSecret={slackSigningSecret}
           slackWSNameInWithoutProxy={slackWSNameInWithoutProxy}
-          onSetSlackSigningSecret={setSlackSigningSecret}
-          onSetSlackBotToken={setSlackBotToken}
+          onSigningSecretChanged={setSlackSigningSecret}
+          onBotTokenChanged={setSlackBotToken}
           onResetSettings={resetWithOutSettings}
           fetchSlackIntegrationData={fetchSlackIntegrationData}
           connectionStatuses={connectionStatuses}

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -90,7 +90,9 @@ const SlackIntegration = (props) => {
   };
 
   const changeSecretAndToken = (secret, token) => {
+    console.log(secret); //
     setSlackSigningSecret(secret);
+    console.log(slackSigningSecret); // null
     setSlackBotToken(token);
   };
 


### PR DESCRIPTION
## 概要
親から on~ で渡す function の名称が不適切なので修正しました。
SlackIntegration の状態変更関数  setSlackSigningSecret と setSlackBotToken を使う場所は
ひ孫の CustomBotWithoutProxySecretTokenSection なので　途中二つのコンポーネントは {...props} で渡しています。


### SlackIntegration (親)
#### CustomBotWithoutProxySettings (子)
##### CustomBotWithoutProxySettingsAccordion (孫)
###### CustomBotWithoutProxySecretTokenSection  (ひ孫）