### PR TITLE
[Fix] Remove spaces from the LDAP authentication code example.

### DIFF
--- a/src/client/js/components/Admin/Security/LdapSecuritySettingContents.jsx
+++ b/src/client/js/components/Admin/Security/LdapSecuritySettingContents.jsx
@@ -225,9 +225,9 @@ class LdapSecuritySettingContents extends React.Component {
                 <p className="form-text text-muted">
                   <small>
                     {t('security_setting.example')}1 - {t('security_setting.ldap.search_filter_example1')}:
-                    <code>(|(uid={'{{ username }}'})(mail={'{{ username }}'}))</code><br />
+                    <code>(|(uid={'{{username}}'})(mail={'{{username}}'}))</code><br />
                     {t('security_setting.example')}2 - {t('security_setting.ldap.search_filter_example2')}:
-                    <code>(sAMAccountName={'{{ username }}'})</code>
+                    <code>(sAMAccountName={'{{username}}'})</code>
                   </small>
                 </p>
               </div>


### PR DESCRIPTION
# 概要

コード修正の提案です。

## 対象画面

セキュリティ設定画面

## 対象機能

LDAP認証設定

## 修正内容

検索フィルターの設定例を `{{ username }}`（スペースあり）から`{{username}}`（スペースなし）に変更

# 詳細

検索フィルターの設定例として
```
例1 - 'uid' または 'mail' に一致:(|(uid={{ username }})(mail={{ username }}))
例2 - 'sAMAccountName' に一致 (Active Directory):(sAMAccountName={{ username }})
```
と記載されていますが実際に`(sAMAccountName={{ username }})`を設定したところ認証に失敗し、
`(sAMAccountName={{username}})`に修正したところ認証に成功しました。
※動作確認を行なった環境ではActive Directoryを使用しています

上記の動作は環境要因でありスペースが含まれていても正常に動作する場合もあるという可能性も考えましたが、
初期値には`(uid={{username}})`（スペースなし）が設定されていること、注釈では
```
ログイン時のユーザー名を使用するには {{username}} の形式を使用してください。
空欄の場合 (uid={{username}}) が使用されます。
```
のようにスペースなしで記載されていることから、スペースなしで統一した方が良いのではないかと思いPRをお送りした次第です。

お手隙の際にご確認の上、ご検討頂ければと思います。
