### PR TITLE
imprv/6627 throw an error when the proxy url is not set

### DIFF
--- a/src/server/routes/apiv3/slack-integration-settings.js
+++ b/src/server/routes/apiv3/slack-integration-settings.js
@@ -107,6 +107,9 @@ module.exports = (crowi) => {
 
   async function postRelationTest(token) {
     const proxyUri = crowi.configManager.getConfig('crowi', 'slackbot:proxyServerUri');
+    if (proxyUri == null) {
+      throw new Error('Proxy URL is not registered');
+    }
 
     const result = await axios.get(urljoin(proxyUri, '/g2s/relation-test'), {
       headers: {


### PR DESCRIPTION
## 概要
ProxyURL がセットされていない時に `Proxy URL is not registered` というエラーを投げるようにしました。

<img width="1064" alt="スクリーンショット 2021-07-05 13 02 28" src="https://user-images.githubusercontent.com/34241526/124416276-98e3e280-dd91-11eb-8b09-f0875dbb3f3f.png">
