### PR TITLE
GW-6360 一度Linkを入力すると、空にしてもPreviewが表示されてしまうBugを修正

### DIFF
--- a/src/client/js/components/PageEditor/LinkEditModal.jsx
+++ b/src/client/js/components/PageEditor/LinkEditModal.jsx
@@ -224,7 +224,6 @@ class LinkEditModal extends React.PureComponent {
   }
 
   handleChangeLinkInput(link) {
-    this.setState({ linkInputValue: link, isUseRelativePath: false, isUsePermanentLink: false });
     let isUseRelativePath = this.state.isUseRelativePath;
     if (!this.state.linkInputValue.startsWith('/') || this.state.linkerType === Linker.types.growiLink) {
       isUseRelativePath = false;

--- a/src/client/js/components/PageEditor/LinkEditModal.jsx
+++ b/src/client/js/components/PageEditor/LinkEditModal.jsx
@@ -224,11 +224,14 @@ class LinkEditModal extends React.PureComponent {
   }
 
   handleChangeLinkInput(link) {
+    this.setState({ linkInputValue: link, isUseRelativePath: false, isUsePermanentLink: false });
     let isUseRelativePath = this.state.isUseRelativePath;
     if (!this.state.linkInputValue.startsWith('/') || this.state.linkerType === Linker.types.growiLink) {
       isUseRelativePath = false;
     }
-    this.setState({ linkInputValue: link, isUseRelativePath, isUsePermanentLink: false });
+    this.setState({
+      linkInputValue: link, isUseRelativePath, isUsePermanentLink: false, permalink: '',
+    });
   }
 
   handleSelecteLinkerType(linkerType) {

--- a/src/client/js/components/PageEditor/LinkEditModal.jsx
+++ b/src/client/js/components/PageEditor/LinkEditModal.jsx
@@ -152,6 +152,7 @@ class LinkEditModal extends React.PureComponent {
     const { t } = this.props;
     const path = this.state.linkInputValue;
     let markdown = '';
+    let permalink = '';
     let previewError = '';
 
     if (path.startsWith('/')) {
@@ -162,6 +163,7 @@ class LinkEditModal extends React.PureComponent {
       try {
         const { page } = await this.props.appContainer.apiGet('/pages.get', { path: pathWithoutFragment, page_id: pageId });
         markdown = page.revision.body;
+        permalink = page.id;
       }
       catch (err) {
         previewError = err.message;
@@ -170,7 +172,7 @@ class LinkEditModal extends React.PureComponent {
     else {
       previewError = t('link_edit.page_not_found_in_preview', { path });
     }
-    this.setState({ markdown, previewError });
+    this.setState({ markdown, previewError, permalink });
   }
 
   getLinkForPreview() {


### PR DESCRIPTION
<img width="517" alt="Screen Shot 2021-06-21 at 12 40 13" src="https://user-images.githubusercontent.com/66785624/122704069-dcb4f300-d28d-11eb-80b8-f7db5e0e64ce.png">

### ストーリー
[GW-6166 Bug: LinkEditModal.jsxの「パーマリンクを使う」チェックボックスがdisabledのままになっている
](https://youtrack.weseek.co.jp/issue/GW-6166)

### タスク
[GW-6360 一度Linkを入力すると、空にしてもPreviewが表示されてしまうBugを修正](https://youtrack.weseek.co.jp/agiles/84-39/current?issue=GW-6360)

### やったこと

- 一度Linkを入力しPermalinkを取得すると、inputを空にしたにも関わらずPreviewが表示されるBugを修正しました。原因は、Permalinkのステートが空になっていないためでした。
- ページプレビューボタンを押した際に、Permalinkを取得できる仕様を復活させました。

### やらないこと
- Typeaheadのクリアボタンを押したときにPreviewを空にする処理は入れてません。理由は、react-bootstrap-typeaheadがそのような仕様になっていない（[クリアボタンを押したときに、onInputChangeが発動しない](https://github.com/ericgio/react-bootstrap-typeahead/issues/408)）ことと、他のところで使われているSearchTypeahead.jsxを編集するのは困難なためです。
- Linkを入力すると、Typeaheadやページプレビューボタンを押さなくてもPermalinkを取得する処理は入れてません。理由は、文字を入力する度にTypeahead側とLinkEditModal.jsxの2箇所でAPIを叩く仕様になってしまうためです。