### PR TITLE
Feat/gw 6074 hide integration diagrams

### DIFF
--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
@@ -73,28 +73,33 @@ const CustomBotWithProxySettings = (props) => {
     <>
       <h2 className="admin-setting-header mb-2">{t('admin:slack_integration.custom_bot_with_proxy_integration')}</h2>
 
-      <CustomBotWithProxyConnectionStatus
-        siteName={siteName}
-        connectionStatuses={connectionStatuses}
-      />
-
-      <div className="form-group row my-4">
-        <label className="text-left text-md-right col-md-3 col-form-label mt-3">Proxy URL</label>
-        <div className="col-md-6 mt-3">
-          <input
-            className="form-control"
-            type="text"
-            name="settingForm[proxyUrl]"
-            defaultValue={newProxyServerUri}
-            onChange={(e) => { setNewProxyServerUri(e.target.value) }}
+      {slackAppIntegrations.length !== 0 && (
+        <>
+          <CustomBotWithProxyConnectionStatus
+            siteName={siteName}
+            connectionStatuses={connectionStatuses}
           />
-        </div>
-        <div className="col-md-2 mt-3 text-center text-md-left">
-          <button type="button" className="btn btn-primary" onClick={updateProxyUri}>{ t('Update') }</button>
-        </div>
-      </div>
 
-      <h2 className="admin-setting-header">{t('admin:slack_integration.integration_procedure')}</h2>
+          <div className="form-group row my-4">
+            <label className="text-left text-md-right col-md-3 col-form-label mt-3">Proxy URL</label>
+            <div className="col-md-6 mt-3">
+              <input
+                className="form-control"
+                type="text"
+                name="settingForm[proxyUrl]"
+                defaultValue={newProxyServerUri}
+                onChange={(e) => { setNewProxyServerUri(e.target.value) }}
+              />
+            </div>
+            <div className="col-md-2 mt-3 text-center text-md-left">
+              <button type="button" className="btn btn-primary" onClick={updateProxyUri}>{ t('Update') }</button>
+            </div>
+          </div>
+
+          <h2 className="admin-setting-header">{t('admin:slack_integration.integration_procedure')}</h2>
+        </>
+      )}
+
       <div className="mx-3">
         {slackAppIntegrations.map((slackAppIntegration, i) => {
           const { tokenGtoP, tokenPtoG } = slackAppIntegration;

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
@@ -73,7 +73,6 @@ const CustomBotWithProxySettings = (props) => {
     <>
       <h2 className="admin-setting-header mb-2">{t('admin:slack_integration.custom_bot_with_proxy_integration')}</h2>
 
-      {/* TODO delete tmp props */}
       <CustomBotWithProxyConnectionStatus
         siteName={siteName}
         connectionStatuses={connectionStatuses}


### PR DESCRIPTION
## 概要
Bot選択時には「Slackワークスペースを追加」ボタンのみが表示され、連携図は表示されないようにしました、

ワークスペースが一つも存在しない時
<img width="1441" alt="スクリーンショット 2021-06-01 18 18 59" src="https://user-images.githubusercontent.com/34241526/120299543-0e2d4500-c306-11eb-99b1-23f1925ccfc1.png">

ワークスペースが存在するとき
<img width="1421" alt="スクリーンショット 2021-06-01 18 19 22" src="https://user-images.githubusercontent.com/34241526/120299717-3ae15c80-c306-11eb-9da2-5086eaf63fbf.png">
