### PR TITLE
Imprv/implement single handler for pid 1 problem

### DIFF
--- a/packages/slackbot-proxy/package.json
+++ b/packages/slackbot-proxy/package.json
@@ -44,7 +44,6 @@
     "cross-env": "^7.0.0",
     "dotenv-flow": "^3.2.0",
     "express-bunyan-logger": "^1.3.3",
-    "express-graceful-exit": "=0.5.0",
     "extensible-custom-error": "^0.0.7",
     "helmet": "^4.6.0",
     "http-errors": "^1.8.0",

--- a/packages/slackbot-proxy/src/Server.ts
+++ b/packages/slackbot-proxy/src/Server.ts
@@ -11,7 +11,6 @@ import methodOverride from 'method-override';
 import helmet from 'helmet';
 import { Express } from 'express';
 import expressBunyanLogger from 'express-bunyan-logger';
-import gracefulExit from 'express-graceful-exit';
 
 import { ConnectionOptions, getConnectionManager } from 'typeorm';
 import { createTerminus } from '@godaddy/terminus';
@@ -125,19 +124,11 @@ export class Server {
     if (serverUri === undefined) {
       throw new Error('The environment variable \'SERVER_URI\' must be defined.');
     }
-
-    const server = this.injector.get<HttpServer>(HttpServer);
-
-    // init express-graceful-exit
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    gracefulExit.init(server!);
   }
 
   $beforeRoutesInit(): void {
-    const expressApp = this.app.getApp();
 
     this.app
-      .use(gracefulExit.middleware(expressApp))
       .use(cookieParser())
       .use(compress({}))
       .use(methodOverride())
@@ -164,8 +155,6 @@ export class Server {
         const connectionManager = getConnectionManager();
         const defaultConnection = connectionManager.get('default');
         await defaultConnection.close();
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        // gracefulExit.gracefulExitHandler(expressApp, server!);
       },
       onShutdown: async() => {
         logger.info('cleanup finished, server is shutting down');

--- a/packages/slackbot-proxy/src/Server.ts
+++ b/packages/slackbot-proxy/src/Server.ts
@@ -145,7 +145,6 @@ export class Server {
   }
 
   $beforeListen(): void {
-    // const expressApp = this.app.getApp();
     const server = this.injector.get<HttpServer>(HttpServer);
 
     // init terminus

--- a/yarn.lock
+++ b/yarn.lock
@@ -7964,13 +7964,6 @@ express-form@~0.12.0:
     object-additions "^0.5.1"
     validator "^2.1.0"
 
-express-graceful-exit@=0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/express-graceful-exit/-/express-graceful-exit-0.5.0.tgz#fcde6495af84f361e66f119bf0e3eca69955f9f1"
-  integrity sha512-gZkxdmgYz6VVHjZiMTaO59N875ugmBnzopF95q8Fzmws86JLNWMwGjLVG4i+99WO4v9L5wl6vKYFyGoHKoNJ7A==
-  dependencies:
-    underscore "^1.4.4"
-
 express-mongo-sanitize@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/express-mongo-sanitize/-/express-mongo-sanitize-2.1.0.tgz#a8c647787c25ded6e97b5e864d113e7687c5d471"
@@ -19056,11 +19049,6 @@ umask@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/umask/-/umask-1.1.0.tgz#f29cebf01df517912bb58ff9c4e50fde8e33320d"
   integrity sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=
-
-underscore@^1.4.4:
-  version "1.13.1"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.1.tgz#0c1c6bd2df54b6b69f2314066d65b6cde6fcf9d1"
-  integrity sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==
 
 unherit@^1.0.4:
   version "1.1.2"


### PR DESCRIPTION
## 概要
pid 1 問題の対策として、siterm を受け取った時に、typeorm の connection を終了する処理を追加しています。

- 確認したこと
slack-bot-proxy を立ち上げた状態で、docker exec で docker 内部にはいり、slack-bot-proxy に関わる部分を kill しました。
  - 結果
sigterm の信号を受け取り、defoultConnection.close() した後に、server をshut down することができました。
```
[INFO] 11:10:49 Restarting: /workspace/growi/packages/slackbot-proxy/src/Server.ts has been modified
11:10:49.930Z  INFO slackbot-proxy:server: server is starting cleanup
11:10:49.934Z  INFO slackbot-proxy:server: cleanup finished, server is shutting down
```