### PR TITLE
Imprv/gw6776 create password reset page

### DIFF
--- a/src/client/js/components/PasswordResetExecutionForm.jsx
+++ b/src/client/js/components/PasswordResetExecutionForm.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { withTranslation } from 'react-i18next';
+
+
+const PasswordResetExecutionForm = (props) => {
+  // const { t } = props;
+
+  return (
+    <div id="password-reset-execution-form">
+      PasswordResetExecutionForm
+    </div>
+  );
+};
+
+PasswordResetExecutionForm.propTypes = {
+  t: PropTypes.func.isRequired, //  i18next
+};
+
+export default withTranslation()(PasswordResetExecutionForm);

--- a/src/client/js/components/PasswordResetExecutionForm.jsx
+++ b/src/client/js/components/PasswordResetExecutionForm.jsx
@@ -8,6 +8,7 @@ const PasswordResetExecutionForm = (props) => {
   // const { t } = props;
 
   return (
+    // TODO: improve the form by GW-6852
     <div id="password-reset-execution-form">
       PasswordResetExecutionForm
     </div>

--- a/src/client/js/components/PasswordResetExecutionForm.jsx
+++ b/src/client/js/components/PasswordResetExecutionForm.jsx
@@ -9,7 +9,7 @@ const PasswordResetExecutionForm = (props) => {
 
   return (
     // TODO: improve the form by GW-6852
-    <div id="password-reset-execution-form">
+    <div>
       PasswordResetExecutionForm
     </div>
   );

--- a/src/client/js/components/PasswordResetExecutionForm.jsx
+++ b/src/client/js/components/PasswordResetExecutionForm.jsx
@@ -4,6 +4,7 @@ import { withTranslation } from 'react-i18next';
 
 
 const PasswordResetExecutionForm = (props) => {
+  // TODO: apply i18n by GW-6861
   // const { t } = props;
 
   return (

--- a/src/client/js/components/PasswordResetRequestForm.jsx
+++ b/src/client/js/components/PasswordResetRequestForm.jsx
@@ -4,6 +4,7 @@ import { withTranslation } from 'react-i18next';
 
 
 const PasswordResetRequestForm = (props) => {
+  // TODO: apply i18n by GW-6861
   // const { t } = props;
 
   return (

--- a/src/client/js/nologin.jsx
+++ b/src/client/js/nologin.jsx
@@ -10,6 +10,7 @@ import AppContainer from './services/AppContainer';
 import InstallerForm from './components/InstallerForm';
 import LoginForm from './components/LoginForm';
 import PasswordResetRequestForm from './components/PasswordResetRequestForm';
+import PasswordResetExecutionForm from './components/PasswordResetExecutionForm';
 
 const i18n = i18nFactory();
 
@@ -86,6 +87,18 @@ if (passwordResetRequestFormElem) {
   ReactDOM.render(
     <I18nextProvider i18n={i18n}>
       <PasswordResetRequestForm />
+    </I18nextProvider>,
+    passwordResetRequestFormElem,
+  );
+}
+
+// render PasswordResetRequestForm
+const PasswordResetExecutionFormElem = document.getElementById('password-reset-request-form');
+if (PasswordResetExecutionFormElem) {
+
+  ReactDOM.render(
+    <I18nextProvider i18n={i18n}>
+      <PasswordResetExecutionForm />
     </I18nextProvider>,
     passwordResetRequestFormElem,
   );

--- a/src/client/js/nologin.jsx
+++ b/src/client/js/nologin.jsx
@@ -93,13 +93,13 @@ if (passwordResetRequestFormElem) {
 }
 
 // render PasswordResetRequestForm
-const PasswordResetExecutionFormElem = document.getElementById('password-reset-request-form');
-if (PasswordResetExecutionFormElem) {
+const passwordResetExecutionFormElem = document.getElementById('password-reset-execution-form');
+if (passwordResetExecutionFormElem) {
 
   ReactDOM.render(
     <I18nextProvider i18n={i18n}>
       <PasswordResetExecutionForm />
     </I18nextProvider>,
-    passwordResetRequestFormElem,
+    passwordResetExecutionFormElem,
   );
 }

--- a/src/server/routes/forgot-password.js
+++ b/src/server/routes/forgot-password.js
@@ -9,6 +9,10 @@ module.exports = function(crowi, app) {
     return res.render('forgot-password');
   };
 
+  actions.resetPassword = async function(req, res) {
+    return res.render('reset-password');
+  };
+
 
   async function sendPasswordResetEmail() {
 

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -178,6 +178,7 @@ module.exports = function(crowi, app) {
 
   app.get('/forgot-password', forgotPassword.forgotPassword);
   app.post('/forgot-password', forgotPassword.api.post);
+  app.get('/reset-password', forgotPassword.resetPassword);
 
   app.get('/share/:linkId', page.showSharedPage);
 

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -178,7 +178,7 @@ module.exports = function(crowi, app) {
 
   app.get('/forgot-password', forgotPassword.forgotPassword);
   app.post('/forgot-password', forgotPassword.api.post);
-  app.get('/reset-password', forgotPassword.resetPassword);
+  app.get('/forgot-password/hogeToken', forgotPassword.resetPassword);
 
   app.get('/share/:linkId', page.showSharedPage);
 

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -178,6 +178,7 @@ module.exports = function(crowi, app) {
 
   app.get('/forgot-password', forgotPassword.forgotPassword);
   app.post('/forgot-password', forgotPassword.api.post);
+  // TODO: apply oneTimeToken to the link by GW−6856
   app.get('/forgot-password/hogeToken', forgotPassword.resetPassword);
 
   app.get('/share/:linkId', page.showSharedPage);

--- a/src/server/views/reset-password.html
+++ b/src/server/views/reset-password.html
@@ -27,7 +27,7 @@
 
   <div id="main" class="main">
     <div id="content-main" class="content-main container-lg">
-      <div id="password-reset-request-form"></div>
+      <div id="password-reset-execution-form"></div>
     </div>
   </div>
 

--- a/src/server/views/reset-password.html
+++ b/src/server/views/reset-password.html
@@ -1,0 +1,34 @@
+{% extends './layout/layout.html' %}
+
+{% block html_title %}{{ customizeService.generateCustomTitleForFixedPageName(t('forgot_password')) }}{% endblock %}
+
+
+{#
+  # Remove default contents
+  #}
+ {% block html_head_loading_legacy %}
+ {% endblock %}
+ {% block html_head_loading_app %}
+ {% endblock %}
+ {% block layout_head_nav %}
+ {% endblock %}
+ {% block sidebar %}
+ {% endblock %}
+ {% block head_warn_alert_siteurl_undefined %}
+ {% endblock %}
+ {% block fixed-controls %}
+ {% endblock %}
+
+ {% block html_additional_headers %}
+   <script src="{{ webpack_asset('js/nologin.js') }}" defer></script>
+ {% endblock %}
+
+{% block layout_main %}
+
+  <div id="main" class="main">
+    <div id="content-main" class="content-main container-lg">
+      <div id="password-reset-request-form"></div>
+    </div>
+  </div>
+
+{% endblock %}


### PR DESCRIPTION
## Task
GW-6776 [front] パスワード再設定用のページを新規に作成する(中身は空)

## View
- 現状、`/forgot-password/hogeToken`(仮) のパスを指定し表示させていますが、将来的に ワンタイムトークンを利用したパスになります
    -  GW-6850 [back] パスワード再設定フォームのリンクにワンタイムトークンを利用する
![Screen Shot 2021-07-20 at 12 27 29](https://user-images.githubusercontent.com/59536731/126257455-b040e3d8-362a-49bc-af93-5491756d4663.png)

