### PR TITLE
feat: Switching the global search scope

### DIFF
--- a/packages/app/resource/locales/en_US/admin/admin.json
+++ b/packages/app/resource/locales/en_US/admin/admin.json
@@ -154,7 +154,9 @@
       "stale_notification": "Display notification on stale pages",
       "stale_notification_desc": "Displays the notification to pages more than 1 year since the last update.",
       "show_all_reply_comments": "Show all reply comments",
-      "show_all_reply_comments_desc": "When the setting value is off, comments other than the latest two are omitted."
+      "show_all_reply_comments_desc": "When the setting value is off, comments other than the latest two are omitted.",
+      "select_search_scope_children_as_default": "Select 'Only children of this tree' as default value of search range",
+      "select_search_scope_children_as_default_desc": "When the setting value is off, 'All pages' is used as default value of search range."
     },
     "code_highlight": "Code highlight",
     "nocdn_desc": "This function is disabled when the environment variable <code>NO_CDN=true</code>.<br>Github style has been forcibly applied.",

--- a/packages/app/resource/locales/ja_JP/admin/admin.json
+++ b/packages/app/resource/locales/ja_JP/admin/admin.json
@@ -148,7 +148,9 @@
       "stale_notification": "古いページに通知を表示する",
       "stale_notification_desc": "最後の更新から1年を超えるページへの通知を表示します。",
       "show_all_reply_comments": "返信コメントを全て表示する",
-      "show_all_reply_comments_desc": "OFFの場合、最新2件のコメント以外が省略されます。"
+      "show_all_reply_comments_desc": "OFFの場合、最新2件のコメント以外が省略されます。",
+      "select_search_scope_children_as_default": "検索範囲のデフォルト設定を「この階層下の子ページ」にする",
+      "select_search_scope_children_as_default_desc": "OFFの場合、検索範囲のデフォルト設定は「全てのページ」になります。"
     },
     "code_highlight": "コードハイライト",
     "nocdn_desc": "この機能は、環境変数 <code>NO_CDN=true</code> の時は無効化されます。<br>GitHub スタイルが適用されています。",

--- a/packages/app/resource/locales/zh_CN/admin/admin.json
+++ b/packages/app/resource/locales/zh_CN/admin/admin.json
@@ -158,7 +158,9 @@
       "stale_notification": "在过期页上显示通知",
       "stale_notification_desc": "显示自上次更新以来超过1年的页面通知。",
       "show_all_reply_comments": "显示所有回复评论",
-      "show_all_reply_comments_desc": "当设置值为“关”时，将忽略最近两个之外的注释。"
+      "show_all_reply_comments_desc": "当设置值为“关”时，将忽略最近两个之外的注释。",
+      "select_search_scope_children_as_default": "Select 'Only children of this tree' as default value of search range",
+      "select_search_scope_children_as_default_desc": "When the setting value is off, 'All pages' is used as default value of search range."
     },
     "code_highlight": "代码突出显示",
     "nocdn_desc": "当强制应用环境变量<code>NO_CDN=true</code><br>Github样式时，此函数被禁用。",

--- a/packages/app/resource/locales/zh_CN/admin/admin.json
+++ b/packages/app/resource/locales/zh_CN/admin/admin.json
@@ -159,8 +159,8 @@
       "stale_notification_desc": "显示自上次更新以来超过1年的页面通知。",
       "show_all_reply_comments": "显示所有回复评论",
       "show_all_reply_comments_desc": "当设置值为“关”时，将忽略最近两个之外的注释。",
-      "select_search_scope_children_as_default": "Select 'Only children of this tree' as default value of search range",
-      "select_search_scope_children_as_default_desc": "When the setting value is off, 'All pages' is used as default value of search range."
+      "select_search_scope_children_as_default": "选择“当前分支以下内容”, 作为搜索范围的默认值",
+      "select_search_scope_children_as_default_desc": "当设置值为“关”时，“所有页面”被作为搜索范围的默认值。"
     },
     "code_highlight": "代码突出显示",
     "nocdn_desc": "当强制应用环境变量<code>NO_CDN=true</code><br>Github样式时，此函数被禁用。",

