### PR TITLE
improve i18n for password reset

### DIFF
--- a/resource/locales/en_US/translation.json
+++ b/resource/locales/en_US/translation.json
@@ -851,6 +851,8 @@
     "reset_password": "Reset Password",
     "sign_in_instead": "Sign in instead",
     "password_reset_request_desc": "You can reset your password here.",
-    "password_reset_excecution_desc": "Enter a new password"
+    "password_reset_excecution_desc": "Enter a new password",
+    "new_password": "New Password",
+    "confirm_new_password": "Confirm the new password"
   }
 }

--- a/resource/locales/en_US/translation.json
+++ b/resource/locales/en_US/translation.json
@@ -846,6 +846,7 @@
   },
   "forgot_password":{
     "forgot_password": "Forgot Password?",
+    "send_email": "Send",
     "return_to_login": "Return to login",
     "reset_password": "Reset Password",
     "sign_in_instead": "Sign in instead",

--- a/resource/locales/en_US/translation.json
+++ b/resource/locales/en_US/translation.json
@@ -41,7 +41,6 @@
   "Update Page": "Update Page",
   "Warning": "Warning",
   "Sign in": "Sign in",
-  "forgot_password": "Forgot password?",
   "Sign up is here": "Sign up",
   "Sign in is here": "Sign in",
   "Sign up": "Sign up",
@@ -844,5 +843,13 @@
     "aws_region": "For the region, enter the AWS region name. ex):us-east-1",
     "aws_custom_endpoint":"For the custom endpoint, specify the URL that starts with http(s)://. Also, the trailing slash is not required.",
     "failed_to_send_a_test_email":"Failed to send a test email using SMTP. Please check your settings."
+  },
+  "forgot_password":{
+    "forgot_password": "Forgot Password?",
+    "return_to_login": "Return to login",
+    "reset_password": "Reset Password",
+    "sign_in_instead": "Sign in instead",
+    "password_reset_request_desc": "You can reset your password here.",
+    "password_reset_excecution_desc": "Enter a new password"
   }
 }

--- a/resource/locales/ja_JP/translation.json
+++ b/resource/locales/ja_JP/translation.json
@@ -840,6 +840,7 @@
   },
   "forgot_password":{
     "forgot_password": "パスワードをお忘れですか?",
+    "send_email": "送信",
     "return_to_login": "ログイン画面に戻る",
     "reset_password": "パスワード リセット",
     "sign_in_instead": "ログインする",

--- a/resource/locales/ja_JP/translation.json
+++ b/resource/locales/ja_JP/translation.json
@@ -42,7 +42,6 @@
   "Update Page": "ページを更新",
   "Warning": "注意",
   "Sign in": "ログイン",
-  "forgot_password": "パスワードをお忘れですか?",
   "Sign up is here": "新規登録はこちら",
   "Sign in is here": "ログインはこちら",
   "Sign up": "新規登録",
@@ -838,5 +837,13 @@
     "aws_region": "リージョンには、AWSリージョン名を入力してください。例: ap-northeast-1",
     "aws_custom_endpoint": "カスタムエンドポイントは、http(s)://で始まるURLを指定してください。また、末尾の/は不要です。",
     "failed_to_send_a_test_email":"SMTPを利用したテストメール送信に失敗しました。設定をみなおしてください。"
+  },
+  "forgot_password":{
+    "forgot_password": "パスワードをお忘れですか?",
+    "return_to_login": "ログイン画面に戻る",
+    "reset_password": "パスワード リセット",
+    "sign_in_instead": "ログインする",
+    "password_reset_request_desc": "ここからパスワードリセットできます",
+    "password_reset_excecution_desc": "新しいパスワードを入力してください"
   }
 }

--- a/resource/locales/ja_JP/translation.json
+++ b/resource/locales/ja_JP/translation.json
@@ -845,6 +845,8 @@
     "reset_password": "パスワード リセット",
     "sign_in_instead": "ログインする",
     "password_reset_request_desc": "ここからパスワードリセットできます",
-    "password_reset_excecution_desc": "新しいパスワードを入力してください"
+    "password_reset_excecution_desc": "新しいパスワードを入力してください",
+    "new_password": "新しいパスワード",
+    "confirm_new_password": "新しいパスワードの確認"
   }
 }

--- a/resource/locales/zh_CN/translation.json
+++ b/resource/locales/zh_CN/translation.json
@@ -856,6 +856,8 @@
     "reset_password": "重设密码",
     "sign_in_instead": "改为登录",
     "password_reset_request_desc": "您可以在此处重置密码",
