### PR TITLE
GW-6986 [front] ユーザーがON/Offを切り替える用のUIを表示させる(見た目のみ)

### DIFF
--- a/packages/app/src/components/PageEditor/OptionsSelector.jsx
+++ b/packages/app/src/components/PageEditor/OptionsSelector.jsx
@@ -207,6 +207,7 @@ class OptionsSelector extends React.Component {
             {this.renderActiveLineMenuItem()}
             {this.renderRealtimeMathJaxMenuItem()}
             {this.renderMarkdownTableAutoFormattingMenuItem()}
+            {this.renderIsTextlintEnabledMenuItem()}
             {/* <DropdownItem divider /> */}
           </DropdownMenu>
 
@@ -280,6 +281,28 @@ class OptionsSelector extends React.Component {
         <div className="d-flex justify-content-between">
           <span className="icon-container"></span>
           <span className="menuitem-label">{ t('page_edit.auto_format_table') }</span>
+          <span className="icon-container"><i className={iconClassName}></i></span>
+        </div>
+      </DropdownItem>
+    );
+  }
+
+  renderIsTextlintEnabledMenuItem() {
+    // TODO: GW-6988 connect to back end
+    const isActive = true;
+    const iconClasses = ['text-info'];
+    if (isActive) {
+      iconClasses.push('ti-check');
+    }
+    const iconClassName = iconClasses.join(' ');
+
+    return (
+      // TODO: GW-6988 connect to back end
+      // eslint-disable-next-line no-console
+      <DropdownItem toggle={false} onClick={console.log('Lint button pressed')}>
+        <div className="d-flex justify-content-between">
+          <span className="icon-container"></span>
+          <span className="menuitem-label">Textlint</span>
           <span className="icon-container"><i className={iconClassName}></i></span>
         </div>
       </DropdownItem>


### PR DESCRIPTION
Editor画面からTextlintのON/OFFの切り替えを行うMenuを追加しました。
ステートやBackendとの接続は後続タスクで行います。
User Settingsの各ルールのON/OFFは別ストーリーで対応予定です。

<img width="239" alt="Screen Shot 2021-08-26 at 17 11 31" src="https://user-images.githubusercontent.com/66785624/130927028-5492906c-c7a1-4a2b-b842-26344dad5f61.png">