--- a/packages/app/src/client/services/AdminCustomizeContainer.js
+++ b/packages/app/src/client/services/AdminCustomizeContainer.js
@@ -35,6 +35,7 @@ export default class AdminCustomizeContainer extends Container {
 
       isEnabledStaleNotification: false,
       isAllReplyShown: false,
+      isSearchScopeChildrenAsDefault: false,
       currentHighlightJsStyleId: '',
       isHighlightJsStyleBorderEnabled: false,
       currentCustomizeTitle: '',
@@ -89,6 +90,7 @@ export default class AdminCustomizeContainer extends Container {
         pageLimitationXL: customizeParams.pageLimitationXL,
         isEnabledStaleNotification: customizeParams.isEnabledStaleNotification,
         isAllReplyShown: customizeParams.isAllReplyShown,
+        isSearchScopeChildrenAsDefault: customizeParams.isSearchScopeChildrenAsDefault,
         currentHighlightJsStyleId: customizeParams.styleName,
         isHighlightJsStyleBorderEnabled: customizeParams.styleBorder,
         currentCustomizeTitle: customizeParams.customizeTitle,
@@ -181,6 +183,13 @@ export default class AdminCustomizeContainer extends Container {
    */
   switchIsAllReplyShown() {
     this.setState({ isAllReplyShown: !this.state.isAllReplyShown });
+  }
+
+  /**
+   * Switch isSearchScopeChildrenAsDefault
+   */
+  switchIsSearchScopeChildrenAsDefault() {
+    this.setState({ isSearchScopeChildrenAsDefault: !this.state.isSearchScopeChildrenAsDefault });
   }
 
   /**
@@ -295,6 +304,7 @@ export default class AdminCustomizeContainer extends Container {
         pageLimitationXL: this.state.pageLimitationXL,
         isEnabledStaleNotification: this.state.isEnabledStaleNotification,
         isAllReplyShown: this.state.isAllReplyShown,
+        isSearchScopeChildrenAsDefault: this.state.isSearchScopeChildrenAsDefault,
       });
       const { customizedParams } = response.data;
       this.setState({
@@ -307,6 +317,7 @@ export default class AdminCustomizeContainer extends Container {
         pageLimitationXL: customizedParams.pageLimitationXL,
         isEnabledStaleNotification: customizedParams.isEnabledStaleNotification,
         isAllReplyShown: customizedParams.isAllReplyShown,
+        isSearchScopeChildrenAsDefault: customizedParams.isSearchScopeChildrenAsDefault,
       });
     }
     catch (err) {

--- a/packages/app/src/components/Admin/Customize/CustomizeFunctionSetting.jsx
+++ b/packages/app/src/components/Admin/Customize/CustomizeFunctionSetting.jsx
@@ -139,6 +139,21 @@ class CustomizeFunctionSetting extends React.Component {
               </div>
             </div>
 
+            <div className="form-group row">
+              <div className="offset-md-3 col-md-6 text-left">
+                <CustomizeFunctionOption
+                  optionId="isSearchScopeChildrenAsDefault"
+                  label={t('admin:customize_setting.function_options.select_search_scope_children_as_default')}
+                  isChecked={adminCustomizeContainer.state.isSearchScopeChildrenAsDefault || false}
+                  onChecked={() => { adminCustomizeContainer.switchIsSearchScopeChildrenAsDefault() }}
+                >
+                  <p className="form-text text-muted">
+                    {t('admin:customize_setting.function_options.select_search_scope_children_as_default_desc')}
+                  </p>
+                </CustomizeFunctionOption>
+              </div>
+            </div>
+
             <AdminUpdateButtonRow onClick={this.onClickSubmit} disabled={adminCustomizeContainer.state.retrieveError != null} />
           </div>
         </div>

--- a/packages/app/src/components/Navbar/GlobalSearch.jsx
+++ b/packages/app/src/components/Navbar/GlobalSearch.jsx
@@ -14,9 +14,11 @@ class GlobalSearch extends React.Component {
   constructor(props) {
     super(props);
 
+    const isSearchScopeChildrenAsDefault = this.props.appContainer.getConfig().isSearchScopeChildrenAsDefault;
+
     this.state = {
       text: '',
-      isScopeChildren: false,
+      isScopeChildren: isSearchScopeChildrenAsDefault,
     };
 
     this.onInputChange = this.onInputChange.bind(this);

--- a/packages/app/src/server/models/config.ts
+++ b/packages/app/src/server/models/config.ts
@@ -129,6 +129,7 @@ export const defaultCrowiConfigs: { [key: string]: any } = {
   'customize:showPageLimitationXL' : 20,
   'customize:isEnabledStaleNotification': false,
   'customize:isAllReplyShown': false,
+  'customize:isSearchScopeChildrenAsDefault': false,
 
   'notification:owner-page:isEnabled': false,
   'notification:group-page:isEnabled': false,
@@ -205,6 +206,7 @@ schema.statics.getLocalconfig = function(crowi) {
     isEnabledXssPrevention: crowi.configManager.getConfig('markdown', 'markdown:xss:isEnabledPrevention'),
     isEnabledTimeline: crowi.configManager.getConfig('crowi', 'customize:isEnabledTimeline'),
     isAllReplyShown: crowi.configManager.getConfig('crowi', 'customize:isAllReplyShown'),
+    isSearchScopeChildrenAsDefault: crowi.configManager.getConfig('crowi', 'customize:isSearchScopeChildrenAsDefault'),
     xssOption: crowi.configManager.getConfig('markdown', 'markdown:xss:option'),
     tagWhiteList: crowi.xssService.getTagWhiteList(),
     attrWhiteList: crowi.xssService.getAttrWhiteList(),

--- a/packages/app/src/server/routes/apiv3/customize-setting.js
+++ b/packages/app/src/server/routes/apiv3/customize-setting.js
@@ -51,6 +51,8 @@ const ErrorV3 = require('../../models/vo/error-apiv3');
  *            type: boolean
  *          isAllReplyShown:
  *            type: boolean
+ *          isSearchScopeChildrenAsDefault:
+ *            type: boolean
  *      CustomizeHighlight:
  *        description: CustomizeHighlight
  *        type: object
@@ -112,6 +114,7 @@ module.exports = (crowi) => {
       body('pageLimitationXL').isInt().isInt({ min: 1, max: 1000 }),
       body('isEnabledStaleNotification').isBoolean(),
       body('isAllReplyShown').isBoolean(),
+      body('isSearchScopeChildrenAsDefault').isBoolean(),
     ],
     customizeTitle: [
       body('customizeTitle').isString(),
@@ -166,6 +169,7 @@ module.exports = (crowi) => {
       pageLimitationXL: await crowi.configManager.getConfig('crowi', 'customize:showPageLimitationXL'),
       isEnabledStaleNotification: await crowi.configManager.getConfig('crowi', 'customize:isEnabledStaleNotification'),
       isAllReplyShown: await crowi.configManager.getConfig('crowi', 'customize:isAllReplyShown'),
+      isSearchScopeChildrenAsDefault: await crowi.configManager.getConfig('crowi', 'customize:isSearchScopeChildrenAsDefault'),
       styleName: await crowi.configManager.getConfig('crowi', 'customize:highlightJsStyle'),
       styleBorder: await crowi.configManager.getConfig('crowi', 'customize:highlightJsStyleBorder'),
       customizeTitle: await crowi.configManager.getConfig('crowi', 'customize:title'),
@@ -363,6 +367,7 @@ module.exports = (crowi) => {
       'customize:showPageLimitationXL': req.body.pageLimitationXL,
       'customize:isEnabledStaleNotification': req.body.isEnabledStaleNotification,
       'customize:isAllReplyShown': req.body.isAllReplyShown,
+      'customize:isSearchScopeChildrenAsDefault': req.body.isSearchScopeChildrenAsDefault,
     };
 
     try {
@@ -377,6 +382,7 @@ module.exports = (crowi) => {
         pageLimitationXL: await crowi.configManager.getConfig('crowi', 'customize:showPageLimitationXL'),
         isEnabledStaleNotification: await crowi.configManager.getConfig('crowi', 'customize:isEnabledStaleNotification'),
         isAllReplyShown: await crowi.configManager.getConfig('crowi', 'customize:isAllReplyShown'),
+        isSearchScopeChildrenAsDefault: await crowi.configManager.getConfig('crowi', 'customize:isSearchScopeChildrenAsDefault'),
       };
       return res.apiv3({ customizedParams });
     }


### PR DESCRIPTION
#4331 の提案実装です。

`isAllReplyShown`が性格的に近いかと思い、参考にしながら実装してみました。  
[開発環境構築手順](https://docs.growi.org/ja/dev/startup-v2/launch-system.html#%E5%88%9D%E5%9B%9E%E8%B5%B7%E5%8B%95)を参考に「フロントエンド・バックエンドサーバーの起動」を実施しての動作確認は実施しています。

Web開発・GitHubともに不慣れですので不足している部分がありましたらご指摘ください。（Pullが難しいようでしたらCloseしていただいても構いません）