### PR TITLE
Lintが有効/無効のロジックを追加

### DIFF
--- a/packages/app/src/components/PageEditor/CodeMirrorEditor.jsx
+++ b/packages/app/src/components/PageEditor/CodeMirrorEditor.jsx
@@ -904,7 +904,7 @@ export default class CodeMirrorEditor extends AbstractEditor {
           className={additionalClasses}
           placeholder="search"
           editorDidMount={(editor) => {
-            // add event handlers
+          // add event handlers
             editor.on('paste', this.pasteHandler);
             editor.on('scrollCursorIntoView', this.scrollCursorIntoViewHandler);
           }}
@@ -942,7 +942,7 @@ export default class CodeMirrorEditor extends AbstractEditor {
           onCursor={this.cursorHandler}
           onScroll={(editor, data) => {
             if (this.props.onScroll != null) {
-              // add line data
+            // add line data
               const line = editor.lineAtHeight(data.top, 'local');
               data.line = line;
               this.props.onScroll(data);
@@ -956,9 +956,9 @@ export default class CodeMirrorEditor extends AbstractEditor {
           }}
         />
 
-        {this.renderLoadingKeymapOverlay()}
+        { this.renderLoadingKeymapOverlay() }
 
-        {this.renderCheatsheetOverlay()}
+        { this.renderCheatsheetOverlay() }
 
         <GridEditModal
           ref={this.gridEditModal}

--- a/packages/app/src/components/PageEditor/CodeMirrorEditor.jsx
+++ b/packages/app/src/components/PageEditor/CodeMirrorEditor.jsx
@@ -148,8 +148,6 @@ export default class CodeMirrorEditor extends AbstractEditor {
     this.showLinkEditHandler = this.showLinkEditHandler.bind(this);
     this.showHandsonTableHandler = this.showHandsonTableHandler.bind(this);
     this.showDrawioHandler = this.showDrawioHandler.bind(this);
-
-    this.initTextlintSettings = this.initTextlintSettings.bind(this);
   }
 
   init() {
@@ -218,7 +216,6 @@ export default class CodeMirrorEditor extends AbstractEditor {
   }
 
   initTextlintSettings() {
-    console.log('init!');
     this.textlintValidator = createValidator(this.textlintConfig);
     this.codemirrorLintConfig = this.isLintEnabled ? { getAnnotations: this.textlintValidator, async: true } : undefined;
   }

--- a/packages/app/src/components/PageEditor/CodeMirrorEditor.jsx
+++ b/packages/app/src/components/PageEditor/CodeMirrorEditor.jsx
@@ -624,7 +624,7 @@ export default class CodeMirrorEditor extends AbstractEditor {
 
     return (
       <div className="overlay overlay-gfm-cheatsheet mt-1 p-3">
-        { this.state.isSimpleCheatsheetShown
+        {this.state.isSimpleCheatsheetShown
           ? (
             <div className="text-right">
               {cheatsheetModalButton}
@@ -857,46 +857,42 @@ export default class CodeMirrorEditor extends AbstractEditor {
     ];
   }
 
+  // TODO: Get configs from db
+  isLintEnabled = true;
+
+  textlintConfig = [
+    {
+      name: 'max-comma',
+    },
+    {
+      name: 'dummy-rule',
+    },
+    {
+      name: 'common-misspellings',
+      options: {
+        ignore: [
+          'isnt',
+          'yuo',
+        ],
+      },
+    },
+  ];
+
+  textlintValidator = createValidator(this.textlintConfig);
+
+  codemirrorLintConfig = this.isLintEnabled ? { getAnnotations: this.textlintValidator, async: true } : undefined;
+
   render() {
     const mode = this.state.isGfmMode ? 'gfm-growi' : undefined;
+    const lint = this.codemirrorLintConfig;
     const additionalClasses = Array.from(this.state.additionalClassSet).join(' ');
     const placeholder = this.state.isGfmMode ? 'Input with Markdown..' : 'Input with Plain Text..';
-
-    // TODO: Get configs from db
-    const isLintEnabled = true;
-    const textlintConfig = [
-      {
-        name: 'max-comma',
-      },
-      {
-        name: 'dummy-rule',
-      },
-      {
-        name: 'common-misspellings',
-        options: {
-          ignore: [
-            'isnt',
-            'yuo',
-          ],
-        },
-      },
-    ];
-
-    const textlintValidator = createValidator(textlintConfig);
-
-    const lint = {};
-    if (isLintEnabled === true) {
-      Object.assign(lint, {
-        getAnnotations: textlintValidator,
-        async: true,
-      });
-    }
 
     const gutters = [];
     if (this.props.lineNumbers != null) {
       gutters.push('CodeMirror-linenumbers', 'CodeMirror-foldgutter');
     }
-    if (isLintEnabled === true) {
+    if (this.isLintEnabled === true) {
       gutters.push('CodeMirror-lint-markers');
     }
 
@@ -908,7 +904,7 @@ export default class CodeMirrorEditor extends AbstractEditor {
           className={additionalClasses}
           placeholder="search"
           editorDidMount={(editor) => {
-          // add event handlers
+            // add event handlers
             editor.on('paste', this.pasteHandler);
             editor.on('scrollCursorIntoView', this.scrollCursorIntoViewHandler);
           }}
@@ -946,7 +942,7 @@ export default class CodeMirrorEditor extends AbstractEditor {
           onCursor={this.cursorHandler}
           onScroll={(editor, data) => {
             if (this.props.onScroll != null) {
-            // add line data
+              // add line data
               const line = editor.lineAtHeight(data.top, 'local');
               data.line = line;
               this.props.onScroll(data);
@@ -960,9 +956,9 @@ export default class CodeMirrorEditor extends AbstractEditor {
           }}
         />
 
-        { this.renderLoadingKeymapOverlay() }
+        {this.renderLoadingKeymapOverlay()}
 
-        { this.renderCheatsheetOverlay() }
+        {this.renderCheatsheetOverlay()}
 
         <GridEditModal
           ref={this.gridEditModal}

--- a/packages/app/src/components/PageEditor/CodeMirrorEditor.jsx
+++ b/packages/app/src/components/PageEditor/CodeMirrorEditor.jsx
@@ -148,12 +148,32 @@ export default class CodeMirrorEditor extends AbstractEditor {
     this.showLinkEditHandler = this.showLinkEditHandler.bind(this);
     this.showHandsonTableHandler = this.showHandsonTableHandler.bind(this);
     this.showDrawioHandler = this.showDrawioHandler.bind(this);
+
+    this.initTextlintSettings = this.initTextlintSettings.bind(this);
   }
 
   init() {
     this.cmCdnRoot = 'https://cdn.jsdelivr.net/npm/codemirror@5.42.0';
     this.cmNoCdnScriptRoot = '/js/cdn';
     this.cmNoCdnStyleRoot = '/styles/cdn';
+
+    // TODO: Get configs from db
+    this.isLintEnabled = true;
+
+    this.textlintConfig = [
+      {
+        name: 'max-comma',
+      },
+      {
+        name: 'common-misspellings',
+        options: {
+          ignore: [
+            'isnt',
+            'yuo',
+          ],
+        },
+      },
+    ];
 
     this.interceptorManager = new InterceptorManager();
     this.interceptorManager.addInterceptors([
@@ -170,6 +190,8 @@ export default class CodeMirrorEditor extends AbstractEditor {
       this.emojiAutoCompleteHelper = new EmojiAutoCompleteHelper(this.props.emojiStrategy);
       this.setState({ isEnabledEmojiAutoComplete: true });
     }
+
+    this.initTextlintSettings();
   }
 
   componentDidMount() {
@@ -193,6 +215,12 @@ export default class CodeMirrorEditor extends AbstractEditor {
     // set keymap
     const keymapMode = nextProps.editorOptions.keymapMode;
     this.setKeymapMode(keymapMode);
+  }
+
+  initTextlintSettings() {
+    console.log('init!');
+    this.textlintValidator = createValidator(this.textlintConfig);
+    this.codemirrorLintConfig = this.isLintEnabled ? { getAnnotations: this.textlintValidator, async: true } : undefined;
   }
 
   getCodeMirror() {
@@ -856,31 +884,6 @@ export default class CodeMirrorEditor extends AbstractEditor {
       </Button>,
     ];
   }
-
-  // TODO: Get configs from db
-  isLintEnabled = true;
-
-  textlintConfig = [
-    {
-      name: 'max-comma',
-    },
-    {
-      name: 'dummy-rule',
-    },
-    {
-      name: 'common-misspellings',
-      options: {
-        ignore: [
-          'isnt',
-          'yuo',
-        ],
-      },
-    },
-  ];
-
-  textlintValidator = createValidator(this.textlintConfig);
-
-  codemirrorLintConfig = this.isLintEnabled ? { getAnnotations: this.textlintValidator, async: true } : undefined;
 
   render() {
     const mode = this.state.isGfmMode ? 'gfm-growi' : undefined;

--- a/packages/app/src/components/PageEditor/CodeMirrorEditor.jsx
+++ b/packages/app/src/components/PageEditor/CodeMirrorEditor.jsx
@@ -862,8 +862,9 @@ export default class CodeMirrorEditor extends AbstractEditor {
     const additionalClasses = Array.from(this.state.additionalClassSet).join(' ');
     const placeholder = this.state.isGfmMode ? 'Input with Markdown..' : 'Input with Plain Text..';
 
-    // TODO: Get config from db
-    const textlintValidator = createValidator([
+    // TODO: Get configs from db
+    const isLintEnabled = true;
+    const textlintConfig = [
       {
         name: 'max-comma',
       },
@@ -879,7 +880,25 @@ export default class CodeMirrorEditor extends AbstractEditor {
           ],
         },
       },
-    ]);
+    ];
+
+    const textlintValidator = createValidator(textlintConfig);
+
+    const lint = {};
+    if (isLintEnabled === true) {
+      Object.assign(lint, {
+        getAnnotations: textlintValidator,
+        async: true,
+      });
+    }
+
+    const gutters = [];
+    if (this.props.lineNumbers != null) {
+      gutters.push('CodeMirror-linenumbers', 'CodeMirror-foldgutter');
+    }
+    if (isLintEnabled === true) {
+      gutters.push('CodeMirror-lint-markers');
+    }
 
     return (
       <React.Fragment>
@@ -910,10 +929,7 @@ export default class CodeMirrorEditor extends AbstractEditor {
             matchTags: { bothTags: true },
             // folding
             foldGutter: this.props.lineNumbers,
-            // Todo: Hide lint marker gutters when disabled
-            gutters: this.props.lineNumbers
-              ? ['CodeMirror-linenumbers', 'CodeMirror-foldgutter', 'CodeMirror-lint-markers']
-              : ['CodeMirror-lint-markers'],
+            gutters,
             // match-highlighter, matchesonscrollbar, annotatescrollbar options
             highlightSelectionMatches: { annotateScrollbar: true },
             // continuelist, indentlist
@@ -925,10 +941,7 @@ export default class CodeMirrorEditor extends AbstractEditor {
               'Shift-Tab': 'indentLess',
               'Ctrl-Q': (cm) => { cm.foldCode(cm.getCursor()) },
             },
-            lint: {
-              getAnnotations: textlintValidator,
-              async: true,
-            },
+            lint,
           }}
           onCursor={this.cursorHandler}
           onScroll={(editor, data) => {

--- a/packages/app/src/components/PageEditor/CodeMirrorEditor.jsx
+++ b/packages/app/src/components/PageEditor/CodeMirrorEditor.jsx
@@ -624,7 +624,7 @@ export default class CodeMirrorEditor extends AbstractEditor {
 
     return (
       <div className="overlay overlay-gfm-cheatsheet mt-1 p-3">
-        {this.state.isSimpleCheatsheetShown
+        { this.state.isSimpleCheatsheetShown
           ? (
             <div className="text-right">
               {cheatsheetModalButton}


### PR DESCRIPTION
Textlint有効/無効の際にCodeMirrorに渡す引数を整理しました。
それに伴い、Gutterも有効/無効で表示/非表示が切り替わるようになりました。

無効の際
<img width="92" alt="Screen Shot 2021-08-13 at 13 13 51" src="https://user-images.githubusercontent.com/66785624/129304742-78d375b7-f47e-4491-8594-31185c980050.png">

有効
<img width="71" alt="Screen Shot 2021-08-13 at 13 14 51" src="https://user-images.githubusercontent.com/66785624/129304743-a40dd4e4-fce8-4744-ac27-6607a1abdb33.png">
