### PR TITLE
imprv: Send error name instead of error type

### DIFF
--- a/packages/slackbot-proxy/src/controllers/growi-to-slack.ts
+++ b/packages/slackbot-proxy/src/controllers/growi-to-slack.ts
@@ -293,7 +293,7 @@ export class GrowiToSlackCtrl {
       logger.error(err);
 
       if (err.code === ErrorCode.PlatformError) {
-        return res.simulateWebAPIPlatformError(err.message, err.code);
+        return res.simulateWebAPIPlatformError(err.message, err.data.error);
       }
 
       return res.simulateWebAPIRequestError(err.message, err.response?.status);


### PR DESCRIPTION
### ストーリー
**GW-7411 [Bot](app) bot が private channel に入っていない場合、bot を join させる旨の toastr を出す**

### タスク
**GW-7377 [エラー回り改修] Proxy から GROWI のレスポンスで WebclientError の 'not_in_channel' などのエラーコードを取得できる**

### 内容
- `slack_webapi_platform_error`などのerror typeではなく`channel_not_found`などのエラー名を返すようにしました。
- 後続タスクでToastrを表示させるときに使用します。