### PR TITLE
Feat/gw 7170 add test to rename page without using rename descendants with stream spy

### DIFF
--- a/packages/app/src/server/service/page.js
+++ b/packages/app/src/server/service/page.js
@@ -3,6 +3,7 @@ import loggerFactory from '~/utils/logger';
 
 const mongoose = require('mongoose');
 const escapeStringRegexp = require('escape-string-regexp');
+const streamToPromise = require('stream-to-promise');
 
 const logger = loggerFactory('growi:models:page');
 const debug = require('debug')('growi:models:page');
@@ -80,7 +81,7 @@ class PageService {
     }
 
     if (isRecursively) {
-      this.renameDescendantsWithStream(page, newPagePath, user, options);
+      await this.renameDescendantsWithStream(page, newPagePath, user, options);
     }
 
     this.pageEvent.emit('delete', page, user, socketClientId);
@@ -189,6 +190,8 @@ class PageService {
     readStream
       .pipe(createBatchStream(BULK_REINDEX_SIZE))
       .pipe(writeStream);
+
+    await streamToPromise(readStream);
   }
 
 

--- a/packages/app/src/test/service/page.test.js
+++ b/packages/app/src/test/service/page.test.js
@@ -240,6 +240,25 @@ describe('PageService', () => {
     xssSpy = jest.spyOn(crowi.xss, 'process').mockImplementation(path => path);
   });
 
