### PR TITLE
Imprv/7442 register service

### DIFF
--- a/packages/slackbot-proxy/src/controllers/slack.ts
+++ b/packages/slackbot-proxy/src/controllers/slack.ts
@@ -146,18 +146,7 @@ export class SlackCtrl {
 
     // register
     if (growiCommand.growiCommandType === 'register') {
-      try {
-        return this.registerService.process(growiCommand, authorizeResult, body as {[key:string]:string});
-      }
-      catch (err) {
-        // WIP
-        return respond(growiCommand.responseUrl, {
-          blocks: [
-            markdownSectionBlock('*Failed to register.*'),
-            markdownSectionBlock('Invite GROWI Bot to the channel first.'),
-          ],
-        });
-      }
+      return this.registerService.process(growiCommand, authorizeResult, body as {[key:string]:string});
     }
 
     // unregister
@@ -289,6 +278,7 @@ export class SlackCtrl {
     const installation = await this.installationRepository.findByTeamIdOrEnterpriseId(installationId!);
 
     const payload = JSON.parse(body.payload);
+    console.log('ぺいろーど！！！\n', payload);
     const callBackId = payload?.view?.callback_id;
 
     // register
@@ -302,13 +292,6 @@ export class SlackCtrl {
           return;
         }
         logger.error(err);
-        // WIP
-        // return respond('responseUrl', {
-        //   blocks: [
-        //     markdownSectionBlock('*Failed to register.*'),
-        //     markdownSectionBlock('Please invite GROWI Bot to the channel first.'),
-        //   ],
-        // });
       }
 
       await this.registerService.notifyServerUriToSlack(authorizeResult.botToken, payload);

--- a/packages/slackbot-proxy/src/controllers/slack.ts
+++ b/packages/slackbot-proxy/src/controllers/slack.ts
@@ -146,7 +146,18 @@ export class SlackCtrl {
 
     // register
     if (growiCommand.growiCommandType === 'register') {
-      return this.registerService.process(growiCommand, authorizeResult, body as {[key:string]:string});
+      try {
+        return this.registerService.process(growiCommand, authorizeResult, body as {[key:string]:string});
+      }
+      catch (err) {
+        // WIP
+        return respond(growiCommand.responseUrl, {
+          blocks: [
+            markdownSectionBlock('*Failed to register.*'),
+            markdownSectionBlock('Invite GROWI Bot to the channel first.'),
+          ],
+        });
+      }
     }
 
     // unregister
@@ -291,6 +302,13 @@ export class SlackCtrl {
           return;
         }
         logger.error(err);
+        // WIP
+        // return respond('responseUrl', {
+        //   blocks: [
+        //     markdownSectionBlock('*Failed to register.*'),
+        //     markdownSectionBlock('Please invite GROWI Bot to the channel first.'),
+        //   ],
+        // });
       }
 
       await this.registerService.notifyServerUriToSlack(authorizeResult.botToken, payload);

--- a/packages/slackbot-proxy/src/services/RegisterService.ts
+++ b/packages/slackbot-proxy/src/services/RegisterService.ts
@@ -1,7 +1,9 @@
 import { Inject, Service } from '@tsed/di';
-import { WebClient, LogLevel, Block } from '@slack/web-api';
 import {
-  markdownSectionBlock, markdownHeaderBlock, inputSectionBlock, GrowiCommand,
+  WebClient, LogLevel, Block, ConversationsSelect,
+} from '@slack/web-api';
+import {
+  markdownSectionBlock, markdownHeaderBlock, inputSectionBlock, GrowiCommand, inputBlock, respond,
 } from '@growi/slack';
 import { AuthorizeResult } from '@slack/oauth';
 import { GrowiCommandProcessor } from '~/interfaces/slack-to-growi/growi-command-processor';
@@ -22,6 +24,13 @@ export class RegisterService implements GrowiCommandProcessor {
     const { botToken } = authorizeResult;
 
     const client = new WebClient(botToken, { logLevel: isProduction ? LogLevel.DEBUG : LogLevel.INFO });
+
+    const conversationsSelectElement: ConversationsSelect = {
+      action_id: 'conversation',
+      type: 'conversations_select',
+      response_url_enabled: true,
+      default_to_current_conversation: true,
+    };
     await client.views.open({
       trigger_id: body.trigger_id,
       view: {
@@ -42,24 +51,13 @@ export class RegisterService implements GrowiCommandProcessor {
         private_metadata: JSON.stringify({ channel: body.channel_name }),
 
         blocks: [
+          inputBlock(conversationsSelectElement, 'conversation', 'Channel to which you want to add'),
           inputSectionBlock('growiUrl', 'GROWI domain', 'contents_input', false, 'https://example.com'),
           inputSectionBlock('tokenPtoG', 'Access Token Proxy to GROWI', 'contents_input', false, 'jBMZvpk.....'),
           inputSectionBlock('tokenGtoP', 'Access Token GROWI to Proxy', 'contents_input', false, 'sdg15av.....'),
         ],
       },
     });
-  }
-
-  async replyToSlack(client: WebClient, channel: string, user: string, text: string, blocks: Array<Block>): Promise<void> {
-    await client.chat.postEphemeral({
-      channel,
-      user,
-      // Recommended including 'text' to provide a fallback when using blocks
-      // refer to https://api.slack.com/methods/chat.postEphemeral#text_usage
-      text,
-      blocks,
-    });
-    return;
   }
 
   async insertOrderRecord(
@@ -72,20 +70,17 @@ export class RegisterService implements GrowiCommandProcessor {
     const tokenPtoG = inputValues.tokenPtoG.contents_input.value;
     const tokenGtoP = inputValues.tokenGtoP.contents_input.value;
 
-    const { channel } = JSON.parse(payload.view.private_metadata);
-
-    const client = new WebClient(botToken, { logLevel: isProduction ? LogLevel.DEBUG : LogLevel.INFO });
-
     try {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const url = new URL(growiUrl);
     }
     catch (error) {
-      const invalidErrorMsg = 'Please enter a valid URL';
-      const blocks = [
-        markdownSectionBlock(invalidErrorMsg),
-      ];
-      await this.replyToSlack(client, channel, payload.user.id, 'Invalid URL', blocks);
+      await respond(payload.response_urls[0].response_url, {
+        text: 'Invalid URL',
+        blocks: [
+          markdownSectionBlock('Please enter a valid URL'),
+        ],
+      });
       throw new InvalidUrlError(growiUrl);
     }
 
@@ -103,8 +98,6 @@ export class RegisterService implements GrowiCommandProcessor {
 
     const serverUri = process.env.SERVER_URI;
 
-    const client = new WebClient(botToken, { logLevel: isProduction ? LogLevel.DEBUG : LogLevel.INFO });
-
     const blocks: Block[] = [];
 
     if (isOfficialMode) {
@@ -115,7 +108,10 @@ export class RegisterService implements GrowiCommandProcessor {
       blocks.push(markdownSectionBlock('*Test Connection* to complete the registration in your GROWI.'));
       blocks.push(markdownHeaderBlock(':white_large_square: 4. (Opt) Manage GROWI commands'));
       blocks.push(markdownSectionBlock('Modify permission settings if you need.'));
-      await this.replyToSlack(client, channel, payload.user.id, 'Proxy URL', blocks);
+      await respond(payload.response_urls[0].response_url, {
+        text: 'Proxy URL',
+        blocks,
+      });
       return;
 
     }
@@ -131,7 +127,10 @@ export class RegisterService implements GrowiCommandProcessor {
     blocks.push(markdownSectionBlock('And *Test Connection* to complete the registration in your GROWI.'));
     blocks.push(markdownHeaderBlock(':white_large_square: 6. (Opt) Manage GROWI commands'));
     blocks.push(markdownSectionBlock('Modify permission settings if you need.'));
-    await this.replyToSlack(client, channel, payload.user.id, 'Proxy URL', blocks);
+    await respond(payload.response_urls[0].response_url, {
+      text: 'Proxy URL',
+      blocks,
+    });
     return;
   }
 


### PR DESCRIPTION
GW-7442 RegisterService 改修

を実装しました。

Bot を招待していない private channel から /growi register を正常に使うことができるようになりました。
ただ、現状 relation test は private channel 対応していない(対応不可能だと思う)なので、以下の後続タスクでユーザーがスムーズに relation test できるようにすることを目指します。

GW-7478 relation-test で private channel 対応させるか、public channel で確認してください的な内容を表示しておく [7442 後続]