### PR TITLE
Imprv/gw6189 move link icons

### DIFF
--- a/src/client/js/components/Admin/SlackIntegration/BotTypeCard.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/BotTypeCard.jsx
@@ -60,8 +60,7 @@ const BotTypeCard = (props) => {
             </span>
           )}
 
-          {/* TODO: add an appropriate links by GW-5614 */}
-          <i className={`fa fa-external-link btn-link ${props.isActive ? 'grw-botcard-title-active' : ''}`} aria-hidden="true"></i>
+          <i className={props.isActive ? 'grw-botcard-title-active' : ''} aria-hidden="true"></i>
         </h3>
       </div>
       <div className="card-body p-4">

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
@@ -72,6 +72,7 @@ const CustomBotWithProxySettings = (props) => {
   return (
     <>
       <h2 className="admin-setting-header mb-2">{t('admin:slack_integration.custom_bot_with_proxy_integration')}
+        {/* TODO: add an appropriate links by GW-5614 */}
         <i className="fa fa-external-link btn-link ml-2" aria-hidden="true"></i>
       </h2>
 

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
@@ -72,7 +72,7 @@ const CustomBotWithProxySettings = (props) => {
   return (
     <>
       <h2 className="admin-setting-header mb-2">{t('admin:slack_integration.custom_bot_with_proxy_integration')}
-        <i className="fa fa-external-link btn-link" aria-hidden="true"></i>
+        <i className="fa fa-external-link btn-link ml-2" aria-hidden="true"></i>
       </h2>
 
       {slackAppIntegrations.length !== 0 && (

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
@@ -71,7 +71,9 @@ const CustomBotWithProxySettings = (props) => {
 
   return (
     <>
-      <h2 className="admin-setting-header mb-2">{t('admin:slack_integration.custom_bot_with_proxy_integration')}</h2>
+      <h2 className="admin-setting-header mb-2">{t('admin:slack_integration.custom_bot_with_proxy_integration')}
+        <i className="fa fa-external-link btn-link" aria-hidden="true"></i>
+      </h2>
 
       {slackAppIntegrations.length !== 0 && (
         <>

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -51,6 +51,7 @@ const CustomBotWithoutProxySettings = (props) => {
   return (
     <>
       <h2 className="admin-setting-header">{t('admin:slack_integration.custom_bot_without_proxy_integration')}
+        {/* TODO: add an appropriate links by GW-5614 */}
         <i className="fa fa-external-link btn-link ml-2" aria-hidden="true"></i>
       </h2>
 

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -51,7 +51,7 @@ const CustomBotWithoutProxySettings = (props) => {
   return (
     <>
       <h2 className="admin-setting-header">{t('admin:slack_integration.custom_bot_without_proxy_integration')}
-        <i className="fa fa-external-link btn-link" aria-hidden="true"></i>
+        <i className="fa fa-external-link btn-link ml-2" aria-hidden="true"></i>
       </h2>
 
       <CustomBotWithoutProxyConnectionStatus

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -50,7 +50,9 @@ const CustomBotWithoutProxySettings = (props) => {
 
   return (
     <>
-      <h2 className="admin-setting-header">{t('admin:slack_integration.custom_bot_without_proxy_integration')}</h2>
+      <h2 className="admin-setting-header">{t('admin:slack_integration.custom_bot_without_proxy_integration')}
+        <i className="fa fa-external-link btn-link" aria-hidden="true"></i>
+      </h2>
 
       <CustomBotWithoutProxyConnectionStatus
         siteName={siteName}

--- a/src/client/js/components/Admin/SlackIntegration/OfficialBotSettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/OfficialBotSettings.jsx
@@ -78,7 +78,7 @@ const OfficialBotSettings = (props) => {
   return (
     <>
       <h2 className="admin-setting-header">{t('admin:slack_integration.official_bot_integration')}
-        <i className="fa fa-external-link btn-link" aria-hidden="true"></i>
+        <i className="fa fa-external-link btn-link ml-2" aria-hidden="true"></i>
       </h2>
       <CustomBotWithProxyConnectionStatus
         siteName={siteName}

--- a/src/client/js/components/Admin/SlackIntegration/OfficialBotSettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/OfficialBotSettings.jsx
@@ -78,6 +78,7 @@ const OfficialBotSettings = (props) => {
   return (
     <>
       <h2 className="admin-setting-header">{t('admin:slack_integration.official_bot_integration')}
+        {/* TODO: add an appropriate links by GW-5614 */}
         <i className="fa fa-external-link btn-link ml-2" aria-hidden="true"></i>
       </h2>
       <CustomBotWithProxyConnectionStatus

--- a/src/client/js/components/Admin/SlackIntegration/OfficialBotSettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/OfficialBotSettings.jsx
@@ -77,7 +77,9 @@ const OfficialBotSettings = (props) => {
 
   return (
     <>
-      <h2 className="admin-setting-header">{t('admin:slack_integration.official_bot_integration')}</h2>
+      <h2 className="admin-setting-header">{t('admin:slack_integration.official_bot_integration')}
+        <i className="fa fa-external-link btn-link" aria-hidden="true"></i>
+      </h2>
       <CustomBotWithProxyConnectionStatus
         siteName={siteName}
         connectionStatuses={connectionStatuses}

--- a/src/client/styles/scss/_admin.scss
+++ b/src/client/styles/scss/_admin.scss
@@ -90,9 +90,6 @@ $slack-work-space-name-card-border: #efc1f6;
   Slack Integration
   */
   .selecting-bot-type {
-    .btn-link {
-      font-size: 1rem;
-    }
     .supplementary-bot-name {
       font-size: 1rem;
     }
@@ -115,6 +112,14 @@ $slack-work-space-name-card-border: #efc1f6;
     }
     .slack-connection-log-body {
       border: 2px solid;
+    }
+  }
+
+  .admin-slack-integration {
+    .admin-setting-header {
+      .btn-link {
+        font-size: 1rem;
+      }
     }
   }
 


### PR DESCRIPTION
## Task
GW-6189 bot cardのリンクアイコンを移動させる

オレンジの枠にあった link iconを〇〇連携の部分に移動させました。

<img width="809" alt="Screen Shot 2021-06-01 at 23 04 11" src="https://user-images.githubusercontent.com/59536731/120337037-ebaf2200-c32d-11eb-9946-bb8ebd5e2942.png">
