### PR TITLE
Fix: "GW-6166 Bug: LinkEditModal.jsxの「パーマリンクを使う」チェックボックスがdisabledのままになっている"

### DIFF
--- a/src/client/js/components/PageEditor/LinkEditModal.jsx
+++ b/src/client/js/components/PageEditor/LinkEditModal.jsx
@@ -153,7 +153,6 @@ class LinkEditModal extends React.PureComponent {
     const path = this.state.linkInputValue;
     let markdown = '';
     let previewError = '';
-    let permalink = '';
 
     if (path.startsWith('/')) {
       const pathWithoutFragment = new URL(path, 'http://dummy').pathname;
@@ -163,8 +162,6 @@ class LinkEditModal extends React.PureComponent {
       try {
         const { page } = await this.props.appContainer.apiGet('/pages.get', { path: pathWithoutFragment, page_id: pageId });
         markdown = page.revision.body;
-        // create permanent link only if path isn't permanent link because checkbox for isUsePermanentLink is disabled when permalink is ''.
-        permalink = !isPermanentLink ? `${window.location.origin}/${page.id}` : '';
       }
       catch (err) {
         previewError = err.message;
@@ -173,7 +170,7 @@ class LinkEditModal extends React.PureComponent {
     else {
       previewError = t('link_edit.page_not_found_in_preview', { path });
     }
-    this.setState({ markdown, previewError, permalink });
+    this.setState({ markdown, previewError });
   }
 
   getLinkForPreview() {
@@ -217,7 +214,8 @@ class LinkEditModal extends React.PureComponent {
   handleChangeTypeahead(selected) {
     const page = selected[0];
     if (page != null) {
-      this.setState({ linkInputValue: page.path });
+      const permalink = `${window.location.origin}/${page.id}`;
+      this.setState({ linkInputValue: page.path, permalink });
     }
   }
 


### PR DESCRIPTION
## タスク
ストーリー：[**GW-6166 Bug: LinkEditModal.jsxの「パーマリンクを使う」チェックボックスがdisabledのままになっている**](https://youtrack.weseek.co.jp/issue/GW-6166)
タスク：[**GW-6170 修正**](https://youtrack.weseek.co.jp/issue/GW-6170)

## バグ概要
<img width="808" alt="Screen Shot 2021-06-16 at 10 40 54" src="https://user-images.githubusercontent.com/66785624/122144993-6714e580-ce8f-11eb-871b-87c481e4c28b.png">

LinkEditModalのLink入力欄のTypeaheadより挿入したいリンクを選択しても「パーマリンクを使う」のチェックボックスがdisabledのままになっている。
右のPreviewボタンを押すとPermalinkが取得され、「パーマリンクを使う」のチェックボックスが選択可能になる

## やったこと
Typeaheadよりパーマリンクを取得し、右のPreviewボタンを押ざずに「パーマリンクを使う」のチェックボックスが選択可能になるようにしました

## やらないこと
ValidatorのisMongoIdを使わない処理はしてません。後続タスクで対応する予定です。