### PR TITLE
Imprv/gw 7185 tags common

### DIFF
--- a/packages/app/src/components/Sidebar/RecentChanges.jsx
+++ b/packages/app/src/components/Sidebar/RecentChanges.jsx
@@ -54,7 +54,7 @@ function LargePageItem({ page }) {
             <PagePathHierarchicalLink linkedPagePath={linkedPagePathLatter} basePath={dPagePath.isRoot ? undefined : dPagePath.former} />
             {locked}
           </h5>
-          <div className="mt-1 mb-2">
+          <div className="grw-tag-labels mt-1 mb-2">
             { tagElements }
           </div>
           <div className="d-flex justify-content-between grw-recent-changes-item-lower pt-1">

--- a/packages/app/src/styles/_tag.scss
+++ b/packages/app/src/styles/_tag.scss
@@ -6,22 +6,14 @@
 
 .grw-tag-labels {
   .grw-tag-label {
-    margin-left: 1px;
-    font-size: 12px;
-    border-radius: $border-radius-xl;
+    font-size: 10px;
+    font-weight: normal;
+    border-radius: $border-radius-sm;
   }
 }
 
 #edit-tag-modal {
   .form-control {
     height: auto;
-  }
-}
-
-.grw-recent-changes {
-  .grw-tag-label {
-    font-size: 10px;
-    font-weight: normal;
-    border-radius: $border-radius-sm;
   }
 }

--- a/packages/app/src/styles/_tag.scss
+++ b/packages/app/src/styles/_tag.scss
@@ -6,7 +6,7 @@
 
 .grw-tag-labels {
   .grw-tag-label {
-    font-size: 10px;
+    font-size: 12px;
     font-weight: normal;
     border-radius: $border-radius-sm;
   }
@@ -15,5 +15,11 @@
 #edit-tag-modal {
   .form-control {
     height: auto;
+  }
+}
+
+.grw-recent-changes {
+  .grw-tag-label {
+    font-size: 10px;
   }
 }

--- a/packages/app/src/styles/theme/_apply-colors-light.scss
+++ b/packages/app/src/styles/theme/_apply-colors-light.scss
@@ -12,7 +12,7 @@ $border-color-table: $gray-200 !default;
 $color-table-hover: $color-table !default;
 $bgcolor-table-hover: rgba(black, 0.075) !default;
 $bgcolor-sidebar-list-group: $bgcolor-list !default;
-$color-tags: $gray-500 !default;
+$color-tags: $secondary !default;
 $bgcolor-tags: $gray-200 !default;
 $border-color-global: $gray-300 !default;
 $border-color-toc: $border-color-global !default;

--- a/packages/app/src/styles/theme/_apply-colors.scss
+++ b/packages/app/src/styles/theme/_apply-colors.scss
@@ -303,11 +303,6 @@ ul.pagination {
       .list-group-item {
         background-color: transparent;
 
-        .grw-tag-label {
-          color: $secondary;
-          background-color: $gray-200;
-        }
-
         .icon-lock {
           color: $color-link;
         }


### PR DESCRIPTION
文字色・太さをサイドバーのタグと同じになるように変え
<img width="626" alt="スクリーンショット 2021-09-01 16 09 47" src="https://user-images.githubusercontent.com/46134198/131627826-c4f1ef60-3765-45ae-b000-7269a300b639.png">

タグの色をダークテーマにも対応させた
<img width="294" alt="スクリーンショット 2021-09-01 16 10 15" src="https://user-images.githubusercontent.com/46134198/131627881-9106feb0-c217-4a12-a063-530e7b738bfb.png">
