### PR TITLE
Added ws name

### DIFF
--- a/src/server/service/slackbot.js
+++ b/src/server/service/slackbot.js
@@ -171,10 +171,11 @@ class SlackBotService extends S2sMessageHandlable {
       return;
     }
 
-    const base = this.crowi.appService.getSiteUrl();
+    const appUrl = this.crowi.appService.getSiteUrl();
+    const appTitle = this.crowi.appService.getAppTitle();
 
     const urls = resultPaths.map((path) => {
-      const url = new URL(path, base);
+      const url = new URL(path, appUrl);
       return `<${decodeURI(url.href)} | ${decodeURI(url.pathname)}>`;
     });
 
@@ -235,6 +236,7 @@ class SlackBotService extends S2sMessageHandlable {
         user: body.user_id,
         text: 'Successed To Search',
         blocks: [
+          this.generateMarkdownSectionBlock(`<${decodeURI(appUrl)}|*${appTitle}*>`),
           this.generateMarkdownSectionBlock(keywordsAndDesc),
           this.generateMarkdownSectionBlock(`${urls.join('\n')}`),
           actionBlocks,


### PR DESCRIPTION
Slackでキーワード検索時に、どのGROWIからの検索結果かわかるようにGROWI名を表示させました。

<img width="288" alt="Screen Shot 2021-06-29 at 13 38 58" src="https://user-images.githubusercontent.com/66785624/123739079-02bb4280-d8e1-11eb-8c10-acdc95203f07.png">
