### PR TITLE
6160 Fetch Access Tokens Upon Update

### DIFF
--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
@@ -13,7 +13,7 @@ const logger = loggerFactory('growi:SlackBotSettings');
 
 const CustomBotWithProxySettings = (props) => {
   const {
-    appContainer, slackAppIntegrations, proxyServerUri, onClickAddSlackWorkspaceBtn, connectionStatuses, onUpdateSlackAppIntegration,
+    appContainer, slackAppIntegrations, proxyServerUri, onClickAddSlackWorkspaceBtn, connectionStatuses, onUpdateTokens,
   } = props;
   const [newProxyServerUri, setNewProxyServerUri] = useState();
   const [integrationIdToDelete, setIntegrationIdToDelete] = useState(null);
@@ -35,8 +35,8 @@ const CustomBotWithProxySettings = (props) => {
   const deleteSlackAppIntegrationHandler = async() => {
     try {
       await appContainer.apiv3.delete('/slack-integration-settings/slack-app-integration', { integrationIdToDelete });
-      if (props.onUpdateSlackAppIntegration != null) {
-        props.onUpdateSlackAppIntegration();
+      if (props.onDeleteSlackAppIntegration != null) {
+        props.onDeleteSlackAppIntegration();
       }
       toastSuccess(t('toaster.delete_slack_integration_procedure'));
     }
@@ -122,7 +122,7 @@ const CustomBotWithProxySettings = (props) => {
                 slackAppIntegrationId={slackAppIntegration._id}
                 tokenGtoP={tokenGtoP}
                 tokenPtoG={tokenPtoG}
-                onUpdateSlackAppIntegration={onUpdateSlackAppIntegration}
+                onUpdateTokens={onUpdateTokens}
               />
             </React.Fragment>
           );
@@ -158,7 +158,7 @@ CustomBotWithProxySettings.propTypes = {
   slackAppIntegrations: PropTypes.array,
   proxyServerUri: PropTypes.string,
   onClickAddSlackWorkspaceBtn: PropTypes.func,
-  onUpdateSlackAppIntegration: PropTypes.func,
+  onDeleteSlackAppIntegration: PropTypes.func,
   connectionStatuses: PropTypes.object.isRequired,
 };
 

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
@@ -160,6 +160,7 @@ CustomBotWithProxySettings.propTypes = {
   onClickAddSlackWorkspaceBtn: PropTypes.func,
   onDeleteSlackAppIntegration: PropTypes.func,
   connectionStatuses: PropTypes.object.isRequired,
+  onUpdateTokens: PropTypes.func,
 };
 
 export default CustomBotWithProxySettingsWrapper;

--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
@@ -13,7 +13,7 @@ const logger = loggerFactory('growi:SlackBotSettings');
 
 const CustomBotWithProxySettings = (props) => {
   const {
-    appContainer, slackAppIntegrations, proxyServerUri, onClickAddSlackWorkspaceBtn, connectionStatuses,
+    appContainer, slackAppIntegrations, proxyServerUri, onClickAddSlackWorkspaceBtn, connectionStatuses, onUpdateSlackAppIntegration,
   } = props;
   const [newProxyServerUri, setNewProxyServerUri] = useState();
   const [integrationIdToDelete, setIntegrationIdToDelete] = useState(null);
@@ -35,8 +35,8 @@ const CustomBotWithProxySettings = (props) => {
   const deleteSlackAppIntegrationHandler = async() => {
     try {
       await appContainer.apiv3.delete('/slack-integration-settings/slack-app-integration', { integrationIdToDelete });
-      if (props.onDeleteSlackAppIntegration != null) {
-        props.onDeleteSlackAppIntegration();
+      if (props.onUpdateSlackAppIntegration != null) {
+        props.onUpdateSlackAppIntegration();
       }
       toastSuccess(t('toaster.delete_slack_integration_procedure'));
     }
@@ -122,6 +122,7 @@ const CustomBotWithProxySettings = (props) => {
                 slackAppIntegrationId={slackAppIntegration._id}
                 tokenGtoP={tokenGtoP}
                 tokenPtoG={tokenPtoG}
+                onUpdateSlackAppIntegration={onUpdateSlackAppIntegration}
               />
             </React.Fragment>
           );
@@ -157,7 +158,7 @@ CustomBotWithProxySettings.propTypes = {
   slackAppIntegrations: PropTypes.array,
   proxyServerUri: PropTypes.string,
   onClickAddSlackWorkspaceBtn: PropTypes.func,
-  onDeleteSlackAppIntegration: PropTypes.func,
+  onUpdateSlackAppIntegration: PropTypes.func,
   connectionStatuses: PropTypes.object.isRequired,
 };
 

--- a/src/client/js/components/Admin/SlackIntegration/OfficialBotSettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/OfficialBotSettings.jsx
@@ -13,7 +13,7 @@ const logger = loggerFactory('growi:SlackBotSettings');
 
 const OfficialBotSettings = (props) => {
   const {
-    appContainer, slackAppIntegrations, proxyServerUri, onClickAddSlackWorkspaceBtn, connectionStatuses,
+    appContainer, slackAppIntegrations, proxyServerUri, onClickAddSlackWorkspaceBtn, connectionStatuses, onUpdateTokens,
   } = props;
   const [siteName, setSiteName] = useState('');
   const [integrationIdToDelete, setIntegrationIdToDelete] = useState(null);
@@ -118,6 +118,7 @@ const OfficialBotSettings = (props) => {
                 slackAppIntegrationId={slackAppIntegration._id}
                 tokenGtoP={tokenGtoP}
                 tokenPtoG={tokenPtoG}
+                onUpdateTokens={onUpdateTokens}
               />
             </React.Fragment>
           );
@@ -157,6 +158,7 @@ OfficialBotSettings.propTypes = {
   onClickAddSlackWorkspaceBtn: PropTypes.func,
   onDeleteSlackAppIntegration: PropTypes.func,
   connectionStatuses: PropTypes.object.isRequired,
+  onUpdateTokens: PropTypes.func,
 };
 
 export default OfficialBotSettingsWrapper;

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -152,8 +152,9 @@ const SlackIntegration = (props) => {
           slackAppIntegrations={slackAppIntegrations}
           proxyServerUri={proxyServerUri}
           onClickAddSlackWorkspaceBtn={createSlackIntegrationData}
-          onUpdateSlackAppIntegration={fetchSlackIntegrationData}
+          onDeleteSlackAppIntegration={fetchSlackIntegrationData}
           connectionStatuses={connectionStatuses}
+          onUpdateTokens={fetchSlackIntegrationData}
         />
       );
       break;

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -152,7 +152,7 @@ const SlackIntegration = (props) => {
           slackAppIntegrations={slackAppIntegrations}
           proxyServerUri={proxyServerUri}
           onClickAddSlackWorkspaceBtn={createSlackIntegrationData}
-          onDeleteSlackAppIntegration={fetchSlackIntegrationData}
+          onUpdateSlackAppIntegration={fetchSlackIntegrationData}
           connectionStatuses={connectionStatuses}
         />
       );

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -129,6 +129,7 @@ const SlackIntegration = (props) => {
           onClickAddSlackWorkspaceBtn={createSlackIntegrationData}
           onDeleteSlackAppIntegration={fetchSlackIntegrationData}
           connectionStatuses={connectionStatuses}
+          onUpdateTokens={fetchSlackIntegrationData}
         />
       );
       break;

--- a/src/client/js/components/Admin/SlackIntegration/WithProxyAccordions.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/WithProxyAccordions.jsx
@@ -76,12 +76,14 @@ const RegisteringProxyUrlProcess = () => {
 
 const GeneratingTokensAndRegisteringProxyServiceProcess = withUnstatedContainers((props) => {
   const { t } = useTranslation();
-  const { appContainer, slackAppIntegrationId, onUpdateSlackAppIntegration } = props;
+  const { appContainer, slackAppIntegrationId } = props;
 
   const regenerateTokensHandler = async() => {
     try {
       await appContainer.apiv3.put('/slack-integration-settings/regenerate-tokens', { slackAppIntegrationId });
-      onUpdateSlackAppIntegration();
+      if (props.onUpdateTokens != null) {
+        props.onUpdateTokens();
+      }
       toastSuccess(t('toaster.update_successed', { target: 'Token' }));
     }
     catch (err) {

--- a/src/client/js/components/Admin/SlackIntegration/WithProxyAccordions.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/WithProxyAccordions.jsx
@@ -271,7 +271,7 @@ const WithProxyAccordions = (props) => {
         slackAppIntegrationId={props.slackAppIntegrationId}
         tokenPtoG={props.tokenPtoG}
         tokenGtoP={props.tokenGtoP}
-        onUpdateSlackAppIntegration={props.onUpdateSlackAppIntegration}
+        onUpdateTokens={props.onUpdateTokens}
       />,
     },
     '③': {
@@ -300,7 +300,7 @@ const WithProxyAccordions = (props) => {
         slackAppIntegrationId={props.slackAppIntegrationId}
         tokenPtoG={props.tokenPtoG}
         tokenGtoP={props.tokenGtoP}
-        onUpdateSlackAppIntegration={props.onUpdateSlackAppIntegration}
+        onUpdateTokens={props.onUpdateTokens}
       />,
     },
     '④': {
@@ -342,7 +342,6 @@ WithProxyAccordions.propTypes = {
   appContainer: PropTypes.instanceOf(AppContainer).isRequired,
   botType: PropTypes.string.isRequired,
   slackAppIntegrationId: PropTypes.string.isRequired,
-  onUpdateSlackAppIntegration: PropTypes.func,
   tokenPtoG: PropTypes.string,
   tokenGtoP: PropTypes.string,
 };

--- a/src/client/js/components/Admin/SlackIntegration/WithProxyAccordions.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/WithProxyAccordions.jsx
@@ -76,12 +76,12 @@ const RegisteringProxyUrlProcess = () => {
 
 const GeneratingTokensAndRegisteringProxyServiceProcess = withUnstatedContainers((props) => {
   const { t } = useTranslation();
-  const { appContainer, slackAppIntegrationId } = props;
+  const { appContainer, slackAppIntegrationId, onUpdateSlackAppIntegration } = props;
 
   const regenerateTokensHandler = async() => {
     try {
       await appContainer.apiv3.put('/slack-integration-settings/regenerate-tokens', { slackAppIntegrationId });
-      // TODO: fetch data by GW-6160
+      onUpdateSlackAppIntegration();
       toastSuccess(t('toaster.update_successed', { target: 'Token' }));
     }
     catch (err) {
@@ -271,6 +271,7 @@ const WithProxyAccordions = (props) => {
         slackAppIntegrationId={props.slackAppIntegrationId}
         tokenPtoG={props.tokenPtoG}
         tokenGtoP={props.tokenGtoP}
+        onUpdateSlackAppIntegration={props.onUpdateSlackAppIntegration}
       />,
     },
     '③': {
@@ -299,6 +300,7 @@ const WithProxyAccordions = (props) => {
         slackAppIntegrationId={props.slackAppIntegrationId}
         tokenPtoG={props.tokenPtoG}
         tokenGtoP={props.tokenGtoP}
+        onUpdateSlackAppIntegration={props.onUpdateSlackAppIntegration}
       />,
     },
     '④': {
@@ -340,6 +342,7 @@ WithProxyAccordions.propTypes = {
   appContainer: PropTypes.instanceOf(AppContainer).isRequired,
   botType: PropTypes.string.isRequired,
   slackAppIntegrationId: PropTypes.string.isRequired,
+  onUpdateSlackAppIntegration: PropTypes.func,
   tokenPtoG: PropTypes.string,
   tokenGtoP: PropTypes.string,
 };


### PR DESCRIPTION
# [GW-6160 アクセストークンの再発行時にfetchさせる](https://youtrack.weseek.co.jp/agiles/84-39/current?issue=GW-6160)

## やったこと
Token GtoP, PtoGを再発行した際にFetchするようにしました。

## できるようになること
今までは再発行した際に新しい値がinputに表示されてなかったが、表示されるようになった