### PR TITLE
fix/6272-6390-adjust-search

### DIFF
--- a/src/server/models/page.js
+++ b/src/server/models/page.js
@@ -985,9 +985,8 @@ module.exports = function(crowi) {
     savedPage = await this.findByPath(revision.path);
     await savedPage.populateDataToShowRevision();
 
-    if (socketClientId != null) {
-      pageEvent.emit('create', savedPage, user, socketClientId);
-    }
+    pageEvent.emit('create', savedPage, user, socketClientId);
+
     return savedPage;
   };
 
@@ -1014,9 +1013,7 @@ module.exports = function(crowi) {
       savedPage = await this.syncRevisionToHackmd(savedPage);
     }
 
-    if (socketClientId != null) {
-      pageEvent.emit('update', savedPage, user, socketClientId);
-    }
+    pageEvent.emit('update', savedPage, user, socketClientId);
 
     return savedPage;
   };


### PR DESCRIPTION
## 再現方法
- `/growi create` コマンドでページを作成する
- `/growi search` コマンドで作成したページが引っかかるような検索を行う

## 症状
- 作成したページが検索結果に現れない
- rebuild index を実行すると検索結果に現れる。

## 問題の原因
- socketId が request に含まれていた場合にのみ、pageEvent を emit していた。

## 解決方法
- socketId の null チェックをやめた
  - socketId が null の場合でも問題なく動作する 