### PR TITLE
fix: Response when no pages are found /growi search

### DIFF
--- a/packages/app/src/server/service/slack-command-handler/search.js
+++ b/packages/app/src/server/service/slack-command-handler/search.js
@@ -35,6 +35,10 @@ module.exports = (crowi) => {
       pages, offset, resultsTotal,
     } = searchResult;
 
+    if (pages.length === 0) {
+      return;
+    }
+
     const keywords = this.getKeywords(args);
 
 

--- a/packages/app/src/server/service/slack-command-handler/search.js
+++ b/packages/app/src/server/service/slack-command-handler/search.js
@@ -365,7 +365,7 @@ module.exports = (crowi) => {
         user: body.user_id,
         text: `No page found with "${keywords}"`,
         blocks: [
-          markdownSectionBlock(`*No page that matches your keyword(s) "${keywords}".*`),
+          markdownSectionBlock(`*No page matches your keyword(s) "${keywords}".*`),
           markdownSectionBlock(':mag: *Help: Searching*'),
           divider(),
           markdownSectionBlock('`word1` `word2` (divide with space) \n Search pages that include both word1, word2 in the title or body'),


### PR DESCRIPTION
## ストーリ
[**GW-7463 [Bug][Bot]/growi searchでヒットしなかった場合にundefined/NaNと出る**](https://youtrack.weseek.co.jp/agiles/84-39/current?issue=GW-7463)

## タスク
[**修正**](https://youtrack.weseek.co.jp/agiles/84-39/current?issue=GW-7464)

## 概要
- `/growi search`コマンド実行時に検索結果が0の場合、Undefined/NaN等の応答が帰ってくるBugを修正
- 原因: `handleCommand`が`retrieveSearchResults`呼び出し、検索結果が0のときに`retrieveSearchResults`がpostEphemeralをしたにも関わらず、returnをしていないため`handleCommand`の方でもpostEphemeralをしてしまう

### Before
<img width="417" alt="Screen Shot 2021-09-17 at 12 17 11" src="https://user-images.githubusercontent.com/66785624/133720735-67f9b54c-fe0d-4abd-b579-0021214c2b0a.png">

### After
<img width="700" alt="Screen Shot 2021-09-17 at 12 38 19" src="https://user-images.githubusercontent.com/66785624/133720741-b3710ec9-50c6-47a4-b436-7ab5004dad44.png">
