### PR TITLE
Imprv/gw 6478 icon etc

### DIFF
--- a/src/client/styles/scss/theme/hufflepuff.scss
+++ b/src/client/styles/scss/theme/hufflepuff.scss
@@ -77,14 +77,14 @@ html[light] {
   // Sidebar list group
   $bgcolor-sidebar-list-group: lighten($themelight, 10%);
 
-  // ↓spring's copy↓
   // Icon colors
-  $color-editor-icons: $color-global;
+  $color-editor-icons: $accentcolor;
 
   // Border colors
-  $border-color-theme: $gray-300; // former: `$navbar-border: $gray-300;`
+  $border-color-theme: lighten($subthemecolor, 40%);
   $bordercolor-inline-code: #ccc8c8; // optional
 
+  // ↓spring's copy↓
   // Dropdown colors
   $bgcolor-dropdown-link-active: $growi-blue;
   $color-dropdown-link-active: $color-reversal;
@@ -234,7 +234,7 @@ html[dark] {
   $color-editor-icons: $themecolor;
 
   // Border colors
-  $border-color-theme: darken($themecolor, 5%);
+  $border-color-theme: darken($themecolor, 25%);
   $bordercolor-inline-code: #4d4d4d; // optional
 
   // Dropdown colors

--- a/src/client/styles/scss/theme/hufflepuff.scss
+++ b/src/client/styles/scss/theme/hufflepuff.scss
@@ -84,14 +84,13 @@ html[light] {
   $border-color-theme: lighten($subthemecolor, 40%);
   $bordercolor-inline-code: #ccc8c8; // optional
 
-  // ↓spring's copy↓
   // Dropdown colors
   $bgcolor-dropdown-link-active: $growi-blue;
   $color-dropdown-link-active: $color-reversal;
   $color-dropdown-link-hover: $color-global;
 
   // admin theme box
-  $color-theme-color-box: $primary;
+  $color-theme-color-box: darken($primary, 5%);
 
   @import 'apply-colors';
   @import 'apply-colors-light';
@@ -172,9 +171,7 @@ html[dark] {
   $third-main-color: #967224;
   $accentcolor: #993439;
 
-  // $primary: $themecolor;
   $primary: darken($themecolor, 10%);
-  // $secondary: $subthemecolor;
   $secondary: $third-main-color;
   $dark: #031018;
 
@@ -210,7 +207,6 @@ html[dark] {
   $bgcolor-search-top-dropdown: $themecolor;
   $border-image-navbar: linear-gradient(to right, #90a555 0%, #3d98a3 50%, #eaab20 100%);
 
-  // ↓mono-blue's copy↓
   // Logo colors
   $bgcolor-logo: #13191c;
   $fillcolor-logo-mark: white;

--- a/src/client/styles/scss/theme/hufflepuff.scss
+++ b/src/client/styles/scss/theme/hufflepuff.scss
@@ -231,7 +231,7 @@ html[dark] {
   $bgcolor-sidebar-list-group: lighten($subthemecolor, 5%);
 
   // Icon colors
-  $color-editor-icons: $color-global;
+  $color-editor-icons: $themecolor;
 
   // Border colors
   $border-color-theme: darken($themecolor, 5%);


### PR DESCRIPTION
Icon,
Border,
admin theme box の色調整，
不要なコメントアウト削除

Icon
<img width="993" alt="icon-dark1" src="https://user-images.githubusercontent.com/46134198/123915245-42565d00-d9bb-11eb-972d-da1a7c148812.png">
↓
<img width="930" alt="icon-dark2" src="https://user-images.githubusercontent.com/46134198/123915263-47b3a780-d9bb-11eb-8bb9-0611a7795079.png">

![スクリーンショット 2021-06-25 19 20 39](https://user-images.githubusercontent.com/46134198/123916242-64041400-d9bc-11eb-8a3d-c2f013aa2f65.png)
↓
![スクリーンショット 2021-06-25 19 21 01](https://user-images.githubusercontent.com/46134198/123916270-6cf4e580-d9bc-11eb-9f06-9dfaf0070189.png)

border
![スクリーンショット 2021-06-25 19 26 16](https://user-images.githubusercontent.com/46134198/123916304-74b48a00-d9bc-11eb-86d3-89b7c92add10.png)
↓
![スクリーンショット 2021-06-25 19 26 37](https://user-images.githubusercontent.com/46134198/123916312-78481100-d9bc-11eb-8384-ca1cd84f3fc8.png)

![スクリーンショット 2021-06-30 12 45 45](https://user-images.githubusercontent.com/46134198/123916340-80a04c00-d9bc-11eb-83cd-2b3d60f74c29.png)
↓
![スクリーンショット 2021-06-30 12 44 51](https://user-images.githubusercontent.com/46134198/123916324-7bdb9800-d9bc-11eb-8f56-549c4f7139a7.png)


admin theme box
![スクリーンショット 2021-06-30 15 40 14](https://user-images.githubusercontent.com/46134198/123916391-901f9500-d9bc-11eb-8594-a1f9b43672a4.png)
↓
![スクリーンショット 2021-06-30 15 40 47](https://user-images.githubusercontent.com/46134198/123916408-957cdf80-d9bc-11eb-81c7-d3325b144013.png)

![スクリーンショット 2021-06-30 15 42 17](https://user-images.githubusercontent.com/46134198/123916432-9b72c080-d9bc-11eb-8359-45741061eafc.png)
