### PR TITLE
Feat:create permission in withoutproxy

### DIFF
--- a/packages/app/src/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/packages/app/src/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -40,7 +40,7 @@ const SlackIntegration = (props) => {
     try {
       const { data } = await appContainer.apiv3.get('/slack-integration-settings');
       const {
-        slackSigningSecret, slackBotToken, slackSigningSecretEnvVars, slackBotTokenEnvVars, slackAppIntegrations, proxyServerUri, commandPermission,
+        slackSigningSecret, slackBotToken, slackSigningSecretEnvVars, slackBotTokenEnvVars, slackAppIntegrations, proxyServerUri,
       } = data.settings;
 
       setErrorMsg(data.errorMsg);

--- a/packages/app/src/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/packages/app/src/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -53,7 +53,6 @@ const SlackIntegration = (props) => {
       setSlackBotTokenEnv(slackBotTokenEnvVars);
       setSlackAppIntegrations(slackAppIntegrations);
       setProxyServerUri(proxyServerUri);
-      console.log(commandPermission);
     }
     catch (err) {
       toastError(err);

--- a/packages/app/src/components/Admin/SlackIntegration/SlackIntegration.jsx
+++ b/packages/app/src/components/Admin/SlackIntegration/SlackIntegration.jsx
@@ -40,7 +40,7 @@ const SlackIntegration = (props) => {
     try {
       const { data } = await appContainer.apiv3.get('/slack-integration-settings');
       const {
-        slackSigningSecret, slackBotToken, slackSigningSecretEnvVars, slackBotTokenEnvVars, slackAppIntegrations, proxyServerUri,
+        slackSigningSecret, slackBotToken, slackSigningSecretEnvVars, slackBotTokenEnvVars, slackAppIntegrations, proxyServerUri, commandPermission,
       } = data.settings;
 
       setErrorMsg(data.errorMsg);
@@ -53,6 +53,7 @@ const SlackIntegration = (props) => {
       setSlackBotTokenEnv(slackBotTokenEnvVars);
       setSlackAppIntegrations(slackAppIntegrations);
       setProxyServerUri(proxyServerUri);
+      console.log(commandPermission);
     }
     catch (err) {
       toastError(err);

--- a/packages/app/src/server/routes/apiv3/slack-integration-settings.js
+++ b/packages/app/src/server/routes/apiv3/slack-integration-settings.js
@@ -179,6 +179,7 @@ module.exports = (crowi) => {
       settings.slackBotTokenEnvVars = configManager.getConfigFromEnvVars('crowi', 'slackbot:withoutProxy:botToken');
       settings.slackSigningSecret = configManager.getConfig('crowi', 'slackbot:withoutProxy:signingSecret');
       settings.slackBotToken = configManager.getConfig('crowi', 'slackbot:withoutProxy:botToken');
+      settings.commandPermission = configManager.getConfig('crowi', 'slackbot:withoutProxy:commandhPermission');
     }
     else {
       settings.proxyServerUri = crowi.configManager.getConfig('crowi', 'slackbot:proxyUri');

--- a/packages/app/src/server/routes/apiv3/slack-integration-settings.js
+++ b/packages/app/src/server/routes/apiv3/slack-integration-settings.js
@@ -179,7 +179,7 @@ module.exports = (crowi) => {
       settings.slackBotTokenEnvVars = configManager.getConfigFromEnvVars('crowi', 'slackbot:withoutProxy:botToken');
       settings.slackSigningSecret = configManager.getConfig('crowi', 'slackbot:withoutProxy:signingSecret');
       settings.slackBotToken = configManager.getConfig('crowi', 'slackbot:withoutProxy:botToken');
-      settings.commandPermission = configManager.getConfig('crowi', 'slackbot:withoutProxy:commandhPermission');
+      settings.commandPermission = configManager.getConfig('crowi', 'slackbot:withoutProxy:commandPermission');
     }
     else {
       settings.proxyServerUri = crowi.configManager.getConfig('crowi', 'slackbot:proxyUri');

--- a/packages/app/src/server/routes/apiv3/slack-integration-settings.js
+++ b/packages/app/src/server/routes/apiv3/slack-integration-settings.js
@@ -362,6 +362,31 @@ module.exports = (crowi) => {
     }
   });
 
+  router.put('/without-proxy/update-permissions', async(req, res) => {
+    const currentBotType = crowi.configManager.getConfig('crowi', 'slackbot:currentBotType');
+    if (currentBotType !== SlackbotType.CUSTOM_WITHOUT_PROXY) {
+      const msg = 'Not CustomBotWithoutProxy';
+      return res.apiv3Err(new ErrorV3(msg, 'not-customBotWithoutProxy'), 400);
+    }
+
+    const { commandPermission } = req.body;
+    const requestParams = {
+      'slackbot:withouProxy:commandPermission': commandPermission,
+    };
+    try {
+      await updateSlackBotSettings(requestParams);
+      crowi.slackIntegrationService.publishUpdatedMessage();
+
+      const customBotWithoutProxyCommandPermissionarams = crowi.configManager.getConfig('crowi', 'slackbot:withoutProxy:commandPermission');
+      return res.apiv3({ customBotWithoutProxyCommandPermissionarams });
+    }
+    catch (error) {
+      const msg = 'Error occured in updating command permission settigns';
+      logger.error('Error', error);
+      return res.apiv3Err(new ErrorV3(msg, 'update-CustomBotSetting-failed'), 500);
+    }
+  });
+
 
   /**
    * @swagger

--- a/packages/app/src/server/routes/apiv3/slack-integration-settings.js
+++ b/packages/app/src/server/routes/apiv3/slack-integration-settings.js
@@ -179,7 +179,7 @@ module.exports = (crowi) => {
       settings.slackBotTokenEnvVars = configManager.getConfigFromEnvVars('crowi', 'slackbot:withoutProxy:botToken');
       settings.slackSigningSecret = configManager.getConfig('crowi', 'slackbot:withoutProxy:signingSecret');
       settings.slackBotToken = configManager.getConfig('crowi', 'slackbot:withoutProxy:botToken');
-      settings.commandPermission = configManager.getConfig('crowi', 'slackbot:withoutProxy:commandPermission');
+      settings.commandPermission = JSON.parse(configManager.getConfig('crowi', 'slackbot:withoutProxy:commandPermission'));
     }
     else {
       settings.proxyServerUri = crowi.configManager.getConfig('crowi', 'slackbot:proxyUri');
@@ -249,6 +249,25 @@ module.exports = (crowi) => {
   const handleBotTypeChanging = async(req, res, initializedBotType) => {
     await resetAllBotSettings(initializedBotType);
     crowi.slackIntegrationService.publishUpdatedMessage();
+
+    if (initializedBotType === 'customBotWithoutProxy') {
+      // set without-proxy command permissions at bot type changing
+      const commandPermission = {};
+      [...defaultSupportedCommandsNameForBroadcastUse, ...defaultSupportedCommandsNameForSingleUse].forEach((commandName) => {
+        commandPermission[commandName] = true;
+      });
+
+      const requestParams = { 'slackbot:withoutProxy:commandPermission': JSON.stringify(commandPermission) };
+      try {
+        await updateSlackBotSettings(requestParams);
+        crowi.slackIntegrationService.publishUpdatedMessage();
+      }
+      catch (error) {
+        const msg = 'Error occured in updating command permission settigns';
+        logger.error('Error', error);
+        return res.apiv3Err(new ErrorV3(msg, 'update-CustomBotSetting-failed'), 500);
+      }
+    }
 
     // TODO Impl to delete AccessToken both of Proxy and GROWI when botType changes.
     const slackBotTypeParam = { slackBotType: crowi.configManager.getConfig('crowi', 'slackbot:currentBotType') };
@@ -362,6 +381,20 @@ module.exports = (crowi) => {
     }
   });
 
+  /**
+   * @swagger
+   *
+   *    /slack-integration-settings/without-proxy/update-permissions/:
+   *      put:
+   *        tags: [UpdateWithoutProxyPermissions]
+   *        operationId: putWithoutProxyPermissions
+   *        summary: update customBotWithoutProxy permissions
+   *        description: Update customBotWithoutProxy permissions.
+   *        responses:
+   *           200:
+   *             description: Succeeded to put CustomBotWithoutProxy permissions.
+   */
+
   router.put('/without-proxy/update-permissions', async(req, res) => {
     const currentBotType = crowi.configManager.getConfig('crowi', 'slackbot:currentBotType');
     if (currentBotType !== SlackbotType.CUSTOM_WITHOUT_PROXY) {
@@ -371,7 +404,7 @@ module.exports = (crowi) => {
 
     const { commandPermission } = req.body;
     const requestParams = {
-      'slackbot:withouProxy:commandPermission': commandPermission,
+      'slackbot:withoutProxy:commandPermission': commandPermission,
     };
     try {
       await updateSlackBotSettings(requestParams);

--- a/packages/app/src/server/service/config-loader.ts
+++ b/packages/app/src/server/service/config-loader.ts
@@ -6,6 +6,8 @@ import ConfigModel, {
   Config, defaultCrowiConfigs, defaultMarkdownConfigs, defaultNotificationConfigs,
 } from '../models/config';
 
+const { defaultSupportedCommandsNameForBroadcastUse, defaultSupportedCommandsNameForSingleUse } = require('@growi/slack');
+
 const logger = loggerFactory('growi:service:ConfigLoader');
 
 enum ValueType { NUMBER, STRING, BOOLEAN }
@@ -30,6 +32,11 @@ const parserDictionary: EnumDictionary<ValueType, ValueParser<number | string | 
   [ValueType.STRING]:  { parse: (v: string) => { return v } },
   [ValueType.BOOLEAN]: { parse: (v: string) => { return envUtils.toBoolean(v) } },
 };
+
+const commandPermission = {};
+[...defaultSupportedCommandsNameForBroadcastUse, ...defaultSupportedCommandsNameForSingleUse].forEach((commandName) => {
+  commandPermission[commandName] = true;
+});
 
 /**
  * The following env vars are excluded because these are currently used before the configuration setup.
@@ -488,9 +495,9 @@ const ENV_VAR_NAME_TO_CONFIG_INFO = {
   },
   SLACKBOT_WITHOUT_PROXY_COMMAND_PERMISSION: {
     ns:      'crowi',
-    key:     'slackbot:withoutProxy:commandsPermission',
+    key:     'slackbot:withoutProxy:commandPermission',
     type:    ValueType.STRING,
-    default: JSON.stringify({ commandPermission: { search: true, create: true, togetter: true } }),
+    default: JSON.stringify(commandPermission),
   },
   SLACKBOT_WITH_PROXY_SALT_FOR_GTOP: {
     ns:      'crowi',

--- a/packages/app/src/server/service/config-loader.ts
+++ b/packages/app/src/server/service/config-loader.ts
@@ -6,7 +6,6 @@ import ConfigModel, {
   Config, defaultCrowiConfigs, defaultMarkdownConfigs, defaultNotificationConfigs,
 } from '../models/config';
 
-const { defaultSupportedCommandsNameForBroadcastUse, defaultSupportedCommandsNameForSingleUse } = require('@growi/slack');
 
 const logger = loggerFactory('growi:service:ConfigLoader');
 
@@ -32,11 +31,6 @@ const parserDictionary: EnumDictionary<ValueType, ValueParser<number | string | 
   [ValueType.STRING]:  { parse: (v: string) => { return v } },
   [ValueType.BOOLEAN]: { parse: (v: string) => { return envUtils.toBoolean(v) } },
 };
-
-const commandPermission = {};
-[...defaultSupportedCommandsNameForBroadcastUse, ...defaultSupportedCommandsNameForSingleUse].forEach((commandName) => {
-  commandPermission[commandName] = true;
-});
 
 /**
  * The following env vars are excluded because these are currently used before the configuration setup.
@@ -497,7 +491,7 @@ const ENV_VAR_NAME_TO_CONFIG_INFO = {
     ns:      'crowi',
     key:     'slackbot:withoutProxy:commandPermission',
     type:    ValueType.STRING,
-    default: JSON.stringify(commandPermission),
+    default: null,
   },
   SLACKBOT_WITH_PROXY_SALT_FOR_GTOP: {
     ns:      'crowi',

--- a/packages/app/src/server/service/config-loader.ts
+++ b/packages/app/src/server/service/config-loader.ts
@@ -486,6 +486,12 @@ const ENV_VAR_NAME_TO_CONFIG_INFO = {
     type:    ValueType.STRING,
     default: null,
   },
+  SLACKBOT_WITHOUT_PROXY_COMMAND_PERMISSION: {
+    ns:      'crowi',
+    key:     'slackbot:withoutProxy:commandsPermission',
+    type:    ValueType.STRING,
+    default: JSON.stringify({ commandPermission: { search: true, create: true, togetter: true } }),
+  },
   SLACKBOT_WITH_PROXY_SALT_FOR_GTOP: {
     ns:      'crowi',
     key:     'slackbot:withProxy:saltForGtoP',


### PR DESCRIPTION
## 概要
without-proxy でもチャンネルごとに権限設定を行うために、権限情報を config-loader に保持するようにしました。
JSON.stringify で string 化し、フロントで parse する予定です。