### PR TITLE
Imprv/7496 7444 payload accessor select service

### DIFF
--- a/packages/slack/src/index.ts
+++ b/packages/slack/src/index.ts
@@ -43,4 +43,5 @@ export * from './utils/slash-command-parser';
 export * from './utils/webclient-factory';
 export * from './utils/welcome-message';
 export * from './utils/required-scopes';
+export * from './utils/interaction-payload-accessor';
 export * from './utils/payload-interaction-id-helpers';

--- a/packages/slack/src/interfaces/growi-command-processor.ts
+++ b/packages/slack/src/interfaces/growi-command-processor.ts
@@ -1,7 +1,6 @@
 import { AuthorizeResult } from '@slack/oauth';
 
 import { GrowiCommand } from './growi-command';
-import { RequestFromSlack } from './request-from-slack';
 
 export interface GrowiCommandProcessor {
   shouldHandleCommand(growiCommand: GrowiCommand): boolean;

--- a/packages/slack/src/interfaces/growi-interaction-processor.ts
+++ b/packages/slack/src/interfaces/growi-interaction-processor.ts
@@ -9,7 +9,7 @@ export interface InteractionHandledResult<V> {
 
 export interface GrowiInteractionProcessor<V> {
 
-  shouldHandleInteraction(interactionPayloadAccessor: any): boolean;
+  shouldHandleInteraction(interactionPayloadAccessor: InteractionPayloadAccessor): boolean;
 
   processInteraction(
     authorizeResult: AuthorizeResult, interactionPayload: any, interactionPayloadAccessor: InteractionPayloadAccessor): Promise<InteractionHandledResult<V>>;

--- a/packages/slack/src/interfaces/growi-interaction-processor.ts
+++ b/packages/slack/src/interfaces/growi-interaction-processor.ts
@@ -7,8 +7,6 @@ export interface InteractionHandledResult<V> {
   isTerminated: boolean;
 }
 
-export type HandlerName = string;
-
 export interface GrowiInteractionProcessor<V> {
 
   shouldHandleInteraction(interactionPayloadAccessor: any): boolean;

--- a/packages/slack/src/interfaces/growi-interaction-processor.ts
+++ b/packages/slack/src/interfaces/growi-interaction-processor.ts
@@ -1,5 +1,6 @@
 import { AuthorizeResult } from '@slack/oauth';
-import { InteractionPayloadAccessor } from 'src/utils/interaction-payload-accessor';
+import { InteractionPayloadAccessor } from '../utils/interaction-payload-accessor';
+
 
 export interface InteractionHandledResult<V> {
   result?: V;

--- a/packages/slack/src/interfaces/growi-interaction-processor.ts
+++ b/packages/slack/src/interfaces/growi-interaction-processor.ts
@@ -1,7 +1,5 @@
 import { AuthorizeResult } from '@slack/oauth';
 
-import { RequestFromSlack } from './request-from-slack';
-
 export interface InteractionHandledResult<V> {
   result: V;
   isTerminated: boolean;
@@ -16,9 +14,8 @@ export type HandlerName = string;
 
 export interface GrowiInteractionProcessor<V> {
 
-  shouldHandleInteraction(interactionPayload: any): boolean;
+  shouldHandleInteraction(interactionPayloadAccessor: any): boolean;
 
-  // TODO: pass reqFromSlack or accessor instead of interactionPayload and use accessor to interact GW-7496
-  processInteraction(authorizeResult: AuthorizeResult, interactionPayload: any): Promise<InteractionHandledResult<V>>;
+  processInteraction(authorizeResult: AuthorizeResult, interactionPayload: any, interactionPayloadAccessor: any): Promise<InteractionHandledResult<V>>;
 
 }

--- a/packages/slack/src/middlewares/parse-slack-interaction-request.ts
+++ b/packages/slack/src/middlewares/parse-slack-interaction-request.ts
@@ -3,7 +3,7 @@ import { InteractionPayloadAccessor } from '../utils/interaction-payload-accesso
 
 import { RequestFromSlack } from '../interfaces/request-from-slack';
 
-
+// TAICHI MEMO: initialize InteractionPayloadAccessor
 export const parseSlackInteractionRequest = (req: RequestFromSlack, res: Response, next: NextFunction): Record<string, any> | void => {
   // There is no payload in the request from slack
   if (req.body.payload == null) {

--- a/packages/slack/src/middlewares/parse-slack-interaction-request.ts
+++ b/packages/slack/src/middlewares/parse-slack-interaction-request.ts
@@ -3,7 +3,6 @@ import { InteractionPayloadAccessor } from '../utils/interaction-payload-accesso
 
 import { RequestFromSlack } from '../interfaces/request-from-slack';
 
-// TAICHI MEMO: initialize InteractionPayloadAccessor
 export const parseSlackInteractionRequest = (req: RequestFromSlack, res: Response, next: NextFunction): Record<string, any> | void => {
   // There is no payload in the request from slack
   if (req.body.payload == null) {

--- a/packages/slack/src/utils/interaction-payload-accessor.ts
+++ b/packages/slack/src/utils/interaction-payload-accessor.ts
@@ -65,14 +65,19 @@ export class InteractionPayloadAccessor implements IInteractionPayloadAccessor {
     return { actionId, callbackId };
   }
 
-  getChannelId(): string | null {
-    // private_metadata should have the channelId parameter when view_submission
+  getChannelName(): string | null {
+    // private_metadata should have the channelName parameter when view_submission
     const privateMetadata = this.getViewPrivateMetaData();
-    if (privateMetadata != null && privateMetadata.channelId != null) {
-      return privateMetadata.channelId;
+    if (privateMetadata != null && privateMetadata.channelName != null) {
+      return privateMetadata.channelName;
     }
 
-    return this.payload.channel.id;
+    const channel = this.payload.channel;
+    if (channel != null) {
+      return this.payload.channel.name;
+    }
+
+    return null;
   }
 
 }

--- a/packages/slack/src/utils/interaction-payload-accessor.ts
+++ b/packages/slack/src/utils/interaction-payload-accessor.ts
@@ -65,4 +65,14 @@ export class InteractionPayloadAccessor implements IInteractionPayloadAccessor {
     return { actionId, callbackId };
   }
 
+  getChannelId(): string | null {
+    // private_metadata should have the channelId parameter when view_submission
+    const privateMetadata = this.getViewPrivateMetaData();
+    if (privateMetadata != null && privateMetadata.channelId != null) {
+      return privateMetadata.channelId;
+    }
+
+    return this.payload.channel.id;
+  }
+
 }

--- a/packages/slack/src/utils/interaction-payload-accessor.ts
+++ b/packages/slack/src/utils/interaction-payload-accessor.ts
@@ -17,7 +17,52 @@ export class InteractionPayloadAccessor implements IInteractionPayloadAccessor {
       return actions[0];
     }
 
-    return;
+    return null;
+  }
+
+  getResponseUrl(): string {
+    const responseUrl = this.payload.response_url;
+    if (responseUrl != null) {
+      return responseUrl;
+    }
+
+    const responseUrls = this.payload.response_urls;
+    if (responseUrls != null && responseUrls[0] != null) {
+      return responseUrls[0].response_url;
+    }
+
+    return '';
+  }
+
+  getStateValues(): any | null {
+    const state = this.payload.state;
+    if (state != null && state.values != null) {
+      return state.values;
+    }
+
+    const view = this.payload.view;
+    if (view != null && view.state != null && view.state.values != null) {
+      return view.state.values;
+    }
+
+    return null;
+  }
+
+  getViewPrivateMetaData(): any | null {
+    const view = this.payload.view;
+
+    if (view != null && view.private_metadata) {
+      return JSON.parse(view.private_metadata);
+    }
+
+    return null;
+  }
+
+  getActionIdAndCallbackIdFromPayLoad(): {[key: string]: string} {
+    const actionId = this.firstAction()?.action_id || '';
+    const callbackId = this.payload.view?.callback_id || '';
+
+    return { actionId, callbackId };
   }
 
 }

--- a/packages/slack/src/utils/payload-interaction-id-helpers.ts
+++ b/packages/slack/src/utils/payload-interaction-id-helpers.ts
@@ -1,12 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-export const getActionIdAndCallbackIdFromPayLoad = (interactionPayload: any): {[key: string]: string} => {
-  const callbackId: string = interactionPayload?.view?.callback_id;
-  // TAICHI TODO: fix this GW-7496
-  // const actionId = req.interactionPayloadAccessor.firstAction?.action_id;
-  const actionId = interactionPayload.actions?.[0]?.action_id;
-  return { actionId, callbackId };
-};
-
 export const getInteractionIdRegexpFromCommandName = (commandname: string): RegExp => {
   return new RegExp(`^${commandname}:\\w+`);
 };

--- a/packages/slackbot-proxy/src/controllers/slack.ts
+++ b/packages/slackbot-proxy/src/controllers/slack.ts
@@ -4,7 +4,7 @@ import {
 
 import axios from 'axios';
 
-import { WebAPICallResult, WebClient } from '@slack/web-api';
+import { WebAPICallResult } from '@slack/web-api';
 import { Installation } from '@slack/oauth';
 
 

--- a/packages/slackbot-proxy/src/controllers/slack.ts
+++ b/packages/slackbot-proxy/src/controllers/slack.ts
@@ -37,7 +37,7 @@ import loggerFactory from '~/utils/logger';
 
 const logger = loggerFactory('slackbot-proxy:controllers:slack');
 
-const postNotAllowedMessage = async(client:WebClient, channelId:string, userId:string, disallowedGrowiUrls:Set<string>, commandName:string):Promise<void> => {
+const postNotAllowedMessage = async(responseUrl, disallowedGrowiUrls:Set<string>, commandName:string):Promise<void> => {
 
   const linkUrlList = Array.from(disallowedGrowiUrls).map((growiUrl) => {
     return '\n'
@@ -47,10 +47,8 @@ const postNotAllowedMessage = async(client:WebClient, channelId:string, userId:s
   const growiDocsLink = 'https://docs.growi.org/en/admin-guide/upgrading/43x.html';
 
 
-  await client.chat.postEphemeral({
+  await axios.post(responseUrl, {
     text: 'Error occured.',
-    channel: channelId,
-    user: userId,
     blocks: [
       markdownSectionBlock('*None of GROWI permitted the command.*'),
       markdownSectionBlock(`*'${commandName}'* command was not allowed.`),
@@ -354,9 +352,7 @@ export class SlackCtrl {
     }
 
     if (relations.length === disallowedGrowiUrls.size) {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      const client = generateWebClient(authorizeResult.botToken!);
-      return postNotAllowedMessage(client, interactionPayload.channel.id, interactionPayload.user.id, disallowedGrowiUrls, commandName);
+      return postNotAllowedMessage(interactionPayloadAccessor.getResponseUrl(), disallowedGrowiUrls, commandName);
     }
 
     /*

--- a/packages/slackbot-proxy/src/controllers/slack.ts
+++ b/packages/slackbot-proxy/src/controllers/slack.ts
@@ -121,12 +121,22 @@ export class SlackCtrl {
     const results = await Promise.allSettled(promises);
     const rejectedResults: PromiseRejectedResult[] = results.filter((result): result is PromiseRejectedResult => result.status === 'rejected');
 
-    try {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      return postEphemeralErrors(rejectedResults, body.channel_id, body.user_id, botToken!);
-    }
-    catch (err) {
-      logger.error(err);
+    // TODO: USE response_url in postEphemeralErrors GW-7508
+    // try {
+    //   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    //   return postEphemeralErrors(rejectedResults, body.channel_id, body.user_id, botToken!);
+    // }
+    // catch (err) {
+    //   logger.error(err);
+    // }
+    if (rejectedResults.length > 0) {
+      logger.error('Growi command failed: No installation found.');
+      await respond(growiCommand.responseUrl, {
+        text: 'Growi command failed',
+        blocks: [
+          markdownSectionBlock('Error occurred while processing GROWI command.'),
+        ],
+      });
     }
   }
 

--- a/packages/slackbot-proxy/src/services/RegisterService.ts
+++ b/packages/slackbot-proxy/src/services/RegisterService.ts
@@ -158,6 +158,7 @@ export class RegisterService implements GrowiCommandProcessor<RegisterCommandBod
   ): Promise<void> {
 
     const serverUri = process.env.SERVER_URI;
+    const responseUrl = interactionPayloadAccessor.getResponseUrl();
 
     const blocks: Block[] = [];
 
@@ -169,7 +170,7 @@ export class RegisterService implements GrowiCommandProcessor<RegisterCommandBod
       blocks.push(markdownSectionBlock('*Test Connection* to complete the registration in your GROWI.'));
       blocks.push(markdownHeaderBlock(':white_large_square: 4. (Opt) Manage GROWI commands'));
       blocks.push(markdownSectionBlock('Modify permission settings if you need.'));
-      await respond(interactionPayloadAccessor.getResponseUrl(), {
+      await respond(responseUrl, {
         text: 'Proxy URL',
         blocks,
       });
@@ -188,7 +189,7 @@ export class RegisterService implements GrowiCommandProcessor<RegisterCommandBod
     blocks.push(markdownSectionBlock('And *Test Connection* to complete the registration in your GROWI.'));
     blocks.push(markdownHeaderBlock(':white_large_square: 6. (Opt) Manage GROWI commands'));
     blocks.push(markdownSectionBlock('Modify permission settings if you need.'));
-    await respond(interactionPayloadAccessor.getResponseUrl(), {
+    await respond(responseUrl, {
       text: 'Proxy URL',
       blocks,
     });

--- a/packages/slackbot-proxy/src/services/RegisterService.ts
+++ b/packages/slackbot-proxy/src/services/RegisterService.ts
@@ -5,10 +5,9 @@ import {
 import {
   markdownSectionBlock, markdownHeaderBlock, inputSectionBlock, GrowiCommand, inputBlock,
   respond, GrowiCommandProcessor, GrowiInteractionProcessor,
-  getInteractionIdRegexpFromCommandName, InteractionHandledResult,
+  getInteractionIdRegexpFromCommandName, InteractionHandledResult, InteractionPayloadAccessor,
 } from '@growi/slack';
 import { AuthorizeResult } from '@slack/oauth';
-import { InteractionPayloadAccessor } from '@growi/slack/src/utils/interaction-payload-accessor';
 import { OrderRepository } from '~/repositories/order';
 import { InvalidUrlError } from '../models/errors';
 import { InstallationRepository } from '~/repositories/installation';

--- a/packages/slackbot-proxy/src/services/RegisterService.ts
+++ b/packages/slackbot-proxy/src/services/RegisterService.ts
@@ -93,7 +93,7 @@ export class RegisterService implements GrowiCommandProcessor<RegisterCommandBod
     const interactionHandledResult: InteractionHandledResult<void> = {
       isTerminated: false,
     };
-    if (!this.shouldHandleInteraction(interactionPayload)) return interactionHandledResult;
+    if (!this.shouldHandleInteraction(interactionPayloadAccessor)) return interactionHandledResult;
 
     interactionHandledResult.result = await this.handleRegisterInteraction(authorizeResult, interactionPayload, interactionPayloadAccessor);
     interactionHandledResult.isTerminated = true;

--- a/packages/slackbot-proxy/src/services/SelectGrowiService.ts
+++ b/packages/slackbot-proxy/src/services/SelectGrowiService.ts
@@ -3,10 +3,9 @@ import { Inject, Service } from '@tsed/di';
 import {
   getInteractionIdRegexpFromCommandName,
   GrowiCommand, GrowiCommandProcessor, GrowiInteractionProcessor,
-  InteractionHandledResult, markdownSectionBlock, replaceOriginal, respond,
+  InteractionHandledResult, markdownSectionBlock, replaceOriginal, respond, InteractionPayloadAccessor,
 } from '@growi/slack';
 import { AuthorizeResult } from '@slack/oauth';
-import { InteractionPayloadAccessor } from '@growi/slack/src/utils/interaction-payload-accessor';
 
 import { Installation } from '~/entities/installation';
 import { Relation } from '~/entities/relation';

--- a/packages/slackbot-proxy/src/services/SelectGrowiService.ts
+++ b/packages/slackbot-proxy/src/services/SelectGrowiService.ts
@@ -1,11 +1,12 @@
 import { Inject, Service } from '@tsed/di';
 
 import {
-  getActionIdAndCallbackIdFromPayLoad,
   getInteractionIdRegexpFromCommandName,
-  GrowiCommand, GrowiCommandProcessor, GrowiInteractionProcessor, initialInteractionHandledResult, InteractionHandledResult, markdownSectionBlock, respond,
+  GrowiCommand, GrowiCommandProcessor, GrowiInteractionProcessor,
+  initialInteractionHandledResult, InteractionHandledResult, markdownSectionBlock, replaceOriginal, respond,
 } from '@growi/slack';
 import { AuthorizeResult } from '@slack/oauth';
+import { InteractionPayloadAccessor } from '@growi/slack/src/utils/interaction-payload-accessor';
 
 import { Installation } from '~/entities/installation';
 import { Relation } from '~/entities/relation';
@@ -28,7 +29,7 @@ export type SelectedGrowiInformation = {
 }
 
 @Service()
-export class SelectGrowiService implements GrowiCommandProcessor, GrowiInteractionProcessor<SelectedGrowiInformation> {
+export class SelectGrowiService implements GrowiCommandProcessor, GrowiInteractionProcessor<SelectedGrowiInformation | null> {
 
   @Inject()
   relationRepository: RelationRepository;
@@ -44,6 +45,7 @@ export class SelectGrowiService implements GrowiCommandProcessor, GrowiInteracti
   }
 
   shouldHandleCommand(growiCommand: GrowiCommand): boolean {
+    // TODO: consider to use the default supported commands for single use
     return true;
   }
 
@@ -100,39 +102,61 @@ export class SelectGrowiService implements GrowiCommandProcessor, GrowiInteracti
   }
 
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-  shouldHandleInteraction(interactionPayload: any): boolean {
-    const { actionId, callbackId } = getActionIdAndCallbackIdFromPayLoad(interactionPayload);
+  shouldHandleInteraction(interactionPayloadAccessor: InteractionPayloadAccessor): boolean {
+    const { actionId, callbackId } = interactionPayloadAccessor.getActionIdAndCallbackIdFromPayLoad();
     const registerRegexp: RegExp = getInteractionIdRegexpFromCommandName('select_growi');
     return registerRegexp.test(actionId) || registerRegexp.test(callbackId);
   }
 
   async processInteraction(
       // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-      authorizeResult: AuthorizeResult, interactionPayload: any,
-  ): Promise<InteractionHandledResult<SelectedGrowiInformation>> {
+      authorizeResult: AuthorizeResult, interactionPayload: any, interactionPayloadAccessor: InteractionPayloadAccessor,
+  ): Promise<InteractionHandledResult<SelectedGrowiInformation | null>> {
     const interactionHandledResult: any = initialInteractionHandledResult;
-    if (!this.shouldHandleInteraction(interactionPayload)) return interactionHandledResult;
-    interactionHandledResult.result = await this.handleSelectInteraction(authorizeResult, interactionPayload);
+    if (!this.shouldHandleInteraction(interactionPayloadAccessor)) return interactionHandledResult;
+
+    interactionHandledResult.result = await this.handleSelectInteraction(authorizeResult, interactionPayload, interactionPayloadAccessor);
     interactionHandledResult.isTerminated = false;
 
-    return interactionHandledResult as InteractionHandledResult<SelectedGrowiInformation>;
+    return interactionHandledResult as InteractionHandledResult<SelectedGrowiInformation | null>;
   }
 
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-  async handleSelectInteraction(authorizeResult: AuthorizeResult, payload:any): Promise<SelectedGrowiInformation> {
-    const { trigger_id: triggerId } = payload;
-    const { state, private_metadata: privateMetadata } = payload?.view;
-    const { value: growiUri } = state?.values?.select_growi?.growi_app?.selected_option;
+  async handleSelectInteraction(
+      // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+      authorizeResult: AuthorizeResult, interactionPayload: any, interactionPayloadAccessor: InteractionPayloadAccessor,
+  ): Promise<SelectedGrowiInformation | null> {
+    const { trigger_id: triggerId } = interactionPayload;
 
-    const parsedPrivateMetadata = JSON.parse(privateMetadata);
+    // TAICHI TODO: FIX THIS
+    console.dir(interactionPayloadAccessor.getStateValues());
+    console.dir(interactionPayloadAccessor.getStateValues()?.select_growi?.growi_app);
+    const { value: growiUri } = interactionPayloadAccessor.getStateValues()?.select_growi?.growi_app?.selected_option;
+
+    const parsedPrivateMetadata = interactionPayloadAccessor.getViewPrivateMetaData();
     const { growiCommand, body: sendCommandBody } = parsedPrivateMetadata;
 
+    const responseUrl = interactionPayloadAccessor.getResponseUrl();
+
     if (growiCommand == null || sendCommandBody == null) {
-      // TODO: postEphemeralErrors
-      throw new Error('growiCommand and body params are required in private_metadata.');
+      logger.error('Growi command failed: growiCommand and body params are required in private_metadata.');
+      await respond(responseUrl, {
+        text: 'Growi command failed',
+        blocks: [
+          markdownSectionBlock('Error occurred while processing GROWI command.'),
+        ],
+      });
+      return null;
     }
 
-    // ovverride trigger_id
+    await replaceOriginal(responseUrl, {
+      text: `Accepted ${growiCommand.growiCommandType} command.`,
+      blocks: [
+        markdownSectionBlock(`Processing your request *"/growi ${growiCommand.growiCommandType}"* on GROWI at ${growiUri} ...`),
+      ],
+    });
+
+    // override trigger_id
     sendCommandBody.trigger_id = triggerId;
 
     const installationId = authorizeResult.enterpriseId || authorizeResult.teamId;
@@ -142,14 +166,14 @@ export class SelectGrowiService implements GrowiCommandProcessor, GrowiInteracti
       installation = await this.installationRepository.findByTeamIdOrEnterpriseId(installationId!);
     }
     catch (err) {
-      logger.error('Growi command failed:\n', err);
-      await respond(payload.response_url, {
+      logger.error('Growi command failed: No installation found.\n', err);
+      await respond(responseUrl, {
         text: 'Growi command failed',
         blocks: [
           markdownSectionBlock('Error occurred while processing GROWI command.'),
         ],
       });
-      throw new Error('No installation found.');
+      return null;
     }
 
     const relation = await this.relationRepository.createQueryBuilder('relation')
@@ -159,8 +183,14 @@ export class SelectGrowiService implements GrowiCommandProcessor, GrowiInteracti
       .getOne();
 
     if (relation == null) {
-      // TODO: postEphemeralErrors
-      throw new Error('No relation found.');
+      logger.error('Growi command failed: No installation found.');
+      await respond(responseUrl, {
+        text: 'Growi command failed',
+        blocks: [
+          markdownSectionBlock('Error occurred while processing GROWI command.'),
+        ],
+      });
+      return null;
     }
 
     return {

--- a/packages/slackbot-proxy/src/services/UnregisterService.ts
+++ b/packages/slackbot-proxy/src/services/UnregisterService.ts
@@ -4,9 +4,8 @@ import { MultiStaticSelect } from '@slack/web-api';
 import {
   actionsBlock, buttonElement, getInteractionIdRegexpFromCommandName,
   GrowiCommand, GrowiCommandProcessor, GrowiInteractionProcessor,
-  inputBlock, InteractionHandledResult, markdownSectionBlock, respond,
+  inputBlock, InteractionHandledResult, markdownSectionBlock, respond, InteractionPayloadAccessor,
 } from '@growi/slack';
-import { InteractionPayloadAccessor } from '@growi/slack/src/utils/interaction-payload-accessor';
 import { AuthorizeResult } from '@slack/oauth';
 import { DeleteResult } from 'typeorm';
 import { RelationRepository } from '~/repositories/relation';

--- a/packages/slackbot-proxy/src/services/UnregisterService.ts
+++ b/packages/slackbot-proxy/src/services/UnregisterService.ts
@@ -121,11 +121,12 @@ export class UnregisterService implements GrowiCommandProcessor, GrowiInteractio
       // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
       authorizeResult: AuthorizeResult, interactionPayload: any, interactionPayloadAccessor: InteractionPayloadAccessor,
   ):Promise<void> {
+    const responseUrl = interactionPayloadAccessor.getResponseUrl();
 
     const selectedOptions = interactionPayloadAccessor.getStateValues()?.growiUris?.selectedGrowiUris?.selected_options;
     if (!Array.isArray(selectedOptions)) {
       logger.error('Unregisteration failed: Mulformed object was detected\n');
-      await respond(interactionPayloadAccessor.getResponseUrl(), {
+      await respond(responseUrl, {
         text: 'Unregistration failed',
         blocks: [
           markdownSectionBlock('Error occurred while unregistering GROWI.'),
@@ -143,7 +144,7 @@ export class UnregisterService implements GrowiCommandProcessor, GrowiInteractio
     }
     catch (err) {
       logger.error('Unregisteration failed:\n', err);
-      await respond(interactionPayloadAccessor.getResponseUrl(), {
+      await respond(responseUrl, {
         text: 'Unregistration failed',
         blocks: [
           markdownSectionBlock('Error occurred while unregistering GROWI.'),
@@ -162,7 +163,7 @@ export class UnregisterService implements GrowiCommandProcessor, GrowiInteractio
     }
     catch (err) {
       logger.error('Unregisteration failed\n', err);
-      await respond(interactionPayloadAccessor.getResponseUrl(), {
+      await respond(responseUrl, {
         text: 'Unregistration failed',
         blocks: [
           markdownSectionBlock('Error occurred while unregistering GROWI.'),
@@ -171,7 +172,7 @@ export class UnregisterService implements GrowiCommandProcessor, GrowiInteractio
       return;
     }
 
-    await respond(interactionPayloadAccessor.getResponseUrl(), {
+    await respond(responseUrl, {
       text: 'Unregistration completed',
       blocks: [
         markdownSectionBlock(`Unregistered *${deleteResult.affected}* GROWI from this workspace.`),

--- a/packages/slackbot-proxy/src/services/growi-uri-injector/block-elements/ButtonActionPayloadDelegator.ts
+++ b/packages/slackbot-proxy/src/services/growi-uri-injector/block-elements/ButtonActionPayloadDelegator.ts
@@ -33,6 +33,10 @@ export class ButtonActionPayloadDelegator implements GrowiUriInjector<TypedBlock
   }
 
   extract(action: ButtonActionPayload): GrowiUriWithOriginalData {
+    // TODO: FIX THIS GW-7508
+    // action.value = restoredData.originalData;
+    // return restoredData;
+
     return JSON.parse(action.value);
   }
 

--- a/packages/slackbot-proxy/src/services/growi-uri-injector/block-elements/ButtonActionPayloadDelegator.ts
+++ b/packages/slackbot-proxy/src/services/growi-uri-injector/block-elements/ButtonActionPayloadDelegator.ts
@@ -33,10 +33,7 @@ export class ButtonActionPayloadDelegator implements GrowiUriInjector<TypedBlock
   }
 
   extract(action: ButtonActionPayload): GrowiUriWithOriginalData {
-    const restoredData: GrowiUriWithOriginalData = JSON.parse(action.value);
-    action.value = restoredData.originalData;
-
-    return restoredData;
+    return JSON.parse(action.value);
   }
 
 


### PR DESCRIPTION
GW-7496 InteractionPayloadAccessor を使って any から値を取り出す処理を書いている箇所を減らす
GW-7444 SelectGrowiService の改修 [上記タスクと同時進行可]

を実装しました。

今回も変更多めです。次から変更ファイル数減らすように細かくします。

## 変更箇所
- InteractionPayloadAccessor を実装しました
- payload.hoge としていたところを accessor のメソッドを使うようにしました
- Select growi コマンドを動くようにしました
  - create コマンドが送られるところまでは確認済みですが、その後の挙動でバグがあるので本体改修と同時に直していきます