### PR TITLE
remove inline-block

### DIFF
--- a/packages/app/src/components/PagePathHierarchicalLink.jsx
+++ b/packages/app/src/components/PagePathHierarchicalLink.jsx
@@ -46,7 +46,7 @@ const PagePathHierarchicalLink = (props) => {
   const RootElm = ({ children }) => {
     return props.isInnerElem
       ? <>{children}</>
-      : <span className="grw-page-path-hierarchical-link d-inline-block text-break">{children}</span>;
+      : <span className="grw-page-path-hierarchical-link text-break">{children}</span>;
   };
 
   return (


### PR DESCRIPTION
タイトルが長い場合に 鍵アイコンがタイトルの右ではなく下にずれてしまうのを修正

<img width="296" alt="スクリーンショット 2021-09-10 17 27 19" src="https://user-images.githubusercontent.com/46134198/132824425-9dec4124-7121-480f-98b8-4cf5c7022a61.png">
