### PR TITLE
GW-7420 Editor SettingsでOFFにした設定がLintに適用されてないのを修正する

### DIFF
--- a/packages/app/src/components/PageEditor/CodeMirrorEditor.jsx
+++ b/packages/app/src/components/PageEditor/CodeMirrorEditor.jsx
@@ -174,7 +174,7 @@ export default class CodeMirrorEditor extends AbstractEditor {
       this.setState({ isEnabledEmojiAutoComplete: true });
     }
 
-    this.initTextlintSettings();
+    this.initializeTextlint();
   }
 
   componentDidMount() {
@@ -200,7 +200,8 @@ export default class CodeMirrorEditor extends AbstractEditor {
     this.setKeymapMode(keymapMode);
   }
 
-  async initTextlintSettings() {
+  async initializeTextlint() {
+    await this.props.onInitializeTextlint();
     // If database has empty array, pass null instead to enable all default rules
     const rulesForValidator = this.props.textlintRules?.length !== 0 ? this.props.textlintRules : null;
     this.textlintValidator = createValidator(rulesForValidator);
@@ -988,6 +989,7 @@ CodeMirrorEditor.propTypes = Object.assign({
   lineNumbers: PropTypes.bool,
   onMarkdownHelpButtonClicked: PropTypes.func,
   onAddAttachmentButtonClicked: PropTypes.func,
+  onInitializeTextlint: PropTypes.func,
 }, AbstractEditor.propTypes);
 
 CodeMirrorEditor.defaultProps = {

--- a/packages/app/src/components/PageEditor/CodeMirrorEditor.jsx
+++ b/packages/app/src/components/PageEditor/CodeMirrorEditor.jsx
@@ -201,11 +201,13 @@ export default class CodeMirrorEditor extends AbstractEditor {
   }
 
   async initializeTextlint() {
-    await this.props.onInitializeTextlint();
-    // If database has empty array, pass null instead to enable all default rules
-    const rulesForValidator = this.props.textlintRules?.length !== 0 ? this.props.textlintRules : null;
-    this.textlintValidator = createValidator(rulesForValidator);
-    this.codemirrorLintConfig = { getAnnotations: this.textlintValidator, async: true };
+    if (this.props.onInitializeTextlint != null) {
+      await this.props.onInitializeTextlint();
+      // If database has empty array, pass null instead to enable all default rules
+      const rulesForValidator = this.props.textlintRules?.length !== 0 ? this.props.textlintRules : null;
+      this.textlintValidator = createValidator(rulesForValidator);
+      this.codemirrorLintConfig = { getAnnotations: this.textlintValidator, async: true };
+    }
   }
 
   getCodeMirror() {

--- a/packages/app/src/components/PageEditor/Editor.jsx
+++ b/packages/app/src/components/PageEditor/Editor.jsx
@@ -47,10 +47,6 @@ class Editor extends AbstractEditor {
     this.renderDropzoneOverlay = this.renderDropzoneOverlay.bind(this);
   }
 
-  componentWillMount() {
-    this.props.editorContainer.retrieveEditorSettings();
-  }
-
   componentDidMount() {
     this.setState({ isComponentDidMount: true });
   }
@@ -323,6 +319,7 @@ class Editor extends AbstractEditor {
                         editorOptions={editorContainer.state.editorOptions}
                         isTextlintEnabled={editorContainer.state.isTextlintEnabled}
                         textlintRules={editorContainer.state.textlintRules}
+                        onInitializeTextlint={editorContainer.retrieveEditorSettings}
                         onPasteFiles={this.pasteFilesHandler}
                         onDragEnter={this.dragEnterHandler}
                         onMarkdownHelpButtonClicked={this.showMarkdownHelp}


### PR DESCRIPTION
## タスク
[GW-7420 Editor SettingsでOFFにした設定がLintに適用されてないのを修正する](https://youtrack.weseek.co.jp/issue/GW-7420
)
## Bug
各LintルールをON/OFFしても反映されず、時にはすべてのルールが有効になってしまうことがある

## 原因
`retrieveEditorSettings()`を呼ぶ前にTextlintの設定を生成(`createValidator()`)されることがあるため
(親であるEditor.jsxと子であるCodeMirrorEditor.jsxのレンダーの順番によってステートが最新でないことがあるため)
対応箇所: https://github.com/weseek/growi/pull/4268#discussion_r703423743

## 試したこと
CodeMirrorEditor.jsxにある`initializeTextlint()`をcomponentDidMountに移し、親であるEditor.jsxのcomponentWillMountにある`retrieveEditorSettings()`より後に呼び出されるようにする
 - 治らず

## 対処法
`initializeTextlint()`内でawaitで呼ぶようにし、必ず最新の情報を取ってきてから`createValidator()`するようにした