### PR TITLE
Fix/gw6485 change accordion content appropriately

### DIFF
--- a/src/client/js/components/Admin/SlackIntegration/WithProxyAccordions.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/WithProxyAccordions.jsx
@@ -35,7 +35,7 @@ const BotCreateProcess = () => {
   );
 };
 
-const BotInstallProcess = () => {
+const BotInstallProcessForOfficialBot = () => {
   const { t } = useTranslation();
   return (
     <div className="my-5 d-flex flex-column align-items-center">
@@ -291,7 +291,7 @@ const WithProxyAccordions = (props) => {
   const officialBotIntegrationProcedure = {
     '①': {
       title: 'install_bot_to_slack',
-      content: <BotInstallProcess />,
+      content: <BotInstallProcessForOfficialBot />,
     },
     '②': {
       title: 'register_for_growi_official_bot_proxy_service',

--- a/src/client/js/components/Admin/SlackIntegration/WithProxyAccordions.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/WithProxyAccordions.jsx
@@ -57,6 +57,25 @@ const BotInstallProcess = () => {
   );
 };
 
+const BotInstallProcessForCustomBotWithProxy = () => {
+  const { t } = useTranslation();
+  return (
+    <div className="container w-75 py-5">
+      <p>1. {t('admin:slack_integration.accordion.select_install_your_app')}</p>
+      <img src="/images/slack-integration/slack-bot-install-your-app-introduction.png" className="border border-light img-fluid mb-5" />
+      <p>2. {t('admin:slack_integration.accordion.select_install_to_workspace')}</p>
+      <img src="/images/slack-integration/slack-bot-install-to-workspace.png" className="border border-light img-fluid mb-5" />
+      <p>3. {t('admin:slack_integration.accordion.click_allow')}</p>
+      <img src="/images/slack-integration/slack-bot-install-your-app-transition-destination.png" className="border border-light img-fluid mb-5" />
+      <p>4. {t('admin:slack_integration.accordion.install_complete_if_checked')}</p>
+      <img src="/images/slack-integration/slack-bot-install-your-app-complete.png" className="border border-light img-fluid mb-5" />
+      <p>5. {t('admin:slack_integration.accordion.invite_bot_to_channel')}</p>
+      <img src="/images/slack-integration/slack-bot-install-to-workspace-joined-bot.png" className="border border-light img-fluid mb-1" />
+      <img src="/images/slack-integration/slack-bot-install-your-app-introduction-to-channel.png" className="border border-light img-fluid" />
+    </div>
+  );
+};
+
 const RegisteringProxyUrlProcess = () => {
   const { t } = useTranslation();
   return (
@@ -307,7 +326,7 @@ const WithProxyAccordions = (props) => {
     },
     '②': {
       title: 'install_bot_to_slack',
-      content: <BotInstallProcess />,
+      content: <BotInstallProcessForCustomBotWithProxy />,
     },
     '③': {
       title: 'register_for_growi_official_bot_proxy_service',


### PR DESCRIPTION
## Task
GW-6485 [Custom bot with proxy] アコーディオンのインストール手順をボタンではなく、説明文に変更

## View
<img width="1003" alt="Screen Shot 2021-06-28 at 14 09 34" src="https://user-images.githubusercontent.com/59536731/123583651-f40a5800-d81a-11eb-889e-e114c552911c.png">
<img width="971" alt="Screen Shot 2021-06-28 at 14 09 40" src="https://user-images.githubusercontent.com/59536731/123583653-f53b8500-d81a-11eb-9bb2-6755e27035de.png">
<img width="1005" alt="Screen Shot 2021-06-28 at 14 09 46" src="https://user-images.githubusercontent.com/59536731/123583654-f5d41b80-d81a-11eb-9f8c-9caaf1fbffc9.png">
