### PR TITLE
change tag position

### DIFF
--- a/src/client/js/components/Sidebar/RecentChanges.jsx
+++ b/src/client/js/components/Sidebar/RecentChanges.jsx
@@ -84,14 +84,16 @@ class RecentChanges extends React.Component {
               {locked}
             </h5>
             <div className="my-2">
+              { tagElements }
+            </div>
+            <div className="pull-left">
               <span className="footstamp-icon mr-1"><FootstampIcon /></span>
               <span className="mr-2 grw-list-counts">{page.seenUsers.length}</span>
               <i className="icon-bubble mr-1"></i>
               <span className="mr-2 grw-list-counts">{page.commentCount}</span>
-              { tagElements }
-              <div className="pull-right small">
-                <FormattedDistanceDate id={page.id} date={page.updatedAt} />
-              </div>
+            </div>
+            <div className="pull-right small">
+              <FormattedDistanceDate id={page.id} date={page.updatedAt} />
             </div>
           </div>
         </div>

--- a/src/client/js/components/Sidebar/RecentChanges.jsx
+++ b/src/client/js/components/Sidebar/RecentChanges.jsx
@@ -83,17 +83,19 @@ class RecentChanges extends React.Component {
               <PagePathHierarchicalLink linkedPagePath={linkedPagePathLatter} basePath={dPagePath.isRoot ? undefined : dPagePath.former} />
               {locked}
             </h5>
-            <div className="my-2">
+            <div className="mt-2">
               { tagElements }
             </div>
-            <div className="pull-left">
-              <span className="footstamp-icon mr-1"><FootstampIcon /></span>
-              <span className="mr-2 grw-list-counts">{page.seenUsers.length}</span>
-              <i className="icon-bubble mr-1"></i>
-              <span className="mr-2 grw-list-counts">{page.commentCount}</span>
-            </div>
-            <div className="pull-right small">
-              <FormattedDistanceDate id={page.id} date={page.updatedAt} />
+            <div className="d-flex justify-content-between">
+              <div className="mt-2">
+                <span className="footstamp-icon mr-1"><FootstampIcon /></span>
+                <span className="mr-2 grw-list-counts">{page.seenUsers.length}</span>
+                <i className="icon-bubble mr-1"></i>
+                <span className="mr-2 grw-list-counts">{page.commentCount}</span>
+              </div>
+              <div className="small mt-auto">
+                <FormattedDistanceDate id={page.id} date={page.updatedAt} />
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
更新日時の長さを考慮して，これから
<img width="361" alt="スクリーンショット 2021-08-05 17 06 23" src="https://user-images.githubusercontent.com/46134198/128461040-b2982800-e24f-46d1-8173-7dca090becb9.png">
↓
<img width="306" alt="スクリーンショット 2021-08-05 17 10 42" src="https://user-images.githubusercontent.com/46134198/128460746-46e9ff6d-a3f7-42e9-9bad-c3eb66fe658e.png">
これに変更になったのでタグの場所を移動させました。


<img width="293" alt="スクリーンショット 2021-08-06 14 31 17" src="https://user-images.githubusercontent.com/46134198/128460836-1555a547-dbdf-4c7b-9314-ca1033834624.png">
