### PR TITLE
imprv/ button hidden

### DIFF
--- a/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
+++ b/src/client/js/components/Admin/SlackIntegration/CustomBotWithProxySettings.jsx
@@ -127,15 +127,17 @@ const CustomBotWithProxySettings = (props) => {
             </React.Fragment>
           );
         })}
-        <div className="row justify-content-center my-5">
-          <button
-            type="button"
-            className="btn btn-outline-primary"
-            onClick={addSlackAppIntegrationHandler}
-          >
-            {`+ ${t('admin:slack_integration.accordion.add_slack_workspace')}`}
-          </button>
-        </div>
+        {slackAppIntegrations.length < 10 && (
+          <div className="row justify-content-center my-5">
+            <button
+              type="button"
+              className="btn btn-outline-primary"
+              onClick={addSlackAppIntegrationHandler}
+            >
+              {`+ ${t('admin:slack_integration.accordion.add_slack_workspace')}`}
+            </button>
+          </div>
+        )}
       </div>
       <DeleteSlackBotSettingsModal
         isResetAll={false}


### PR DESCRIPTION
## 概要

withProxy の slack app が10個に達したら `slackワークスペースを追加` ボタンを非表示になるようにしました。

<img width="1036" alt="スクリーンショット 2021-07-02 14 49 56" src="https://user-images.githubusercontent.com/34241526/124227158-2d0d3a00-db45-11eb-82b0-3c250fa1d17f.png">

<img width="1035" alt="スクリーンショット 2021-07-02 14 49 46" src="https://user-images.githubusercontent.com/34241526/124227168-30a0c100-db45-11eb-8e99-6a2219a3d6cd.png">