+  describe('rename page without using renameDescendantsWithStreamSpy', () => {
+    let pageEventSpy;
+    beforeEach(async() => {
+      pageEventSpy = jest.spyOn(crowi.pageService.pageEvent, 'emit').mockImplementation();
+    });
+
+    describe('renamePage()', () => {
+      test('rename page with different tree with isRecursively', async() => {
+        const resultPage = await crowi.pageService.renamePage(parentForRename6, '/parentForRename6/renamedChild', testUser1, {}, true);
+        const wrongPage = await Page.findOne({ path: '/parentForRename6/renamedChild/renamedChild' });
+        const expectPage = await Page.findOne({ path: '/parentForRename6/renamedChild' });
+
+        expect(resultPage.path).toEqual(expectPage.path);
+        expect(wrongPage).toBeNull();
+      });
+    });
+
+  });
+
   describe('rename page', () => {
     let pageEventSpy;
     let renameDescendantsWithStreamSpy;
@@ -402,25 +421,6 @@ describe('PageService', () => {
       expect(redirectedFromPageRevision.path).toBe('/parentForRename3/child');
       expect(redirectedFromPageRevision.body).toBe('redirect /renamed3/child');
     });
-  });
-
-  describe('rename page without using renameDescendantsWithStreamSpy', () => {
-    let pageEventSpy;
-    beforeEach(async() => {
-      pageEventSpy = jest.spyOn(crowi.pageService.pageEvent, 'emit').mockImplementation();
-    });
-
-    describe('renamePage()', () => {
-      test('rename page with different tree with isRecursively', async() => {
-        const resultPage = await crowi.pageService.renamePage(parentForRename6, '/parentForRename6/renamedChild', testUser1, {}, true);
-        const wrongPage = await Page.findOne({ path: '/parentForRename6/renamedChild/renamedChild' });
-        const expectPage = await Page.findOne({ path: '/parentForRename6/renamedChild' });
-
-        expect(resultPage.path).toEqual(expectPage.path);
-        expect(wrongPage).toBeNull();
-      });
-    });
-
   });
 
   describe('duplicate page', () => {

--- a/packages/app/src/test/service/page.test.js
+++ b/packages/app/src/test/service/page.test.js
@@ -18,6 +18,10 @@ let parentForRename6;
 let parentForRename7;
 let parentForRename8;
 let parentForRename9;
+
+let irrelevantPage1;
+let irrelevantPage2;
+
 let childForRename1;
 let childForRename2;
 let childForRename3;
@@ -122,6 +126,18 @@ describe('PageService', () => {
         lastUpdateUser: testUser1,
       },
       {
+        path: '/parentForRename6-2021H1',
+        grant: Page.GRANT_PUBLIC,
+        creator: testUser1,
+        lastUpdateUser: testUser1,
+      },
+      {
+        path: '/level1-2021H1',
+        grant: Page.GRANT_PUBLIC,
+        creator: testUser1,
+        lastUpdateUser: testUser1,
+      },
+      {
         path: '/parentForRename1/child',
         grant: Page.GRANT_PUBLIC,
         creator: testUser1,
@@ -215,6 +231,9 @@ describe('PageService', () => {
     parentForRename8 = await Page.findOne({ path: '/level1/level2/child' });
     parentForRename9 = await Page.findOne({ path: '/level1/level2/level2' });
 
+    irrelevantPage1 = await Page.findOne({ path: '/parentForRename6-2021H1' });
+    irrelevantPage2 = await Page.findOne({ path: '/level1-2021H1' });
+
     parentForDuplicate = await Page.findOne({ path: '/parentForDuplicate' });
 
     parentForDelete1 = await Page.findOne({ path: '/parentForDelete1' });
@@ -267,9 +286,11 @@ describe('PageService', () => {
     test('rename page with different tree with isRecursively [deeper]', async() => {
       const resultPage = await crowi.pageService.renamePage(parentForRename6, '/parentForRename6/renamedChild', testUser1, {}, true);
       const wrongPage = await Page.findOne({ path: '/parentForRename6/renamedChild/renamedChild' });
-      const expectPage = await Page.findOne({ path: '/parentForRename6/renamedChild' });
+      const expectPage1 = await Page.findOne({ path: '/parentForRename6/renamedChild' });
+      const expectPage2 = await Page.findOne({ path: '/parentForRename6-2021H1' });
 
-      expect(resultPage.path).toEqual(expectPage.path);
+      expect(resultPage.path).toEqual(expectPage1.path);
+      expect(expectPage2.path).not.toBeNull();
       expect(wrongPage).toBeNull();
     });
 
@@ -278,10 +299,12 @@ describe('PageService', () => {
       const expectPage1 = await Page.findOne({ path: '/level1' });
       const expectPage2 = await Page.findOne({ path: '/level1/child' });
       const expectPage3 = await Page.findOne({ path: '/level1/level2' });
+      const expectPage4 = await Page.findOne({ path: '/level1-2021H1' });
 
       expect(expectPage1).not.toBeNull();
       expect(expectPage2).not.toBeNull();
       expect(expectPage3).not.toBeNull();
+      expect(expectPage4).not.toBeNull();
     });
   });
 

--- a/packages/app/src/test/service/page.test.js
+++ b/packages/app/src/test/service/page.test.js
@@ -18,7 +18,6 @@ let parentForRename6;
 let parentForRename7;
 let parentForRename8;
 let parentForRename9;
-
 let childForRename1;
 let childForRename2;
 let childForRename3;
@@ -265,33 +264,25 @@ describe('PageService', () => {
   });
 
   describe('rename page without using renameDescendantsWithStreamSpy', () => {
-    let pageEventSpy;
-    beforeEach(async() => {
-      pageEventSpy = jest.spyOn(crowi.pageService.pageEvent, 'emit').mockImplementation();
+    test('rename page with different tree with isRecursively [deeper]', async() => {
+      const resultPage = await crowi.pageService.renamePage(parentForRename6, '/parentForRename6/renamedChild', testUser1, {}, true);
+      const wrongPage = await Page.findOne({ path: '/parentForRename6/renamedChild/renamedChild' });
+      const expectPage = await Page.findOne({ path: '/parentForRename6/renamedChild' });
+
+      expect(resultPage.path).toEqual(expectPage.path);
+      expect(wrongPage).toBeNull();
     });
 
-    describe('renamePage()', () => {
-      test('rename page with different tree with isRecursively [deeper]', async() => {
-        const resultPage = await crowi.pageService.renamePage(parentForRename6, '/parentForRename6/renamedChild', testUser1, {}, true);
-        const wrongPage = await Page.findOne({ path: '/parentForRename6/renamedChild/renamedChild' });
-        const expectPage = await Page.findOne({ path: '/parentForRename6/renamedChild' });
+    test('rename page with different tree with isRecursively [shallower]', async() => {
+      await crowi.pageService.renamePage(parentForRename7, '/level1', testUser1, {}, true);
+      const expectPage1 = await Page.findOne({ path: '/level1' });
+      const expectPage2 = await Page.findOne({ path: '/level1/child' });
+      const expectPage3 = await Page.findOne({ path: '/level1/level2' });
 
-        expect(resultPage.path).toEqual(expectPage.path);
-        expect(wrongPage).toBeNull();
-      });
-
-      test('rename page with different tree with isRecursively [shallower]', async() => {
-        await crowi.pageService.renamePage(parentForRename7, '/level1', testUser1, {}, true);
-        const expectPage1 = await Page.findOne({ path: '/level1' });
-        const expectPage2 = await Page.findOne({ path: '/level1/child' });
-        const expectPage3 = await Page.findOne({ path: '/level1/level2' });
-
-        expect(expectPage1).not.toBeNull();
-        expect(expectPage2).not.toBeNull();
-        expect(expectPage3).not.toBeNull();
-      });
+      expect(expectPage1).not.toBeNull();
+      expect(expectPage2).not.toBeNull();
+      expect(expectPage3).not.toBeNull();
     });
-
   });
 
   describe('rename page', () => {

--- a/packages/app/src/test/service/page.test.js
+++ b/packages/app/src/test/service/page.test.js
@@ -14,6 +14,7 @@ let parentForRename1;
 let parentForRename2;
 let parentForRename3;
 let parentForRename4;
+let parentForRename6;
 
 let childForRename1;
 let childForRename2;
@@ -90,6 +91,12 @@ describe('PageService', () => {
       },
       {
         path: '/parentForRename4',
+        grant: Page.GRANT_PUBLIC,
+        creator: testUser1,
+        lastUpdateUser: testUser1,
+      },
+      {
+        path: '/parentForRename6',
         grant: Page.GRANT_PUBLIC,
         creator: testUser1,
         lastUpdateUser: testUser1,
@@ -183,6 +190,7 @@ describe('PageService', () => {
     parentForRename2 = await Page.findOne({ path: '/parentForRename2' });
     parentForRename3 = await Page.findOne({ path: '/parentForRename3' });
     parentForRename4 = await Page.findOne({ path: '/parentForRename4' });
+    parentForRename6 = await Page.findOne({ path: '/parentForRename5' });
 
     parentForDuplicate = await Page.findOne({ path: '/parentForDuplicate' });
 

--- a/packages/app/src/test/service/page.test.js
+++ b/packages/app/src/test/service/page.test.js
@@ -404,6 +404,24 @@ describe('PageService', () => {
     });
   });
 
+  describe('rename page without using renameDescendantsWithStreamSpy', () => {
+    let pageEventSpy;
+    beforeEach(async() => {
+      pageEventSpy = jest.spyOn(crowi.pageService.pageEvent, 'emit').mockImplementation();
+    });
+
+    describe('renamePage()', () => {
+      test('rename page with different tree with isRecursively', async() => {
+        const resultPage = await crowi.pageService.renamePage(parentForRename6, '/parentForRename6/renamedChild', testUser1, {}, true);
+        const wrongPage = await Page.findOne({ path: '/parentForRename6/renamedChild/renamedChild' });
+        const expectPage = await Page.findOne({ path: '/parentForRename6/renamedChild' });
+
+        expect(resultPage.path).toEqual(expectPage.path);
+        expect(wrongPage).toBeNull();
+      });
+    });
+
+  });
 
   describe('duplicate page', () => {
     let duplicateDescendantsWithStreamSpy;

--- a/packages/app/src/test/service/page.test.js
+++ b/packages/app/src/test/service/page.test.js
@@ -291,6 +291,8 @@ describe('PageService', () => {
 
       expect(resultPage.path).toEqual(expectPage1.path);
       expect(expectPage2.path).not.toBeNull();
+
+      // Check that pages that are not to be renamed have not been renamed
       expect(wrongPage).toBeNull();
     });
 
@@ -304,6 +306,8 @@ describe('PageService', () => {
       expect(expectPage1).not.toBeNull();
       expect(expectPage2).not.toBeNull();
       expect(expectPage3).not.toBeNull();
+
+      // Check that pages that are not to be renamed have not been renamed
       expect(expectPage4).not.toBeNull();
     });
   });

--- a/packages/app/src/test/service/page.test.js
+++ b/packages/app/src/test/service/page.test.js
@@ -105,6 +105,24 @@ describe('PageService', () => {
         lastUpdateUser: testUser1,
       },
       {
+        path: '/level1/level2',
+        grant: Page.GRANT_PUBLIC,
+        creator: testUser1,
+        lastUpdateUser: testUser1,
+      },
+      {
+        path: '/level1/level2/child',
+        grant: Page.GRANT_PUBLIC,
+        creator: testUser1,
+        lastUpdateUser: testUser1,
+      },
+      {
+        path: '/level1/level2/level2',
+        grant: Page.GRANT_PUBLIC,
+        creator: testUser1,
+        lastUpdateUser: testUser1,
+      },
+      {
         path: '/parentForRename1/child',
         grant: Page.GRANT_PUBLIC,
         creator: testUser1,
@@ -194,6 +212,9 @@ describe('PageService', () => {
     parentForRename3 = await Page.findOne({ path: '/parentForRename3' });
     parentForRename4 = await Page.findOne({ path: '/parentForRename4' });
     parentForRename6 = await Page.findOne({ path: '/parentForRename6' });
+    parentForRename7 = await Page.findOne({ path: '/level1/level2' });
+    parentForRename8 = await Page.findOne({ path: '/level1/level2/child' });
+    parentForRename9 = await Page.findOne({ path: '/level1/level2/level2' });
 
     parentForDuplicate = await Page.findOne({ path: '/parentForDuplicate' });
 
@@ -257,6 +278,17 @@ describe('PageService', () => {
 
         expect(resultPage.path).toEqual(expectPage.path);
         expect(wrongPage).toBeNull();
+      });
+
+      test('rename page with different tree with isRecursively [shallower]', async() => {
+        await crowi.pageService.renamePage(parentForRename7, '/level1', testUser1, {}, true);
+        const expectPage1 = await Page.findOne({ path: '/level1' });
+        const expectPage2 = await Page.findOne({ path: '/level1/child' });
+        const expectPage3 = await Page.findOne({ path: '/level1/level2' });
+
+        expect(expectPage1).not.toBeNull();
+        expect(expectPage2).not.toBeNull();
+        expect(expectPage3).not.toBeNull();
       });
     });
 

--- a/packages/app/src/test/service/page.test.js
+++ b/packages/app/src/test/service/page.test.js
@@ -15,6 +15,9 @@ let parentForRename2;
 let parentForRename3;
 let parentForRename4;
 let parentForRename6;
+let parentForRename7;
+let parentForRename8;
+let parentForRename9;
 
 let childForRename1;
 let childForRename2;
@@ -247,7 +250,7 @@ describe('PageService', () => {
     });
 
     describe('renamePage()', () => {
-      test('rename page with different tree with isRecursively', async() => {
+      test('rename page with different tree with isRecursively [deeper]', async() => {
         const resultPage = await crowi.pageService.renamePage(parentForRename6, '/parentForRename6/renamedChild', testUser1, {}, true);
         const wrongPage = await Page.findOne({ path: '/parentForRename6/renamedChild/renamedChild' });
         const expectPage = await Page.findOne({ path: '/parentForRename6/renamedChild' });

--- a/packages/app/src/test/service/page.test.js
+++ b/packages/app/src/test/service/page.test.js
@@ -190,7 +190,7 @@ describe('PageService', () => {
     parentForRename2 = await Page.findOne({ path: '/parentForRename2' });
     parentForRename3 = await Page.findOne({ path: '/parentForRename3' });
     parentForRename4 = await Page.findOne({ path: '/parentForRename4' });
-    parentForRename6 = await Page.findOne({ path: '/parentForRename5' });
+    parentForRename6 = await Page.findOne({ path: '/parentForRename6' });
 
     parentForDuplicate = await Page.findOne({ path: '/parentForDuplicate' });
 


### PR DESCRIPTION
## 概要

[こちらの FB ](https://github.com/weseek/growi/pull/4178#issue-718382325) で頂いた以下3点のテストを  renameDescendantsWithStreamSpy を使わない形式で追加しました。
- より深い階層への移動
- より浅い階層への移動
- その他の懸念点