### PR TITLE
Imprv/gw7228 saving activity document when a comment created

### DIFF
--- a/packages/app/src/server/models/activity.ts
+++ b/packages/app/src/server/models/activity.ts
@@ -8,7 +8,7 @@ import loggerFactory from '../../utils/logger';
 import ActivityDefine from '../util/activityDefine';
 
 import Watcher from './watcher';
-import { InAppNotification } from './in-app-notification';
+// import { InAppNotification } from './in-app-notification';
 // import activityEvent from '../events/activity';
 
 const logger = loggerFactory('growi:models:activity');

--- a/packages/app/src/server/models/activity.ts
+++ b/packages/app/src/server/models/activity.ts
@@ -8,7 +8,7 @@ import loggerFactory from '../../utils/logger';
 import ActivityDefine from '../util/activityDefine';
 
 import Watcher from './watcher';
-// import { InAppNotification } from './in-app-notification';
+import { InAppNotification } from './in-app-notification';
 // import activityEvent from '../events/activity';
 
 const logger = loggerFactory('growi:models:activity');
@@ -196,11 +196,11 @@ activitySchema.methods.getNotificationTargetUsers = async function() {
 };
 
 /**
-   * saved hook
+   * saved hook   TODO: getNotificationTargetUsers by GW-7346
    */
 activitySchema.post('save', async(savedActivity: ActivityDocument) => {
   try {
-    const notificationUsers = await savedActivity.getNotificationTargetUsers();
+    // const notificationUsers = await savedActivity.getNotificationTargetUsers();
 
     // await Promise.all(notificationUsers.map(user => InAppNotification.upsertByActivity(user, savedActivity)));
     return;

--- a/packages/app/src/server/models/comment.js
+++ b/packages/app/src/server/models/comment.js
@@ -1,5 +1,6 @@
 // disable no-return-await for model functions
 /* eslint-disable no-return-await */
+import { Activity } from './activity';
 
 module.exports = function(crowi) {
   const debug = require('debug')('growi:models:comment');
@@ -116,8 +117,14 @@ module.exports = function(crowi) {
       throw err;
     }
 
-
     await commentEvent.emit('create', savedComment.creator);
+    try {
+      const activityLog = await Activity.createByPageComment(savedComment);
+      debug('Activity created', activityLog);
+    }
+    catch (err) {
+      throw err;
+    }
   });
 
   return mongoose.model('Comment', commentSchema);


### PR DESCRIPTION
- Activity をDBに保存(コメント作成時)
<img width="1242" alt="Screen Shot 2021-09-19 at 15 27 56" src="https://user-images.githubusercontent.com/59536731/133917797-453c663c-aace-429b-a62b-969664dc47cc.png">


- activityLog
```
activityLog {
  _id: 6146d8f5e3cb3a1399b4b23e,
  user: 61444dadb9ce7d0f8da3bac3,
  targetModel: 'Page',
  target: 61444dffb9ce7d0f8da3bacf,
  eventModel: 'Comment',
  event: 6146d8f5e3cb3a1399b4b23d,
  action: 'COMMENT',
  createdAt: 2021-09-19T06:30:13.856Z,
  __v: 0
}
```