### PR TITLE
Imprv:create one relation method

### DIFF
--- a/packages/slackbot-proxy/src/services/RelationsService.ts
+++ b/packages/slackbot-proxy/src/services/RelationsService.ts
@@ -142,6 +142,7 @@ export class RelationsService {
       return relationResult;
     }));
 
+    // Pick up only a relation which status is "rejected" in results. Like bellow
     const rejectedResults: PromiseRejectedResult[] = results.filter((result): result is PromiseRejectedResult => result.status === 'rejected');
 
     return {

--- a/packages/slackbot-proxy/src/services/RelationsService.ts
+++ b/packages/slackbot-proxy/src/services/RelationsService.ts
@@ -128,8 +128,8 @@ export class RelationsService {
     const disallowedGrowiUrls:Set<string> = new Set();
     let commandName = '';
 
-    const results = await Promise.allSettled(relations.map(async(relation) => {
-      const relationResult = await this.checkEachRelation(relation, actionId, callbackId, channelName);
+    const results = await Promise.allSettled(relations.map((relation) => {
+      const relationResult = this.checkEachRelation(relation, actionId, callbackId, channelName);
       const { allowedRelation, disallowedGrowiUrl, eachRelationCommandName } = relationResult;
 
       if (allowedRelation != null) {
@@ -139,18 +139,17 @@ export class RelationsService {
         disallowedGrowiUrls.add(disallowedGrowiUrl);
       }
       commandName = eachRelationCommandName;
-
+      return relationResult;
     }));
 
     const rejectedResults: PromiseRejectedResult[] = results.filter((result): result is PromiseRejectedResult => result.status === 'rejected');
 
-    // return this.relationsResult(relations, actionId, callbackId, channelName);
     return {
       allowedRelations, disallowedGrowiUrls, commandName, rejectedResults,
     };
   }
 
-  async checkEachRelation(relation:Relation, actionId:string, callbackId:string, channelName:string):Promise<checkEachRelationResult> {
+  checkEachRelation(relation:Relation, actionId:string, callbackId:string, channelName:string):checkEachRelationResult {
 
     let allowedRelation:Relation|null = null;
     let disallowedGrowiUrl:string|null = null;


### PR DESCRIPTION
## 概要
- https://github.com/weseek/growi/pull/4251 の PR で指摘された内容を修正しました。
> これって後続タスク？
第一引数が relation: Relation のメソッドがどこかにないといけない。

- relations でまとめて処理するのではなく relation に対して行う method を作成しました。