### PR TITLE
Imprv/gw 6440 font contrast

### DIFF
--- a/src/client/styles/scss/theme/hufflepuff.scss
+++ b/src/client/styles/scss/theme/hufflepuff.scss
@@ -106,6 +106,12 @@ html[light] {
     }
   }
 
+  .card.border-primary {
+    .card-header.bg-primary.text-light {
+      color: $subthemecolor !important;
+    }
+  }
+
   .growi:not(.login-page) {
     // add background-image
     #page-wrapper,

--- a/src/client/styles/scss/theme/hufflepuff.scss
+++ b/src/client/styles/scss/theme/hufflepuff.scss
@@ -294,4 +294,28 @@ html[dark] {
       background-size: cover;
     }
   }
+
+  // login and register
+  .nologin {
+    #page-wrapper {
+      background-color: $themedark;
+      background-image: url('/images/themes/hufflepuff/badger-light.png');
+      background-attachment: fixed;
+      background-position: bottom;
+      background-size: cover;
+    }
+
+    .login-header,
+    .login-dialog {
+      background-color: rgba(black, 0.1);
+    }
+
+    .link-switch {
+      color: $color-global;
+    }
+
+    .grw-external-auth-form {
+      border-color: $accentcolor !important;
+    }
+  }
 }

--- a/src/client/styles/scss/theme/hufflepuff.scss
+++ b/src/client/styles/scss/theme/hufflepuff.scss
@@ -106,12 +106,6 @@ html[light] {
     }
   }
 
-  .card.border-primary {
-    .card-header.bg-primary.text-light {
-      color: $subthemecolor !important;
-    }
-  }
-
   .growi:not(.login-page) {
     // add background-image
     #page-wrapper,

--- a/src/client/styles/scss/theme/hufflepuff.scss
+++ b/src/client/styles/scss/theme/hufflepuff.scss
@@ -180,11 +180,9 @@ html[dark] {
 
   // Background colors
   $bgcolor-global: $themedark;
-  // $bgcolor-global: #3d3f38;
   // $bgcolor-navbar: #27343b;
   $bgcolor-inline-code: $subthemecolor;
   $bgcolor-card: darken($themedark, 5%);
-  // ↓mono-blue's copy↓
   $bgcolor-highlighted: rgba($primary, 0.5);
 
   // Font colors
@@ -212,6 +210,7 @@ html[dark] {
   $bgcolor-search-top-dropdown: $themecolor;
   $border-image-navbar: linear-gradient(to right, #90a555 0%, #3d98a3 50%, #eaab20 100%);
 
+  // ↓mono-blue's copy↓
   // Logo colors
   $bgcolor-logo: #13191c;
   $fillcolor-logo-mark: white;


### PR DESCRIPTION
Tips 文字色のコントラスト改善のため色変更，
darkのログイン画面の背景もlightと同じように追加  

<img width="856" alt="li1" src="https://user-images.githubusercontent.com/46134198/123230997-c10e4e80-d512-11eb-9529-c14e76f89311.png">
↓
<img width="847" alt="li2" src="https://user-images.githubusercontent.com/46134198/123231049-ccfa1080-d512-11eb-9603-35a83c4b4bcb.png">
.

<img width="1432" alt="スクリーンショット 2021-06-24 17 39 53" src="https://user-images.githubusercontent.com/46134198/123231536-4134b400-d513-11eb-992f-f13d06ad22c9.png">
