### PR TITLE
Fix/gw 6222 reset button position

### DIFF
--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -63,9 +63,9 @@ const CustomBotWithoutProxySettings = (props) => {
       <h2 className="admin-setting-header">{t('admin:slack_integration.integration_procedure')}</h2>
       <div className={(props.slackSigningSecret != null || props.slackBotToken != null) ? 'px-3 mb-5' : 'px-3 my-5'}>
         {(props.slackSigningSecret != null || props.slackBotToken != null) && (
-          <div className="d-flex justify-content-end my-3">
+          <div className="d-flex justify-content-end my-4">
             <button
-              className="pull-right btn text-danger border-danger"
+              className="btn text-danger border-danger"
               type="button"
               onClick={() => setIsDeleteConfirmModalShown(true)}
             >{t('admin:slack_integration.reset')}

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -61,11 +61,11 @@ const CustomBotWithoutProxySettings = (props) => {
       />
 
       <h2 className="admin-setting-header">{t('admin:slack_integration.integration_procedure')}</h2>
-      <div className={(props.slackSigningSecret != null || props.slackBotToken != null) ? 'px-3 mb-5' : 'px-3 my-5'}>
+      <div className="px-3 my-5">
         {(props.slackSigningSecret != null || props.slackBotToken != null) && (
-          <div className="d-flex justify-content-end">
+          <div className="d-flex justify-content-end　my-3">
             <button
-              className="my-3 pull-right btn text-danger border-danger"
+              className="pull-right btn text-danger border-danger"
               type="button"
               onClick={() => setIsDeleteConfirmModalShown(true)}
             >{t('admin:slack_integration.reset')}

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -61,8 +61,8 @@ const CustomBotWithoutProxySettings = (props) => {
       />
 
       <h2 className="admin-setting-header">{t('admin:slack_integration.integration_procedure')}</h2>
-      <div className={props.slackSigningSecret || props.slackBotToken ? 'px-3 mb-5' : 'px-3 my-5'}>
-        {(props.slackSigningSecret || props.slackBotToken) && (
+      <div className={(props.slackSigningSecret != null || props.slackBotToken != null) ? 'px-3 mb-5' : 'px-3 my-5'}>
+        {(props.slackSigningSecret != null || props.slackBotToken != null) && (
           <div className="d-flex justify-content-end">
             <button
               className="my-3 pull-right btn text-danger border-danger"

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -61,9 +61,9 @@ const CustomBotWithoutProxySettings = (props) => {
       />
 
       <h2 className="admin-setting-header">{t('admin:slack_integration.integration_procedure')}</h2>
-      <div className="px-3 my-5">
+      <div className={(props.slackSigningSecret != null || props.slackBotToken != null) ? 'px-3 mb-5' : 'px-3 my-5'}>
         {(props.slackSigningSecret != null || props.slackBotToken != null) && (
-          <div className="d-flex justify-content-end　my-3">
+          <div className="d-flex justify-content-end my-3">
             <button
               className="pull-right btn text-danger border-danger"
               type="button"

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -61,7 +61,7 @@ const CustomBotWithoutProxySettings = (props) => {
       />
 
       <h2 className="admin-setting-header">{t('admin:slack_integration.integration_procedure')}</h2>
-      <div className={props.slackSigningSecret || props.slackBotToken ? 'mx-3 mb-5' : 'mx-3 my-5'}>
+      <div className={props.slackSigningSecret || props.slackBotToken ? 'px-3 mb-5' : 'px-3 my-5'}>
         {(props.slackSigningSecret || props.slackBotToken) && (
           <div className="d-flex justify-content-end">
             <button

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -61,11 +61,11 @@ const CustomBotWithoutProxySettings = (props) => {
       />
 
       <h2 className="admin-setting-header">{t('admin:slack_integration.integration_procedure')}</h2>
-      <div className="my-5 mx-3">
+      <div className="mb-5 mx-3">
         <div className="d-flex justify-content-end">
           {(props.slackSigningSecret || props.slackBotToken) && (
             <button
-              className="mb-3 pull-right btn text-danger border-danger"
+              className="my-3 pull-right btn text-danger border-danger"
               type="button"
               onClick={() => setIsDeleteConfirmModalShown(true)}
             >{t('admin:slack_integration.reset')}

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -61,16 +61,17 @@ const CustomBotWithoutProxySettings = (props) => {
       />
 
       <h2 className="admin-setting-header">{t('admin:slack_integration.integration_procedure')}</h2>
-
-      {(props.slackSigningSecret || props.slackBotToken) && (
-      <button
-        className="mx-3 pull-right btn text-danger border-danger"
-        type="button"
-        onClick={() => setIsDeleteConfirmModalShown(true)}
-      >{t('admin:slack_integration.reset')}
-      </button>
-      )}
       <div className="my-5 mx-3">
+        <div className="d-flex justify-content-end">
+          {(props.slackSigningSecret || props.slackBotToken) && (
+            <button
+              className="mb-3 pull-right btn text-danger border-danger"
+              type="button"
+              onClick={() => setIsDeleteConfirmModalShown(true)}
+            >{t('admin:slack_integration.reset')}
+            </button>
+          )}
+        </div>
         {/* {isConnectedFailed && (<>Settings #1 <span className="text-danger">{t('admin:slack_integration.integration_failed')}</span></>)} */}
         <CustomBotWithoutProxySettingsAccordion
           {...props}

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -61,7 +61,7 @@ const CustomBotWithoutProxySettings = (props) => {
       />
 
       <h2 className="admin-setting-header">{t('admin:slack_integration.integration_procedure')}</h2>
-      <div className="mb-5 mx-3">
+      <div className={props.slackSigningSecret || props.slackBotToken ? 'mx-3 mb-5' : 'mx-3 my-5'}>
         {(props.slackSigningSecret || props.slackBotToken) && (
           <div className="d-flex justify-content-end">
             <button

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -62,16 +62,16 @@ const CustomBotWithoutProxySettings = (props) => {
 
       <h2 className="admin-setting-header">{t('admin:slack_integration.integration_procedure')}</h2>
       <div className="mb-5 mx-3">
-        <div className="d-flex justify-content-end">
-          {(props.slackSigningSecret || props.slackBotToken) && (
+        {(props.slackSigningSecret || props.slackBotToken) && (
+          <div className="d-flex justify-content-end">
             <button
               className="my-3 pull-right btn text-danger border-danger"
               type="button"
               onClick={() => setIsDeleteConfirmModalShown(true)}
             >{t('admin:slack_integration.reset')}
             </button>
-          )}
-        </div>
+          </div>
+        )}
         {/* {isConnectedFailed && (<>Settings #1 <span className="text-danger">{t('admin:slack_integration.integration_failed')}</span></>)} */}
         <CustomBotWithoutProxySettingsAccordion
           {...props}

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithoutProxySettings.jsx
@@ -62,16 +62,16 @@ const CustomBotWithoutProxySettings = (props) => {
 
       <h2 className="admin-setting-header">{t('admin:slack_integration.integration_procedure')}</h2>
       <div className={(props.slackSigningSecret != null || props.slackBotToken != null) ? 'px-3 mb-5' : 'px-3 my-5'}>
-        {(props.slackSigningSecret != null || props.slackBotToken != null) && (
-          <div className="d-flex justify-content-end my-4">
+        <div className="d-flex justify-content-end">
+          {(props.slackSigningSecret != null || props.slackBotToken != null) && (
             <button
-              className="btn text-danger border-danger"
+              className="btn text-danger border-danger my-4"
               type="button"
               onClick={() => setIsDeleteConfirmModalShown(true)}
             >{t('admin:slack_integration.reset')}
             </button>
-          </div>
-        )}
+          )}
+        </div>
         {/* {isConnectedFailed && (<>Settings #1 <span className="text-danger">{t('admin:slack_integration.integration_failed')}</span></>)} */}
         <CustomBotWithoutProxySettingsAccordion
           {...props}


### PR DESCRIPTION
## 概要
withProxy の 設定リセットボタンの位置を修正しました。

[before]
<img width="1050" alt="スクリーンショット 2021-06-03 15 37 26" src="https://user-images.githubusercontent.com/34241526/120598779-a69c0480-c481-11eb-86fe-7ec70a9c91af.png">

[after]
<img width="1046" alt="スクリーンショット 2021-06-03 15 32 46" src="https://user-images.githubusercontent.com/34241526/120598462-3b523280-c481-11eb-880e-bae8bdcbe6db.png">

## メモ
リセットボタンが存在するときは mb-5 存在しないときは my-5 にしている

