### PR TITLE
Imprv/swrify indent size

### DIFF
--- a/src/client/js/components/PageEditor/Editor.jsx
+++ b/src/client/js/components/PageEditor/Editor.jsx
@@ -9,6 +9,7 @@ import {
 } from 'reactstrap';
 
 import Dropzone from 'react-dropzone';
+import { useIndentSize } from '~/stores/editor';
 
 // import EditorContainer from '../../services/EditorContainer';
 
@@ -311,8 +312,7 @@ class EditorSubstance extends AbstractEditor {
                       // eslint-disable-next-line arrow-body-style
                   <CodeMirrorEditor
                     ref={(c) => { this.cmEditor = c }}
-                    // TODO GW-6870 to SWRrify
-                    // indentSize={editorContainer.state.indentSize}
+                    indentSize={this.props.indentSize}
                     // editorOptions={editorContainer.state.editorOptions}
                     onPasteFiles={this.pasteFilesHandler}
                     onDragEnter={this.dragEnterHandler}
@@ -377,9 +377,11 @@ EditorSubstance.propTypes = Object.assign({
 }, AbstractEditor.propTypes);
 
 
-const Editor = () =>{
+const Editor = () => {
+  const { data: indentSize } = useIndentSize()
+
   return (
-    <EditorSubstance />
+    <EditorSubstance indentSize={indentSize} />
   )
 }
 

--- a/src/client/js/components/PageEditor/OptionsSelector.jsx
+++ b/src/client/js/components/PageEditor/OptionsSelector.jsx
@@ -9,7 +9,6 @@ import {
 
 import { withUnstatedContainers } from '../UnstatedUtils';
 import EditorContainer from '../../services/EditorContainer';
-import { useIndentSize } from '~/stores/editor';
 
 
 export const defaultEditorOptions = {
@@ -22,7 +21,7 @@ export const defaultPreviewOptions = {
   renderMathJaxInRealtime: false,
 };
 
-class OptionsSelectorSubstance extends React.Component {
+class OptionsSelector extends React.Component {
 
   constructor(props) {
     super(props);
@@ -116,6 +115,10 @@ class OptionsSelectorSubstance extends React.Component {
     this.setState({ isCddMenuOpened: !this.state.isCddMenuOpened });
   }
 
+  onChangeIndentSize(newValue) {
+    const { editorContainer } = this.props;
+    editorContainer.setState({ indentSize: newValue });
+  }
 
   renderThemeSelector() {
     const { editorContainer } = this.props;
@@ -325,21 +328,6 @@ class OptionsSelectorSubstance extends React.Component {
     );
   }
 
-}
-
-const OptionsSelector = () => {
-  const { data: indentSize } = useIndentSize()
-  const [indentSize, setIndentSize] = useState(indentSize)
-
-  const onChangeIndentSize = (newValue) => {
-    setIndentSize(newValue)
-  }
-
-  return(
-    <OptionsSelectorSubstance
-      onChangeIndentSize={onChangeIndentSize}
-    />
-  )
 }
 
 /**

--- a/src/client/js/components/PageEditor/OptionsSelector.jsx
+++ b/src/client/js/components/PageEditor/OptionsSelector.jsx
@@ -115,6 +115,7 @@ class OptionsSelector extends React.Component {
     this.setState({ isCddMenuOpened: !this.state.isCddMenuOpened });
   }
 
+  // TODO: useIndentSize after EditorNavbnavBottom is shown
   onChangeIndentSize(newValue) {
     const { editorContainer } = this.props;
     editorContainer.setState({ indentSize: newValue });

--- a/src/client/js/components/PageEditor/OptionsSelector.jsx
+++ b/src/client/js/components/PageEditor/OptionsSelector.jsx
@@ -115,7 +115,7 @@ class OptionsSelector extends React.Component {
     this.setState({ isCddMenuOpened: !this.state.isCddMenuOpened });
   }
 
-  // TODO: useIndentSize after EditorNavbnavBottom is shown
+  // TODO: useIndentSize after EditorNavbarBottom is shown
   onChangeIndentSize(newValue) {
     const { editorContainer } = this.props;
     editorContainer.setState({ indentSize: newValue });

--- a/src/client/js/components/PageEditor/OptionsSelector.jsx
+++ b/src/client/js/components/PageEditor/OptionsSelector.jsx
@@ -9,6 +9,7 @@ import {
 
 import { withUnstatedContainers } from '../UnstatedUtils';
 import EditorContainer from '../../services/EditorContainer';
+import { useIndentSize } from '~/stores/editor';
 
 
 export const defaultEditorOptions = {
@@ -21,7 +22,7 @@ export const defaultPreviewOptions = {
   renderMathJaxInRealtime: false,
 };
 
-class OptionsSelector extends React.Component {
+class OptionsSelectorSubstance extends React.Component {
 
   constructor(props) {
     super(props);
@@ -115,10 +116,6 @@ class OptionsSelector extends React.Component {
     this.setState({ isCddMenuOpened: !this.state.isCddMenuOpened });
   }
 
-  onChangeIndentSize(newValue) {
-    const { editorContainer } = this.props;
-    editorContainer.setState({ indentSize: newValue });
-  }
 
   renderThemeSelector() {
     const { editorContainer } = this.props;
@@ -328,6 +325,21 @@ class OptionsSelector extends React.Component {
     );
   }
 
+}
+
+const OptionsSelector = () => {
+  const { data: indentSize } = useIndentSize()
+  const [indentSize, setIndentSize] = useState(indentSize)
+
+  const onChangeIndentSize = (newValue) => {
+    setIndentSize(newValue)
+  }
+
+  return(
+    <OptionsSelectorSubstance
+      onChangeIndentSize={onChangeIndentSize}
+    />
+  )
 }
 
 /**

--- a/src/client/js/services/EditorContainer.js
+++ b/src/client/js/services/EditorContainer.js
@@ -32,7 +32,6 @@ export default class EditorContainer extends Container {
 
       editorOptions: {},
       previewOptions: {},
-      indentSize:  4,  // indentSize: this.appContainer.config.adminPreferredIndentSize || 4,
     };
 
     this.isSetBeforeunloadEventHandler = false;

--- a/src/pages/[[...path]].tsx
+++ b/src/pages/[[...path]].tsx
@@ -29,7 +29,7 @@ import {
   useForbidden, useNotFound, useTrash, useShared, useShareLinkId, useIsSharedUser, useIsAbleToDeleteCompletely,
   useAppTitle, useSiteUrl, useConfidential, useIsEnabledStaleNotification,
   useSearchServiceConfigured, useSearchServiceReachable, useIsMailerSetup,
-  useAclEnabled, useHasSlackConfig, useDrawioUri, useHackmdUri, useMathJax, useNoCnd, useEditorConfig
+  useAclEnabled, useHasSlackConfig, useDrawioUri, useHackmdUri, useMathJax, useNoCdn, useEditorConfig
 } from '../stores/context';
 import { useCurrentPageSWR } from '../stores/page';
 import { useRendererSettings } from '~/stores/renderer';
@@ -102,7 +102,7 @@ const GrowiPage: NextPage<Props> = (props: Props) => {
   useDrawioUri(props.drawioUri);
   useHackmdUri(props.hackmdUri);
   useMathJax(props.mathJax)
-  useNoCnd(props.noCdn)
+  useNoCdn(props.noCdn)
 
   useRendererSettings({
     isEnabledLinebreaks: props.isEnabledLinebreaks,

--- a/src/pages/[[...path]].tsx
+++ b/src/pages/[[...path]].tsx
@@ -34,6 +34,7 @@ import {
 import { useCurrentPageSWR } from '../stores/page';
 import { useRendererSettings } from '~/stores/renderer';
 import { EditorMode, useEditorMode, useIsMobile } from '~/stores/ui';
+import { useIndentSize } from '~/stores/editor';
 
 
 const logger = loggerFactory('growi:pages:all');
@@ -103,6 +104,7 @@ const GrowiPage: NextPage<Props> = (props: Props) => {
   useHackmdUri(props.hackmdUri);
   useMathJax(props.mathJax)
   useNoCdn(props.noCdn)
+  useIndentSize(props.adminPreferredIndentSize);
 
   useRendererSettings({
     isEnabledLinebreaks: props.isEnabledLinebreaks,

--- a/src/stores/context.tsx
+++ b/src/stores/context.tsx
@@ -92,7 +92,7 @@ export const useMathJax = (initialData?: string): SWRResponse<string, any> => {
   return useStaticSWR('mathJax', initialData);
 };
 
-export const useNoCnd = (initialData?: string): SWRResponse<string, any> => {
+export const useNoCdn = (initialData?: string): SWRResponse<string, any> => {
   return useStaticSWR('noCdn', initialData);
 };
 

--- a/src/stores/editor.tsx
+++ b/src/stores/editor.tsx
@@ -1,0 +1,6 @@
+import { SWRResponse } from 'swr';
+import { useStaticSWR } from './use-static-swr';
+
+export const useIndentSize = (initialData?: any): SWRResponse<any, any> => {
+  return useStaticSWR('indentSize', initialData)
+}


### PR DESCRIPTION
## 概要
EditorContainer.js の indentSize という state を SWR 化しました。

この state をどこの store に配属するかで以下の候補を考えました。
- インデントは見た目なので ui.tsx
- page 編集のことなので page.tsx
- 環境変数っぽい要素あるので context.tsx
- 新規に、editor.tsx を作成する

現状の措置として stores に editor.tsx  を作成しました。
今後、editorContainer の editorOptions  内にある theme や keymap もここに移行させるものだと思っています。

