### PR TITLE
Imprv/refactor test to slack

### DIFF
--- a/packages/slack/src/utils/check-communicable.ts
+++ b/packages/slack/src/utils/check-communicable.ts
@@ -71,7 +71,7 @@ const retrieveWorkspaceName = async(client: WebClient): Promise<string> => {
  * @param token bot OAuth token
  * @returns
  */
-export const testToSlack = async(token:string): Promise<ConnectionStatus> => {
+export const getConnectionStatus = async(token:string): Promise<ConnectionStatus> => {
   const client = generateWebClient(token);
   const status: ConnectionStatus = {};
 
@@ -99,7 +99,7 @@ export const getConnectionStatuses = async(tokens: string[]): Promise<{[key: str
   const map = tokens
     .reduce<Promise<Map<string, ConnectionStatus>>>(
       async(acc, token) => {
-        const status: ConnectionStatus = await testToSlack(token);
+        const status: ConnectionStatus = await getConnectionStatus(token);
 
         (await acc).set(token, status);
         return acc;

--- a/packages/slack/src/utils/check-communicable.ts
+++ b/packages/slack/src/utils/check-communicable.ts
@@ -68,6 +68,29 @@ const retrieveWorkspaceName = async(client: WebClient): Promise<string> => {
 };
 
 /**
+ * @param token bot OAuth token
+ * @returns
+ */
+export const testToSlack = async(token:string): Promise<ConnectionStatus> => {
+  const client = generateWebClient(token);
+  const status: ConnectionStatus = {};
+
+  try {
+    // try to connect
+    const resultTestSlackApiServer = await testSlackApiServer(client);
+    // check scope
+    await checkSlackScopes(resultTestSlackApiServer);
+    // retrieve workspace name
+    status.workspaceName = await retrieveWorkspaceName(client);
+  }
+  catch (err) {
+    status.error = err;
+  }
+
+  return status;
+};
+
+/**
  * Get token string to ConnectionStatus map
  * @param tokens Array of bot OAuth token
  * @returns
@@ -76,23 +99,10 @@ export const getConnectionStatuses = async(tokens: string[]): Promise<{[key: str
   const map = tokens
     .reduce<Promise<Map<string, ConnectionStatus>>>(
       async(acc, token) => {
-        const client = generateWebClient(token);
-
-        const status: ConnectionStatus = {};
-        try {
-          // try to connect
-          await testSlackApiServer(client);
-          // retrieve workspace name
-          status.workspaceName = await retrieveWorkspaceName(client);
-        }
-        catch (err) {
-          status.error = err;
-        }
+        const status: ConnectionStatus = await testToSlack(token);
 
         (await acc).set(token, status);
-
         return acc;
-
       },
       // define initial accumulator
       Promise.resolve(new Map<string, ConnectionStatus>()),
@@ -100,16 +110,6 @@ export const getConnectionStatuses = async(tokens: string[]): Promise<{[key: str
 
   // convert to object
   return Object.fromEntries(await map);
-};
-
-/**
- * @param token bot OAuth token
- * @returns
- */
-export const testToSlack = async(token:string): Promise<void> => {
-  const client = generateWebClient(token);
-  const res = await testSlackApiServer(client);
-  await checkSlackScopes(res);
 };
 
 export const sendSuccessMessage = async(token:string, channel:string, appSiteUrl:string): Promise<void> => {

--- a/packages/slackbot-proxy/src/controllers/growi-to-slack.ts
+++ b/packages/slackbot-proxy/src/controllers/growi-to-slack.ts
@@ -107,12 +107,9 @@ export class GrowiToSlackCtrl {
         return res.status(400).send({ message: `failed to request to GROWI. err: ${err.message}` });
       }
 
-      try {
-        await getConnectionStatus(token);
-      }
-      catch (err) {
-        logger.error(err);
-        return res.status(400).send({ message: `failed to test. err: ${err.message}` });
+      const status = await getConnectionStatus(token);
+      if(status.error != null){
+        return res.status(400).send({message: `failed to get onnection. err: ${status.error}`})
       }
 
       return res.send({ relation, slackBotToken: token });
@@ -145,12 +142,9 @@ export class GrowiToSlackCtrl {
       return res.status(400).send({ message: 'installation is invalid' });
     }
 
-    try {
-      await getConnectionStatus(token);
-    }
-    catch (err) {
-      logger.error(err);
-      return res.status(400).send({ message: `failed to test. err: ${err.message}` });
+    const status = await getConnectionStatus(token);
+    if(status.error != null){
+      return res.status(400).send({message: `failed to get onnection. err: ${status.error}`})
     }
 
     logger.debug('relation test is success', order);

--- a/packages/slackbot-proxy/src/controllers/growi-to-slack.ts
+++ b/packages/slackbot-proxy/src/controllers/growi-to-slack.ts
@@ -6,7 +6,7 @@ import axios from 'axios';
 import { WebAPICallOptions, WebAPICallResult } from '@slack/web-api';
 
 import {
-  verifyGrowiToSlackRequest, getConnectionStatuses, testToSlack, generateWebClient,
+  verifyGrowiToSlackRequest, getConnectionStatuses, getConnectionStatus, generateWebClient,
 } from '@growi/slack';
 
 import { GrowiReq } from '~/interfaces/growi-to-slack/growi-req';
@@ -108,7 +108,7 @@ export class GrowiToSlackCtrl {
       }
 
       try {
-        await testToSlack(token);
+        await getConnectionStatus(token);
       }
       catch (err) {
         logger.error(err);
@@ -146,7 +146,7 @@ export class GrowiToSlackCtrl {
     }
 
     try {
-      await testToSlack(token);
+      await getConnectionStatus(token);
     }
     catch (err) {
       logger.error(err);

--- a/packages/slackbot-proxy/src/controllers/growi-to-slack.ts
+++ b/packages/slackbot-proxy/src/controllers/growi-to-slack.ts
@@ -108,8 +108,8 @@ export class GrowiToSlackCtrl {
       }
 
       const status = await getConnectionStatus(token);
-      if(status.error != null){
-        return res.status(400).send({message: `failed to get onnection. err: ${status.error}`})
+      if (status.error != null){
+        return res.status(400).send({ message: `failed to get connection. err: ${status.error}` })
       }
 
       return res.send({ relation, slackBotToken: token });
@@ -143,8 +143,8 @@ export class GrowiToSlackCtrl {
     }
 
     const status = await getConnectionStatus(token);
-    if(status.error != null){
-      return res.status(400).send({message: `failed to get onnection. err: ${status.error}`})
+    if (status.error != null){
+      return res.status(400).send({ message: `failed to get connection. err: ${status.error}` })
     }
 
     logger.debug('relation test is success', order);

--- a/src/server/routes/apiv3/slack-integration-settings.js
+++ b/src/server/routes/apiv3/slack-integration-settings.js
@@ -536,7 +536,11 @@ module.exports = (crowi) => {
     }
 
     const slackBotToken = crowi.configManager.getConfig('crowi', 'slackbot:token');
-    await getConnectionStatus(slackBotToken);
+    const status = await getConnectionStatus(slackBotToken);
+    // console.log('status', status);
+    if (status.error != null) {
+      return res.apiv3Err(new ErrorV3(`Error occured while getting connection. Cause: ${status.error}`, 'send-message-failed'));
+    }
 
     const { channel } = req.body;
     const appSiteURL = crowi.configManager.getConfig('crowi', 'app:siteUrl');

--- a/src/server/routes/apiv3/slack-integration-settings.js
+++ b/src/server/routes/apiv3/slack-integration-settings.js
@@ -538,7 +538,7 @@ module.exports = (crowi) => {
     const slackBotToken = crowi.configManager.getConfig('crowi', 'slackbot:token');
     const status = await getConnectionStatus(slackBotToken);
     if (status.error != null) {
-      return res.apiv3Err(new ErrorV3(`Error occured while getting connection. Cause: ${status.error}`, 'send-message-failed'));
+      return res.apiv3Err(new ErrorV3(`Error occured while getting connection. ${status.error}`, 'send-message-failed'));
     }
 
     const { channel } = req.body;

--- a/src/server/routes/apiv3/slack-integration-settings.js
+++ b/src/server/routes/apiv3/slack-integration-settings.js
@@ -537,7 +537,6 @@ module.exports = (crowi) => {
 
     const slackBotToken = crowi.configManager.getConfig('crowi', 'slackbot:token');
     const status = await getConnectionStatus(slackBotToken);
-    // console.log('status', status);
     if (status.error != null) {
       return res.apiv3Err(new ErrorV3(`Error occured while getting connection. Cause: ${status.error}`, 'send-message-failed'));
     }

--- a/src/server/routes/apiv3/slack-integration-settings.js
+++ b/src/server/routes/apiv3/slack-integration-settings.js
@@ -536,13 +536,7 @@ module.exports = (crowi) => {
     }
 
     const slackBotToken = crowi.configManager.getConfig('crowi', 'slackbot:token');
-    try {
-      await getConnectionStatus(slackBotToken);
-    }
-    catch (error) {
-      logger.error('Error', error);
-      return res.apiv3Err(new ErrorV3(`Error occured while testing. Cause: ${error.message}`, 'test-failed', error.stack));
-    }
+    await getConnectionStatus(slackBotToken);
 
     const { channel } = req.body;
     const appSiteURL = crowi.configManager.getConfig('crowi', 'app:siteUrl');

--- a/src/server/routes/apiv3/slack-integration-settings.js
+++ b/src/server/routes/apiv3/slack-integration-settings.js
@@ -5,7 +5,7 @@ const axios = require('axios');
 const urljoin = require('url-join');
 const loggerFactory = require('@alias/logger');
 
-const { getConnectionStatuses, testToSlack, sendSuccessMessage } = require('@growi/slack');
+const { getConnectionStatus, getConnectionStatuses, sendSuccessMessage } = require('@growi/slack');
 
 const ErrorV3 = require('../../models/vo/error-apiv3');
 
@@ -537,7 +537,7 @@ module.exports = (crowi) => {
 
     const slackBotToken = crowi.configManager.getConfig('crowi', 'slackbot:token');
     try {
-      await testToSlack(slackBotToken);
+      await getConnectionStatus(slackBotToken);
     }
     catch (error) {
       logger.error('Error', error);


### PR DESCRIPTION
## 概要
- slack パッケージの check-communicable.ts にある testToSlack メソッドをリファクタし getConnectionStatus としています。
このリファクタによって、scope でエラーが発生した場合、status.error に値が入るようになっています。

- status.error の有無によって`CustomBotWithoutProxyConnectionStatus` コンポーネントの状態を変更しています。(GW-6082 管理画面 > Slack 連携にアクセスした際、ConnectionStatus の中身に応じてコンポーネントの状態を変える)