### PR TITLE
Fix/bug not function post ephemeral error

### DIFF
--- a/packages/slackbot-proxy/src/controllers/slack.ts
+++ b/packages/slackbot-proxy/src/controllers/slack.ts
@@ -152,7 +152,14 @@ export class SlackCtrl {
     const installationId = authorizeResult.enterpriseId || authorizeResult.teamId;
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const installation = await this.installationRepository.findByTeamIdOrEnterpriseId(installationId!);
-    const relations = await this.relationRepository.find({ installation });
+    // const relations = await this.relationRepository.find({ installation });
+
+    const relations = await this.relationRepository.createQueryBuilder('relation')
+      .where('relation.installationId = :id', { id: installation?.id })
+      .leftJoinAndSelect('relation.installation', 'installation')
+      .getMany();
+
+    console.log('relations', relations);
 
     if (relations.length === 0) {
       return res.json({
@@ -251,7 +258,6 @@ export class SlackCtrl {
     * forward to GROWI server
     */
     const relation = await this.relationRepository.findOne({ installation, growiUri: req.growiUri });
-
     if (relation == null) {
       logger.error('*No relation found.*');
       return;

--- a/packages/slackbot-proxy/src/controllers/slack.ts
+++ b/packages/slackbot-proxy/src/controllers/slack.ts
@@ -152,14 +152,10 @@ export class SlackCtrl {
     const installationId = authorizeResult.enterpriseId || authorizeResult.teamId;
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const installation = await this.installationRepository.findByTeamIdOrEnterpriseId(installationId!);
-    // const relations = await this.relationRepository.find({ installation });
-
     const relations = await this.relationRepository.createQueryBuilder('relation')
       .where('relation.installationId = :id', { id: installation?.id })
       .leftJoinAndSelect('relation.installation', 'installation')
       .getMany();
-
-    console.log('relations', relations);
 
     if (relations.length === 0) {
       return res.json({

--- a/packages/slackbot-proxy/src/controllers/slack.ts
+++ b/packages/slackbot-proxy/src/controllers/slack.ts
@@ -254,6 +254,7 @@ export class SlackCtrl {
     * forward to GROWI server
     */
     const relation = await this.relationRepository.findOne({ installation, growiUri: req.growiUri });
+
     if (relation == null) {
       logger.error('*No relation found.*');
       return;

--- a/packages/slackbot-proxy/src/services/SelectGrowiService.ts
+++ b/packages/slackbot-proxy/src/services/SelectGrowiService.ts
@@ -93,7 +93,12 @@ export class SelectGrowiService implements GrowiCommandProcessor {
     // ovverride trigger_id
     sendCommandBody.trigger_id = triggerId;
 
-    const relation = await this.relationRepository.findOne({ installation, growiUri });
+    // const relation = await this.relationRepository.findOne({ installation, growiUri });
+    const relation = await this.relationRepository.createQueryBuilder('relation')
+      .where('relation.growiUri =:growiUri', { growiUri })
+      .andWhere('relation.installationId = :id', { id: installation?.id })
+      .leftJoinAndSelect('relation.installation', 'installation')
+      .getOne();
 
     if (relation == null) {
       // TODO: postEphemeralErrors

--- a/packages/slackbot-proxy/src/services/SelectGrowiService.ts
+++ b/packages/slackbot-proxy/src/services/SelectGrowiService.ts
@@ -93,7 +93,6 @@ export class SelectGrowiService implements GrowiCommandProcessor {
     // ovverride trigger_id
     sendCommandBody.trigger_id = triggerId;
 
-    // const relation = await this.relationRepository.findOne({ installation, growiUri });
     const relation = await this.relationRepository.createQueryBuilder('relation')
       .where('relation.growiUri =:growiUri', { growiUri })
       .andWhere('relation.installationId = :id', { id: installation?.id })


### PR DESCRIPTION
## 概要
slack.ts 107 行目の postEphemeralErrors が機能しない問題を修正。

- 原因
slack.ts 84行目の relations 中に installation が含まれていないことによって、
107 行目の postEphemeralErrors が botToken の欠落します。
それによって機能していなかった模様です。

- 解決策
installation を join しています。
```slack.ts
const botToken = relations[0].installation?.data.bot?.token; // relations[0] should be exist // relations[0] にない
...
 try {
      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
      return postEphemeralErrors(rejectedResults, body.channel_id, body.user_id, botToken!);
    }
```
