### PR TITLE
Imprv/slack app review for adding info in lp(add links)

### DIFF
--- a/packages/slackbot-proxy/src/controllers/slack.ts
+++ b/packages/slackbot-proxy/src/controllers/slack.ts
@@ -318,6 +318,9 @@ export class SlackCtrl {
       + '<a href="/">'
       + 'Go to install page'
       + '</a>'
+      + '<a href="https://docs.growi.org/ja/admin-guide/management-cookbook/slack-integration/official-bot-settings.html">'
+      + 'How to set up ?'
+      + '</a>'
       + '</body></html>');
     }
 

--- a/packages/slackbot-proxy/src/controllers/slack.ts
+++ b/packages/slackbot-proxy/src/controllers/slack.ts
@@ -317,10 +317,6 @@ export class SlackCtrl {
       + '<h1>Illegal state, try it again.</h1>'
       + '<a href="/">'
       + 'Go to install page'
-      + '</a>'
-      + '<a href="https://docs.growi.org/ja/admin-guide/management-cookbook/slack-integration/official-bot-settings.html">'
-      + 'How to set up ?'
-      + '</a>'
       + '</body></html>');
     }
 
@@ -331,15 +327,24 @@ export class SlackCtrl {
         const appPageUrl = `https://slack.com/apps/${installation.appId}`;
 
         res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
-        res.end('<html>'
-        + '<head><meta name="viewport" content="width=device-width,initial-scale=1"></head>'
+        res.end(
+          '<html>'
+        + '<head><meta name="viewport" content="width=device-width,initial-scale=1">'
+        + '<link href="/bootstrap/css/bootstrap.min.css" rel="stylesheet" >'
+        + '</head>'
         + '<body style="text-align:center; padding-top:20%;">'
         + '<h1>Congratulations!</h1>'
         + '<p>GROWI Bot installation has succeeded.</p>'
-        + `<a href="${appPageUrl}">`
+        + '<div class="d-inline-flex flex-column">'
+        + `<a class="btn btn-outline-primary mb-3" href="${appPageUrl}">`
         + 'Access to Slack App detail page.'
         + '</a>'
-        + '</body></html>');
+        + '<a class="btn btn-outline-primary" href="https://docs.growi.org/en/admin-guide/management-cookbook/slack-integration/official-bot-settings.html">'
+        + 'How to set up ?'
+        + '</a>'
+        // + '</div>'
+        + '</body></html>',
+        );
       },
       failure: (error, installOptions, req, res) => {
         res.writeHead(500, { 'Content-Type': 'text/html; charset=utf-8' });

--- a/packages/slackbot-proxy/src/controllers/slack.ts
+++ b/packages/slackbot-proxy/src/controllers/slack.ts
@@ -317,6 +317,7 @@ export class SlackCtrl {
       + '<h1>Illegal state, try it again.</h1>'
       + '<a href="/">'
       + 'Go to install page'
+      + '</a>'
       + '</body></html>');
     }
 

--- a/packages/slackbot-proxy/src/controllers/slack.ts
+++ b/packages/slackbot-proxy/src/controllers/slack.ts
@@ -330,7 +330,7 @@ export class SlackCtrl {
         res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
         res.end('<html>'
         + '<head><meta name="viewport" content="width=device-width,initial-scale=1">'
-        + '<link href="/bootstrap/css/bootstrap.min.css" rel="stylesheet" >'
+        + '<link href="/bootstrap/css/bootstrap.min.css" rel="stylesheet">'
         + '</head>'
         + '<body style="text-align:center; padding-top:20%;">'
         + '<h1>Congratulations!</h1>'

--- a/packages/slackbot-proxy/src/controllers/slack.ts
+++ b/packages/slackbot-proxy/src/controllers/slack.ts
@@ -328,8 +328,7 @@ export class SlackCtrl {
         const appPageUrl = `https://slack.com/apps/${installation.appId}`;
 
         res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
-        res.end(
-          '<html>'
+        res.end('<html>'
         + '<head><meta name="viewport" content="width=device-width,initial-scale=1">'
         + '<link href="/bootstrap/css/bootstrap.min.css" rel="stylesheet" >'
         + '</head>'
@@ -344,8 +343,7 @@ export class SlackCtrl {
         + 'How to set up ?'
         + '</a>'
         // + '</div>'
-        + '</body></html>',
-        );
+        + '</body></html>');
       },
       failure: (error, installOptions, req, res) => {
         res.writeHead(500, { 'Content-Type': 'text/html; charset=utf-8' });

--- a/packages/slackbot-proxy/src/controllers/slack.ts
+++ b/packages/slackbot-proxy/src/controllers/slack.ts
@@ -342,7 +342,7 @@ export class SlackCtrl {
         + '<a class="btn btn-outline-primary" href="https://docs.growi.org/en/admin-guide/management-cookbook/slack-integration/official-bot-settings.html">'
         + 'How to set up ?'
         + '</a>'
-        // + '</div>'
+        + '</div>'
         + '</body></html>');
       },
       failure: (error, installOptions, req, res) => {

--- a/packages/slackbot-proxy/src/views/top.ejs
+++ b/packages/slackbot-proxy/src/views/top.ejs
@@ -22,6 +22,7 @@
           <a href="/term">
             Term of Service
           </a>
+          <a href="https://docs.growi.org/en/admin-guide/management-cookbook/slack-integration/official-bot-settings.html">How to set up ?</a>
         <% } %>
       </div>
     </div>

--- a/packages/slackbot-proxy/src/views/top.ejs
+++ b/packages/slackbot-proxy/src/views/top.ejs
@@ -14,6 +14,7 @@
           <img alt="Add to Slack" height="40" width="139" src="/images/add-to-slack.png"/>
         </a>
       </div>
+      <a class="btn btn-outline-primary" href="https://docs.growi.org/en/admin-guide/management-cookbook/slack-integration/official-bot-settings.html">How to set up ?</a>
       <div class="d-flex justify-content-evenly my-3">
         <% if (isOfficialMode) { %>
           <a href="/privacy">
@@ -22,7 +23,6 @@
           <a href="/term">
             Term of Service
           </a>
-          <a href="https://docs.growi.org/en/admin-guide/management-cookbook/slack-integration/official-bot-settings.html">How to set up ?</a>
         <% } %>
       </div>
     </div>


### PR DESCRIPTION
## 目的
slack からの review を修正すること
- 修正内容
  > Could you please add some information to your landing page regarding the steps required to configure the GROWI Slack app e.g how to get a GROWI domain, how to get required access tokens etc.
おおよその意味
GROWI Slackアプリの設定に必要な手順について、ランディングページに情報を追加していただけないでしょうか（GROWIドメインの取得方法、必要なアクセストークンの取得方法など）。


## 実装したこと
- slack.ts （controllers の handleCallback） に docs の link を追加
- top.ejs に docs の link を追加

## イメージ
<img width="1347" alt="Screen Shot 2021-08-12 at 19 24 25" src="https://user-images.githubusercontent.com/57100766/129208559-a706b320-af8d-480f-89cb-8ebfa3545d69.png">

<img width="1915" alt="Screen Shot 2021-08-12 at 21 05 00" src="https://user-images.githubusercontent.com/57100766/129208544-11ede773-9b21-454a-9558-01cbd6dad682.png">
