### PR TITLE
fix: Backspace key on last line doesn't work in vim mode

### DIFF
--- a/packages/app/src/components/PageEditor/CodeMirrorEditor.jsx
+++ b/packages/app/src/components/PageEditor/CodeMirrorEditor.jsx
@@ -900,6 +900,7 @@ export default class CodeMirrorEditor extends AbstractEditor {
 
         <ReactCodeMirror
           ref={(c) => { this.cm = c }}
+          detach
           className={additionalClasses}
           placeholder="search"
           editorDidMount={(editor) => {


### PR DESCRIPTION
fix #4328 