-    "password_reset_excecution_desc": "输入新的密码"
+    "password_reset_excecution_desc": "输入新的密码",
+    "new_password": "新密码",
+    "confirm_new_password": "确认新密码"
   }
 }

--- a/resource/locales/zh_CN/translation.json
+++ b/resource/locales/zh_CN/translation.json
@@ -851,6 +851,7 @@
   },
   "forgot_password":{
     "forgot_password": "忘记密码？",
+    "send_email": "发送",
     "return_to_login": "返回登录",
     "reset_password": "重设密码",
     "sign_in_instead": "改为登录",

--- a/resource/locales/zh_CN/translation.json
+++ b/resource/locales/zh_CN/translation.json
@@ -43,7 +43,6 @@
 	"Update Page": "更新本页",
 	"Warning": "警告",
   "Sign in": "登录",
-  "forgot_password": "忘记密码？",
 	"Sign up is here": "注册",
 	"Sign in is here": "登录",
 	"Sign up": "注册",
@@ -849,5 +848,13 @@
     "aws_region": "关于地区，请输入AWS地区名，例如：ap-east-1",
     "aws_custom_endpoint": "关于自定义端点，请指定以http(s)://开头的URL，链接末尾不需要添加“/”",
     "failed_to_send_a_test_email":"SMTP方式测试邮件发送失败，请检查相关设定。"
+  },
+  "forgot_password":{
+    "forgot_password": "忘记密码？",
+    "return_to_login": "返回登录",
+    "reset_password": "重设密码",
+    "sign_in_instead": "改为登录",
+    "password_reset_request_desc": "您可以在此处重置密码",
+    "password_reset_excecution_desc": "输入新的密码"
   }
 }

