### PR TITLE
cahnge color & position

### DIFF
--- a/src/client/js/components/Sidebar/RecentChanges.jsx
+++ b/src/client/js/components/Sidebar/RecentChanges.jsx
@@ -60,7 +60,7 @@ class RecentChanges extends React.Component {
 
     let locked;
     if (page.grant !== 1) {
-      locked = <span><i className="icon-lock" /></span>;
+      locked = <span><i className="icon-lock ml-2" /></span>;
     }
 
     const tags = page.tags;

--- a/src/client/styles/scss/_recent-changes.scss
+++ b/src/client/styles/scss/_recent-changes.scss
@@ -11,5 +11,9 @@
     .grw-list-counts {
       font-size: 12px;
     }
+
+    .icon-lock {
+      font-size: 14px;
+    }
   }
 }

--- a/src/client/styles/scss/theme/_apply-colors.scss
+++ b/src/client/styles/scss/theme/_apply-colors.scss
@@ -263,6 +263,14 @@ ul.pagination {
       }
     }
   }
+
+  .list-group {
+    .list-group-item {
+      .icon-lock {
+        color: $color-link;
+      }
+    }
+  }
 }
 
 /*


### PR DESCRIPTION
鍵マークの場所，サイズ，
色はページ名と同じ色に変更
<img width="281" alt="スクリーンショット 2021-08-05 16 08 31" src="https://user-images.githubusercontent.com/46134198/128306914-fbfab440-12b0-4445-ab7f-8a39069a1e9e.png">
