### PR TITLE
Imprv/not change bot type fetching

### DIFF
--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -183,7 +183,11 @@ const SlackIntegration = (props) => {
           </a>
         </h2>
 
-        {Object.keys(connectionStatuses).length === 0 ? <h1>hoeg</h1>
+        {Object.keys(connectionStatuses).length === 0 ? (
+          <div className="text-muted text-center">
+            <i className="fa fa-2x fa-spinner fa-pulse mr-1"></i>
+          </div>
+        )
         : (
           <>
             <div className="d-flex justify-content-end">

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -157,6 +157,7 @@ const SlackIntegration = (props) => {
       break;
   }
 
+  console.log(connectionStatuses);
   return (
     <>
       <ConfirmBotChangeModal
@@ -182,17 +183,20 @@ const SlackIntegration = (props) => {
           </a>
         </h2>
 
-        <div className="d-flex justify-content-end">
-          <button
-            className="btn btn-outline-danger"
-            type="button"
-            onClick={() => setIsDeleteConfirmModalShown(true)}
-          >{t('admin:slack_integration.reset_all_settings')}
-          </button>
-        </div>
+        {Object.keys(connectionStatuses).length === 0 ? <h1>hoeg</h1>
+        : (
+          <>
+            <div className="d-flex justify-content-end">
+              <button
+                className="btn btn-outline-danger"
+                type="button"
+                onClick={() => setIsDeleteConfirmModalShown(true)}
+              >{t('admin:slack_integration.reset_all_settings')}
+              </button>
+            </div>
 
-        <div className="row my-5 flex-wrap-reverse justify-content-center">
-          {botTypes.map((botType) => {
+            <div className="row my-5 flex-wrap-reverse justify-content-center">
+              {botTypes.map((botType) => {
             return (
               <div key={botType} className="m-3">
                 <BotTypeCard
@@ -203,7 +207,9 @@ const SlackIntegration = (props) => {
               </div>
             );
           })}
-        </div>
+            </div>
+          </>
+        )}
       </div>
 
       {settingsComponent}

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -27,6 +27,7 @@ const SlackIntegration = (props) => {
   const [slackAppIntegrations, setSlackAppIntegrations] = useState();
   const [proxyServerUri, setProxyServerUri] = useState();
   const [connectionStatuses, setConnectionStatuses] = useState({});
+  const [isLoading, setIsLoading] = useState(true);
 
 
   const fetchSlackIntegrationData = useCallback(async() => {
@@ -44,6 +45,7 @@ const SlackIntegration = (props) => {
       setSlackBotTokenEnv(slackBotTokenEnvVars);
       setSlackAppIntegrations(slackAppIntegrations);
       setProxyServerUri(proxyServerUri);
+      setIsLoading(false);
     }
     catch (err) {
       toastError(err);
@@ -113,6 +115,34 @@ const SlackIntegration = (props) => {
     setSelectedBotType(null);
   };
 
+    return (
+      <>
+        <div className="d-flex justify-content-end">
+          <button
+            className="btn btn-outline-danger"
+            type="button"
+            onClick={() => setIsDeleteConfirmModalShown(true)}
+          >{t('admin:slack_integration.reset_all_settings')}
+          </button>
+        </div>
+
+        <div className="row my-5 flex-wrap-reverse justify-content-center">
+          {botTypes.map((botType) => {
+        return (
+          <div key={botType} className="m-3">
+            <BotTypeCard
+              botType={botType}
+              isActive={currentBotType === botType}
+              onBotTypeSelectHandler={botTypeSelectHandler}
+            />
+          </div>
+        );
+      })}
+        </div>
+      </>
+    );
+
+  };
   let settingsComponent = null;
 
   switch (currentBotType) {
@@ -157,7 +187,6 @@ const SlackIntegration = (props) => {
       break;
   }
 
-  console.log(connectionStatuses);
   return (
     <>
       <ConfirmBotChangeModal
@@ -183,7 +212,7 @@ const SlackIntegration = (props) => {
           </a>
         </h2>
 
-        {Object.keys(connectionStatuses).length === 0 ? (
+        {isLoading ? (
           <div className="text-muted text-center">
             <i className="fa fa-2x fa-spinner fa-pulse mr-1"></i>
           </div>
@@ -213,7 +242,9 @@ const SlackIntegration = (props) => {
           })}
             </div>
           </>
-        )}
+)}
+
+
       </div>
 
       {settingsComponent}

--- a/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -115,34 +115,6 @@ const SlackIntegration = (props) => {
     setSelectedBotType(null);
   };
 
-    return (
-      <>
-        <div className="d-flex justify-content-end">
-          <button
-            className="btn btn-outline-danger"
-            type="button"
-            onClick={() => setIsDeleteConfirmModalShown(true)}
-          >{t('admin:slack_integration.reset_all_settings')}
-          </button>
-        </div>
-
-        <div className="row my-5 flex-wrap-reverse justify-content-center">
-          {botTypes.map((botType) => {
-        return (
-          <div key={botType} className="m-3">
-            <BotTypeCard
-              botType={botType}
-              isActive={currentBotType === botType}
-              onBotTypeSelectHandler={botTypeSelectHandler}
-            />
-          </div>
-        );
-      })}
-        </div>
-      </>
-    );
-
-  };
   let settingsComponent = null;
 
   switch (currentBotType) {
@@ -187,6 +159,14 @@ const SlackIntegration = (props) => {
       break;
   }
 
+  if (isLoading) {
+    return (
+      <div className="text-muted text-center">
+        <i className="fa fa-2x fa-spinner fa-pulse mr-1"></i>
+      </div>
+    );
+  }
+
   return (
     <>
       <ConfirmBotChangeModal
@@ -212,24 +192,17 @@ const SlackIntegration = (props) => {
           </a>
         </h2>
 
-        {isLoading ? (
-          <div className="text-muted text-center">
-            <i className="fa fa-2x fa-spinner fa-pulse mr-1"></i>
-          </div>
-        )
-        : (
-          <>
-            <div className="d-flex justify-content-end">
-              <button
-                className="btn btn-outline-danger"
-                type="button"
-                onClick={() => setIsDeleteConfirmModalShown(true)}
-              >{t('admin:slack_integration.reset_all_settings')}
-              </button>
-            </div>
+        <div className="d-flex justify-content-end">
+          <button
+            className="btn btn-outline-danger"
+            type="button"
+            onClick={() => setIsDeleteConfirmModalShown(true)}
+          >{t('admin:slack_integration.reset_all_settings')}
+          </button>
+        </div>
 
-            <div className="row my-5 flex-wrap-reverse justify-content-center">
-              {botTypes.map((botType) => {
+        <div className="row my-5 flex-wrap-reverse justify-content-center">
+          {botTypes.map((botType) => {
             return (
               <div key={botType} className="m-3">
                 <BotTypeCard
@@ -240,11 +213,7 @@ const SlackIntegration = (props) => {
               </div>
             );
           })}
-            </div>
-          </>
-)}
-
-
+        </div>
       </div>
 
       {settingsComponent}


### PR DESCRIPTION
## 概要

今までは、admin/slack-integration にアクセス直後、データを Slack App から取得する前に BotType を変更できました。
これは　connectionStatuses を取得しに行っている間に別の botType を選択できてしまう状態です。
今回の修正では fetch してくるまで BotType を変更できないようにしています。
fetch してくるまでの間はspinner の状態にしています。