--- a/src/client/js/components/LoginForm.jsx
+++ b/src/client/js/components/LoginForm.jsx
@@ -269,7 +269,7 @@ class LoginForm extends React.Component {
                 <div className="row">
                   <div className="col-12 text-right py-2">
                     <a href="/forgot-password" className="d-block link-switch mb-1">
-                      <i className="icon-key"></i> {t('forgot_password')}
+                      <i className="icon-key"></i> {t('forgot_password.forgot_password')}
                     </a>
                     <a href="#register" id="register" className="link-switch" onClick={this.switchForm}>
                       <i className="ti-check-box"></i> {t('Sign up is here')}

--- a/src/client/js/components/PasswordResetExecutionForm.jsx
+++ b/src/client/js/components/PasswordResetExecutionForm.jsx
@@ -5,7 +5,7 @@ import { withTranslation } from 'react-i18next';
 
 const PasswordResetExecutionForm = (props) => {
   // TODO: apply i18n by GW-6861
-  // const { t } = props;
+  const { t } = props;
 
   return (
     <form role="form" className="form" method="post">
@@ -20,10 +20,10 @@ const PasswordResetExecutionForm = (props) => {
         </div>
       </div>
       <div className="form-group">
-        <input name="reset-password-btn" className="btn btn-lg btn-primary btn-block" value="Reset Password" type="submit" />
+        <input name="reset-password-btn" className="btn btn-lg btn-primary btn-block" value={t('forgot_password.reset_password')} type="submit" />
       </div>
       <a href="/login">
-        <i className="icon-login mr-1"></i>Sign in instead
+        <i className="icon-login mr-1"></i>{t('forgot_password.sign_in_instead')}
       </a>
     </form>
   );

--- a/src/client/js/components/PasswordResetExecutionForm.jsx
+++ b/src/client/js/components/PasswordResetExecutionForm.jsx
@@ -4,7 +4,6 @@ import { withTranslation } from 'react-i18next';
 
 
 const PasswordResetExecutionForm = (props) => {
-  // TODO: apply i18n by GW-6861
   const { t } = props;
 
   return (

--- a/src/client/js/components/PasswordResetExecutionForm.jsx
+++ b/src/client/js/components/PasswordResetExecutionForm.jsx
@@ -10,12 +10,12 @@ const PasswordResetExecutionForm = (props) => {
     <form role="form" className="form" method="post">
       <div className="form-group">
         <div className="input-group">
-          <input name="password" placeholder="New Password" className="form-control" type="password" />
+          <input name="password" placeholder={t('forgot_password.new_password')} className="form-control" type="password" />
         </div>
       </div>
       <div className="form-group">
         <div className="input-group">
-          <input name="password" placeholder="Confirm the new password" className="form-control" type="password" />
+          <input name="password" placeholder={t('forgot_password.confirm_new_password')} className="form-control" type="password" />
         </div>
       </div>
       <div className="form-group">

--- a/src/client/js/components/PasswordResetRequestForm.jsx
+++ b/src/client/js/components/PasswordResetRequestForm.jsx
@@ -4,8 +4,7 @@ import { withTranslation } from 'react-i18next';
 
 
 const PasswordResetRequestForm = (props) => {
-  // TODO: apply i18n by GW-6861
-  // const { t } = props;
+  const { t } = props;
 
   return (
     <form role="form" className="form" method="post">
@@ -15,10 +14,10 @@ const PasswordResetRequestForm = (props) => {
         </div>
       </div>
       <div className="form-group">
-        <input name="reset-password-btn" className="btn btn-lg btn-primary btn-block" value="Reset Password" type="submit" />
+        <input name="reset-password-btn" className="btn btn-lg btn-primary btn-block" value={t('forgot_password.reset_password')} type="submit" />
       </div>
       <a href="/login">
-        <i className="icon-login mr-1"></i>Return to login
+        <i className="icon-login mr-1"></i>{t('forgot_password.return_to_login')}
       </a>
     </form>
   );

--- a/src/client/js/components/PasswordResetRequestForm.jsx
+++ b/src/client/js/components/PasswordResetRequestForm.jsx
@@ -14,7 +14,7 @@ const PasswordResetRequestForm = (props) => {
         </div>
       </div>
       <div className="form-group">
-        <input name="reset-password-btn" className="btn btn-lg btn-primary btn-block" value={t('forgot_password.reset_password')} type="submit" />
+        <input name="reset-password-btn" className="btn btn-lg btn-primary btn-block" value={t('forgot_password.send_email')} type="submit" />
       </div>
       <a href="/login">
         <i className="icon-login mr-1"></i>{t('forgot_password.return_to_login')}

--- a/src/server/views/forgot-password.html
+++ b/src/server/views/forgot-password.html
@@ -32,8 +32,8 @@
           <div class="col-md-6 mt-5">
             <div class="text-center">
               <h1><i class="icon-lock large"></i></h1>
-              <h2 class="text-center">Forgot Password?</h2>
-              <p>You can reset your password here.</p>
+              <h2 class="text-center">{{ t('forgot_password.forgot_password') }}</h2>
+              <p>{{ t('forgot_password.password_reset_request_desc') }}</p>
               <div id="password-reset-request-form"></div>
             </div>
           </div>

--- a/src/server/views/reset-password.html
+++ b/src/server/views/reset-password.html
@@ -32,7 +32,7 @@
           <div class="col-md-6 mt-5">
             <div class="text-center">
               <h1><i class="icon-lock-open large"></i></h1>
-              <h2 class="text-center">Reset Password</h2>
+              <h2 class="text-center">{{ t('forgot_password.reset_password') }}</h2>
               <p>{{ t('forgot_password.password_reset_excecution_desc') }}</p>
               <div id="password-reset-execution-form"></div>
             </div>

--- a/src/server/views/reset-password.html
+++ b/src/server/views/reset-password.html
@@ -33,8 +33,7 @@
             <div class="text-center">
               <h1><i class="icon-lock-open large"></i></h1>
               <h2 class="text-center">Reset Password</h2>
-              <!-- TODO: show user email by GW-6778 -->
-              <p>Enter a new password for foo@example.com.</p>
+              <p>{{ t('forgot_password.password_reset_excecution_desc') }}</p>
               <div id="password-reset-execution-form"></div>
             </div>
           </div>


### PR DESCRIPTION
## Task
GW-6861 [front] i18nを適用させる

## View
### ログイン画面
<img width="498" alt="Screen Shot 2021-07-28 at 19 21 43" src="https://user-images.githubusercontent.com/59536731/127307093-9215b44a-1ca5-4758-afc3-af5d9b520608.png">

### パスワードリセットリクエスト画面
<img width="619" alt="Screen Shot 2021-07-28 at 19 21 49" src="https://user-images.githubusercontent.com/59536731/127307097-97620399-e7a5-47af-9ebb-e3fac261d7df.png">
- ボタンを「パスワードリセット」から「送信」に変更しました。

### パスワードリセット実行画面
<img width="621" alt="Screen Shot 2021-07-28 at 19 22 02" src="https://user-images.githubusercontent.com/59536731/127307099-81850ae5-0912-489e-a8c0-1c0bbf32237a.png">
