### PR TITLE
Create external account

### DIFF
--- a/src/client/js/components/Admin/Security/LdapAuthTest.jsx
+++ b/src/client/js/components/Admin/Security/LdapAuthTest.jsx
@@ -114,7 +114,7 @@ class LdapAuthTest extends React.Component {
 
         <div className="form-group">
           <label><h5>Logs</h5></label>
-          <textarea id="taLogs" className="col" rows="4" value={this.state.logs} readOnly />
+          <textarea id="taLogs" className="col form-control" rows="4" value={this.state.logs} readOnly />
         </div>
 
         <div>

--- a/src/client/js/components/Me/AssociateModal.jsx
+++ b/src/client/js/components/Me/AssociateModal.jsx
@@ -71,7 +71,7 @@ class AssociateModal extends React.Component {
 
     return (
       <Modal isOpen={this.props.isOpen} toggle={this.props.onClose} size="lg">
-        <ModalHeader className="bg-info text-light" toggle={this.props.onClose}>
+        <ModalHeader className="bg-primary text-light" toggle={this.props.onClose}>
           { t('admin:user_management.create_external_account') }
         </ModalHeader>
         <ModalBody>
@@ -118,7 +118,7 @@ class AssociateModal extends React.Component {
           </div>
         </ModalBody>
         <ModalFooter className="border-top-0">
-          <button type="button" className="btn btn-info mt-3" onClick={this.onClickAddBtn}>
+          <button type="button" className="btn btn-primary mt-3" onClick={this.onClickAddBtn}>
             <i className="fa fa-plus-circle" aria-hidden="true"></i>
             {t('add')}
           </button>


### PR DESCRIPTION
外部アカウント作成モーダルはライト, ダーク含めて全テーマ同じ色だった
→ 各テーマ色に対応

<img width="909" alt="元" src="https://user-images.githubusercontent.com/46134198/125581819-3f1ba9b7-0766-4ae0-8bb3-0d6068c23bc8.png">
↓
<img width="813" alt="スクリーンショット 2021-07-14 16 11 46" src="https://user-images.githubusercontent.com/46134198/125581860-cadd83a0-8dd8-4068-8d66-bbf8a93274cb.png">

（参考）その他のテーマ一部
<img width="817" alt="スクリーンショット 2021-07-14 16 12 40" src="https://user-images.githubusercontent.com/46134198/125581927-afebd445-06b0-4c79-8816-8c0824d2fde9.png">
<img width="821" alt="スクリーンショット 2021-07-14 16 36 08" src="https://user-images.githubusercontent.com/46134198/125582201-b005fea5-e125-443f-9c3d-376df7459de3.png">

