### PR TITLE
Imprv/gw 7388 fb

### DIFF
--- a/packages/app/src/components/Sidebar/RecentChanges.jsx
+++ b/packages/app/src/components/Sidebar/RecentChanges.jsx
@@ -56,7 +56,7 @@ function LargePageItem({ page }) {
   const tags = page.tags;
   const tagElements = tags.map((tag) => {
     return (
-      <a key={tag} href={`/_search?q=tag:${tag.name}`} className="grw-tag-label badge badge-secondary mr-2 small">
+      <a key={tag.name} href={`/_search?q=tag:${tag.name}`} className="grw-tag-label badge badge-secondary mr-2 small">
         {tag.name}
       </a>
     );

--- a/packages/app/src/styles/_recent-changes.scss
+++ b/packages/app/src/styles/_recent-changes.scss
@@ -5,9 +5,10 @@
 
   .grw-recent-changes-resize-button {
     font-size: 12px;
-    transform: translateY(4px);
+    line-height: normal;
+    transform: translateY(6px);
 
-    .custom-control-input:not(:checked) + .custom-control-label::before {
+    .custom-control-label::before {
       padding-left: 16px;
       content: 'L';
     }

--- a/packages/app/src/styles/_sidebar.scss
+++ b/packages/app/src/styles/_sidebar.scss
@@ -133,6 +133,10 @@
   .grw-drawer-toggler {
     display: none; // invisible in default
   }
+
+  .grw-sidebar-content-header {
+    min-width: 260px;
+  }
 }
 
 // Dock Mode

--- a/packages/app/src/styles/_sidebar.scss
+++ b/packages/app/src/styles/_sidebar.scss
@@ -135,7 +135,7 @@
   }
 
   .grw-sidebar-content-header {
-    min-width: 260px;
+    min-width: $grw-sidebar-content-min-width + 20px;
   }
 }
 


### PR DESCRIPTION
1. 幅を狭めたときにRecent Changesが折り返されるのを修正

![image](https://user-images.githubusercontent.com/46134198/132540273-dd5ba216-3b2a-46ef-8244-bc5fee0476c2.png)
↓
<img width="271" alt="スクリーンショット 2021-09-09 0 40 30" src="https://user-images.githubusercontent.com/46134198/132540942-28464f19-6ce4-40c7-b85b-b4ce619edbe7.png">

2. コンソールのエラーを解消
　　tagのmapのkeyにtag(name, id など複数の値)が渡されてたことが原因

3. トグルスイッチボタンの中の文字を中央に寄せた