### PR TITLE
Add an error message "password is too short" to the user registration pages

### DIFF
--- a/src/server/form/invited.js
+++ b/src/server/form/invited.js
@@ -5,5 +5,5 @@ const field = form.field;
 module.exports = form(
   field('invitedForm.username').required().is(/^[\da-zA-Z\-_.]+$/),
   field('invitedForm.name').required(),
-  field('invitedForm.password').required().is(/^[\x20-\x7F]{6,}$/),
+  field('invitedForm.password').required().is(/^[\x20-\x7F]*$/).minLength(6),
 );

--- a/src/server/form/register.js
+++ b/src/server/form/register.js
@@ -6,6 +6,6 @@ module.exports = form(
   field('registerForm.username').required().is(/^[\da-zA-Z\-_.]+$/),
   field('registerForm.name').required(),
   field('registerForm.email').required(),
-  field('registerForm.password').required().is(/^[\x20-\x7F]{6,}$/),
+  field('registerForm.password').required().is(/^[\x20-\x7F]*$/).minLength(6),
   field('registerForm[app:globalLang]'),
 );


### PR DESCRIPTION
ユーザー登録でパスワードが5文字以下のときに “registerForm.password has invalid characters” と表示される問題の修正です。

修正前:
![Screenshot from 2021-06-04 11-58-19](https://user-images.githubusercontent.com/54441600/120739376-60e84600-c52c-11eb-919c-c97bb877deab.png)

修正後:
![Screenshot from 2021-06-04 11-58-25](https://user-images.githubusercontent.com/54441600/120739383-634aa000-c52c-11eb-8b80-b5482dc603c0.png)

英数字記号以外の文字を使い、かつ短い場合:
![Screenshot from 2021-06-04 11-58-53](https://user-images.githubusercontent.com/54441600/120739408-69408100-c52c-11eb-8372-a67bce8021ff.png)
