### PR TITLE
Feat/6924 use utc for cache expire at

### DIFF
--- a/packages/slackbot-proxy/src/controllers/growi-to-slack.ts
+++ b/packages/slackbot-proxy/src/controllers/growi-to-slack.ts
@@ -3,7 +3,6 @@ import {
 } from '@tsed/common';
 import axios from 'axios';
 import createError from 'http-errors';
-import { addHours } from 'date-fns';
 
 import { WebAPICallResult } from '@slack/web-api';
 
@@ -186,7 +185,8 @@ export class GrowiToSlackCtrl {
     logger.debug('relation test is success', order);
 
     // temporary cache for 48 hours
-    const expiredAtCommands = addHours(new Date(), 48);
+    const nowDate = new Date();
+    const expiredAtCommands = nowDate.getTime() + 48 * 60 * 60 * 1000;
 
     // Transaction is not considered because it is used infrequently,
     const response = await this.relationRepository.createQueryBuilder('relation')

--- a/packages/slackbot-proxy/src/controllers/growi-to-slack.ts
+++ b/packages/slackbot-proxy/src/controllers/growi-to-slack.ts
@@ -3,6 +3,7 @@ import {
 } from '@tsed/common';
 import axios from 'axios';
 import createError from 'http-errors';
+import { addHours } from 'date-fns';
 
 import { WebAPICallResult } from '@slack/web-api';
 
@@ -185,8 +186,7 @@ export class GrowiToSlackCtrl {
     logger.debug('relation test is success', order);
 
     // temporary cache for 48 hours
-    const nowDate = new Date();
-    const expiredAtCommands = nowDate.getTime() + 48 * 60 * 60 * 1000;
+    const expiredAtCommands = addHours(new Date(), 48);
 
     // Transaction is not considered because it is used infrequently,
     const response = await this.relationRepository.createQueryBuilder('relation')

--- a/packages/slackbot-proxy/src/entities/relation-mock.ts
+++ b/packages/slackbot-proxy/src/entities/relation-mock.ts
@@ -53,11 +53,6 @@ export class RelationMock {
   @CreateDateColumn()
   expiredAtCommands: Date;
 
-  isExpiredCommands():boolean {
-    const now = Date.now();
-    return this.expiredAtCommands.getTime() < now;
-  }
-
   getDistanceInMillisecondsToExpiredAt(baseDate:Date):number {
     return differenceInMilliseconds(this.expiredAtCommands, baseDate);
   }

--- a/packages/slackbot-proxy/src/entities/relation-mock.ts
+++ b/packages/slackbot-proxy/src/entities/relation-mock.ts
@@ -1,7 +1,6 @@
 import {
   Column, CreateDateColumn, Entity, PrimaryGeneratedColumn, UpdateDateColumn, ManyToOne, Index,
 } from 'typeorm';
-import { differenceInMilliseconds } from 'date-fns';
 import { Installation } from './installation';
 
 
@@ -50,11 +49,11 @@ export class RelationMock {
   @Column({ type: 'json' })
   permittedChannelsForEachCommand : PermittedChannelsForEachCommand
 
-  @CreateDateColumn()
-  expiredAtCommands: Date;
+  @Column({ type: 'bigint' })
+  expiredAtCommands: number;
 
   getDistanceInMillisecondsToExpiredAt(baseDate:Date):number {
-    return differenceInMilliseconds(this.expiredAtCommands, baseDate);
+    return this.expiredAtCommands - baseDate.getTime();
   }
 
 }

--- a/packages/slackbot-proxy/src/entities/relation-mock.ts
+++ b/packages/slackbot-proxy/src/entities/relation-mock.ts
@@ -49,7 +49,7 @@ export class RelationMock {
   @Column({ type: 'json' })
   permittedChannelsForEachCommand : PermittedChannelsForEachCommand
 
-  @Column({ type: 'bigint' })
+  @Column({ type: 'timestamp' })
   expiredAtCommands: number;
 
   getDistanceInMillisecondsToExpiredAt(baseDate:Date):number {

--- a/packages/slackbot-proxy/src/entities/relation-mock.ts
+++ b/packages/slackbot-proxy/src/entities/relation-mock.ts
@@ -1,3 +1,4 @@
+import { differenceInMilliseconds } from 'date-fns';
 import {
   Column, CreateDateColumn, Entity, PrimaryGeneratedColumn, UpdateDateColumn, ManyToOne, Index,
 } from 'typeorm';
@@ -50,10 +51,10 @@ export class RelationMock {
   permittedChannelsForEachCommand : PermittedChannelsForEachCommand
 
   @Column({ type: 'timestamp' })
-  expiredAtCommands: number;
+  expiredAtCommands: Date;
 
   getDistanceInMillisecondsToExpiredAt(baseDate:Date):number {
-    return this.expiredAtCommands - baseDate.getTime();
+    return differenceInMilliseconds(this.expiredAtCommands, baseDate);
   }
 
 }

--- a/packages/slackbot-proxy/src/entities/relation.ts
+++ b/packages/slackbot-proxy/src/entities/relation.ts
@@ -1,3 +1,4 @@
+import { differenceInMilliseconds } from 'date-fns';
 import {
   Column, CreateDateColumn, Entity, PrimaryGeneratedColumn, UpdateDateColumn, ManyToOne, Index,
 } from 'typeorm';
@@ -40,7 +41,8 @@ export class Relation {
   expiredAtCommands: number;
 
   getDistanceInMillisecondsToExpiredAt(baseDate:Date):number {
-    return this.expiredAtCommands - baseDate.getTime();
+    // differenceInMilliseconds uses Date.getTime() internally
+    return differenceInMilliseconds(this.expiredAtCommands, baseDate);
   }
 
 }

--- a/packages/slackbot-proxy/src/entities/relation.ts
+++ b/packages/slackbot-proxy/src/entities/relation.ts
@@ -40,11 +40,6 @@ export class Relation {
   @CreateDateColumn()
   expiredAtCommands: Date;
 
-  isExpiredCommands():boolean {
-    const now = Date.now();
-    return this.expiredAtCommands.getTime() < now;
-  }
-
   getDistanceInMillisecondsToExpiredAt(baseDate:Date):number {
     return differenceInMilliseconds(this.expiredAtCommands, baseDate);
   }

--- a/packages/slackbot-proxy/src/entities/relation.ts
+++ b/packages/slackbot-proxy/src/entities/relation.ts
@@ -1,7 +1,6 @@
 import {
   Column, CreateDateColumn, Entity, PrimaryGeneratedColumn, UpdateDateColumn, ManyToOne, Index,
 } from 'typeorm';
-import { differenceInMilliseconds } from 'date-fns';
 import { Installation } from './installation';
 
 @Entity()
@@ -37,11 +36,11 @@ export class Relation {
   @Column('simple-array')
   supportedCommandsForSingleUse: string[];
 
-  @CreateDateColumn()
-  expiredAtCommands: Date;
+  @Column({ type: 'bigint' })
+  expiredAtCommands: number;
 
   getDistanceInMillisecondsToExpiredAt(baseDate:Date):number {
-    return differenceInMilliseconds(this.expiredAtCommands, baseDate);
+    return this.expiredAtCommands - baseDate.getTime();
   }
 
 }

--- a/packages/slackbot-proxy/src/entities/relation.ts
+++ b/packages/slackbot-proxy/src/entities/relation.ts
@@ -38,10 +38,10 @@ export class Relation {
   supportedCommandsForSingleUse: string[];
 
   @Column({ type: 'timestamp' })
-  expiredAtCommands: number;
+  expiredAtCommands: Date;
 
   getDistanceInMillisecondsToExpiredAt(baseDate:Date):number {
-    // differenceInMilliseconds uses Date.getTime() internally
+    // differenceInMilliseconds uses Date.prototype.getTime() internally
     return differenceInMilliseconds(this.expiredAtCommands, baseDate);
   }
 

--- a/packages/slackbot-proxy/src/entities/relation.ts
+++ b/packages/slackbot-proxy/src/entities/relation.ts
@@ -36,7 +36,7 @@ export class Relation {
   @Column('simple-array')
   supportedCommandsForSingleUse: string[];
 
-  @Column({ type: 'bigint' })
+  @Column({ type: 'timestamp' })
   expiredAtCommands: number;
 
   getDistanceInMillisecondsToExpiredAt(baseDate:Date):number {

--- a/packages/slackbot-proxy/src/services/RelationsService.ts
+++ b/packages/slackbot-proxy/src/services/RelationsService.ts
@@ -1,5 +1,6 @@
 import { Inject, Service } from '@tsed/di';
 import axios from 'axios';
+import { addHours } from 'date-fns';
 
 import { Relation } from '~/entities/relation';
 import { RelationRepository } from '~/repositories/relation';
@@ -29,8 +30,7 @@ export class RelationsService {
     const { supportedCommandsForBroadcastUse, supportedCommandsForSingleUse } = res.data;
     relation.supportedCommandsForBroadcastUse = supportedCommandsForBroadcastUse;
     relation.supportedCommandsForSingleUse = supportedCommandsForSingleUse;
-    const nowDate = new Date();
-    relation.expiredAtCommands = nowDate.getTime() + 48 * 60 * 60 * 1000;
+    relation.expiredAtCommands = addHours(new Date(), 48);
 
     return this.relationRepository.save(relation);
   }

--- a/packages/slackbot-proxy/src/services/RelationsService.ts
+++ b/packages/slackbot-proxy/src/services/RelationsService.ts
@@ -1,6 +1,5 @@
 import { Inject, Service } from '@tsed/di';
 import axios from 'axios';
-import { addHours } from 'date-fns';
 
 import { Relation } from '~/entities/relation';
 import { RelationRepository } from '~/repositories/relation';
@@ -30,7 +29,8 @@ export class RelationsService {
     const { supportedCommandsForBroadcastUse, supportedCommandsForSingleUse } = res.data;
     relation.supportedCommandsForBroadcastUse = supportedCommandsForBroadcastUse;
     relation.supportedCommandsForSingleUse = supportedCommandsForSingleUse;
-    relation.expiredAtCommands = addHours(new Date(), 48);
+    const nowDate = new Date();
+    relation.expiredAtCommands = nowDate.getTime() + 48 * 60 * 60 * 1000;
 
     return this.relationRepository.save(relation);
   }
@@ -49,7 +49,7 @@ export class RelationsService {
     }
 
     // 24 hours
-    if (distanceMillisecondsToExpiredAt < 1000 * 60 * 60 * 24) {
+    if (distanceMillisecondsToExpiredAt < 24 * 60 * 60 * 1000) {
       try {
         this.syncSupportedGrowiCommands(relation);
       }


### PR DESCRIPTION
GW-6924 expiredAt を評価する際に関わっているDate オブジェクトをUTCの時間帯に固定して、expiredAtが必ず24hours になるようにする

を実装しました。

1. MySQL のデータ型を timestamp にすることで DB 内では必ず UTC で保存
2. expiredAtCommands の計算は、内部で Date.prototype.getTime() を使用している date-fns の differenceInMilliseconds() を使用

この２点により、必ず UTC で計算するようになっています。

### 参考
MySQL: https://dev.mysql.com/doc/refman/8.0/en/datetime.html
> MySQL converts TIMESTAMP values from the current time zone to UTC for storage, and back from UTC to the current time zone for retrieval.

differenceInMilliseconds(): https://github.com/date-fns/date-fns/blob/master/src/differenceInMilliseconds/index.ts#L38

Date.prototype.getTime(): https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getTime
> getTime() always uses UTC for time representation.