### PR TITLE
used window.location not pageContainer

### DIFF
--- a/src/client/js/components/Page/RevisionRenderer.jsx
+++ b/src/client/js/components/Page/RevisionRenderer.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 
 import { withUnstatedContainers } from '../UnstatedUtils';
 import AppContainer from '../../services/AppContainer';
-import PageContainer from '../../services/PageContainer';
 import NavigationContainer from '../../services/NavigationContainer';
 import GrowiRenderer from '../../util/GrowiRenderer';
 
@@ -25,7 +24,7 @@ class RevisionRenderer extends React.PureComponent {
   initCurrentRenderingContext() {
     this.currentRenderingContext = {
       markdown: this.props.markdown,
-      currentPagePath: this.props.pageContainer.state.path,
+      currentPagePath: decodeURIComponent(window.location.pathname),
     };
   }
 
@@ -121,11 +120,10 @@ class RevisionRenderer extends React.PureComponent {
 /**
  * Wrapper component for using unstated
  */
-const RevisionRendererWrapper = withUnstatedContainers(RevisionRenderer, [AppContainer, PageContainer, NavigationContainer]);
+const RevisionRendererWrapper = withUnstatedContainers(RevisionRenderer, [AppContainer, NavigationContainer]);
 
 RevisionRenderer.propTypes = {
   appContainer: PropTypes.instanceOf(AppContainer).isRequired,
-  pageContainer: PropTypes.instanceOf(PageContainer).isRequired,
   navigationContainer: PropTypes.instanceOf(NavigationContainer).isRequired,
   growiRenderer: PropTypes.instanceOf(GrowiRenderer).isRequired,
   markdown: PropTypes.string.isRequired,


### PR DESCRIPTION
## Task
GW-6573 修正
検索画面でlsxが正常に表示されないのを修正しました。

## Before

<img width="1235" alt="Screen Shot 2021-07-01 at 23 37 44" src="https://user-images.githubusercontent.com/59536731/124142764-7b7af400-dac5-11eb-9e48-4a5dd8e3e7bd.png">


## After
- 検索結果のSidebarに関しては仕様なので、no Contentsの表示のままです。
<img width="1035" alt="Screen Shot 2021-07-01 at 23 35 24" src="https://user-images.githubusercontent.com/59536731/124142485-3787ef00-dac5-11eb-9d51-14cd33a1566f.png">
