### PR TITLE
Imprv/gw7244 editor settings view

### DIFF
--- a/packages/app/src/components/Me/EditorSettings.tsx
+++ b/packages/app/src/components/Me/EditorSettings.tsx
@@ -1,6 +1,5 @@
 import React, { FC } from 'react';
 import { useTranslation } from 'react-i18next';
-import PropTypes from 'prop-types';
 
 
 type Props = {
@@ -20,8 +19,8 @@ export const WithoutJapaneseTextLintRulesSettings: FC<Props> = () => {
 
 
 export const EditorSettings: FC<Props> = () => {
+  // TODO: apply i18n by GW-7244
   const { t } = useTranslation();
-  // TODO: apply i18n byGW-7244
 
   return (
     <>
@@ -41,6 +40,9 @@ export const EditorSettings: FC<Props> = () => {
             <label className="custom-control-label" htmlFor="ja-hiragana-keishikimeishi">
               <strong>ja-hiragana-keishikimeishi</strong>
             </label>
+            <p className="form-text text-muted small">
+              Textlint rules to check easy-to-read Keishikimeishi(pronouns) written in Hiragana than Kanji.
+            </p>
           </div>
 
           <div className="custom-control custom-switch custom-checkbox-success">
@@ -54,6 +56,9 @@ export const EditorSettings: FC<Props> = () => {
             <label className="custom-control-label" htmlFor="ja-no-abusage">
               <strong>ja-no-abusage</strong>
             </label>
+            <p className="form-text text-muted small">
+              Textlint rules to check for common misuse
+            </p>
           </div>
 
           <div className="custom-control custom-switch custom-checkbox-success">
@@ -67,6 +72,9 @@ export const EditorSettings: FC<Props> = () => {
             <label className="custom-control-label" htmlFor="ja-no-inappropriate-words">
               <strong>ja-no-inappropriate-words</strong>
             </label>
+            <p className="form-text text-muted small">
+              Textlint rule to check for inappropriate expressions
+            </p>
           </div>
 
           <div className="custom-control custom-switch custom-checkbox-success">
@@ -80,6 +88,9 @@ export const EditorSettings: FC<Props> = () => {
             <label className="custom-control-label" htmlFor="ja-no-mixed-period">
               <strong>ja-no-mixed-period</strong>
             </label>
+            <p className="form-text text-muted small">
+              A rule to check that a paragraph always has a punctuation mark at the end
+            </p>
           </div>
 
           <div className="custom-control custom-switch custom-checkbox-success">
@@ -93,6 +104,10 @@ export const EditorSettings: FC<Props> = () => {
             <label className="custom-control-label" htmlFor="ja-no-redundant-expression">
               <strong>ja-no-redundant-expression</strong>
             </label>
+            <p className="form-text text-muted small">
+              A textlint rule that prohibits redundant expressions.
+              Redundant expressions are expressions that make sense even if they are omitted from the sentence.
+            </p>
           </div>
 
           <div className="custom-control custom-switch custom-checkbox-success">
@@ -106,6 +121,9 @@ export const EditorSettings: FC<Props> = () => {
             <label className="custom-control-label" htmlFor="max-kanji-continuous-len">
               <strong>max-kanji-continuous-len</strong>
             </label>
+            <p className="form-text text-muted small">
+              {t('admin:app_setting.file_delivery_method_redirect_info')}
+            </p>
           </div>
 
           <div className="custom-control custom-switch custom-checkbox-success">
@@ -119,6 +137,9 @@ export const EditorSettings: FC<Props> = () => {
             <label className="custom-control-label" htmlFor="max-ten">
               <strong>max-ten</strong>
             </label>
+            <p className="form-text text-muted small">
+              textlint rule is that limit maximum ten(、) count of sentence.
+            </p>
           </div>
 
           <div className="custom-control custom-switch custom-checkbox-success">
@@ -132,6 +153,9 @@ export const EditorSettings: FC<Props> = () => {
             <label className="custom-control-label" htmlFor="no-double-negative-ja">
               <strong>no-double-negative-ja</strong>
             </label>
+            <p className="form-text text-muted small">
+              A textlint rule that detects double negation.
+            </p>
           </div>
 
           <div className="custom-control custom-switch custom-checkbox-success">
@@ -145,6 +169,9 @@ export const EditorSettings: FC<Props> = () => {
             <label className="custom-control-label" htmlFor="no-doubled-conjunction">
               <strong>no-doubled-conjunction</strong>
             </label>
+            <p className="form-text text-muted small">
+              This module is a textlint plugin to check duplicated same conjunctions.
+            </p>
           </div>
 
           <div className="custom-control custom-switch custom-checkbox-success">
@@ -158,6 +185,9 @@ export const EditorSettings: FC<Props> = () => {
             <label className="custom-control-label" htmlFor="no-doubled-joshi">
               <strong>no-doubled-joshi</strong>
             </label>
+            <p className="form-text text-muted small">
+              A textlint rule that checks that the same particle appears consecutively in one sentence.
+            </p>
           </div>
 
           <div className="custom-control custom-switch custom-checkbox-success">
@@ -171,6 +201,9 @@ export const EditorSettings: FC<Props> = () => {
             <label className="custom-control-label" htmlFor="no-dropping-the-ra">
               <strong>no-dropping-the-ra</strong>
             </label>
+            <p className="form-text text-muted small">
+              A textlint rule that disallow to use Half-width kana.
+            </p>
           </div>
 
           <div className="custom-control custom-switch custom-checkbox-success">
@@ -184,6 +217,9 @@ export const EditorSettings: FC<Props> = () => {
             <label className="custom-control-label" htmlFor="no-hankaku-kana">
               <strong>no-hankaku-kana</strong>
             </label>
+            <p className="form-text text-muted small">
+              A textlint rule that checks tari tari.
+            </p>
           </div>
 
           <div className="custom-control custom-switch custom-checkbox-success">
@@ -197,6 +233,9 @@ export const EditorSettings: FC<Props> = () => {
             <label className="custom-control-label" htmlFor="prefer-tari-tari">
               <strong>prefer-tari-tari</strong>
             </label>
+            <p className="form-text text-muted small">
+              {t('admin:app_setting.file_delivery_method_redirect_info')}
+            </p>
           </div>
 
           <div className="row my-3">
@@ -227,6 +266,9 @@ export const EditorSettings: FC<Props> = () => {
             <label className="custom-control-label" htmlFor="common-misspellings">
               <strong>common-misspellings</strong>
             </label>
+            <p className="form-text text-muted small">
+              {t('admin:app_setting.file_delivery_method_redirect_info')}
+            </p>
           </div>
 
           <div className="custom-control custom-switch custom-checkbox-success">
@@ -240,6 +282,9 @@ export const EditorSettings: FC<Props> = () => {
             <label className="custom-control-label" htmlFor="max-comma">
               <strong>max-comma</strong>
             </label>
+            <p className="form-text text-muted small">
+              {t('admin:app_setting.file_delivery_method_redirect_info')}
+            </p>
           </div>
 
           <div className="custom-control custom-switch custom-checkbox-success">
@@ -253,6 +298,9 @@ export const EditorSettings: FC<Props> = () => {
             <label className="custom-control-label" htmlFor="sentence-length">
               <strong>sentence-length</strong>
             </label>
+            <p className="form-text text-muted small">
+              {t('admin:app_setting.file_delivery_method_redirect_info')}
+            </p>
           </div>
 
           <div className="row my-3">

--- a/packages/app/src/components/Me/EditorSettings.tsx
+++ b/packages/app/src/components/Me/EditorSettings.tsx
@@ -24,7 +24,7 @@ export const EditorSettings: FC<Props> = () => {
 
   return (
     <>
-      <h4 className="mt-4">Japanese Settings</h4>
+      <h2 className="border-bottom my-4">Japanese Settings</h2>
 
       <div className="form-group row">
         <div className="offset-md-3 col-md-6 text-left">
@@ -250,7 +250,7 @@ export const EditorSettings: FC<Props> = () => {
       </div>
 
 
-      <h4 className="mt-4">Common Settings</h4>
+      <h2 className="border-bottom my-4">Common Settings</h2>
 
       <div className="form-group row">
         <div className="offset-md-3 col-md-6 text-left">

--- a/packages/app/src/components/Me/EditorSettings.tsx
+++ b/packages/app/src/components/Me/EditorSettings.tsx
@@ -267,7 +267,7 @@ export const EditorSettings: FC<Props> = () => {
               <strong>common-misspellings</strong>
             </label>
             <p className="form-text text-muted small">
-              {t('admin:app_setting.file_delivery_method_redirect_info')}
+              A textlint rule to find common misspellings from Wikipedia: Lists of common misspellings.
             </p>
           </div>
 
@@ -283,7 +283,9 @@ export const EditorSettings: FC<Props> = () => {
               <strong>max-comma</strong>
             </label>
             <p className="form-text text-muted small">
-              {t('admin:app_setting.file_delivery_method_redirect_info')}
+              max: maximum number of , <br />
+              Default: 4
+
             </p>
           </div>
 
@@ -299,7 +301,7 @@ export const EditorSettings: FC<Props> = () => {
               <strong>sentence-length</strong>
             </label>
             <p className="form-text text-muted small">
-              {t('admin:app_setting.file_delivery_method_redirect_info')}
+              A textlint rule that limit Maximum Length of Sentence.
             </p>
           </div>
 

--- a/packages/app/src/components/Me/EditorSettings.tsx
+++ b/packages/app/src/components/Me/EditorSettings.tsx
@@ -5,13 +5,13 @@ import { useTranslation } from 'react-i18next';
 type Props = {
 }
 
-export const JapaneseTextLintRuleSettings: FC<Props> = () => {
+export const ClickJapaneseTextLintRuleSettingsHandler: FC<Props> = () => {
   return (
     <></>
   );
 };
 
-export const WithoutJapaneseTextLintRulesSettings: FC<Props> = () => {
+export const ClickCommonTextLintRulesSettingsHandler: FC<Props> = () => {
   return (
     <></>
   );
@@ -138,7 +138,7 @@ export const EditorSettings: FC<Props> = () => {
               <strong>max-ten</strong>
             </label>
             <p className="form-text text-muted small">
-              textlint rule is that limit maximum ten(、) count of sentence.
+              Textlint rule is that limit maximum ten(、) count of sentence.
             </p>
           </div>
 
@@ -283,7 +283,7 @@ export const EditorSettings: FC<Props> = () => {
               <strong>max-comma</strong>
             </label>
             <p className="form-text text-muted small">
-              textlint rule is that limit maximum ten(、) count of sentence. <br />
+              Textlint rule is that limit maximum ten(、) count of sentence. <br />
               Default: 4
             </p>
           </div>

--- a/packages/app/src/components/Me/EditorSettings.tsx
+++ b/packages/app/src/components/Me/EditorSettings.tsx
@@ -26,62 +26,210 @@ export const EditorSettings: FC<Props> = () => {
   return (
     <>
       <h4 className="mt-4">Japanese Settings</h4>
-      <div className="offset-lg-2  col-lg-9">
-        <div className="row">
+      {/* <div className="offset-lg-2  col-lg-9">
+        <div className="row"> */}
 
-          <table className="table table-bordered col-lg-8 mb-5">
-            <thead>
-              <tr>
-                <th scope="col">{ t('scope_of_page_disclosure') }</th>
-                <th scope="col">{ t('set_point') }</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <th scope="row">{ t('Public') }</th>
-                <td>{ t('always_displayed') }</td>
-              </tr>
-              <tr>
-                <th scope="row">{ t('Anyone with the link') }</th>
-                <td>{ t('always_hidden') }</td>
-              </tr>
-              <tr>
-                <th scope="row">{ t('Only me') }</th>
-                <td>
-                  <div className="custom-control custom-switch custom-checkbox-success">
-                    <input
-                      type="checkbox"
-                      className="custom-control-input"
-                      id="isShowRestrictedByOwner"
-                      // checked={adminGeneralSecurityContainer.state.isShowRestrictedByOwner}
-                      // onChange={() => { adminGeneralSecurityContainer.switchIsShowRestrictedByOwner() }}
-                    />
-                    <label className="custom-control-label" htmlFor="isShowRestrictedByOwner">
-                      {t('displayed_or_hidden')}
-                    </label>
-                  </div>
-                </td>
-              </tr>
-              <tr>
-                <th scope="row">{ t('Only inside the group') }</th>
-                <td>
-                  <div className="custom-control custom-switch custom-checkbox-success">
-                    <input
-                      type="checkbox"
-                      className="custom-control-input"
-                      id="isShowRestrictedByGroup"
-                      // checked={adminGeneralSecurityContainer.state.isShowRestrictedByGroup}
-                      // onChange={() => { adminGeneralSecurityContainer.switchIsShowRestrictedByGroup() }}
-                    />
-                    <label className="custom-control-label" htmlFor="isShowRestrictedByGroup">
-                      {t('displayed_or_hidden')}
-                    </label>
-                  </div>
-                </td>
-              </tr>
-            </tbody>
-          </table>
+      <div className="form-group row">
+        <div className="offset-md-3 col-md-6 text-left">
 
+          <div className="custom-control custom-switch custom-checkbox-success">
+            <input
+              type="checkbox"
+              className="custom-control-input"
+              id="highlightBorder"
+              // checked={adminCustomizeContainer.state.isHighlightJsStyleBorderEnabled}
+              // onChange={() => { adminCustomizeContainer.switchHighlightJsStyleBorder() }}
+            />
+            <label className="custom-control-label" htmlFor="highlightBorder">
+              <strong>Border</strong>
+            </label>
+          </div>
+
+          <div className="custom-control custom-switch custom-checkbox-success">
+            <input
+              type="checkbox"
+              className="custom-control-input"
+              id="highlightBorder"
+              // checked={adminCustomizeContainer.state.isHighlightJsStyleBorderEnabled}
+              // onChange={() => { adminCustomizeContainer.switchHighlightJsStyleBorder() }}
+            />
+            <label className="custom-control-label" htmlFor="highlightBorder">
+              <strong>Border</strong>
+            </label>
+          </div>
+
+          <div className="custom-control custom-switch custom-checkbox-success">
+            <input
+              type="checkbox"
+              className="custom-control-input"
+              id="highlightBorder"
+              // checked={adminCustomizeContainer.state.isHighlightJsStyleBorderEnabled}
+              // onChange={() => { adminCustomizeContainer.switchHighlightJsStyleBorder() }}
+            />
+            <label className="custom-control-label" htmlFor="highlightBorder">
+              <strong>Border</strong>
+            </label>
+          </div>
+
+          <div className="custom-control custom-switch custom-checkbox-success">
+            <input
+              type="checkbox"
+              className="custom-control-input"
+              id="highlightBorder"
+              // checked={adminCustomizeContainer.state.isHighlightJsStyleBorderEnabled}
+              // onChange={() => { adminCustomizeContainer.switchHighlightJsStyleBorder() }}
+            />
+            <label className="custom-control-label" htmlFor="highlightBorder">
+              <strong>Border</strong>
+            </label>
+          </div>
+
+          <div className="custom-control custom-switch custom-checkbox-success">
+            <input
+              type="checkbox"
+              className="custom-control-input"
+              id="highlightBorder"
+              // checked={adminCustomizeContainer.state.isHighlightJsStyleBorderEnabled}
+              // onChange={() => { adminCustomizeContainer.switchHighlightJsStyleBorder() }}
+            />
+            <label className="custom-control-label" htmlFor="highlightBorder">
+              <strong>Border</strong>
+            </label>
+          </div>
+
+          <div className="custom-control custom-switch custom-checkbox-success">
+            <input
+              type="checkbox"
+              className="custom-control-input"
+              id="highlightBorder"
+              // checked={adminCustomizeContainer.state.isHighlightJsStyleBorderEnabled}
+              // onChange={() => { adminCustomizeContainer.switchHighlightJsStyleBorder() }}
+            />
+            <label className="custom-control-label" htmlFor="highlightBorder">
+              <strong>Border</strong>
+            </label>
+          </div>
+
+          <div className="custom-control custom-switch custom-checkbox-success">
+            <input
+              type="checkbox"
+              className="custom-control-input"
+              id="highlightBorder"
+              // checked={adminCustomizeContainer.state.isHighlightJsStyleBorderEnabled}
+              // onChange={() => { adminCustomizeContainer.switchHighlightJsStyleBorder() }}
+            />
+            <label className="custom-control-label" htmlFor="highlightBorder">
+              <strong>Border</strong>
+            </label>
+          </div>
+
+          <div className="custom-control custom-switch custom-checkbox-success">
+            <input
+              type="checkbox"
+              className="custom-control-input"
+              id="highlightBorder"
+              // checked={adminCustomizeContainer.state.isHighlightJsStyleBorderEnabled}
+              // onChange={() => { adminCustomizeContainer.switchHighlightJsStyleBorder() }}
+            />
+            <label className="custom-control-label" htmlFor="highlightBorder">
+              <strong>Border</strong>
+            </label>
+          </div>
+
+          <div className="custom-control custom-switch custom-checkbox-success">
+            <input
+              type="checkbox"
+              className="custom-control-input"
+              id="highlightBorder"
+              // checked={adminCustomizeContainer.state.isHighlightJsStyleBorderEnabled}
+              // onChange={() => { adminCustomizeContainer.switchHighlightJsStyleBorder() }}
+            />
+            <label className="custom-control-label" htmlFor="highlightBorder">
+              <strong>Border</strong>
+            </label>
+          </div>
+
+          <div className="custom-control custom-switch custom-checkbox-success">
+            <input
+              type="checkbox"
+              className="custom-control-input"
+              id="highlightBorder"
+              // checked={adminCustomizeContainer.state.isHighlightJsStyleBorderEnabled}
+              // onChange={() => { adminCustomizeContainer.switchHighlightJsStyleBorder() }}
+            />
+            <label className="custom-control-label" htmlFor="highlightBorder">
+              <strong>Border</strong>
+            </label>
+          </div>
+
+          <div className="custom-control custom-switch custom-checkbox-success">
+            <input
+              type="checkbox"
+              className="custom-control-input"
+              id="highlightBorder"
+              // checked={adminCustomizeContainer.state.isHighlightJsStyleBorderEnabled}
+              // onChange={() => { adminCustomizeContainer.switchHighlightJsStyleBorder() }}
+            />
+            <label className="custom-control-label" htmlFor="highlightBorder">
+              <strong>Border</strong>
+            </label>
+          </div>
+
+          <div className="custom-control custom-switch custom-checkbox-success">
+            <input
+              type="checkbox"
+              className="custom-control-input"
+              id="highlightBorder"
+              // checked={adminCustomizeContainer.state.isHighlightJsStyleBorderEnabled}
+              // onChange={() => { adminCustomizeContainer.switchHighlightJsStyleBorder() }}
+            />
+            <label className="custom-control-label" htmlFor="highlightBorder">
+              <strong>Border</strong>
+            </label>
+          </div>
+
+          <div className="custom-control custom-switch custom-checkbox-success">
+            <input
+              type="checkbox"
+              className="custom-control-input"
+              id="highlightBorder"
+              // checked={adminCustomizeContainer.state.isHighlightJsStyleBorderEnabled}
+              // onChange={() => { adminCustomizeContainer.switchHighlightJsStyleBorder() }}
+            />
+            <label className="custom-control-label" htmlFor="highlightBorder">
+              <strong>Border</strong>
+            </label>
+          </div>
+
+          <div className="row my-3">
+            <div className="offset-4 col-5">
+              <button type="button" className="btn btn-primary">
+                {t('Update')}
+              </button>
+            </div>
+          </div>
+
+        </div>
+      </div>
+
+
+      <h4 className="mt-4">Common Settings</h4>
+
+      <div className="form-group row">
+        <div className="offset-md-3 col-md-6 text-left">
+
+          <div className="custom-control custom-switch custom-checkbox-success">
+            <input
+              type="checkbox"
+              className="custom-control-input"
+              id="highlightBorder"
+              // checked={adminCustomizeContainer.state.isHighlightJsStyleBorderEnabled}
+              // onChange={() => { adminCustomizeContainer.switchHighlightJsStyleBorder() }}
+            />
+            <label className="custom-control-label" htmlFor="highlightBorder">
+              <strong>Border</strong>
+            </label>
+          </div>
         </div>
       </div>
     </>

--- a/packages/app/src/components/Me/EditorSettings.tsx
+++ b/packages/app/src/components/Me/EditorSettings.tsx
@@ -24,6 +24,72 @@ export const EditorSettings: FC<Props> = () => {
 
   return (
     <>
+      <h2 className="border-bottom my-4">Common Settings</h2>
+
+      <div className="form-group row">
+        <div className="offset-md-3 col-md-6 text-left">
+
+          <div className="custom-control custom-switch custom-checkbox-success">
+            <input
+              type="checkbox"
+              className="custom-control-input"
+              id="common-misspellings"
+              // checked={}
+              // onChange={}
+            />
+            <label className="custom-control-label" htmlFor="common-misspellings">
+              <strong>common-misspellings</strong>
+            </label>
+            <p className="form-text text-muted small">
+              Textlint rules to find common misspellings from Wikipedia: Lists of common misspellings.
+            </p>
+          </div>
+
+          <div className="custom-control custom-switch custom-checkbox-success">
+            <input
+              type="checkbox"
+              className="custom-control-input"
+              id="max-comma"
+              // checked={}
+              // onChange={}
+            />
+            <label className="custom-control-label" htmlFor="max-comma">
+              <strong>max-comma</strong>
+            </label>
+            <p className="form-text text-muted small">
+              Textlint rule is that limit maximum ten(、) count of sentence. <br />
+              Default: 4
+            </p>
+          </div>
+
+          <div className="custom-control custom-switch custom-checkbox-success">
+            <input
+              type="checkbox"
+              className="custom-control-input"
+              id="sentence-length"
+              // checked={}
+              // onChange={}
+            />
+            <label className="custom-control-label" htmlFor="sentence-length">
+              <strong>sentence-length</strong>
+            </label>
+            <p className="form-text text-muted small">
+              Textlint rules that limit Maximum Length of Sentence.
+            </p>
+          </div>
+
+          <div className="row my-3">
+            <div className="offset-4 col-5">
+              <button type="button" className="btn btn-primary">
+                {t('Update')}
+              </button>
+            </div>
+          </div>
+
+        </div>
+      </div>
+
+
       <h2 className="border-bottom my-4">Japanese Settings</h2>
 
       <div className="form-group row">
@@ -250,70 +316,6 @@ export const EditorSettings: FC<Props> = () => {
       </div>
 
 
-      <h2 className="border-bottom my-4">Common Settings</h2>
-
-      <div className="form-group row">
-        <div className="offset-md-3 col-md-6 text-left">
-
-          <div className="custom-control custom-switch custom-checkbox-success">
-            <input
-              type="checkbox"
-              className="custom-control-input"
-              id="common-misspellings"
-              // checked={}
-              // onChange={}
-            />
-            <label className="custom-control-label" htmlFor="common-misspellings">
-              <strong>common-misspellings</strong>
-            </label>
-            <p className="form-text text-muted small">
-              Textlint rules to find common misspellings from Wikipedia: Lists of common misspellings.
-            </p>
-          </div>
-
-          <div className="custom-control custom-switch custom-checkbox-success">
-            <input
-              type="checkbox"
-              className="custom-control-input"
-              id="max-comma"
-              // checked={}
-              // onChange={}
-            />
-            <label className="custom-control-label" htmlFor="max-comma">
-              <strong>max-comma</strong>
-            </label>
-            <p className="form-text text-muted small">
-              Textlint rule is that limit maximum ten(、) count of sentence. <br />
-              Default: 4
-            </p>
-          </div>
-
-          <div className="custom-control custom-switch custom-checkbox-success">
-            <input
-              type="checkbox"
-              className="custom-control-input"
-              id="sentence-length"
-              // checked={}
-              // onChange={}
-            />
-            <label className="custom-control-label" htmlFor="sentence-length">
-              <strong>sentence-length</strong>
-            </label>
-            <p className="form-text text-muted small">
-              Textlint rules that limit Maximum Length of Sentence.
-            </p>
-          </div>
-
-          <div className="row my-3">
-            <div className="offset-4 col-5">
-              <button type="button" className="btn btn-primary">
-                {t('Update')}
-              </button>
-            </div>
-          </div>
-
-        </div>
-      </div>
     </>
   );
 };

--- a/packages/app/src/components/Me/EditorSettings.tsx
+++ b/packages/app/src/components/Me/EditorSettings.tsx
@@ -257,6 +257,14 @@ export const EditorSettings: FC<Props> = () => {
             </label>
           </div>
 
+          <div className="row my-3">
+            <div className="offset-4 col-5">
+              <button type="button" className="btn btn-primary">
+                {t('Update')}
+              </button>
+            </div>
+          </div>
+
         </div>
       </div>
     </>

--- a/packages/app/src/components/Me/EditorSettings.tsx
+++ b/packages/app/src/components/Me/EditorSettings.tsx
@@ -73,7 +73,7 @@ export const EditorSettings: FC<Props> = () => {
               <strong>ja-no-inappropriate-words</strong>
             </label>
             <p className="form-text text-muted small">
-              Textlint rule to check for inappropriate expressions
+              Textlint rules to check for inappropriate expressions
             </p>
           </div>
 
@@ -89,7 +89,7 @@ export const EditorSettings: FC<Props> = () => {
               <strong>ja-no-mixed-period</strong>
             </label>
             <p className="form-text text-muted small">
-              A rule to check that a paragraph always has a punctuation mark at the end
+              Textlint rules to check that a paragraph always has a punctuation mark at the end
             </p>
           </div>
 
@@ -105,7 +105,7 @@ export const EditorSettings: FC<Props> = () => {
               <strong>ja-no-redundant-expression</strong>
             </label>
             <p className="form-text text-muted small">
-              A textlint rule that prohibits redundant expressions.
+              Textlint rules that prohibits redundant expressions.
               Redundant expressions are expressions that make sense even if they are omitted from the sentence.
             </p>
           </div>
@@ -122,7 +122,7 @@ export const EditorSettings: FC<Props> = () => {
               <strong>max-kanji-continuous-len</strong>
             </label>
             <p className="form-text text-muted small">
-              {t('admin:app_setting.file_delivery_method_redirect_info')}
+              Textlint rules that limits the maximum number of consecutive Kanji.
             </p>
           </div>
 
@@ -154,7 +154,7 @@ export const EditorSettings: FC<Props> = () => {
               <strong>no-double-negative-ja</strong>
             </label>
             <p className="form-text text-muted small">
-              A textlint rule that detects double negation.
+              Textlint rules that detects double negation.
             </p>
           </div>
 
@@ -170,7 +170,7 @@ export const EditorSettings: FC<Props> = () => {
               <strong>no-doubled-conjunction</strong>
             </label>
             <p className="form-text text-muted small">
-              This module is a textlint plugin to check duplicated same conjunctions.
+              Textlint rules to check duplicated same conjunctions.
             </p>
           </div>
 
@@ -186,7 +186,7 @@ export const EditorSettings: FC<Props> = () => {
               <strong>no-doubled-joshi</strong>
             </label>
             <p className="form-text text-muted small">
-              A textlint rule that checks that the same particle appears consecutively in one sentence.
+              Textlint rules that checks that the same particle appears consecutively in one sentence.
             </p>
           </div>
 
@@ -202,7 +202,7 @@ export const EditorSettings: FC<Props> = () => {
               <strong>no-dropping-the-ra</strong>
             </label>
             <p className="form-text text-muted small">
-              A textlint rule that detects the word dropping the ra.
+              Textlint rules that detects the word dropping the ra.
             </p>
           </div>
 
@@ -218,7 +218,7 @@ export const EditorSettings: FC<Props> = () => {
               <strong>no-hankaku-kana</strong>
             </label>
             <p className="form-text text-muted small">
-              A textlint rule that disallow to use Half-width kana.
+              Textlint rules that disallow to use Half-width kana.
             </p>
           </div>
 
@@ -234,7 +234,7 @@ export const EditorSettings: FC<Props> = () => {
               <strong>prefer-tari-tari</strong>
             </label>
             <p className="form-text text-muted small">
-              A textlint rule that checks tari tari.
+              Textlint rules that checks tari tari.
             </p>
           </div>
 
@@ -267,7 +267,7 @@ export const EditorSettings: FC<Props> = () => {
               <strong>common-misspellings</strong>
             </label>
             <p className="form-text text-muted small">
-              A textlint rule to find common misspellings from Wikipedia: Lists of common misspellings.
+              Textlint rules to find common misspellings from Wikipedia: Lists of common misspellings.
             </p>
           </div>
 
@@ -301,7 +301,7 @@ export const EditorSettings: FC<Props> = () => {
               <strong>sentence-length</strong>
             </label>
             <p className="form-text text-muted small">
-              A textlint rule that limit Maximum Length of Sentence.
+              Textlint rules that limit Maximum Length of Sentence.
             </p>
           </div>
 

--- a/packages/app/src/components/Me/EditorSettings.tsx
+++ b/packages/app/src/components/Me/EditorSettings.tsx
@@ -26,8 +26,6 @@ export const EditorSettings: FC<Props> = () => {
   return (
     <>
       <h4 className="mt-4">Japanese Settings</h4>
-      {/* <div className="offset-lg-2  col-lg-9">
-        <div className="row"> */}
 
       <div className="form-group row">
         <div className="offset-md-3 col-md-6 text-left">
@@ -36,12 +34,12 @@ export const EditorSettings: FC<Props> = () => {
             <input
               type="checkbox"
               className="custom-control-input"
-              id="highlightBorder"
+              id="ja-hiragana-keishikimeishi"
               // checked={adminCustomizeContainer.state.isHighlightJsStyleBorderEnabled}
               // onChange={() => { adminCustomizeContainer.switchHighlightJsStyleBorder() }}
             />
-            <label className="custom-control-label" htmlFor="highlightBorder">
-              <strong>Border</strong>
+            <label className="custom-control-label" htmlFor="ja-hiragana-keishikimeishi">
+              <strong>ja-hiragana-keishikimeishi</strong>
             </label>
           </div>
 
@@ -49,12 +47,12 @@ export const EditorSettings: FC<Props> = () => {
             <input
               type="checkbox"
               className="custom-control-input"
-              id="highlightBorder"
+              id="ja-no-abusage"
               // checked={adminCustomizeContainer.state.isHighlightJsStyleBorderEnabled}
               // onChange={() => { adminCustomizeContainer.switchHighlightJsStyleBorder() }}
             />
-            <label className="custom-control-label" htmlFor="highlightBorder">
-              <strong>Border</strong>
+            <label className="custom-control-label" htmlFor="ja-no-abusage">
+              <strong>ja-no-abusage</strong>
             </label>
           </div>
 
@@ -62,12 +60,12 @@ export const EditorSettings: FC<Props> = () => {
             <input
               type="checkbox"
               className="custom-control-input"
-              id="highlightBorder"
+              id="ja-no-inappropriate-words"
               // checked={adminCustomizeContainer.state.isHighlightJsStyleBorderEnabled}
               // onChange={() => { adminCustomizeContainer.switchHighlightJsStyleBorder() }}
             />
-            <label className="custom-control-label" htmlFor="highlightBorder">
-              <strong>Border</strong>
+            <label className="custom-control-label" htmlFor="ja-no-inappropriate-words">
+              <strong>ja-no-inappropriate-words</strong>
             </label>
           </div>
 
@@ -75,12 +73,12 @@ export const EditorSettings: FC<Props> = () => {
             <input
               type="checkbox"
               className="custom-control-input"
-              id="highlightBorder"
+              id="ja-no-mixed-period"
               // checked={adminCustomizeContainer.state.isHighlightJsStyleBorderEnabled}
               // onChange={() => { adminCustomizeContainer.switchHighlightJsStyleBorder() }}
             />
-            <label className="custom-control-label" htmlFor="highlightBorder">
-              <strong>Border</strong>
+            <label className="custom-control-label" htmlFor="ja-no-mixed-period">
+              <strong>ja-no-mixed-period</strong>
             </label>
           </div>
 
@@ -88,12 +86,12 @@ export const EditorSettings: FC<Props> = () => {
             <input
               type="checkbox"
               className="custom-control-input"
-              id="highlightBorder"
+              id="ja-no-redundant-expression"
               // checked={adminCustomizeContainer.state.isHighlightJsStyleBorderEnabled}
               // onChange={() => { adminCustomizeContainer.switchHighlightJsStyleBorder() }}
             />
-            <label className="custom-control-label" htmlFor="highlightBorder">
-              <strong>Border</strong>
+            <label className="custom-control-label" htmlFor="ja-no-redundant-expression">
+              <strong>ja-no-redundant-expression</strong>
             </label>
           </div>
 
@@ -101,12 +99,12 @@ export const EditorSettings: FC<Props> = () => {
             <input
               type="checkbox"
               className="custom-control-input"
-              id="highlightBorder"
+              id="max-kanji-continuous-len"
               // checked={adminCustomizeContainer.state.isHighlightJsStyleBorderEnabled}
               // onChange={() => { adminCustomizeContainer.switchHighlightJsStyleBorder() }}
             />
-            <label className="custom-control-label" htmlFor="highlightBorder">
-              <strong>Border</strong>
+            <label className="custom-control-label" htmlFor="max-kanji-continuous-len">
+              <strong>max-kanji-continuous-len</strong>
             </label>
           </div>
 
@@ -114,12 +112,12 @@ export const EditorSettings: FC<Props> = () => {
             <input
               type="checkbox"
               className="custom-control-input"
-              id="highlightBorder"
+              id="max-ten"
               // checked={adminCustomizeContainer.state.isHighlightJsStyleBorderEnabled}
               // onChange={() => { adminCustomizeContainer.switchHighlightJsStyleBorder() }}
             />
-            <label className="custom-control-label" htmlFor="highlightBorder">
-              <strong>Border</strong>
+            <label className="custom-control-label" htmlFor="max-ten">
+              <strong>max-ten</strong>
             </label>
           </div>
 
@@ -127,12 +125,12 @@ export const EditorSettings: FC<Props> = () => {
             <input
               type="checkbox"
               className="custom-control-input"
-              id="highlightBorder"
+              id="no-double-negative-ja"
               // checked={adminCustomizeContainer.state.isHighlightJsStyleBorderEnabled}
               // onChange={() => { adminCustomizeContainer.switchHighlightJsStyleBorder() }}
             />
-            <label className="custom-control-label" htmlFor="highlightBorder">
-              <strong>Border</strong>
+            <label className="custom-control-label" htmlFor="no-double-negative-ja">
+              <strong>no-double-negative-ja</strong>
             </label>
           </div>
 
@@ -140,12 +138,12 @@ export const EditorSettings: FC<Props> = () => {
             <input
               type="checkbox"
               className="custom-control-input"
-              id="highlightBorder"
+              id="no-doubled-conjunction"
               // checked={adminCustomizeContainer.state.isHighlightJsStyleBorderEnabled}
               // onChange={() => { adminCustomizeContainer.switchHighlightJsStyleBorder() }}
             />
-            <label className="custom-control-label" htmlFor="highlightBorder">
-              <strong>Border</strong>
+            <label className="custom-control-label" htmlFor="no-doubled-conjunction">
+              <strong>no-doubled-conjunction</strong>
             </label>
           </div>
 
@@ -153,12 +151,12 @@ export const EditorSettings: FC<Props> = () => {
             <input
               type="checkbox"
               className="custom-control-input"
-              id="highlightBorder"
+              id="no-doubled-joshi"
               // checked={adminCustomizeContainer.state.isHighlightJsStyleBorderEnabled}
               // onChange={() => { adminCustomizeContainer.switchHighlightJsStyleBorder() }}
             />
-            <label className="custom-control-label" htmlFor="highlightBorder">
-              <strong>Border</strong>
+            <label className="custom-control-label" htmlFor="no-doubled-joshi">
+              <strong>no-doubled-joshi</strong>
             </label>
           </div>
 
@@ -166,12 +164,12 @@ export const EditorSettings: FC<Props> = () => {
             <input
               type="checkbox"
               className="custom-control-input"
-              id="highlightBorder"
+              id="no-dropping-the-ra"
               // checked={adminCustomizeContainer.state.isHighlightJsStyleBorderEnabled}
               // onChange={() => { adminCustomizeContainer.switchHighlightJsStyleBorder() }}
             />
-            <label className="custom-control-label" htmlFor="highlightBorder">
-              <strong>Border</strong>
+            <label className="custom-control-label" htmlFor="no-dropping-the-ra">
+              <strong>no-dropping-the-ra</strong>
             </label>
           </div>
 
@@ -179,12 +177,12 @@ export const EditorSettings: FC<Props> = () => {
             <input
               type="checkbox"
               className="custom-control-input"
-              id="highlightBorder"
+              id="no-hankaku-kana"
               // checked={adminCustomizeContainer.state.isHighlightJsStyleBorderEnabled}
               // onChange={() => { adminCustomizeContainer.switchHighlightJsStyleBorder() }}
             />
-            <label className="custom-control-label" htmlFor="highlightBorder">
-              <strong>Border</strong>
+            <label className="custom-control-label" htmlFor="no-hankaku-kana">
+              <strong>no-hankaku-kana</strong>
             </label>
           </div>
 
@@ -192,12 +190,12 @@ export const EditorSettings: FC<Props> = () => {
             <input
               type="checkbox"
               className="custom-control-input"
-              id="highlightBorder"
+              id="prefer-tari-tari"
               // checked={adminCustomizeContainer.state.isHighlightJsStyleBorderEnabled}
               // onChange={() => { adminCustomizeContainer.switchHighlightJsStyleBorder() }}
             />
-            <label className="custom-control-label" htmlFor="highlightBorder">
-              <strong>Border</strong>
+            <label className="custom-control-label" htmlFor="prefer-tari-tari">
+              <strong>prefer-tari-tari</strong>
             </label>
           </div>
 
@@ -222,12 +220,12 @@ export const EditorSettings: FC<Props> = () => {
             <input
               type="checkbox"
               className="custom-control-input"
-              id="highlightBorder"
+              id="common-misspellings"
               // checked={adminCustomizeContainer.state.isHighlightJsStyleBorderEnabled}
               // onChange={() => { adminCustomizeContainer.switchHighlightJsStyleBorder() }}
             />
-            <label className="custom-control-label" htmlFor="highlightBorder">
-              <strong>Border</strong>
+            <label className="custom-control-label" htmlFor="common-misspellings">
+              <strong>common-misspellings</strong>
             </label>
           </div>
 
@@ -235,12 +233,12 @@ export const EditorSettings: FC<Props> = () => {
             <input
               type="checkbox"
               className="custom-control-input"
-              id="highlightBorder"
+              id="max-comma"
               // checked={adminCustomizeContainer.state.isHighlightJsStyleBorderEnabled}
               // onChange={() => { adminCustomizeContainer.switchHighlightJsStyleBorder() }}
             />
-            <label className="custom-control-label" htmlFor="highlightBorder">
-              <strong>Border</strong>
+            <label className="custom-control-label" htmlFor="max-comma">
+              <strong>max-comma</strong>
             </label>
           </div>
 
@@ -248,12 +246,12 @@ export const EditorSettings: FC<Props> = () => {
             <input
               type="checkbox"
               className="custom-control-input"
-              id="highlightBorder"
+              id="sentence-length"
               // checked={adminCustomizeContainer.state.isHighlightJsStyleBorderEnabled}
               // onChange={() => { adminCustomizeContainer.switchHighlightJsStyleBorder() }}
             />
-            <label className="custom-control-label" htmlFor="highlightBorder">
-              <strong>Border</strong>
+            <label className="custom-control-label" htmlFor="sentence-length">
+              <strong>sentence-length</strong>
             </label>
           </div>
 

--- a/packages/app/src/components/Me/EditorSettings.tsx
+++ b/packages/app/src/components/Me/EditorSettings.tsx
@@ -21,7 +21,7 @@ export const WithoutJapaneseTextLintRulesSettings: FC<Props> = () => {
 
 export const EditorSettings: FC<Props> = () => {
   const { t } = useTranslation();
-  // TODO: apply i18n
+  // TODO: apply i18n byGW-7244
 
   return (
     <>
@@ -230,6 +230,33 @@ export const EditorSettings: FC<Props> = () => {
               <strong>Border</strong>
             </label>
           </div>
+
+          <div className="custom-control custom-switch custom-checkbox-success">
+            <input
+              type="checkbox"
+              className="custom-control-input"
+              id="highlightBorder"
+              // checked={adminCustomizeContainer.state.isHighlightJsStyleBorderEnabled}
+              // onChange={() => { adminCustomizeContainer.switchHighlightJsStyleBorder() }}
+            />
+            <label className="custom-control-label" htmlFor="highlightBorder">
+              <strong>Border</strong>
+            </label>
+          </div>
+
+          <div className="custom-control custom-switch custom-checkbox-success">
+            <input
+              type="checkbox"
+              className="custom-control-input"
+              id="highlightBorder"
+              // checked={adminCustomizeContainer.state.isHighlightJsStyleBorderEnabled}
+              // onChange={() => { adminCustomizeContainer.switchHighlightJsStyleBorder() }}
+            />
+            <label className="custom-control-label" htmlFor="highlightBorder">
+              <strong>Border</strong>
+            </label>
+          </div>
+
         </div>
       </div>
     </>

--- a/packages/app/src/components/Me/EditorSettings.tsx
+++ b/packages/app/src/components/Me/EditorSettings.tsx
@@ -35,8 +35,8 @@ export const EditorSettings: FC<Props> = () => {
               type="checkbox"
               className="custom-control-input"
               id="ja-hiragana-keishikimeishi"
-              // checked={adminCustomizeContainer.state.isHighlightJsStyleBorderEnabled}
-              // onChange={() => { adminCustomizeContainer.switchHighlightJsStyleBorder() }}
+              // checked={}
+              // onChange={}
             />
             <label className="custom-control-label" htmlFor="ja-hiragana-keishikimeishi">
               <strong>ja-hiragana-keishikimeishi</strong>
@@ -48,8 +48,8 @@ export const EditorSettings: FC<Props> = () => {
               type="checkbox"
               className="custom-control-input"
               id="ja-no-abusage"
-              // checked={adminCustomizeContainer.state.isHighlightJsStyleBorderEnabled}
-              // onChange={() => { adminCustomizeContainer.switchHighlightJsStyleBorder() }}
+              // checked={}
+              // onChange={}
             />
             <label className="custom-control-label" htmlFor="ja-no-abusage">
               <strong>ja-no-abusage</strong>
@@ -61,8 +61,8 @@ export const EditorSettings: FC<Props> = () => {
               type="checkbox"
               className="custom-control-input"
               id="ja-no-inappropriate-words"
-              // checked={adminCustomizeContainer.state.isHighlightJsStyleBorderEnabled}
-              // onChange={() => { adminCustomizeContainer.switchHighlightJsStyleBorder() }}
+              // checked={}
+              // onChange={}
             />
             <label className="custom-control-label" htmlFor="ja-no-inappropriate-words">
               <strong>ja-no-inappropriate-words</strong>
@@ -74,8 +74,8 @@ export const EditorSettings: FC<Props> = () => {
               type="checkbox"
               className="custom-control-input"
               id="ja-no-mixed-period"
-              // checked={adminCustomizeContainer.state.isHighlightJsStyleBorderEnabled}
-              // onChange={() => { adminCustomizeContainer.switchHighlightJsStyleBorder() }}
+              // checked={}
+              // onChange={}
             />
             <label className="custom-control-label" htmlFor="ja-no-mixed-period">
               <strong>ja-no-mixed-period</strong>
@@ -87,8 +87,8 @@ export const EditorSettings: FC<Props> = () => {
               type="checkbox"
               className="custom-control-input"
               id="ja-no-redundant-expression"
-              // checked={adminCustomizeContainer.state.isHighlightJsStyleBorderEnabled}
-              // onChange={() => { adminCustomizeContainer.switchHighlightJsStyleBorder() }}
+              // checked={}
+              // onChange={}
             />
             <label className="custom-control-label" htmlFor="ja-no-redundant-expression">
               <strong>ja-no-redundant-expression</strong>
@@ -100,8 +100,8 @@ export const EditorSettings: FC<Props> = () => {
               type="checkbox"
               className="custom-control-input"
               id="max-kanji-continuous-len"
-              // checked={adminCustomizeContainer.state.isHighlightJsStyleBorderEnabled}
-              // onChange={() => { adminCustomizeContainer.switchHighlightJsStyleBorder() }}
+              // checked={}
+              // onChange={}
             />
             <label className="custom-control-label" htmlFor="max-kanji-continuous-len">
               <strong>max-kanji-continuous-len</strong>
@@ -113,8 +113,8 @@ export const EditorSettings: FC<Props> = () => {
               type="checkbox"
               className="custom-control-input"
               id="max-ten"
-              // checked={adminCustomizeContainer.state.isHighlightJsStyleBorderEnabled}
-              // onChange={() => { adminCustomizeContainer.switchHighlightJsStyleBorder() }}
+              // checked={}
+              // onChange={}
             />
             <label className="custom-control-label" htmlFor="max-ten">
               <strong>max-ten</strong>
@@ -126,8 +126,8 @@ export const EditorSettings: FC<Props> = () => {
               type="checkbox"
               className="custom-control-input"
               id="no-double-negative-ja"
-              // checked={adminCustomizeContainer.state.isHighlightJsStyleBorderEnabled}
-              // onChange={() => { adminCustomizeContainer.switchHighlightJsStyleBorder() }}
+              // checked={}
+              // onChange={}
             />
             <label className="custom-control-label" htmlFor="no-double-negative-ja">
               <strong>no-double-negative-ja</strong>
@@ -139,8 +139,8 @@ export const EditorSettings: FC<Props> = () => {
               type="checkbox"
               className="custom-control-input"
               id="no-doubled-conjunction"
-              // checked={adminCustomizeContainer.state.isHighlightJsStyleBorderEnabled}
-              // onChange={() => { adminCustomizeContainer.switchHighlightJsStyleBorder() }}
+              // checked={}
+              // onChange={}
             />
             <label className="custom-control-label" htmlFor="no-doubled-conjunction">
               <strong>no-doubled-conjunction</strong>
@@ -152,8 +152,8 @@ export const EditorSettings: FC<Props> = () => {
               type="checkbox"
               className="custom-control-input"
               id="no-doubled-joshi"
-              // checked={adminCustomizeContainer.state.isHighlightJsStyleBorderEnabled}
-              // onChange={() => { adminCustomizeContainer.switchHighlightJsStyleBorder() }}
+              // checked={}
+              // onChange={}
             />
             <label className="custom-control-label" htmlFor="no-doubled-joshi">
               <strong>no-doubled-joshi</strong>
@@ -165,8 +165,8 @@ export const EditorSettings: FC<Props> = () => {
               type="checkbox"
               className="custom-control-input"
               id="no-dropping-the-ra"
-              // checked={adminCustomizeContainer.state.isHighlightJsStyleBorderEnabled}
-              // onChange={() => { adminCustomizeContainer.switchHighlightJsStyleBorder() }}
+              // checked={}
+              // onChange={}
             />
             <label className="custom-control-label" htmlFor="no-dropping-the-ra">
               <strong>no-dropping-the-ra</strong>
@@ -178,8 +178,8 @@ export const EditorSettings: FC<Props> = () => {
               type="checkbox"
               className="custom-control-input"
               id="no-hankaku-kana"
-              // checked={adminCustomizeContainer.state.isHighlightJsStyleBorderEnabled}
-              // onChange={() => { adminCustomizeContainer.switchHighlightJsStyleBorder() }}
+              // checked={}
+              // onChange={}
             />
             <label className="custom-control-label" htmlFor="no-hankaku-kana">
               <strong>no-hankaku-kana</strong>
@@ -191,8 +191,8 @@ export const EditorSettings: FC<Props> = () => {
               type="checkbox"
               className="custom-control-input"
               id="prefer-tari-tari"
-              // checked={adminCustomizeContainer.state.isHighlightJsStyleBorderEnabled}
-              // onChange={() => { adminCustomizeContainer.switchHighlightJsStyleBorder() }}
+              // checked={}
+              // onChange={}
             />
             <label className="custom-control-label" htmlFor="prefer-tari-tari">
               <strong>prefer-tari-tari</strong>
@@ -221,8 +221,8 @@ export const EditorSettings: FC<Props> = () => {
               type="checkbox"
               className="custom-control-input"
               id="common-misspellings"
-              // checked={adminCustomizeContainer.state.isHighlightJsStyleBorderEnabled}
-              // onChange={() => { adminCustomizeContainer.switchHighlightJsStyleBorder() }}
+              // checked={}
+              // onChange={}
             />
             <label className="custom-control-label" htmlFor="common-misspellings">
               <strong>common-misspellings</strong>
@@ -234,8 +234,8 @@ export const EditorSettings: FC<Props> = () => {
               type="checkbox"
               className="custom-control-input"
               id="max-comma"
-              // checked={adminCustomizeContainer.state.isHighlightJsStyleBorderEnabled}
-              // onChange={() => { adminCustomizeContainer.switchHighlightJsStyleBorder() }}
+              // checked={}
+              // onChange={}
             />
             <label className="custom-control-label" htmlFor="max-comma">
               <strong>max-comma</strong>
@@ -247,8 +247,8 @@ export const EditorSettings: FC<Props> = () => {
               type="checkbox"
               className="custom-control-input"
               id="sentence-length"
-              // checked={adminCustomizeContainer.state.isHighlightJsStyleBorderEnabled}
-              // onChange={() => { adminCustomizeContainer.switchHighlightJsStyleBorder() }}
+              // checked={}
+              // onChange={}
             />
             <label className="custom-control-label" htmlFor="sentence-length">
               <strong>sentence-length</strong>

--- a/packages/app/src/components/Me/EditorSettings.tsx
+++ b/packages/app/src/components/Me/EditorSettings.tsx
@@ -202,7 +202,7 @@ export const EditorSettings: FC<Props> = () => {
               <strong>no-dropping-the-ra</strong>
             </label>
             <p className="form-text text-muted small">
-              A textlint rule that disallow to use Half-width kana.
+              A textlint rule that detects the word dropping the ra.
             </p>
           </div>
 
@@ -218,7 +218,7 @@ export const EditorSettings: FC<Props> = () => {
               <strong>no-hankaku-kana</strong>
             </label>
             <p className="form-text text-muted small">
-              A textlint rule that checks tari tari.
+              A textlint rule that disallow to use Half-width kana.
             </p>
           </div>
 
@@ -234,7 +234,7 @@ export const EditorSettings: FC<Props> = () => {
               <strong>prefer-tari-tari</strong>
             </label>
             <p className="form-text text-muted small">
-              {t('admin:app_setting.file_delivery_method_redirect_info')}
+              A textlint rule that checks tari tari.
             </p>
           </div>
 

--- a/packages/app/src/components/Me/EditorSettings.tsx
+++ b/packages/app/src/components/Me/EditorSettings.tsx
@@ -283,9 +283,8 @@ export const EditorSettings: FC<Props> = () => {
               <strong>max-comma</strong>
             </label>
             <p className="form-text text-muted small">
-              max: maximum number of , <br />
+              textlint rule is that limit maximum ten(、) count of sentence. <br />
               Default: 4
-
             </p>
           </div>
 

--- a/packages/app/src/components/Me/EditorSettings.tsx
+++ b/packages/app/src/components/Me/EditorSettings.tsx
@@ -6,10 +6,84 @@ import PropTypes from 'prop-types';
 type Props = {
 }
 
+export const JapaneseTextLintRuleSettings: FC<Props> = () => {
+  return (
+    <></>
+  );
+};
+
+export const WithoutJapaneseTextLintRulesSettings: FC<Props> = () => {
+  return (
+    <></>
+  );
+};
+
+
 export const EditorSettings: FC<Props> = () => {
   const { t } = useTranslation();
+  // TODO: apply i18n
 
   return (
-    <div>hge</div>
+    <>
+      <h4 className="mt-4">Japanese Settings</h4>
+      <div className="offset-lg-2  col-lg-9">
+        <div className="row">
+
+          <table className="table table-bordered col-lg-8 mb-5">
+            <thead>
+              <tr>
+                <th scope="col">{ t('scope_of_page_disclosure') }</th>
+                <th scope="col">{ t('set_point') }</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th scope="row">{ t('Public') }</th>
+                <td>{ t('always_displayed') }</td>
+              </tr>
+              <tr>
+                <th scope="row">{ t('Anyone with the link') }</th>
+                <td>{ t('always_hidden') }</td>
+              </tr>
+              <tr>
+                <th scope="row">{ t('Only me') }</th>
+                <td>
+                  <div className="custom-control custom-switch custom-checkbox-success">
+                    <input
+                      type="checkbox"
+                      className="custom-control-input"
+                      id="isShowRestrictedByOwner"
+                      // checked={adminGeneralSecurityContainer.state.isShowRestrictedByOwner}
+                      // onChange={() => { adminGeneralSecurityContainer.switchIsShowRestrictedByOwner() }}
+                    />
+                    <label className="custom-control-label" htmlFor="isShowRestrictedByOwner">
+                      {t('displayed_or_hidden')}
+                    </label>
+                  </div>
+                </td>
+              </tr>
+              <tr>
+                <th scope="row">{ t('Only inside the group') }</th>
+                <td>
+                  <div className="custom-control custom-switch custom-checkbox-success">
+                    <input
+                      type="checkbox"
+                      className="custom-control-input"
+                      id="isShowRestrictedByGroup"
+                      // checked={adminGeneralSecurityContainer.state.isShowRestrictedByGroup}
+                      // onChange={() => { adminGeneralSecurityContainer.switchIsShowRestrictedByGroup() }}
+                    />
+                    <label className="custom-control-label" htmlFor="isShowRestrictedByGroup">
+                      {t('displayed_or_hidden')}
+                    </label>
+                  </div>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+
+        </div>
+      </div>
+    </>
   );
 };

--- a/packages/app/src/components/Me/EditorSettings.tsx
+++ b/packages/app/src/components/Me/EditorSettings.tsx
@@ -1,0 +1,15 @@
+import React, { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+import PropTypes from 'prop-types';
+
+
+type Props = {
+}
+
+export const EditorSettings: FC<Props> = () => {
+  const { t } = useTranslation();
+
+  return (
+    <div>hge</div>
+  );
+};

--- a/packages/app/src/components/Me/PersonalSettings.jsx
+++ b/packages/app/src/components/Me/PersonalSettings.jsx
@@ -8,6 +8,7 @@ import UserSettings from './UserSettings';
 import PasswordSettings from './PasswordSettings';
 import ExternalAccountLinkedMe from './ExternalAccountLinkedMe';
 import ApiSettings from './ApiSettings';
+import { EditorSettings } from './EditorSettings';
 
 const PersonalSettings = (props) => {
 
@@ -41,8 +42,8 @@ const PersonalSettings = (props) => {
       },
       editor_settings: {
         Icon: () => <i className="icon-fw icon-pencil"></i>,
-        Content: ApiSettings,
-        i18n: t(' Settings'),
+        Content: EditorSettings,
+        i18n: t('Editor Settings'),
         index: 4,
       },
     };

--- a/packages/app/src/components/Me/PersonalSettings.jsx
+++ b/packages/app/src/components/Me/PersonalSettings.jsx
@@ -39,6 +39,12 @@ const PersonalSettings = (props) => {
         i18n: t('API Settings'),
         index: 3,
       },
+      editor_settings: {
+        Icon: () => <i className="icon-fw icon-pencil"></i>,
+        Content: ApiSettings,
+        i18n: t(' Settings'),
+        index: 4,
+      },
     };
   }, [t]);
 


### PR DESCRIPTION
## Task
GW-7244 User設定ページにタブを新規作成し、日本語とそれ以外の切り替えswitchを表示する(見た目のみ)

## View
(カスタムナビのボーダーがずれているのは、写真の撮り方を間違えただけなので気にしなくて大丈夫です。)
![FireShot Capture 099 - User Settings - GROWI - localhost](https://user-images.githubusercontent.com/59536731/131425756-53ed58bf-2d94-425d-b89c-c63a48f12779.png)


## TODO
- GW-7267 Editor settingsにi18nを適用させる
- GW-7275 Editor設定の共通化 
後続タスクで着手します。