### PR TITLE
Imprv/gw7342 create popup component

### DIFF
--- a/packages/app/src/components/Navbar/GrowiNavbar.jsx
+++ b/packages/app/src/components/Navbar/GrowiNavbar.jsx
@@ -28,14 +28,14 @@ class GrowiNavbar extends React.Component {
 
     return (
       <>
+        <li>
+          <InAppNotificationDropdown />
+        </li>
         <li className="nav-item d-none d-md-block">
           <button className="px-md-2 nav-link btn-create-page border-0 bg-transparent" type="button" onClick={navigationContainer.openPageCreateModal}>
             <i className="icon-pencil mr-2"></i>
             <span className="d-none d-lg-block">{ t('New') }</span>
           </button>
-        </li>
-        <li>
-          <InAppNotificationDropdown />
         </li>
         <li className="grw-personal-dropdown nav-item dropdown dropdown-toggle dropdown-toggle-no-caret">
           <PersonalDropdown />

--- a/packages/app/src/components/Navbar/GrowiNavbar.jsx
+++ b/packages/app/src/components/Navbar/GrowiNavbar.jsx
@@ -7,6 +7,7 @@ import { UncontrolledTooltip } from 'reactstrap';
 import { withUnstatedContainers } from '../UnstatedUtils';
 import NavigationContainer from '~/client/services/NavigationContainer';
 import AppContainer from '~/client/services/AppContainer';
+import HeaderNotification from '~/components/PageEditor/HeaderNotification';
 
 
 import GrowiLogo from '../Icons/GrowiLogo';
@@ -27,16 +28,15 @@ class GrowiNavbar extends React.Component {
 
     return (
       <>
-        <button className="px-md-2 nav-link btn-create-page border-0 bg-transparent" type="button">
-          <i className="icon-bell mr-2"></i>
-        </button>
         <li className="nav-item d-none d-md-block">
           <button className="px-md-2 nav-link btn-create-page border-0 bg-transparent" type="button" onClick={navigationContainer.openPageCreateModal}>
             <i className="icon-pencil mr-2"></i>
             <span className="d-none d-lg-block">{ t('New') }</span>
           </button>
         </li>
-
+        <li>
+          <HeaderNotification />
+        </li>
         <li className="grw-personal-dropdown nav-item dropdown dropdown-toggle dropdown-toggle-no-caret">
           <PersonalDropdown />
         </li>

--- a/packages/app/src/components/Navbar/GrowiNavbar.jsx
+++ b/packages/app/src/components/Navbar/GrowiNavbar.jsx
@@ -7,7 +7,7 @@ import { UncontrolledTooltip } from 'reactstrap';
 import { withUnstatedContainers } from '../UnstatedUtils';
 import NavigationContainer from '~/client/services/NavigationContainer';
 import AppContainer from '~/client/services/AppContainer';
-import HeaderNotification from '~/components/PageEditor/HeaderNotification';
+import InAppNotificationDropdown from '~/components/PageEditor/InAppNotificationDropdown';
 
 
 import GrowiLogo from '../Icons/GrowiLogo';
@@ -35,7 +35,7 @@ class GrowiNavbar extends React.Component {
           </button>
         </li>
         <li>
-          <HeaderNotification />
+          <InAppNotificationDropdown />
         </li>
         <li className="grw-personal-dropdown nav-item dropdown dropdown-toggle dropdown-toggle-no-caret">
           <PersonalDropdown />

--- a/packages/app/src/components/Navbar/GrowiNavbar.jsx
+++ b/packages/app/src/components/Navbar/GrowiNavbar.jsx
@@ -27,6 +27,9 @@ class GrowiNavbar extends React.Component {
 
     return (
       <>
+        <button className="px-md-2 nav-link btn-create-page border-0 bg-transparent" type="button">
+          <i className="icon-bell mr-2"></i>
+        </button>
         <li className="nav-item d-none d-md-block">
           <button className="px-md-2 nav-link btn-create-page border-0 bg-transparent" type="button" onClick={navigationContainer.openPageCreateModal}>
             <i className="icon-pencil mr-2"></i>

--- a/packages/app/src/components/Navbar/GrowiNavbar.jsx
+++ b/packages/app/src/components/Navbar/GrowiNavbar.jsx
@@ -31,12 +31,14 @@ class GrowiNavbar extends React.Component {
         <li>
           <InAppNotificationDropdown />
         </li>
+
         <li className="nav-item d-none d-md-block">
           <button className="px-md-2 nav-link btn-create-page border-0 bg-transparent" type="button" onClick={navigationContainer.openPageCreateModal}>
             <i className="icon-pencil mr-2"></i>
             <span className="d-none d-lg-block">{ t('New') }</span>
           </button>
         </li>
+
         <li className="grw-personal-dropdown nav-item dropdown dropdown-toggle dropdown-toggle-no-caret">
           <PersonalDropdown />
         </li>

--- a/packages/app/src/components/PageEditor/HeaderNotification.tsx
+++ b/packages/app/src/components/PageEditor/HeaderNotification.tsx
@@ -79,7 +79,6 @@ export default class HeaderNotification extends React.Component<Props, State> {
   // }
 
   toggle() {
-    console.log('toggle');
     const { open, count } = this.state;
     if (!open && count > 0) {
       this.updateStatus();

--- a/packages/app/src/components/PageEditor/HeaderNotification.tsx
+++ b/packages/app/src/components/PageEditor/HeaderNotification.tsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import { Dropdown, DropdownToggle, DropdownMenu } from 'reactstrap';
+// import DropdownMenu from './HeaderNotification/DropdownMenu';
+// import Icon from './Common/Icon'
+// import Crowi from 'client/util/Crowi'
+// import { Notification } from 'client/types/crowi'
+
+interface Props {
+  // crowi: Crowi
+  me: string
+}
+
+interface State {
+  count: number
+  loaded: boolean
+  notifications: Notification[]
+  open: boolean
+}
+
+export default class HeaderNotification extends React.Component<Props, State> {
+
+  constructor(props: Props) {
+    super(props);
+
+    this.state = {
+      count: 0,
+      loaded: false,
+      notifications: [],
+      open: false,
+    };
+  }
+
+  // componentDidMount() {
+  //   this.initializeSocket();
+  //   this.fetchList();
+  //   this.fetchStatus();
+  // }
+
+  // initializeSocket() {
+  //   this.props.crowi.getWebSocket().on('notification updated', (data: { user: string }) => {
+  //     if (this.props.me === data.user) {
+  //       this.fetchList();
+  //       this.fetchStatus();
+  //     }
+  //   });
+  // }
+
+  // async fetchStatus() {
+  //   try {
+  //     const { count = null } = await this.props.crowi.apiGet('/notification.status');
+  //     if (count !== null && count !== this.state.count) {
+  //       this.setState({ count });
+  //     }
+  //   }
+  //   catch (err) {
+  //     // TODO: error handling
+  //   }
+  // }
+
+  async updateStatus() {
+    try {
+      // await this.props.crowi.apiPost('/notification.read');
+      this.setState({ count: 0 });
+    }
+    catch (err) {
+      // TODO: error handling
+    }
+  }
+
+  // async fetchList() {
+  //   const limit = 6;
+  //   try {
+  //     const { notifications } = await this.props.crowi.apiGet('/notification.list', { limit });
+  //     this.setState({ loaded: true, notifications });
+  //   }
+  //   catch (err) {
+  //     // TODO: error handling
+  //   }
+  // }
+
+  toggle() {
+    console.log('toggle');
+    const { open, count } = this.state;
+    if (!open && count > 0) {
+      this.updateStatus();
+    }
+    this.setState({ open: !open });
+  }
+
+  // async handleNotificationOnClick(notification: Notification) {
+  //   try {
+  //     await this.props.crowi.apiPost('/notification.open', { id: notification._id });
+  //     // jump to target page
+  //     window.location.href = notification.target.path;
+  //   }
+  //   catch (err) {
+  //     // TODO: error handling
+  //   }
+  // }
+
+  render() {
+    const {
+      count, open, loaded, notifications,
+    } = this.state;
+
+    const badge = count > 0 ? <span className="badge badge-pill badge-danger notification-badge">{count}</span> : '';
+
+    return (
+      <Dropdown className="notification-wrapper" isOpen={open} toggle={this.toggle}>
+        <DropdownToggle tag="a" className="nav-link">
+          <i className="icon-bell mr-2"></i>
+          {/* {badge} */}
+        </DropdownToggle>
+        <DropdownMenu>hoge</DropdownMenu>
+      </Dropdown>
+    );
+  }
+
+}

--- a/packages/app/src/components/PageEditor/InAppNotificationDropdown.tsx
+++ b/packages/app/src/components/PageEditor/InAppNotificationDropdown.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Dropdown, DropdownToggle, DropdownMenu } from 'reactstrap';
-// import DropdownMenu from './HeaderNotification/DropdownMenu';
+// import DropdownMenu from './InAppNotificationDropdown/DropdownMenu';
 // import Icon from './Common/Icon'
 // import Crowi from 'client/util/Crowi'
 // import { Notification } from 'client/types/crowi'
@@ -17,7 +17,7 @@ interface State {
   open: boolean
 }
 
-export default class HeaderNotification extends React.Component<Props, State> {
+export default class InAppNotificationDropdown extends React.Component<Props, State> {
 
   constructor(props: Props) {
     super(props);


### PR DESCRIPTION
## Task
GW-7342 通知用のPopupコンポーネントを作成し、ナビバーに追加する(中身は空)

※参考元から今必要のないものは一旦コメントアウトしています。
※functional component化は後続タスクでやります。

## View
- isOpen=false
<img width="651" alt="Screen Shot 2021-09-07 at 17 46 31" src="https://user-images.githubusercontent.com/59536731/132315018-7b0ce415-f114-413a-9bad-6fa16ddb7280.png">

- isOpen=true
<img width="198" alt="Screen Shot 2021-09-07 at 17 46 52" src="https://user-images.githubusercontent.com/59536731/132315028-7feeedb7-00a7-4906-8105-f8191b9518db.png">
