### PR TITLE
Feat/admin disable link sharing front disable button using config

### DIFF
--- a/resource/locales/en_US/translation.json
+++ b/resource/locales/en_US/translation.json
@@ -148,6 +148,7 @@
   "original_path":"Original path",
   "new_path":"New path",
   "duplicated_path":"duplicated_path",
+  "Link sharing is disabled": "Link sharing is disabled",
   "personal_dropdown": {
     "home": "Home",
     "settings": "Settings",

--- a/resource/locales/ja_JP/translation.json
+++ b/resource/locales/ja_JP/translation.json
@@ -151,7 +151,7 @@
   "original_path":"元のパス",
   "new_path":"新しいパス",
   "duplicated_path":"重複したパス",
-  "Link sharing is disabled": "リンクのシェアは許可されていません",
+  "Link sharing is disabled": "リンクのシェアは無効化されています",
   "personal_dropdown": {
     "home": "ホーム",
     "settings": "設定",

--- a/resource/locales/ja_JP/translation.json
+++ b/resource/locales/ja_JP/translation.json
@@ -151,6 +151,7 @@
   "original_path":"元のパス",
   "new_path":"新しいパス",
   "duplicated_path":"重複したパス",
+  "Link sharing is disabled": "リンクのシェアは許可されていません",
   "personal_dropdown": {
     "home": "ホーム",
     "settings": "設定",

--- a/resource/locales/zh_CN/translation.json
+++ b/resource/locales/zh_CN/translation.json
@@ -157,6 +157,7 @@
   "original_path":"Original path",
   "new_path":"New path",
   "duplicated_path":"duplicated_path",
+  "Link sharing is disabled": "你不允许分享该链接",
 	"form_validation": {
 		"error_message": "有些值不正确",
 		"required": "%s 是必需的",

--- a/src/client/js/components/PageAccessoriesModal.jsx
+++ b/src/client/js/components/PageAccessoriesModal.jsx
@@ -26,6 +26,7 @@ const PageAccessoriesModal = (props) => {
   const {
     t, pageAccessoriesContainer, onClose, isGuestUser, isSharedUser, isNotFoundPage,
   } = props;
+  const isLinkSharingDisabled = pageAccessoriesContainer.appContainer.config.disableLinkSharing;
   const { switchActiveTab } = pageAccessoriesContainer;
   const { activeTab, activeComponents } = pageAccessoriesContainer.state;
   const [isWindowExpanded, setIsWindowExpanded] = useState(false);
@@ -60,10 +61,10 @@ const PageAccessoriesModal = (props) => {
         Icon: ShareLinkIcon,
         i18n: t('share_links.share_link_management'),
         index: 4,
-        isLinkEnabled: v => !isGuestUser && !isSharedUser && !isNotFoundPage,
+        isLinkEnabled: v => !isGuestUser && !isSharedUser && !isNotFoundPage && !isLinkSharingDisabled,
       },
     };
-  }, [t, isGuestUser, isSharedUser, isNotFoundPage]);
+  }, [t, isGuestUser, isSharedUser, isNotFoundPage, isLinkSharingDisabled]);
 
   const closeModalHandler = useCallback(() => {
     if (onClose == null) {

--- a/src/client/js/components/PageAccessoriesModalControl.jsx
+++ b/src/client/js/components/PageAccessoriesModalControl.jsx
@@ -19,6 +19,7 @@ const PageAccessoriesModalControl = (props) => {
   const {
     t, pageAccessoriesContainer, isGuestUser, isSharedUser, isNotFoundPage,
   } = props;
+  const isLinkSharingDisabled = pageAccessoriesContainer.appContainer.config.disableLinkSharing;
 
   const accessoriesBtnList = useMemo(() => {
     return [
@@ -49,11 +50,11 @@ const PageAccessoriesModalControl = (props) => {
       {
         name: 'shareLink',
         Icon: <ShareLinkIcon />,
-        disabled: isGuestUser || isSharedUser || isNotFoundPage,
+        disabled: isGuestUser || isSharedUser || isNotFoundPage || isLinkSharingDisabled,
         i18n: t('share_links.share_link_management'),
       },
     ];
-  }, [t, isGuestUser, isSharedUser, isNotFoundPage]);
+  }, [t, isGuestUser, isSharedUser, isNotFoundPage, isLinkSharingDisabled]);
 
   return (
     <div className="grw-page-accessories-control d-flex flex-nowrap align-items-center justify-content-end justify-content-lg-between">
@@ -62,6 +63,9 @@ const PageAccessoriesModalControl = (props) => {
         let tooltipMessage;
         if (accessory.disabled) {
           tooltipMessage = isNotFoundPage ? t('not_found_page.page_not_exist') : t('Not available for guest');
+          if (accessory.name === 'shareLink' && isLinkSharingDisabled) {
+            tooltipMessage = t('Link sharing is disabled');
+          }
         }
         else {
           tooltipMessage = accessory.i18n;


### PR DESCRIPTION
タスクGW-6412, GW-6413の実装が完了したのでご確認お願いします。
GW-6412 [Front] AppContainer内で、configの値からisLinkSharingDisabledを取得し、this.isLinkSharingDisabled = isLinkSharingDisabled
GW-6413 [Front] PageAccesoriesModal、ModalControlでisLinkSharingDisabledを使ってdisableを分岐する

よろしくお願いいたします。
以下検証動画です。

**説明：**
Link sharingをDenyすると、ShareLinkボタンは押せなくなり、カーソルを合わせるとLink sharing is disabledと表示されます。
Link sharingをAllowすると、いつも通りShareLinkが使えます。

https://user-images.githubusercontent.com/58432773/123361414-fc0f9100-d5a9-11eb-9bcc-d59c2a07e9e0.mov

