### PR TITLE
Imprv/gw7228 create activity parameter

### DIFF
--- a/packages/app/src/server/models/activity.ts
+++ b/packages/app/src/server/models/activity.ts
@@ -209,6 +209,10 @@ export default (crowi: Crowi) => {
     }
   });
 
+  /*
+    Define Activity on crowi.event by GW-7345
+  */
+
   // because mongoose's 'remove' hook fired only when remove by a method of Document (not by a Model method)
   // move 'save' hook from mongoose's events to activityEvent if I have a time.
   // activityEvent.on('remove', async(activity: ActivityDocument) => {

--- a/packages/app/src/server/models/activity.ts
+++ b/packages/app/src/server/models/activity.ts
@@ -7,6 +7,8 @@ import loggerFactory from '~/utils/logger';
 import ActivityDefine from '../util/activityDefine';
 import Crowi from '../crowi';
 
+import { getOrCreateModel } from '../util/mongoose-utils';
+
 const logger = loggerFactory('growi:models:activity');
 
 export interface ActivityDocument extends Document {
@@ -226,7 +228,8 @@ export default (crowi: Crowi) => {
   //   }
   // });
 
-  const Activity = model<ActivityDocument, ActivityModel>('Activity', activitySchema);
+  // const Activity = model<ActivityDocument, ActivityModel>('Activity', activitySchema);
+  const Activity = getOrCreateModel<ActivityDocument, ActivityModel>('Activity', activitySchema);
 
   return Activity;
 };

--- a/packages/app/src/server/models/activity.ts
+++ b/packages/app/src/server/models/activity.ts
@@ -211,16 +211,16 @@ export default (crowi: Crowi) => {
 
   // because mongoose's 'remove' hook fired only when remove by a method of Document (not by a Model method)
   // move 'save' hook from mongoose's events to activityEvent if I have a time.
-  activityEvent.on('remove', async(activity: ActivityDocument) => {
-    const Notification = crowi.model('Notification');
+  // activityEvent.on('remove', async(activity: ActivityDocument) => {
+  //   const Notification = crowi.model('Notification');
 
-    try {
-      await Notification.removeActivity(activity);
-    }
-    catch (err) {
-      logger.error(err);
-    }
-  });
+  //   try {
+  //     await Notification.removeActivity(activity);
+  //   }
+  //   catch (err) {
+  //     logger.error(err);
+  //   }
+  // });
 
   const Activity = model<ActivityDocument, ActivityModel>('Activity', activitySchema);
 

--- a/packages/app/src/server/models/activity.ts
+++ b/packages/app/src/server/models/activity.ts
@@ -199,9 +199,9 @@ export default (crowi: Crowi) => {
   activitySchema.post('save', async(savedActivity: ActivityDocument) => {
     const Notification = crowi.model('Notification');
     try {
-      const notificationUsers = await savedActivity.getNotificationTargetUsers();
-
-      await Promise.all(notificationUsers.map(user => Notification.upsertByActivity(user, savedActivity)));
+      // TODO: enable to use getNotificationTargetUsers
+      // const notificationUsers = await savedActivity.getNotificationTargetUsers();
+      // await Promise.all(notificationUsers.map(user => Notification.upsertByActivity(user, savedActivity)));
       return;
     }
     catch (err) {

--- a/packages/app/src/server/models/comment.js
+++ b/packages/app/src/server/models/comment.js
@@ -109,6 +109,12 @@ module.exports = function(crowi) {
       })
       .catch(() => {
       });
+
+    Activity.createByPageComment(savedComment)
+      .then((activityLog) => {
+        debug('Activity created', activityLog);
+      })
+      .catch((err) => {});
   });
 
   return mongoose.model('Comment', commentSchema);

--- a/packages/app/src/server/models/comment.js
+++ b/packages/app/src/server/models/comment.js
@@ -102,6 +102,7 @@ module.exports = function(crowi) {
    */
   commentSchema.post('save', (savedComment) => {
     const Page = crowi.model('Page');
+    const Activity = crowi.model('Activity');
 
     Page.updateCommentCount(savedComment.page)
       .then((page) => {

--- a/packages/app/src/server/models/comment.js
+++ b/packages/app/src/server/models/comment.js
@@ -1,6 +1,7 @@
 // disable no-return-await for model functions
 /* eslint-disable no-return-await */
 
+import Activity from '~/server/models/activity';
 module.exports = function(crowi) {
   const debug = require('debug')('growi:models:comment');
   const mongoose = require('mongoose');
@@ -102,7 +103,7 @@ module.exports = function(crowi) {
    */
   commentSchema.post('save', (savedComment) => {
     const Page = crowi.model('Page');
-    const Activity = crowi.model('Activity');
+    // const Activity = crowi.model('Activity');
 
     Page.updateCommentCount(savedComment.page)
       .then((page) => {

--- a/packages/app/src/server/models/index.js
+++ b/packages/app/src/server/models/index.js
@@ -1,3 +1,5 @@
+import Activity from './activity';
+
 module.exports = {
   Page: require('./page'),
   // TODO GW-2746 bulk export pages
@@ -17,4 +19,5 @@ module.exports = {
   GlobalNotificationSlackSetting: require('./GlobalNotificationSetting/GlobalNotificationSlackSetting'),
   ShareLink: require('./share-link'),
   SlackAppIntegration: require('./slack-app-integration'),
+  Activity,
 };

--- a/packages/app/src/server/models/index.js
+++ b/packages/app/src/server/models/index.js
@@ -1,4 +1,4 @@
-import Activity from './activity';
+// import Activity from './activity';
 
 module.exports = {
   Page: require('./page'),
@@ -19,5 +19,5 @@ module.exports = {
   GlobalNotificationSlackSetting: require('./GlobalNotificationSetting/GlobalNotificationSlackSetting'),
   ShareLink: require('./share-link'),
   SlackAppIntegration: require('./slack-app-integration'),
-  Activity,
+  // Activity,
 };


### PR DESCRIPTION
## Task 
GW-7228 コメントした際に、activityLogが出力されるようにする

## コメント時のlogの出力結果
- ` console.log('activityLog', activityLog);`を追加

```
    Activity.createByPageComment(savedComment)
      .then((activityLog) => {
        debug('Activity created', activityLog);
        console.log('activityLog', activityLog);
      })
      .catch((err) => {});

```
↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓
```
activityLog {
  _id: 6135ce9c64acb2179e721513,
  user: 61264c6429869a067eb01b75,
  targetModel: 'Page',
  target: 61264c6429869a067eb01b76,
  eventModel: 'Comment',
  event: 6135ce9c64acb2179e721512,
  action: 'COMMENT',
  createdAt: 2021-09-06T08:17:32.529Z,
  __v: 0
}

```