### PR TITLE
Imprv/gw 6474 6431 6532 update endpoints

### DIFF
--- a/.github/workflows/list-unhealthy-branches.yml
+++ b/.github/workflows/list-unhealthy-branches.yml
@@ -37,7 +37,7 @@ jobs:
         status: custom
         payload: |
           {
-            text: '<!channel> There is some *illegal named branches* on GitHub.',
+            text: '<!channel> There is some branches *with illegal names* on GitHub.',
             channel: '#ci',
             attachments: ${{ steps.list-branches.outputs.SLACK_ATTACHMENTS_ILLEGAL }}
           }
@@ -51,7 +51,7 @@ jobs:
         status: custom
         payload: |
           {
-            text: '<!channel> There is some *illegal named branches* on GitHub.',
+            text: '<!channel> There is some branches *that are no longer updated* on GitHub.',
             channel: '#ci',
             attachments: ${{ steps.list-branches.outputs.SLACK_ATTACHMENTS_INACTIVE }}
           }

--- a/src/client/js/components/Admin/Users/UserInviteModal.jsx
+++ b/src/client/js/components/Admin/Users/UserInviteModal.jsx
@@ -194,7 +194,7 @@ class UserInviteModal extends React.Component {
     try {
       const emailList = await adminUsersContainer.createUserInvited(shapedEmailList, this.state.sendEmail);
       this.setState({ emailInputValue: '' });
-      this.setState({ invitedEmailList: emailList });
+      this.setState({ invitedEmailList: emailList.createUser });
       toastSuccess('Inviting user success');
     }
     catch (err) {

--- a/src/client/js/components/Admin/Users/UserInviteModal.jsx
+++ b/src/client/js/components/Admin/Users/UserInviteModal.jsx
@@ -194,7 +194,7 @@ class UserInviteModal extends React.Component {
     try {
       const emailList = await adminUsersContainer.createUserInvited(shapedEmailList, this.state.sendEmail);
       this.setState({ emailInputValue: '' });
-      this.setState({ invitedEmailList: emailList.createUser });
+      this.setState({ invitedEmailList: emailList });
       toastSuccess('Inviting user success');
     }
     catch (err) {

--- a/src/client/js/services/AdminUsersContainer.js
+++ b/src/client/js/services/AdminUsersContainer.js
@@ -164,8 +164,8 @@ export default class AdminUsersContainer extends Container {
       sendEmail,
     });
     await this.retrieveUsersByPagingNum(this.state.activePage);
-    const { afterWorkEmailList } = response.data;
-    return afterWorkEmailList;
+    const { createUser } = response.data;
+    return createUser;
   }
 
   /**

--- a/src/client/js/services/AdminUsersContainer.js
+++ b/src/client/js/services/AdminUsersContainer.js
@@ -164,8 +164,7 @@ export default class AdminUsersContainer extends Container {
       sendEmail,
     });
     await this.retrieveUsersByPagingNum(this.state.activePage);
-    const { createUser, failedEmailList } = response.data;
-    return { createUser, failedEmailList };
+    return response.data;
   }
 
   /**

--- a/src/client/js/services/AdminUsersContainer.js
+++ b/src/client/js/services/AdminUsersContainer.js
@@ -164,8 +164,8 @@ export default class AdminUsersContainer extends Container {
       sendEmail,
     });
     await this.retrieveUsersByPagingNum(this.state.activePage);
-    const { invitedUserList } = response.data;
-    return invitedUserList;
+    const { afterWorkEmailList } = response.data;
+    return afterWorkEmailList;
   }
 
   /**

--- a/src/client/js/services/AdminUsersContainer.js
+++ b/src/client/js/services/AdminUsersContainer.js
@@ -164,8 +164,8 @@ export default class AdminUsersContainer extends Container {
       sendEmail,
     });
     await this.retrieveUsersByPagingNum(this.state.activePage);
-    const { createUser } = response.data;
-    return createUser;
+    const { createUser, failedEmailList } = response.data;
+    return { createUser, failedEmailList };
   }
 
   /**

--- a/src/server/models/user.js
+++ b/src/server/models/user.js
@@ -574,12 +574,12 @@ module.exports = function(crowi) {
     const createdUserList = [];
     const failedToCreateUserEmailList = creationEmailList;
 
-    const promise = creationEmailList.map(async(email) => {
+    const promises = creationEmailList.map(async(email) => {
       const user = await this.createUserByEmail(email);
       return user;
     });
 
-    await Promise.allSettled(promise)
+    await Promise.allSettled(promises)
       .then((results) => {
         results.forEach((result) => {
           if (result.status === 'fulfilled') {

--- a/src/server/models/user.js
+++ b/src/server/models/user.js
@@ -4,7 +4,6 @@ const debug = require('debug')('growi:models:user');
 const logger = require('@alias/logger')('growi:models:user');
 const mongoose = require('mongoose');
 const mongoosePaginate = require('mongoose-paginate-v2');
-const path = require('path');
 const uniqueValidator = require('mongoose-unique-validator');
 const md5 = require('md5');
 

--- a/src/server/models/user.js
+++ b/src/server/models/user.js
@@ -573,7 +573,8 @@ module.exports = function(crowi) {
     const creationEmailList = emailList.filter((email) => { return existingEmailList.indexOf(email) === -1 });
 
     const createdUserList = [];
-    let failedToCreatetReason;
+    const failedToCreateUserEmailList = creationEmailList;
+    let failedToCreateReason = '';
 
     const promise = creationEmailList.map(async(email) => {
       const user = await this.createUserByEmail(email);
@@ -585,14 +586,23 @@ module.exports = function(crowi) {
         results.forEach((result) => {
           if (result.status === 'fulfilled') {
             createdUserList.push(result.value);
+
+            // remove created user
+            const index = failedToCreateUserEmailList.indexOf(result.value.email);
+            failedToCreateUserEmailList.splice(index, 1);
           }
           else {
-            failedToCreatetReason = result.reason;
+            failedToCreateReason = result.reason;
           }
         });
       });
 
-    return { existingEmailList, createdUserList };
+    const failedToCreateUser = {
+      emailList: failedToCreateUserEmailList,
+      msg: failedToCreateReason,
+    };
+
+    return { existingEmailList, createdUserList, failedToCreateUser };
   };
 
   userSchema.statics.sendEmailbyUserList = async function(userList) {

--- a/src/server/models/user.js
+++ b/src/server/models/user.js
@@ -589,26 +589,6 @@ module.exports = function(crowi) {
     }));
 
     return { createdUserList, existingEmailList, failedToCreateUserEmailList };
-
-    // const promises = creationEmailList.map((email) => {
-    //   return this.createUserByEmail(email);
-    // });
-
-    // const results = await Promise.allSettled(promises);
-    // results
-    //   .forEach((result) => {
-    //     if (result.status === 'fulfilled') {
-    //       createdUserList.push(result.value);
-    //       // remove created user
-    //       const index = failedToCreateUserEmailList.indexOf(result.value.email);
-    //       failedToCreateUserEmailList.splice(index, 1);
-    //     }
-    //     else {
-    //       logger.error(result.reason);
-    //     }
-    //   });
-
-    // return { createdUserList, existingEmailList, failedToCreateUserEmailList };
   };
 
   userSchema.statics.createUserByEmailAndPasswordAndStatus = async function(name, username, email, password, lang, status, callback) {

--- a/src/server/models/user.js
+++ b/src/server/models/user.js
@@ -574,8 +574,9 @@ module.exports = function(crowi) {
     const createdUserList = [];
     const failedToCreateUserEmailList = [];
 
-    await Promise.all(creationEmailList.map(async(email) => {
+    for (const email of creationEmailList) {
       try {
+        // eslint-disable-next-line no-await-in-loop
         const createdUser = await this.createUserByEmail(email);
         createdUserList.push(createdUser);
       }
@@ -586,7 +587,7 @@ module.exports = function(crowi) {
           reason: err,
         });
       }
-    }));
+    }
 
     return { createdUserList, existingEmailList, failedToCreateUserEmailList };
   };

--- a/src/server/models/user.js
+++ b/src/server/models/user.js
@@ -610,18 +610,6 @@ module.exports = function(crowi) {
 
   };
 
-  userSchema.statics.createUsersByInvitation = async function(emailList) {
-    validateCrowi();
-
-    if (!Array.isArray(emailList)) {
-      debug('emailList is not array');
-    }
-
-    const afterWorkEmailList = await this.createUsersByEmailList(emailList);
-
-    return afterWorkEmailList;
-  };
-
   userSchema.statics.createUserByEmailAndPasswordAndStatus = async function(name, username, email, password, lang, status, callback) {
     const User = this;
     const newUser = new User();

--- a/src/server/models/user.js
+++ b/src/server/models/user.js
@@ -598,35 +598,6 @@ module.exports = function(crowi) {
     return { existingEmailList, createdUserList, failedToCreateUserEmailList };
   };
 
-  userSchema.statics.sendEmailbyUserList = async function(userList) {
-    const { appService, mailService } = crowi;
-    const appTitle = appService.getAppTitle();
-
-    await Promise.all(userList.map(async(user) => {
-      if (user.password == null) {
-        return;
-      }
-
-      try {
-        return mailService.send({
-          to: user.email,
-          subject: `Invitation to ${appTitle}`,
-          template: path.join(crowi.localeDir, 'en_US/admin/userInvitation.txt'),
-          vars: {
-            email: user.email,
-            password: user.password,
-            url: crowi.appService.getSiteUrl(),
-            appTitle,
-          },
-        });
-      }
-      catch (err) {
-        return debug('fail to send email: ', err);
-      }
-    }));
-
-  };
-
   userSchema.statics.createUserByEmailAndPasswordAndStatus = async function(name, username, email, password, lang, status, callback) {
     const User = this;
     const newUser = new User();

--- a/src/server/models/user.js
+++ b/src/server/models/user.js
@@ -596,12 +596,12 @@ module.exports = function(crowi) {
         });
       });
 
-    const failedToCreateUser = {
+    const failed = {
       emailList: failedToCreateUserEmailList,
       msg: failedToCreateReason,
     };
 
-    return { existingEmailList, createdUserList, failedToCreateUser };
+    return { existingEmailList, createdUserList, failed };
   };
 
   userSchema.statics.sendEmailbyUserList = async function(userList) {

--- a/src/server/models/user.js
+++ b/src/server/models/user.js
@@ -573,10 +573,24 @@ module.exports = function(crowi) {
     const creationEmailList = emailList.filter((email) => { return existingEmailList.indexOf(email) === -1 });
 
     const createdUserList = [];
-    await Promise.all(creationEmailList.map(async(email) => {
-      const createdEmail = await this.createUserByEmail(email);
-      createdUserList.push(createdEmail);
-    }));
+    let failedToCreatetReason;
+
+    const promise = creationEmailList.map(async(email) => {
+      const user = await this.createUserByEmail(email);
+      return user;
+    });
+
+    await Promise.allSettled(promise)
+      .then((results) => {
+        results.forEach((result) => {
+          if (result.status === 'fulfilled') {
+            createdUserList.push(result.value);
+          }
+          else {
+            failedToCreatetReason = result.reason;
+          }
+        });
+      });
 
     return { existingEmailList, createdUserList };
   };

--- a/src/server/models/user.js
+++ b/src/server/models/user.js
@@ -586,7 +586,6 @@ module.exports = function(crowi) {
         results.forEach((result) => {
           if (result.status === 'fulfilled') {
             createdUserList.push(result.value);
-
             // remove created user
             const index = failedToCreateUserEmailList.indexOf(result.value.email);
             failedToCreateUserEmailList.splice(index, 1);

--- a/src/server/models/user.js
+++ b/src/server/models/user.js
@@ -610,7 +610,7 @@ module.exports = function(crowi) {
 
   };
 
-  userSchema.statics.createUsersByInvitation = async function(emailList, toSendEmail) {
+  userSchema.statics.createUsersByInvitation = async function(emailList) {
     validateCrowi();
 
     if (!Array.isArray(emailList)) {
@@ -618,10 +618,6 @@ module.exports = function(crowi) {
     }
 
     const afterWorkEmailList = await this.createUsersByEmailList(emailList);
-
-    if (toSendEmail) {
-      await this.sendEmailbyUserList(afterWorkEmailList.createdUserList);
-    }
 
     return afterWorkEmailList;
   };

--- a/src/server/models/user.js
+++ b/src/server/models/user.js
@@ -579,19 +579,18 @@ module.exports = function(crowi) {
       return user;
     });
 
-    await Promise.allSettled(promises)
-      .then((results) => {
-        results.forEach((result) => {
-          if (result.status === 'fulfilled') {
-            createdUserList.push(result.value);
-            // remove created user
-            const index = failedToCreateUserEmailList.indexOf(result.value.email);
-            failedToCreateUserEmailList.splice(index, 1);
-          }
-          else {
-            logger.error(result.reason);
-          }
-        });
+    const results = await Promise.allSettled(promises);
+    results
+      .forEach((result) => {
+        if (result.status === 'fulfilled') {
+          createdUserList.push(result.value);
+          // remove created user
+          const index = failedToCreateUserEmailList.indexOf(result.value.email);
+          failedToCreateUserEmailList.splice(index, 1);
+        }
+        else {
+          logger.error(result.reason);
+        }
       });
 
     return { existingEmailList, createdUserList, failedToCreateUserEmailList };

--- a/src/server/models/user.js
+++ b/src/server/models/user.js
@@ -574,7 +574,6 @@ module.exports = function(crowi) {
 
     const createdUserList = [];
     const failedToCreateUserEmailList = creationEmailList;
-    let failedToCreateReason = '';
 
     const promise = creationEmailList.map(async(email) => {
       const user = await this.createUserByEmail(email);
@@ -591,17 +590,12 @@ module.exports = function(crowi) {
             failedToCreateUserEmailList.splice(index, 1);
           }
           else {
-            failedToCreateReason = result.reason;
+            logger.error(result.reason);
           }
         });
       });
 
-    const failed = {
-      emailList: failedToCreateUserEmailList,
-      msg: failedToCreateReason,
-    };
-
-    return { existingEmailList, createdUserList, failed };
+    return { existingEmailList, createdUserList, failedToCreateUserEmailList };
   };
 
   userSchema.statics.sendEmailbyUserList = async function(userList) {

--- a/src/server/models/user.js
+++ b/src/server/models/user.js
@@ -584,7 +584,7 @@ module.exports = function(crowi) {
         logger.error(err);
         failedToCreateUserEmailList.push({
           email,
-          reason: err,
+          reason: err.message,
         });
       }
     }

--- a/src/server/models/user.js
+++ b/src/server/models/user.js
@@ -608,7 +608,7 @@ module.exports = function(crowi) {
     //     }
     //   });
 
-    return { createdUserList, existingEmailList, failedToCreateUserEmailList };
+    // return { createdUserList, existingEmailList, failedToCreateUserEmailList };
   };
 
   userSchema.statics.createUserByEmailAndPasswordAndStatus = async function(name, username, email, password, lang, status, callback) {

--- a/src/server/models/user.js
+++ b/src/server/models/user.js
@@ -593,7 +593,7 @@ module.exports = function(crowi) {
         }
       });
 
-    return { existingEmailList, createdUserList, failedToCreateUserEmailList };
+    return { createdUserList, existingEmailList, failedToCreateUserEmailList };
   };
 
   userSchema.statics.createUserByEmailAndPasswordAndStatus = async function(name, username, email, password, lang, status, callback) {

--- a/src/server/models/user.js
+++ b/src/server/models/user.js
@@ -574,9 +574,8 @@ module.exports = function(crowi) {
     const createdUserList = [];
     const failedToCreateUserEmailList = creationEmailList;
 
-    const promises = creationEmailList.map(async(email) => {
-      const user = await this.createUserByEmail(email);
-      return user;
+    const promises = creationEmailList.map((email) => {
+      return this.createUserByEmail(email);
     });
 
     const results = await Promise.allSettled(promises);

--- a/src/server/routes/apiv3/users.js
+++ b/src/server/routes/apiv3/users.js
@@ -147,51 +147,12 @@ module.exports = (crowi) => {
         });
       });
 
-
-    // .then((results) => {
-    //   results.forEach((result) => {
-    //     console.log(result);
-    //     if (result.status === 'fulfilled') {
-    //       sendedEmailUserList.push(result.value);
-    //       // remove email sended user
-    //       const index = failedToSendEmailList.indexOf(result.value.email);
-    //       failedToSendEmailList.splice(index, 1);
-    //     }
-    //     else {
-    //       failedToSendEmailReason = result.reason;
-    //     }
-    //   });
-    // });
-
     const faildToSendEmailUser = {
       emailList: failedToSendEmailList,
       msg: failedToSendEmailReason,
     };
 
     return { sendedEmailUserList, faildToSendEmailUser };
-
-    // await Promise.allSettled(userList.map(async(user) => {
-    //   if (user.password == null) {
-    //     return;
-    //   }
-
-    //   try {
-    //     return mailService.send({
-    //       to: user.email,
-    //       subject: `Invitation to ${appTitle}`,
-    //       template: path.join(crowi.localeDir, 'en_US/admin/userInvitation.txt'),
-    //       vars: {
-    //         email: user.email,
-    //         password: user.password,
-    //         url: crowi.appService.getSiteUrl(),
-    //         appTitle,
-    //       },
-    //     });
-    //   }
-    //   catch (err) {
-    //     return logger.debug('fail to send email: ', err);
-    //   }
-    // }));
   };
 
   /**

--- a/src/server/routes/apiv3/users.js
+++ b/src/server/routes/apiv3/users.js
@@ -142,7 +142,7 @@ module.exports = (crowi) => {
         logger.error(err);
         failedToSendEmailList.push({
           email: user.email,
-          reason: err,
+          reason: err.message,
         });
       }
     }

--- a/src/server/routes/apiv3/users.js
+++ b/src/server/routes/apiv3/users.js
@@ -362,8 +362,8 @@ module.exports = (crowi) => {
       return res.apiv3({ invitedUserList }, 201);
     }
     catch (err) {
-      logger.error('Error', err);
-      return res.apiv3Err(new ErrorV3(err));
+      const msg = 'Failed to send mail';
+      return res.apiv3Err(new ErrorV3(msg));
     }
   });
 

--- a/src/server/routes/apiv3/users.js
+++ b/src/server/routes/apiv3/users.js
@@ -400,6 +400,7 @@ module.exports = (crowi) => {
    */
   router.post('/invite', loginRequiredStrictly, adminRequired, csrf, validator.inviteEmail, apiV3FormValidator, async(req, res) => {
 
+    // Delete duplicate email addresses
     const emailList = Array.from(new Set(req.body.shapedEmailList));
 
     // Create users

--- a/src/server/routes/apiv3/users.js
+++ b/src/server/routes/apiv3/users.js
@@ -122,6 +122,10 @@ module.exports = (crowi) => {
     const { appService, mailService } = crowi;
     const appTitle = appService.getAppTitle();
 
+    const sendedEmailUserList = [];
+    const failedToSendEmailList = userList.map((user) => { return user.email });
+    const failedToSendEmailReason = '';
+
     const promise = userList.map(async(user) => {
       return mailService.send({
         to: user.email,
@@ -135,6 +139,36 @@ module.exports = (crowi) => {
         },
       });
     });
+
+    await Promise.allSettled(promise)
+      .then((results) => {
+        results.forEach((result) => {
+          console.log(result);
+        });
+      });
+
+
+    // .then((results) => {
+    //   results.forEach((result) => {
+    //     console.log(result);
+    //     if (result.status === 'fulfilled') {
+    //       sendedEmailUserList.push(result.value);
+    //       // remove email sended user
+    //       const index = failedToSendEmailList.indexOf(result.value.email);
+    //       failedToSendEmailList.splice(index, 1);
+    //     }
+    //     else {
+    //       failedToSendEmailReason = result.reason;
+    //     }
+    //   });
+    // });
+
+    const faildToSendEmailUser = {
+      emailList: failedToSendEmailList,
+      msg: failedToSendEmailReason,
+    };
+
+    return { sendedEmailUserList, faildToSendEmailUser };
 
     // await Promise.allSettled(userList.map(async(user) => {
     //   if (user.password == null) {
@@ -158,7 +192,6 @@ module.exports = (crowi) => {
     //     return logger.debug('fail to send email: ', err);
     //   }
     // }));
-
   };
 
   /**
@@ -414,8 +447,8 @@ module.exports = (crowi) => {
     try {
       if (req.body.sendEmail) {
         await sendEmailbyUserList(afterWorkEmailList.createdUserList);
+        return res.apiv3({ afterWorkEmailList }, 201);
       }
-      return res.apiv3({ afterWorkEmailList }, 201);
     }
     catch (err) {
       const msg = 'Failed to send email';

--- a/src/server/routes/apiv3/users.js
+++ b/src/server/routes/apiv3/users.js
@@ -358,11 +358,16 @@ module.exports = (crowi) => {
    */
   router.post('/invite', loginRequiredStrictly, adminRequired, csrf, validator.inviteEmail, apiV3FormValidator, async(req, res) => {
 
+    const emailList = req.body.shapedEmailList;
     let afterWorkEmailList;
+
+    if (!Array.isArray(emailList)) {
+      logger.debug('emailList is not array');
+    }
 
     // Create users
     try {
-      afterWorkEmailList = await User.createUsersByInvitation(req.body.shapedEmailList);
+      afterWorkEmailList = await User.createUsersByEmailList(req.body.shapedEmailList);
     }
     catch (err) {
       const msg = 'Failed to create user';

--- a/src/server/routes/apiv3/users.js
+++ b/src/server/routes/apiv3/users.js
@@ -118,7 +118,7 @@ module.exports = (crowi) => {
     query('limit').if(value => value != null).isInt({ max: 300 }).withMessage('You should set less than 300 or not to set limit.'),
   ];
 
-  const sendEmailbyUserList = async(userList) => {
+  const sendEmailByUserList = async(userList) => {
     const { appService, mailService } = crowi;
     const appTitle = appService.getAppTitle();
 
@@ -409,7 +409,7 @@ module.exports = (crowi) => {
 
     // Send email
     if (req.body.sendEmail) {
-      const sendEmail = await sendEmailbyUserList(createUser.createdUserList);
+      const sendEmail = await sendEmailByUserList(createUser.createdUserList);
       if (sendEmail.failedToSendEmailList.length > 0) {
         failedEmailList.push(sendEmail.failedToSendEmailList);
       }

--- a/src/server/routes/apiv3/users.js
+++ b/src/server/routes/apiv3/users.js
@@ -364,8 +364,9 @@ module.exports = (crowi) => {
     try {
       afterWorkEmailList = await User.createUsersByInvitation(req.body.shapedEmailList);
     }
-    catch {
+    catch (err) {
       const msg = 'Failed to create user';
+      logger.error('Error', err);
       return res.apiv3Err(new ErrorV3(msg));
     }
 
@@ -378,6 +379,7 @@ module.exports = (crowi) => {
     }
     catch (err) {
       const msg = 'Failed to send email';
+      logger.error('Error', err);
       return res.apiv3Err(new ErrorV3(msg, afterWorkEmailList.createdUserList));
     }
   });

--- a/src/server/routes/apiv3/users.js
+++ b/src/server/routes/apiv3/users.js
@@ -121,8 +121,6 @@ module.exports = (crowi) => {
   const sendEmailByUserList = async(userList) => {
     const { appService, mailService } = crowi;
     const appTitle = appService.getAppTitle();
-
-    const succeededToSendEmailList = [];
     const failedToSendEmailList = [];
 
     for (const user of userList) {
@@ -139,7 +137,6 @@ module.exports = (crowi) => {
             appTitle,
           },
         });
-        succeededToSendEmailList.push(user.email);
       }
       catch (err) {
         logger.error(err);
@@ -150,7 +147,7 @@ module.exports = (crowi) => {
       }
     }
 
-    return { succeededToSendEmailList, failedToSendEmailList };
+    return { failedToSendEmailList };
   };
 
   /**

--- a/src/server/routes/apiv3/users.js
+++ b/src/server/routes/apiv3/users.js
@@ -143,7 +143,12 @@ module.exports = (crowi) => {
     await Promise.allSettled(promise)
       .then((results) => {
         results.forEach((result) => {
-          console.log(result);
+          if (result.status === 'fulfilled') {
+            const email = result.value.accepted[0];
+            const index = failedToSendEmailList.indexOf(email);
+            // remove faild send email
+            failedToSendEmailList.splice(index, 1);
+          }
         });
       });
 

--- a/src/server/routes/apiv3/users.js
+++ b/src/server/routes/apiv3/users.js
@@ -404,7 +404,7 @@ module.exports = (crowi) => {
 
     // Create users
     const afterWorkEmailList = await User.createUsersByEmailList(req.body.shapedEmailList);
-    if (afterWorkEmailList.failedToCreateUserEmailList.length > 0) {
+    if (afterWorkEmailList.failedToCreateUserEmailList.length > 0 && afterWorkEmailList.createdUserList.length === 0) {
       return res.apiv3Err(new ErrorV3('Failed to create user', afterWorkEmailList.failedToCreateUserEmailList));
     }
 

--- a/src/server/routes/apiv3/users.js
+++ b/src/server/routes/apiv3/users.js
@@ -145,6 +145,7 @@ module.exports = (crowi) => {
         succeededToSendEmailList.push(user.email);
       }
       catch (err) {
+        logger.error(err);
         failedToSendEmailList.push({
           email: user.email,
           reason: err,

--- a/src/server/routes/apiv3/users.js
+++ b/src/server/routes/apiv3/users.js
@@ -400,12 +400,10 @@ module.exports = (crowi) => {
    */
   router.post('/invite', loginRequiredStrictly, adminRequired, csrf, validator.inviteEmail, apiV3FormValidator, async(req, res) => {
 
-    if (!Array.isArray(req.body.shapedEmailList)) {
-      logger.debug('emailList is not array');
-    }
+    const emailList = Array.from(new Set(req.body.shapedEmailList));
 
     // Create users
-    const createUser = await User.createUsersByEmailList(req.body.shapedEmailList);
+    const createUser = await User.createUsersByEmailList(emailList);
     if (createUser.failedToCreateUserEmailList.length > 0 && createUser.createdUserList.length === 0) {
       return res.apiv3Err(new ErrorV3('Failed to create user', createUser.failedToCreateUserEmailList));
     }

--- a/src/server/routes/apiv3/users.js
+++ b/src/server/routes/apiv3/users.js
@@ -394,6 +394,9 @@ module.exports = (crowi) => {
    *                    existingEmailList:
    *                      type: object
    *                      description: Users email that already exists
+   *                    failedToCreateUserEmailList:
+   *                      type: object
+   *                      description: Users email that failed to create
    */
   router.post('/invite', loginRequiredStrictly, adminRequired, csrf, validator.inviteEmail, apiV3FormValidator, async(req, res) => {
 

--- a/src/server/routes/apiv3/users.js
+++ b/src/server/routes/apiv3/users.js
@@ -389,22 +389,12 @@ module.exports = (crowi) => {
    */
   router.post('/invite', loginRequiredStrictly, adminRequired, csrf, validator.inviteEmail, apiV3FormValidator, async(req, res) => {
 
-    const emailList = req.body.shapedEmailList;
-    let afterWorkEmailList;
-
-    if (!Array.isArray(emailList)) {
+    if (!Array.isArray(req.body.shapedEmailList)) {
       logger.debug('emailList is not array');
     }
 
     // Create users
-    try {
-      afterWorkEmailList = await User.createUsersByEmailList(req.body.shapedEmailList);
-    }
-    catch (err) {
-      const msg = 'Failed to create user';
-      logger.error('Error', err);
-      return res.apiv3Err(new ErrorV3(msg));
-    }
+    const afterWorkEmailList = await User.createUsersByEmailList(req.body.shapedEmailList);
 
     // Send email
     try {

--- a/src/server/routes/apiv3/users.js
+++ b/src/server/routes/apiv3/users.js
@@ -402,19 +402,19 @@ module.exports = (crowi) => {
     }
 
     // Create users
-    const afterWorkEmailList = await User.createUsersByEmailList(req.body.shapedEmailList);
-    if (afterWorkEmailList.failedToCreateUserEmailList.length > 0 && afterWorkEmailList.createdUserList.length === 0) {
-      return res.apiv3Err(new ErrorV3('Failed to create user', afterWorkEmailList.failedToCreateUserEmailList));
+    const createUser = await User.createUsersByEmailList(req.body.shapedEmailList);
+    if (createUser.failedToCreateUserEmailList.length > 0 && createUser.createdUserList.length === 0) {
+      return res.apiv3Err(new ErrorV3('Failed to create user', createUser.failedToCreateUserEmailList));
     }
 
     // Send email
     if (req.body.sendEmail) {
-      const failedToSendEmailList = await sendEmailbyUserList(afterWorkEmailList.createdUserList);
+      const failedToSendEmailList = await sendEmailbyUserList(createUser.createdUserList);
       if (failedToSendEmailList.length > 0) {
         return res.apiv3Err(new ErrorV3('Failed to send email', failedToSendEmailList));
       }
     }
-    return res.apiv3({ afterWorkEmailList }, 201);
+    return res.apiv3({ createUser }, 201);
   });
 
   /**

--- a/src/server/routes/apiv3/users.js
+++ b/src/server/routes/apiv3/users.js
@@ -146,7 +146,7 @@ module.exports = (crowi) => {
           if (result.status === 'fulfilled') {
             const email = result.value.accepted[0];
             sendedEmailUserList.push(userList.filter((user) => { return user.email === email })[0]);
-            // remove faild send email
+            // remove failed send email
             const index = failedToSendEmailList.indexOf(email);
             failedToSendEmailList.splice(index, 1);
           }
@@ -156,12 +156,12 @@ module.exports = (crowi) => {
         });
       });
 
-    const faild = {
+    const failed = {
       emailList: failedToSendEmailList,
       msg: failedToSendEmailReason,
     };
 
-    return { sendedEmailUserList, faild };
+    return { sendedEmailUserList, failed };
   };
 
   /**
@@ -412,13 +412,17 @@ module.exports = (crowi) => {
 
     // Create users
     const createUsersByEmailList = await User.createUsersByEmailList(req.body.shapedEmailList);
+    if (createUsersByEmailList.failed.msg !== '') {
+      return res.apiv3Err(new ErrorV3(createUsersByEmailList.failed));
+    }
 
     // Send email
     if (req.body.sendEmail) {
-      const sendedEmailList = await sendEmailbyUserList(createUsersByEmailList.createdUserList);
+      const sendEmailList = await sendEmailbyUserList(createUsersByEmailList.createdUserList);
+      if (createUsersByEmailList.failed.msg) {
+        return res.apiv3Err(new ErrorV3(sendEmailList.failed));
+      }
     }
-    console.log(sendedEmailList);
-
     return res.apiv3({ createUsersByEmailList }, 201);
   });
 

--- a/src/server/routes/apiv3/users.js
+++ b/src/server/routes/apiv3/users.js
@@ -415,7 +415,11 @@ module.exports = (crowi) => {
       }
     }
 
-    return res.apiv3({ createUser, failedEmailList }, 201);
+    return res.apiv3({
+      createdUserList: createUser.createdUserList,
+      existingEmailList: createUser.existingEmailList,
+      failedEmailList,
+    }, 201);
   });
 
   /**

--- a/src/server/routes/apiv3/users.js
+++ b/src/server/routes/apiv3/users.js
@@ -425,9 +425,9 @@ module.exports = (crowi) => {
    *                    existingEmailList:
    *                      type: object
    *                      description: Users email that already exists
-   *                    failedToCreateUserEmailList:
+   *                    failedEmailList:
    *                      type: object
-   *                      description: Users email that failed to create
+   *                      description: Users email that failed to create or send email
    */
   router.post('/invite', loginRequiredStrictly, adminRequired, csrf, validator.inviteEmail, apiV3FormValidator, async(req, res) => {
 

--- a/src/server/routes/apiv3/users.js
+++ b/src/server/routes/apiv3/users.js
@@ -124,7 +124,7 @@ module.exports = (crowi) => {
 
     const failedToSendEmailList = userList.map((user) => { return user.email });
 
-    const promise = userList.map(async(user) => {
+    const promise = userList.map((user) => {
       return mailService.send({
         to: user.email,
         subject: `Invitation to ${appTitle}`,
@@ -138,19 +138,18 @@ module.exports = (crowi) => {
       });
     });
 
-    await Promise.allSettled(promise)
-      .then((results) => {
-        results.forEach((result) => {
-          if (result.status === 'fulfilled') {
-            const email = result.value.accepted[0];
-            // remove failed send email
-            const index = failedToSendEmailList.indexOf(email);
-            failedToSendEmailList.splice(index, 1);
-          }
-          else {
-            logger.error(result.reason);
-          }
-        });
+    const results = await Promise.allSettled(promise);
+    results
+      .forEach((result) => {
+        if (result.status === 'fulfilled') {
+          const email = result.value.accepted[0];
+          // remove failed send email
+          const index = failedToSendEmailList.indexOf(email);
+          failedToSendEmailList.splice(index, 1);
+        }
+        else {
+          logger.error(result.reason);
+        }
       });
 
     return failedToSendEmailList;

--- a/src/server/routes/apiv3/users.js
+++ b/src/server/routes/apiv3/users.js
@@ -443,9 +443,9 @@ module.exports = (crowi) => {
 
     // Send email
     if (req.body.sendEmail) {
-      const semdEmail = await sendEmailbyUserList(createUser.createdUserList);
-      if (semdEmail.failedToSendEmailList.length > 0) {
-        failedEmailList.push(semdEmail.failedToSendEmailList);
+      const sendEmail = await sendEmailbyUserList(createUser.createdUserList);
+      if (sendEmail.failedToSendEmailList.length > 0) {
+        failedEmailList.push(sendEmail.failedToSendEmailList);
       }
     }
 

--- a/src/server/routes/apiv3/users.js
+++ b/src/server/routes/apiv3/users.js
@@ -122,28 +122,42 @@ module.exports = (crowi) => {
     const { appService, mailService } = crowi;
     const appTitle = appService.getAppTitle();
 
-    await Promise.allSettled(userList.map(async(user) => {
-      if (user.password == null) {
-        return;
-      }
+    const promise = userList.map(async(user) => {
+      return mailService.send({
+        to: user.email,
+        subject: `Invitation to ${appTitle}`,
+        template: path.join(crowi.localeDir, 'en_US/admin/userInvitation.txt'),
+        vars: {
+          email: user.email,
+          password: user.password,
+          url: crowi.appService.getSiteUrl(),
+          appTitle,
+        },
+      });
+    });
 
-      try {
-        return mailService.send({
-          to: user.email,
-          subject: `Invitation to ${appTitle}`,
-          template: path.join(crowi.localeDir, 'en_US/admin/userInvitation.txt'),
-          vars: {
-            email: user.email,
-            password: user.password,
-            url: crowi.appService.getSiteUrl(),
-            appTitle,
-          },
-        });
-      }
-      catch (err) {
-        return logger.debug('fail to send email: ', err);
-      }
-    }));
+    // await Promise.allSettled(userList.map(async(user) => {
+    //   if (user.password == null) {
+    //     return;
+    //   }
+
+    //   try {
+    //     return mailService.send({
+    //       to: user.email,
+    //       subject: `Invitation to ${appTitle}`,
+    //       template: path.join(crowi.localeDir, 'en_US/admin/userInvitation.txt'),
+    //       vars: {
+    //         email: user.email,
+    //         password: user.password,
+    //         url: crowi.appService.getSiteUrl(),
+    //         appTitle,
+    //       },
+    //     });
+    //   }
+    //   catch (err) {
+    //     return logger.debug('fail to send email: ', err);
+    //   }
+    // }));
 
   };
 

--- a/src/server/routes/apiv3/users.js
+++ b/src/server/routes/apiv3/users.js
@@ -377,7 +377,7 @@ module.exports = (crowi) => {
       return res.apiv3({ afterWorkEmailList }, 201);
     }
     catch (err) {
-      const msg = 'Failed to send mail';
+      const msg = 'Failed to send email';
       return res.apiv3Err(new ErrorV3(msg, afterWorkEmailList.createdUserList));
     }
   });

--- a/src/server/routes/apiv3/users.js
+++ b/src/server/routes/apiv3/users.js
@@ -18,6 +18,17 @@ const PAGE_ITEMS = 50;
 
 const validator = {};
 
+class SendEmailError extends Error {
+
+  constructor(message = '', email = '') {
+    super();
+
+    this.message = message;
+    this.email = email;
+  }
+
+}
+
 /**
  * @swagger
  *  tags:
@@ -125,8 +136,9 @@ module.exports = (crowi) => {
     const succeededToSendEmailList = [];
     const failedToSendEmailList = [];
 
-    await Promise.all(userList.map(async(user) => {
+    for (const user of userList) {
       try {
+        // eslint-disable-next-line no-await-in-loop
         await mailService.send({
           to: user.email,
           subject: `Invitation to ${appTitle}`,
@@ -147,7 +159,7 @@ module.exports = (crowi) => {
           reason: err,
         });
       }
-    }));
+    }
 
     return { succeededToSendEmailList, failedToSendEmailList };
   };

--- a/src/server/routes/apiv3/users.js
+++ b/src/server/routes/apiv3/users.js
@@ -124,7 +124,7 @@ module.exports = (crowi) => {
 
     const failedToSendEmailList = userList.map((user) => { return user.email });
 
-    const promise = userList.map((user) => {
+    const promises = userList.map((user) => {
       return mailService.send({
         to: user.email,
         subject: `Invitation to ${appTitle}`,
@@ -138,7 +138,7 @@ module.exports = (crowi) => {
       });
     });
 
-    const results = await Promise.allSettled(promise);
+    const results = await Promise.allSettled(promises);
     results
       .forEach((result) => {
         if (result.status === 'fulfilled') {

--- a/src/server/routes/apiv3/users.js
+++ b/src/server/routes/apiv3/users.js
@@ -18,17 +18,6 @@ const PAGE_ITEMS = 50;
 
 const validator = {};
 
-class SendEmailError extends Error {
-
-  constructor(message = '', email = '') {
-    super();
-
-    this.message = message;
-    this.email = email;
-  }
-
-}
-
 /**
  * @swagger
  *  tags:

--- a/src/server/routes/apiv3/users.js
+++ b/src/server/routes/apiv3/users.js
@@ -414,7 +414,9 @@ module.exports = (crowi) => {
     const createUsersByEmailList = await User.createUsersByEmailList(req.body.shapedEmailList);
 
     // Send email
-    const sendedEmailList = await sendEmailbyUserList(createUsersByEmailList.createdUserList);
+    if (req.body.sendEmail) {
+      const sendedEmailList = await sendEmailbyUserList(createUsersByEmailList.createdUserList);
+    }
     console.log(sendedEmailList);
 
     return res.apiv3({ createUsersByEmailList }, 201);

--- a/src/server/routes/apiv3/users.js
+++ b/src/server/routes/apiv3/users.js
@@ -444,17 +444,10 @@ module.exports = (crowi) => {
     const afterWorkEmailList = await User.createUsersByEmailList(req.body.shapedEmailList);
 
     // Send email
-    try {
-      if (req.body.sendEmail) {
-        await sendEmailbyUserList(afterWorkEmailList.createdUserList);
-        return res.apiv3({ afterWorkEmailList }, 201);
-      }
-    }
-    catch (err) {
-      const msg = 'Failed to send email';
-      logger.error('Error', err);
-      return res.apiv3Err(new ErrorV3(msg, afterWorkEmailList.createdUserList));
-    }
+    const sendedEmailList = await sendEmailbyUserList(afterWorkEmailList.createdUserList);
+    console.log(sendedEmailList);
+
+    return res.apiv3({ afterWorkEmailList }, 201);
   });
 
   /**

--- a/src/server/routes/apiv3/users.js
+++ b/src/server/routes/apiv3/users.js
@@ -124,7 +124,7 @@ module.exports = (crowi) => {
 
     const sendedEmailUserList = [];
     const failedToSendEmailList = userList.map((user) => { return user.email });
-    const failedToSendEmailReason = '';
+    let failedToSendEmailReason = '';
 
     const promise = userList.map(async(user) => {
       return mailService.send({
@@ -145,9 +145,13 @@ module.exports = (crowi) => {
         results.forEach((result) => {
           if (result.status === 'fulfilled') {
             const email = result.value.accepted[0];
-            const index = failedToSendEmailList.indexOf(email);
+            sendedEmailUserList.push(userList.filter((user) => { return user.email === email })[0]);
             // remove faild send email
+            const index = failedToSendEmailList.indexOf(email);
             failedToSendEmailList.splice(index, 1);
+          }
+          else {
+            failedToSendEmailReason = result.reason;
           }
         });
       });
@@ -407,13 +411,13 @@ module.exports = (crowi) => {
     }
 
     // Create users
-    const afterWorkEmailList = await User.createUsersByEmailList(req.body.shapedEmailList);
+    const createUsersByEmailList = await User.createUsersByEmailList(req.body.shapedEmailList);
 
     // Send email
-    const sendedEmailList = await sendEmailbyUserList(afterWorkEmailList.createdUserList);
+    const sendedEmailList = await sendEmailbyUserList(createUsersByEmailList.createdUserList);
     console.log(sendedEmailList);
 
-    return res.apiv3({ afterWorkEmailList }, 201);
+    return res.apiv3({ createUsersByEmailList }, 201);
   });
 
   /**

--- a/src/server/routes/apiv3/users.js
+++ b/src/server/routes/apiv3/users.js
@@ -358,11 +358,11 @@ module.exports = (crowi) => {
    */
   router.post('/invite', loginRequiredStrictly, adminRequired, csrf, validator.inviteEmail, apiV3FormValidator, async(req, res) => {
 
-    let invitedUserList;
+    let afterWorkEmailList;
 
     // Create users
     try {
-      invitedUserList = await User.createUsersByInvitation(req.body.shapedEmailList);
+      afterWorkEmailList = await User.createUsersByInvitation(req.body.shapedEmailList);
     }
     catch {
       const msg = 'Failed to create user';
@@ -372,13 +372,13 @@ module.exports = (crowi) => {
     // Send email
     try {
       if (req.body.sendEmail) {
-        await User.sendEmailbyUserList(invitedUserList.createdUserList);
+        await User.sendEmailbyUserList(afterWorkEmailList.createdUserList);
       }
-      return res.apiv3({ invitedUserList }, 201);
+      return res.apiv3({ afterWorkEmailList }, 201);
     }
     catch (err) {
       const msg = 'Failed to send mail';
-      return res.apiv3Err(new ErrorV3(msg, invitedUserList.createdUserList));
+      return res.apiv3Err(new ErrorV3(msg, afterWorkEmailList.createdUserList));
     }
   });
 

--- a/src/server/routes/apiv3/users.js
+++ b/src/server/routes/apiv3/users.js
@@ -156,12 +156,12 @@ module.exports = (crowi) => {
         });
       });
 
-    const faildToSendEmailUser = {
+    const faild = {
       emailList: failedToSendEmailList,
       msg: failedToSendEmailReason,
     };
 
-    return { sendedEmailUserList, faildToSendEmailUser };
+    return { sendedEmailUserList, faild };
   };
 
   /**

--- a/src/server/routes/apiv3/users.js
+++ b/src/server/routes/apiv3/users.js
@@ -150,40 +150,6 @@ module.exports = (crowi) => {
     }));
 
     return { succeededToSendEmailList, failedToSendEmailList };
-
-    // const failedToSendEmailList = userList.map((user) => { return user.email });
-
-    // const promises = userList.map(async(user) => {
-    //   const sendEmail = await mailService.send({
-    //     to: user.email,
-    //     subject: `Invitation to ${appTitle}`,
-    //     template: path.join(crowi.localeDir, 'en_US/admin/userInvitation.txt'),
-    //     vars: {
-    //       email: user.email,
-    //       password: user.password,
-    //       url: crowi.appService.getSiteUrl(),
-    //       appTitle,
-    //     },
-    //   });
-    //   return { user, sendEmail };
-    // });
-
-    // const results = await Promise.allSettled(promises);
-    // results
-    //   .forEach((result) => {
-    //     if (result.status === 'fulfilled') {
-    //       const email = result.value.accepted[0];
-    //       // remove failed send email
-    //       const index = failedToSendEmailList.indexOf(email);
-    //       failedToSendEmailList.splice(index, 1);
-    //     }
-    //     else {
-    //       console.log(result);
-    //       logger.error(result.reason);
-    //     }
-    //   });
-
-    // return failedToSendEmailList;
   };
 
   /**


### PR DESCRIPTION
## タスク
- [GW-6474](https://youtrack.weseek.co.jp/agiles/84-39/current?issue=GW-6474) users/invite エンドポイントの修正
- [GW-6431](https://youtrack.weseek.co.jp/agiles/84-39/current?issue=GW-6431)メール送信に失敗した場合、適切なエラーメッセージを管理者に返す
- [GW-6532](https://youtrack.weseek.co.jp/agiles/84-39/current?issue=GW-6532) 同一のメールアドレスでユーザーの仮発行をしようとした時に表示が崩れる問題の修正

##  概要
- `/users/invite` のエンドポイント修正を行いました。ユーザー作成プロセスと招待メールの送信プロセスを分け、ユーザーの作成成功かつメールの送信に失敗した場合は作成したユーザーをフロントに渡すようにしました。
- メールの送信に失敗した場合は `Failed to send email` というメッセージを返すようにしました。
  - 後続タスク([GW-6496](https://youtrack.weseek.co.jp/agiles/84-39/current?issue=GW-6496) )でフロントに渡した、ユーザーのメールアドレスを toast に列挙する を行います。
- https://github.com/weseek/growi/pull/3928#discussion_r659157716

## 課題
現状、/users/invite でエラーが2種類ある。（ユーザー作成、メール送信）。後続タスクで、ユーザーの作成成功かつメールの送信失敗したユーザーのメールアドレスを toast に列挙する場合、エラーをどのようにハンドリングするかを考える必要がある。

## 課題の解決策
- エラーのメッセージで比較する
- エラーにステータスコードを設けてそれを比較する