### PR TITLE
move

### DIFF
--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySecretTokenSection.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySecretTokenSection.jsx
@@ -2,8 +2,15 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import PropTypes from 'prop-types';
 import AdminUpdateButtonRow from '../Common/AdminUpdateButtonRow';
+import AppContainer from '../../../services/AppContainer';
+import { withUnstatedContainers } from '../../UnstatedUtils';
+import { toastSuccess, toastError } from '../../../util/apiNotification';
+
 
 const CustomBotWithoutProxySecretTokenSection = (props) => {
+  const {
+    appContainer, slackSigningSecret, slackBotToken, slackSigningSecretEnv, slackBotTokenEnv,
+  } = props;
   const { t } = useTranslation();
 
   const onChangeSigningSecretHandler = (signingSecretInput) => {
@@ -18,9 +25,19 @@ const CustomBotWithoutProxySecretTokenSection = (props) => {
     }
   };
 
-  const updateSecretTokenHandler = () => {
-    if (props.updateSecretTokenHandler != null) {
-      props.updateSecretTokenHandler();
+
+  const currentBotType = 'customBotWithoutProxy';
+  const updatedSecretToken = async() => {
+    try {
+      await appContainer.apiv3.put('/slack-integration-settings/without-proxy/update-settings', {
+        slackSigningSecret,
+        slackBotToken,
+        currentBotType,
+      });
+      toastSuccess(t('toaster.update_successed', { target: t('admin:slack_integration.custom_bot_without_proxy_settings') }));
+    }
+    catch (err) {
+      toastError(err);
     }
   };
 
@@ -35,7 +52,7 @@ const CustomBotWithoutProxySecretTokenSection = (props) => {
           <input
             className="form-control"
             type="text"
-            value={props.slackSigningSecret || ''}
+            value={slackSigningSecret || ''}
             onChange={e => onChangeSigningSecretHandler(e.target.value)}
           />
         </div>
@@ -45,7 +62,7 @@ const CustomBotWithoutProxySecretTokenSection = (props) => {
           <input
             className="form-control"
             type="text"
-            value={props.slackSigningSecretEnv || ''}
+            value={slackSigningSecretEnv || ''}
             readOnly
           />
           <p className="form-text text-muted">
@@ -64,7 +81,7 @@ const CustomBotWithoutProxySecretTokenSection = (props) => {
           <input
             className="form-control"
             type="text"
-            value={props.slackBotToken || ''}
+            value={slackBotToken || ''}
             onChange={e => onChangeBotTokenHandler(e.target.value)}
           />
         </div>
@@ -74,7 +91,7 @@ const CustomBotWithoutProxySecretTokenSection = (props) => {
           <input
             className="form-control"
             type="text"
-            value={props.slackBotTokenEnv || ''}
+            value={slackBotTokenEnv || ''}
             readOnly
           />
           <p className="form-text text-muted">
@@ -85,14 +102,16 @@ const CustomBotWithoutProxySecretTokenSection = (props) => {
 
       </div>
 
-      <AdminUpdateButtonRow onClick={updateSecretTokenHandler} disabled={false} />
+      <AdminUpdateButtonRow onClick={updatedSecretToken} disabled={false} />
 
     </div>
   );
 };
 
+const CustomBotWithoutProxySecretTokenSectionWrapper = withUnstatedContainers(CustomBotWithoutProxySecretTokenSection, [AppContainer]);
+
 CustomBotWithoutProxySecretTokenSection.propTypes = {
-  updateSecretTokenHandler: PropTypes.func,
+  appContainer: PropTypes.instanceOf(AppContainer).isRequired,
   onChangeSigningSecretHandler: PropTypes.func,
   onChangeBotTokenHandler: PropTypes.func,
   slackSigningSecret: PropTypes.string,
@@ -101,4 +120,4 @@ CustomBotWithoutProxySecretTokenSection.propTypes = {
   slackBotTokenEnv: PropTypes.string,
 };
 
-export default CustomBotWithoutProxySecretTokenSection;
+export default CustomBotWithoutProxySecretTokenSectionWrapper;

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettingsAccordion.jsx
@@ -1,11 +1,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
-import AppContainer from '../../../services/AppContainer';
-import AdminAppContainer from '../../../services/AdminAppContainer';
-import { withUnstatedContainers } from '../../UnstatedUtils';
 import Accordion from '../Common/Accordion';
-import { toastSuccess, toastError } from '../../../util/apiNotification';
 import CustomBotWithoutProxySecretTokenSection from './CustomBotWithoutProxySecretTokenSection';
 
 export const botInstallationStep = {
@@ -16,36 +12,15 @@ export const botInstallationStep = {
 };
 
 const CustomBotWithoutProxySettingsAccordion = ({
-  appContainer, activeStep,
+  activeStep,
   connectionMessage, connectionErrorCode, testChannel, slackSigningSecret, slackSigningSecretEnv, slackBotToken, slackBotTokenEnv,
   isRegisterSlackCredentials, isIntegrationSuccess,
-  fetchSlackIntegrationData, inputTestChannelHandler, onTestFormSubmitted, onSetSlackSigningSecret, onSetSlackBotToken,
+  inputTestChannelHandler, onTestFormSubmitted, onSetSlackSigningSecret, onSetSlackBotToken,
 }) => {
   const { t } = useTranslation();
   // TODO: GW-5644 Store default open accordion
   // eslint-disable-next-line no-unused-vars
   const [defaultOpenAccordionKeys, setDefaultOpenAccordionKeys] = useState(new Set([activeStep]));
-  const currentBotType = 'customBotWithoutProxy';
-
-
-  const updateSecretTokenHandler = async() => {
-    try {
-      await appContainer.apiv3.put('/slack-integration-settings/without-proxy/update-settings', {
-        slackSigningSecret,
-        slackBotToken,
-        currentBotType,
-      });
-
-      if (fetchSlackIntegrationData == null) {
-        return null;
-      }
-      fetchSlackIntegrationData();
-      toastSuccess(t('toaster.update_successed', { target: t('admin:slack_integration.custom_bot_without_proxy_settings') }));
-    }
-    catch (err) {
-      toastError(err);
-    }
-  };
 
   const onChangeSigningSecretHandler = (signingSecretInput) => {
     if (onSetSlackSigningSecret != null) {
@@ -123,7 +98,6 @@ const CustomBotWithoutProxySettingsAccordion = ({
         title={<><span className="mr-2">③</span>{t('admin:slack_integration.accordion.register_secret_and_token')}{isRegisterSlackCredentials && <i className="ml-3 text-success fa fa-check"></i>}</>}
       >
         <CustomBotWithoutProxySecretTokenSection
-          updateSecretTokenHandler={updateSecretTokenHandler}
           onChangeSigningSecretHandler={onChangeSigningSecretHandler}
           onChangeBotTokenHandler={onChangeBotTokenHandler}
           slackSigningSecret={slackSigningSecret}
@@ -189,10 +163,8 @@ const CustomBotWithoutProxySettingsAccordion = ({
   );
 };
 
-const CustomBotWithoutProxySettingsAccordionWrapper = withUnstatedContainers(CustomBotWithoutProxySettingsAccordion, [AppContainer, AdminAppContainer]);
 
 CustomBotWithoutProxySettingsAccordion.propTypes = {
-  appContainer: PropTypes.instanceOf(AppContainer).isRequired,
   slackSigningSecret: PropTypes.string,
   slackSigningSecretEnv: PropTypes.string,
   slackBotToken: PropTypes.string,
@@ -207,8 +179,7 @@ CustomBotWithoutProxySettingsAccordion.propTypes = {
   onSetSlackBotToken: PropTypes.func,
   connectionMessage: PropTypes.string,
   connectionErrorCode: PropTypes.string,
-  adminAppContainer: PropTypes.instanceOf(AdminAppContainer).isRequired,
   activeStep: PropTypes.oneOf(Object.values(botInstallationStep)).isRequired,
 };
 
-export default CustomBotWithoutProxySettingsAccordionWrapper;
+export default CustomBotWithoutProxySettingsAccordion;


### PR DESCRIPTION
## 概要
updateSecretTokenHandler を 子供に移動させ、名称を updateSecretedToken としました。

### 理由 
- secret と token の更新は、親の `CustomBotWithoutProxySettingsAccordion ` の責務ではなく子供の `CustomBotWithoutProxySecretTokenSection` だからです。
- また、`CustomBotWithoutProxySettingsAccordion `  で関数を定義すると、無駄な props のやりとりが発生するため子供に移動させました。