### PR TITLE
Feat/7240 p2g validation rewrite

### DIFF
--- a/packages/app/src/server/models/slack-app-integration-mock.js
+++ b/packages/app/src/server/models/slack-app-integration-mock.js
@@ -9,9 +9,8 @@ const permittedChannelsForEachCommandSchema = new mongoose.Schema({
 const schema = new mongoose.Schema({
   tokenGtoP: { type: String, required: true, unique: true },
   tokenPtoG: { type: String, required: true, unique: true },
-  supportedCommandsForBroadcastUse: { type: [String], default: [] },
-  supportedCommandsForSingleUse: { type: [String], default: [] },
-  permittedChannelsForEachCommand: permittedChannelsForEachCommandSchema,
+  supportedCommandsForBroadcastUse: Map,
+  supportedCommandsForSingleUse: Map,
 });
 
 class SlackAppIntegrationMock {

--- a/packages/app/src/server/models/slack-app-integration-mock.js
+++ b/packages/app/src/server/models/slack-app-integration-mock.js
@@ -9,8 +9,8 @@ const permittedChannelsForEachCommandSchema = new mongoose.Schema({
 const schema = new mongoose.Schema({
   tokenGtoP: { type: String, required: true, unique: true },
   tokenPtoG: { type: String, required: true, unique: true },
-  supportedCommandsForBroadcastUse: Map,
-  supportedCommandsForSingleUse: Map,
+  permissionsForBroadcastUseCommands: Map,
+  permissionsForSingleUseCommands: Map,
 });
 
 class SlackAppIntegrationMock {

--- a/packages/app/src/server/routes/apiv3/slack-integration-settings.js
+++ b/packages/app/src/server/routes/apiv3/slack-integration-settings.js
@@ -416,15 +416,21 @@ module.exports = (crowi) => {
         supportedCommandsForSingleUse: defaultSupportedCommandsNameForSingleUse,
       });
       // MOCK DATA DELETE THIS GW-6972 ---------------
+      /* This code represents the creation of the new SlackAppIntegration model instance. */
       const SlackAppIntegrationMock = mongoose.model('SlackAppIntegrationMock');
+      const initialSupportedCommandsForBroadcastUse = new Map();
+      const initialSupportedCommandsForSingleUse = new Map();
+      defaultSupportedCommandsNameForBroadcastUse.forEach((commandName) => {
+        initialSupportedCommandsForBroadcastUse.set(commandName, true);
+      });
+      defaultSupportedCommandsNameForSingleUse.forEach((commandName) => {
+        initialSupportedCommandsForSingleUse.set(commandName, true);
+      });
       const MOCK = await SlackAppIntegrationMock.create({
         tokenGtoP,
         tokenPtoG,
-        supportedCommandsForBroadcastUse: defaultSupportedCommandsNameForBroadcastUse,
-        supportedCommandsForSingleUse: defaultSupportedCommandsNameForSingleUse,
-        permittedChannelsForEachCommand: {
-          channelsObject: new Map(),
-        },
+        permissionsForBroadcastUseCommands: initialSupportedCommandsForBroadcastUse,
+        permissionsForSingleUseCommands: initialSupportedCommandsForSingleUse,
       });
       // MOCK DATA DELETE THIS GW-6972 ---------------
       return res.apiv3(slackAppTokens, 200);

--- a/packages/app/src/server/routes/apiv3/slack-integration.js
+++ b/packages/app/src/server/routes/apiv3/slack-integration.js
@@ -84,7 +84,10 @@ module.exports = (crowi) => {
     let isPermitted = false;
     [...permissionsForBroadcastUseCommands.keys(), ...permissionsForSingleUseCommands.keys()].forEach((commandName) => {
       // boolean or string[]
-      const permission = permissionsForBroadcastUseCommands.get(commandName);
+      let permission = permissionsForBroadcastUseCommands.get(commandName);
+      if (permission === undefined) {
+        permission = permissionsForSingleUseCommands.get(commandName);
+      }
 
       // ex. search OR search:handlerName
       const commandRegExp = new RegExp(`(^${commandName}$)|(^${commandName}:\\w+)`);

--- a/packages/slackbot-proxy/src/entities/relation-mock.ts
+++ b/packages/slackbot-proxy/src/entities/relation-mock.ts
@@ -36,10 +36,10 @@ export class RelationMock {
   growiUri: string;
 
   @Column({ type: 'json' })
-  permissionSettingsForBroadcastUseCommands: PermissionSettingsInterface;
+  permissionsForBroadcastUseCommands: PermissionSettingsInterface;
 
   @Column({ type: 'json' })
-  permissionSettingsForSingleUseCommands: PermissionSettingsInterface;
+  permissionsForSingleUseCommands: PermissionSettingsInterface;
 
   @CreateDateColumn()
   expiredAtCommands: Date;

--- a/packages/slackbot-proxy/src/entities/relation-mock.ts
+++ b/packages/slackbot-proxy/src/entities/relation-mock.ts
@@ -4,14 +4,8 @@ import {
 import { differenceInMilliseconds } from 'date-fns';
 import { Installation } from './installation';
 
-
-// expected data see below
-//   commandToChannelMap: {
-//     create: ['srv', 'admin'],
-//     search: ['admin'],
-//   }
-interface PermittedChannelsForEachCommand {
-  commandToChannelMap: { [command: string]: string[] };
+interface PermissionSettingsInterface {
+  [commandName: string]: boolean | string[],
 }
 
 @Entity()
@@ -41,14 +35,11 @@ export class RelationMock {
   @Column()
   growiUri: string;
 
-  @Column('simple-array')
-  supportedCommandsForBroadcastUse: string[];
-
-  @Column('simple-array')
-  supportedCommandsForSingleUse: string[];
+  @Column({ type: 'json' })
+  permissionSettingsForBroadcastUseCommands: PermissionSettingsInterface;
 
   @Column({ type: 'json' })
-  permittedChannelsForEachCommand : PermittedChannelsForEachCommand
+  permissionSettingsForSingleUseCommands: PermissionSettingsInterface;
 
   @CreateDateColumn()
   expiredAtCommands: Date;


### PR DESCRIPTION
GW-7240 [7018 最終版のMockで改修] GROWI 本体で proxy からのリクエストを適切に制限できる

を実装しました。ご確認お願いします。

コメント：確認動画では、proxy からのリクエストは GROWI に必ず届くようにしています。

https://user-images.githubusercontent.com/58432773/131446818-4f01eeee-41ba-42c5-810a-4f1a623dcbba.mov

