### PR TITLE
fix view count

### DIFF
--- a/src/client/js/components/Sidebar/RecentChanges.jsx
+++ b/src/client/js/components/Sidebar/RecentChanges.jsx
@@ -66,6 +66,15 @@ class RecentChanges extends React.Component {
       locked = <span><i className="icon-lock" /></span>;
     }
 
+    const tags = page.tags;
+    const tagElements = tags.map((tag) => {
+      return (
+        <a key={tag} href={`/_search?q=tag:${tag.name}`} className="grw-tag-label badge badge-secondary mr-2">
+          {tag.name}
+        </a>
+      );
+    });
+
     return (
       <li className="list-group-item p-2">
         <div className="d-flex w-100">
@@ -81,6 +90,7 @@ class RecentChanges extends React.Component {
               <span className="seen-user-count">{pageContainer.state.countOfSeenUsers}</span>
               <i className="icon-bubble"></i>
               <span>{page.commentCount}</span>
+              { tagElements }
               <br />
               <FormattedDistanceDate id={page.id} date={page.updatedAt} />
             </div>

--- a/src/client/js/components/Sidebar/RecentChanges.jsx
+++ b/src/client/js/components/Sidebar/RecentChanges.jsx
@@ -63,14 +63,6 @@ class RecentChanges extends React.Component {
       locked = <span><i className="icon-lock" /></span>;
     }
 
-    const tags = page.tags;
-    const tagElements = tags.map((tag) => {
-      return (
-        <a key={tag} href={`/_search?q=tag:${tag.name}`} className="grw-tag-label badge badge-secondary mr-2">
-          {tag.name}
-        </a>
-      );
-    });
 
     return (
       <li className="list-group-item p-2">
@@ -87,7 +79,6 @@ class RecentChanges extends React.Component {
               <span className="seen-user-count">{page.seenUsers.length}</span>
               <i className="icon-bubble"></i>
               <span>{page.commentCount}</span>
-              { tagElements }
               <br />
               <FormattedDistanceDate id={page.id} date={page.updatedAt} />
             </div>

--- a/src/client/js/components/Sidebar/RecentChanges.jsx
+++ b/src/client/js/components/Sidebar/RecentChanges.jsx
@@ -9,7 +9,6 @@ import DevidedPagePath from '@commons/models/devided-page-path';
 import LinkedPagePath from '@commons/models/linked-page-path';
 import PagePathHierarchicalLink from '@commons/components/PagePathHierarchicalLink';
 
-import PageContainer from '../../services/PageContainer';
 import FootstampIcon from '../FootstampIcon';
 
 import { withUnstatedContainers } from '../UnstatedUtils';
@@ -25,7 +24,6 @@ class RecentChanges extends React.Component {
   static propTypes = {
     t: PropTypes.func.isRequired, // i18next
     appContainer: PropTypes.instanceOf(AppContainer).isRequired,
-    pageContainer: PropTypes.instanceOf(PageContainer).isRequired,
   };
 
   constructor(props) {
@@ -59,7 +57,6 @@ class RecentChanges extends React.Component {
         <PagePathHierarchicalLink linkedPagePath={linkedPagePathFormer} />
       </div>
     );
-    const { pageContainer } = this.props;
 
     let locked;
     if (page.grant !== 1) {
@@ -87,7 +84,7 @@ class RecentChanges extends React.Component {
             </h5>
             <div className="text-right small">
               <span className="mr-1 footstamp-icon"><FootstampIcon /></span>
-              <span className="seen-user-count">{pageContainer.state.countOfSeenUsers}</span>
+              <span className="seen-user-count">{page.seenUsers.length}</span>
               <i className="icon-bubble"></i>
               <span>{page.commentCount}</span>
               { tagElements }
@@ -128,7 +125,7 @@ class RecentChanges extends React.Component {
 /**
  * Wrapper component for using unstated
  */
-const RecentChangesWrapper = withUnstatedContainers(RecentChanges, [AppContainer, PageContainer]);
+const RecentChangesWrapper = withUnstatedContainers(RecentChanges, [AppContainer]);
 
 
 export default withTranslation()(RecentChangesWrapper);

--- a/src/server/models/page.js
+++ b/src/server/models/page.js
@@ -767,7 +767,7 @@ module.exports = function(crowi) {
     // find
     builder.addConditionToPagenate(opt.offset, opt.limit, sortOpt);
     builder.populateDataToList(User.USER_FIELDS_EXCEPT_CONFIDENTIAL);
-    const pages = await builder.query.exec('find');
+    const pages = await builder.query.lean().exec('find');
 
     const result = {
       pages, totalCount, offset: opt.offset, limit: opt.limit,

--- a/src/server/models/page.js
+++ b/src/server/models/page.js
@@ -767,14 +767,7 @@ module.exports = function(crowi) {
     // find
     builder.addConditionToPagenate(opt.offset, opt.limit, sortOpt);
     builder.populateDataToList(User.USER_FIELDS_EXCEPT_CONFIDENTIAL);
-    const pages = await builder.query.lean().exec('find');
-    const PageTagRelation = mongoose.model('PageTagRelation');
-    await Promise.all(pages.map(async(page) => {
-      const relations = await PageTagRelation.find({ relatedPage: page._id }).populate('relatedTag');
-      page.tags = relations.map((relation) => {
-        return relation.relatedTag;
-      });
-    }));
+    const pages = await builder.query.exec('find');
 
     const result = {
       pages, totalCount, offset: opt.offset, limit: opt.limit,

--- a/src/server/models/page.js
+++ b/src/server/models/page.js
@@ -767,7 +767,14 @@ module.exports = function(crowi) {
     // find
     builder.addConditionToPagenate(opt.offset, opt.limit, sortOpt);
     builder.populateDataToList(User.USER_FIELDS_EXCEPT_CONFIDENTIAL);
-    const pages = await builder.query.exec('find');
+    const pages = await builder.query.lean().exec('find');
+    const PageTagRelation = mongoose.model('PageTagRelation');
+    await Promise.all(pages.map(async(page) => {
+      const relations = await PageTagRelation.find({ relatedPage: page._id }).populate('relatedTag');
+      page.tags = relations.map((relation) => {
+        return relation.relatedTag;
+      });
+    }));
 
     const result = {
       pages, totalCount, offset: opt.offset, limit: opt.limit,


### PR DESCRIPTION
コンフリクトしたのでpage.jsの770行目だけ前のtagの差分反映されてます。


表示されているページの閲覧数 がサイドバーの全ての閲覧数に表示されていた
→ 各ページに対応した閲覧数を表示
（画像はホームだけ2）
<img width="271" alt="スクリーンショット 2021-07-27 15 21 56" src="https://user-images.githubusercontent.com/46134198/127106888-764f9bc7-d4fe-47b7-98a7-12d849c94a81.png">
