### PR TITLE
imprv: get supported growi actions reg exps

### DIFF
--- a/packages/app/src/server/util/slack-integration.ts
+++ b/packages/app/src/server/util/slack-integration.ts
@@ -1,3 +1,5 @@
+import { getSupportedGrowiActionsRegExp } from '@growi/slack';
+
 type CommandPermission = { [key:string]: string[] | boolean }
 
 export const checkPermission = (
@@ -8,8 +10,7 @@ export const checkPermission = (
   Object.entries(commandPermission).forEach((entry) => {
     const [command, value] = entry;
     const permission = value;
-    const commandRegExp = new RegExp(`(^${command}$)|(^${command}:\\w+)`);
-
+    const commandRegExp = getSupportedGrowiActionsRegExp(command);
     if (!commandRegExp.test(commandOrActionIdOrCallbackId)) return;
 
     // permission check

--- a/packages/slack/src/utils/get-supported-growi-actions-regexps.ts
+++ b/packages/slack/src/utils/get-supported-growi-actions-regexps.ts
@@ -1,3 +1,7 @@
 export const getSupportedGrowiActionsRegExps = (supportedGrowiCommands: string[]): RegExp[] => {
   return supportedGrowiCommands.map(command => new RegExp(`^${command}:\\w+`));
 };
+
+export const getSupportedGrowiActionsRegExp = (supportedGrowiCommand: string): RegExp => {
+  return new RegExp(`(^${supportedGrowiCommand}$)|(^${supportedGrowiCommand}:\\w+)`);
+};

--- a/packages/slackbot-proxy/src/services/RelationsService.ts
+++ b/packages/slackbot-proxy/src/services/RelationsService.ts
@@ -3,7 +3,7 @@ import { Inject, Service } from '@tsed/di';
 import axios from 'axios';
 import { addHours } from 'date-fns';
 
-import { REQUEST_TIMEOUT_FOR_PTOG } from '@growi/slack';
+import { REQUEST_TIMEOUT_FOR_PTOG, getSupportedGrowiActionsRegExp } from '@growi/slack';
 import { Relation } from '~/entities/relation';
 import { RelationRepository } from '~/repositories/relation';
 
@@ -163,7 +163,7 @@ export class RelationsService {
     [...singleUse, ...broadCastUse].forEach(async(tempCommandName) => {
 
       // ex. search OR search:handlerName
-      const commandRegExp = new RegExp(`(^${tempCommandName}$)|(^${tempCommandName}:\\w+)`);
+      const commandRegExp = getSupportedGrowiActionsRegExp(tempCommandName);
       // skip this forEach loop if the requested command is not in permissionsForBroadcastUseCommands and permissionsForSingleUseCommands
       if (!commandRegExp.test(actionId) && !commandRegExp.test(callbackId)) {
         return;


### PR DESCRIPTION
## 概要
以下を slack package の util のものを使うように改修しました。

```const commandRegExp = new RegExp(`(^${tempCommandName}$)|(^${tempCommandName}:\\w+)`);```