### PR TITLE
Feat/gw 6477 6423 issue the appropriate toast when inviting users

### DIFF
--- a/src/client/js/components/Admin/Users/UserInviteModal.jsx
+++ b/src/client/js/components/Admin/Users/UserInviteModal.jsx
@@ -55,6 +55,7 @@ class UserInviteModal extends React.Component {
         msg = `Existing email<br>${msg}`;
         toastWarning(msg);
         break;
+      // TODO: GW-6496
       case 'error':
         toastError(msg);
         break;
@@ -223,6 +224,7 @@ class UserInviteModal extends React.Component {
       if (emailList.existingEmailList.length > 0) {
         this.showToasterByEmailList(emailList.existingEmailList, 'warning');
       }
+      // TODO: GW-6496
     }
     catch (err) {
       toastError(err);

--- a/src/client/js/components/Admin/Users/UserInviteModal.jsx
+++ b/src/client/js/components/Admin/Users/UserInviteModal.jsx
@@ -9,7 +9,7 @@ import {
   Modal, ModalHeader, ModalBody, ModalFooter,
 } from 'reactstrap';
 
-import { toastSuccess, toastError } from '../../../util/apiNotification';
+import { toastSuccess, toastError, toastWarning } from '../../../util/apiNotification';
 
 import { withUnstatedContainers } from '../../UnstatedUtils';
 import AppContainer from '../../../services/AppContainer';
@@ -193,9 +193,16 @@ class UserInviteModal extends React.Component {
 
     try {
       const emailList = await adminUsersContainer.createUserInvited(shapedEmailList, this.state.sendEmail);
+      const existingEmailList = emailList.existingEmailList;
+      if (existingEmailList.length > 0) {
+        let msg = 'Email addresses already exist\n\n';
+        existingEmailList.forEach((email) => {
+          msg += `${email}\n`;
+        });
+        toastWarning(msg);
+      }
       this.setState({ emailInputValue: '' });
       this.setState({ invitedEmailList: emailList });
-      toastSuccess('Inviting user success');
     }
     catch (err) {
       toastError(err);

--- a/src/client/js/components/Admin/Users/UserInviteModal.jsx
+++ b/src/client/js/components/Admin/Users/UserInviteModal.jsx
@@ -41,6 +41,24 @@ class UserInviteModal extends React.Component {
     toastSuccess('Copied Mail and Password');
   }
 
+  showToasterByEmailList(emailList, toast) {
+    let msg = '';
+    emailList.forEach((email) => {
+      msg += `${email}\n`;
+    });
+    switch (toast) {
+      case 'success':
+        toastSuccess(msg);
+        break;
+      case 'warning':
+        toastWarning(msg);
+        break;
+      case 'error':
+        toastError(msg);
+        break;
+    }
+  }
+
   renderModalBody() {
     const { t } = this.props;
 
@@ -193,16 +211,12 @@ class UserInviteModal extends React.Component {
 
     try {
       const emailList = await adminUsersContainer.createUserInvited(shapedEmailList, this.state.sendEmail);
-      const existingEmailList = emailList.existingEmailList;
-      if (existingEmailList.length > 0) {
-        let msg = 'Email addresses already exist\n\n';
-        existingEmailList.forEach((email) => {
-          msg += `${email}\n`;
-        });
-        toastWarning(msg);
-      }
       this.setState({ emailInputValue: '' });
       this.setState({ invitedEmailList: emailList });
+
+      if (emailList.existingEmailList.length > 0) {
+        this.showToasterByEmailList(emailList.existingEmailList, 'warning');
+      }
     }
     catch (err) {
       toastError(err);

--- a/src/client/js/components/Admin/Users/UserInviteModal.jsx
+++ b/src/client/js/components/Admin/Users/UserInviteModal.jsx
@@ -44,13 +44,15 @@ class UserInviteModal extends React.Component {
   showToasterByEmailList(emailList, toast) {
     let msg = '';
     emailList.forEach((email) => {
-      msg += `${email}\n`;
+      msg += `・ ${email}<br>`;
     });
     switch (toast) {
       case 'success':
+        msg = `User has been created<br>${msg}`;
         toastSuccess(msg);
         break;
       case 'warning':
+        msg = `Existing email<br>${msg}`;
         toastWarning(msg);
         break;
       case 'error':

--- a/src/client/js/components/Admin/Users/UserInviteModal.jsx
+++ b/src/client/js/components/Admin/Users/UserInviteModal.jsx
@@ -44,7 +44,7 @@ class UserInviteModal extends React.Component {
   showToasterByEmailList(emailList, toast) {
     let msg = '';
     emailList.forEach((email) => {
-      msg += `・ ${email}<br>`;
+      msg += `・${email}<br>`;
     });
     switch (toast) {
       case 'success':

--- a/src/client/js/components/Admin/Users/UserInviteModal.jsx
+++ b/src/client/js/components/Admin/Users/UserInviteModal.jsx
@@ -214,6 +214,10 @@ class UserInviteModal extends React.Component {
       this.setState({ emailInputValue: '' });
       this.setState({ invitedEmailList: emailList });
 
+      if (emailList.createdUserList.length > 0) {
+        const createdEmailList = emailList.createdUserList.map((user) => { return user.email });
+        this.showToasterByEmailList(createdEmailList, 'success');
+      }
       if (emailList.existingEmailList.length > 0) {
         this.showToasterByEmailList(emailList.existingEmailList, 'warning');
       }

--- a/src/client/js/util/apiNotification.js
+++ b/src/client/js/util/apiNotification.js
@@ -20,6 +20,14 @@ const toastrOption = {
     hideDuration: '100',
     timeOut: '3000',
   },
+  warning: {
+    closeButton: true,
+    progressBar: true,
+    newestOnTop: false,
+    showDuration: '100',
+    hideDuration: '100',
+    timeOut: '6000',
+  },
 };
 
 // accepts both a single error and an array of errors
@@ -36,6 +44,6 @@ export const toastSuccess = (body, header = 'Success', option = toastrOption.suc
   toastr.success(body, header, option);
 };
 
-export const toastWarning = (body, header = 'Warning', option = toastrOption.success) => {
+export const toastWarning = (body, header = 'Warning', option = toastrOption.warning) => {
   toastr.warning(body, header, option);
 };

--- a/src/client/js/util/apiNotification.js
+++ b/src/client/js/util/apiNotification.js
@@ -36,6 +36,6 @@ export const toastSuccess = (body, header = 'Success', option = toastrOption.suc
   toastr.success(body, header, option);
 };
 
-export const toastWarning = (body, header = 'Warning', option = toastrOption.warning) => {
+export const toastWarning = (body, header = 'Warning', option = toastrOption.success) => {
   toastr.warning(body, header, option);
 };

--- a/src/client/js/util/apiNotification.js
+++ b/src/client/js/util/apiNotification.js
@@ -35,3 +35,7 @@ export const toastError = (err, header = 'Error', option = toastrOption.error) =
 export const toastSuccess = (body, header = 'Success', option = toastrOption.success) => {
   toastr.success(body, header, option);
 };
+
+export const toastWarning = (body, header = 'Warning', option = toastrOption.warning) => {
+  toastr.warning(body, header, option);
+};


### PR DESCRIPTION
## 概要
ユーザーを招待する際に適切な toast を表示するようにしました。
エラー時の toast は後続タスクで行います。

- ユーザー作成成功時
<img width="217" alt="スクリーンショット 2021-06-29 16 11 03" src="https://user-images.githubusercontent.com/34241526/123753314-abbf6880-d8f4-11eb-8864-8ed9fb1dc3a0.png">

- 既存のユーザーのメールアドレスで招待しようとした時
<img width="219" alt="スクリーンショット 2021-06-29 16 10 40" src="https://user-images.githubusercontent.com/34241526/123753321-ae21c280-d8f4-11eb-865f-45ebd0a6b98f.png">

- 混合
<img width="236" alt="スクリーンショット 2021-06-29 17 56 30" src="https://user-images.githubusercontent.com/34241526/123768555-63f40d80-d903-11eb-8172-c42472f140ed.png">

