### PR TITLE
Imprv/7445 improve commands process

### DIFF
--- a/packages/app/src/server/routes/apiv3/slack-integration.js
+++ b/packages/app/src/server/routes/apiv3/slack-integration.js
@@ -133,6 +133,7 @@ module.exports = (crowi) => {
 
   async function handleCommands(req, res, client) {
     const { body } = req;
+    const { growiCommand } = body;
 
     if (body.text == null) {
       return 'No text.';

--- a/packages/app/src/server/service/slack-command-handler/create-page-service.js
+++ b/packages/app/src/server/service/slack-command-handler/create-page-service.js
@@ -26,6 +26,7 @@ class CreatePageService {
 
       // Send a message when page creation is complete
       const growiUri = this.crowi.appService.getSiteUrl();
+      // TODO: FIX THIS GW-7446
       await client.chat.postEphemeral({
         channel: channelId,
         user: payload.user.id,

--- a/packages/app/src/server/service/slack-command-handler/create.js
+++ b/packages/app/src/server/service/slack-command-handler/create.js
@@ -10,7 +10,7 @@ module.exports = (crowi) => {
   const BaseSlackCommandHandler = require('./slack-command-handler');
   const handler = new BaseSlackCommandHandler();
 
-  handler.handleCommand = async(client, body) => {
+  handler.handleCommand = async(growiCommand, client, body) => {
     await client.views.open({
       trigger_id: body.trigger_id,
 
@@ -39,7 +39,7 @@ module.exports = (crowi) => {
     });
   };
 
-  handler.handleBlockActions = async function(client, payload, handlerMethodName) {
+  handler.handleInteractions = async function(client, payload, handlerMethodName) {
     await this[handlerMethodName](client, payload);
   };
 

--- a/packages/app/src/server/service/slack-command-handler/help.js
+++ b/packages/app/src/server/service/slack-command-handler/help.js
@@ -1,4 +1,4 @@
-const { markdownSectionBlock } = require('@growi/slack');
+const { markdownSectionBlock, respond } = require('@growi/slack');
 const { default: axios } = require('axios');
 
 module.exports = () => {
@@ -13,7 +13,7 @@ module.exports = () => {
     message += '`/growi create`                          Create new page\n\n';
     message += '`/growi search [keyword]`       Search pages\n\n';
     message += '`/growi togetter`                      Create new page with existing slack conversations (Alpha)\n\n';
-    await axios.post(growiCommand.responseUrl, {
+    await respond(growiCommand.responseUrl, {
       text: 'Help',
       blocks: [
         markdownSectionBlock(message),

--- a/packages/app/src/server/service/slack-command-handler/help.js
+++ b/packages/app/src/server/service/slack-command-handler/help.js
@@ -1,10 +1,11 @@
 const { markdownSectionBlock } = require('@growi/slack');
+const { default: axios } = require('axios');
 
 module.exports = () => {
   const BaseSlackCommandHandler = require('./slack-command-handler');
   const handler = new BaseSlackCommandHandler();
 
-  handler.handleCommand = (client, body) => {
+  handler.handleCommand = (growiCommand, client, body) => {
     // adjust spacing
     let message = '*Help*\n\n';
     message += 'Usage:     `/growi [command] [args]`\n\n';
@@ -12,9 +13,7 @@ module.exports = () => {
     message += '`/growi create`                          Create new page\n\n';
     message += '`/growi search [keyword]`       Search pages\n\n';
     message += '`/growi togetter`                      Create new page with existing slack conversations (Alpha)\n\n';
-    client.chat.postEphemeral({
-      channel: body.channel_id,
-      user: body.user_id,
+    await axios.post(growiCommand.responseUrl, {
       text: 'Help',
       blocks: [
         markdownSectionBlock(message),

--- a/packages/app/src/server/service/slack-command-handler/help.js
+++ b/packages/app/src/server/service/slack-command-handler/help.js
@@ -1,5 +1,4 @@
 const { markdownSectionBlock, respond } = require('@growi/slack');
-const { default: axios } = require('axios');
 
 module.exports = () => {
   const BaseSlackCommandHandler = require('./slack-command-handler');

--- a/packages/app/src/server/service/slack-command-handler/search.js
+++ b/packages/app/src/server/service/slack-command-handler/search.js
@@ -13,10 +13,11 @@ module.exports = (crowi) => {
   const BaseSlackCommandHandler = require('./slack-command-handler');
   const handler = new BaseSlackCommandHandler(crowi);
 
-  handler.handleCommand = async function(client, body, args) {
+  handler.handleCommand = async function(growiCommand, client, body) {
+    const { growiCommandArgs } = growiCommand;
     let searchResult;
     try {
-      searchResult = await this.retrieveSearchResults(client, body, args);
+      searchResult = await this.retrieveSearchResults(client, body, growiCommandArgs);
     }
     catch (err) {
       logger.error('Failed to get search results.', err);
@@ -35,12 +36,15 @@ module.exports = (crowi) => {
       pages, offset, resultsTotal,
     } = searchResult;
 
-    const keywords = this.getKeywords(args);
+    const keywords = this.getKeywords(growiCommandArgs);
 
 
     let searchResultsDesc;
 
+    // TODO: handle correctly when case 0 GW-7446
     switch (resultsTotal) {
+      case 0:
+        return; // do something GW-7446
       case 1:
         searchResultsDesc = `*${resultsTotal}* page is found.`;
         break;
@@ -95,21 +99,6 @@ module.exports = (crowi) => {
       contextBlock,
     ];
 
-    // DEFAULT show "Share" button
-    // const actionBlocks = {
-    //   type: 'actions',
-    //   elements: [
-    //     {
-    //       type: 'button',
-    //       text: {
-    //         type: 'plain_text',
-    //         text: 'Share',
-    //       },
-    //       style: 'primary',
-    //       action_id: 'shareSearchResults',
-    //     },
-    //   ],
-    // };
     const actionBlocks = {
       type: 'actions',
       elements: [
@@ -134,21 +123,19 @@ module.exports = (crowi) => {
             text: 'Next',
           },
           action_id: 'search:showNextResults',
-          value: JSON.stringify({ offset, body, args }),
+          value: JSON.stringify({ offset, body, growiCommandArgs }),
         },
       );
     }
     blocks.push(actionBlocks);
 
-    await client.chat.postEphemeral({
-      channel: body.channel_id,
-      user: body.user_id,
+    await axios.post(growiCommand.responseUrl, {
       text: 'Successed To Search',
       blocks,
     });
   };
 
-  handler.handleBlockActions = async function(client, payload, handlerMethodName) {
+  handler.handleInteractions = async function(client, payload, handlerMethodName) {
     await this[handlerMethodName](client, payload);
   };
 
@@ -216,7 +203,11 @@ module.exports = (crowi) => {
 
     let searchResultsDesc;
 
+    // TODO: FIX THIS when case 0 GW-7446
     switch (resultsTotal) {
+      case 0:
+        return;
+
       case 1:
         searchResultsDesc = `*${resultsTotal}* page is found.`;
         break;
@@ -333,7 +324,7 @@ module.exports = (crowi) => {
   };
 
   handler.retrieveSearchResults = async function(client, body, args, offset = 0) {
-    const firstKeyword = args[1];
+    const firstKeyword = args[0];
     if (firstKeyword == null) {
       client.chat.postEphemeral({
         channel: body.channel_id,

--- a/packages/app/src/server/service/slack-command-handler/search.js
+++ b/packages/app/src/server/service/slack-command-handler/search.js
@@ -2,7 +2,7 @@ import loggerFactory from '~/utils/logger';
 
 const logger = loggerFactory('growi:service:SlackCommandHandler:search');
 
-const { markdownSectionBlock, divider } = require('@growi/slack');
+const { markdownSectionBlock, divider, respond } = require('@growi/slack');
 const { formatDistanceStrict } = require('date-fns');
 const axios = require('axios');
 const SlackbotError = require('../../models/vo/slackbot-error');
@@ -129,7 +129,7 @@ module.exports = (crowi) => {
     }
     blocks.push(actionBlocks);
 
-    await axios.post(growiCommand.responseUrl, {
+    await respond(growiCommand.responseUrl, {
       text: 'Successed To Search',
       blocks,
     });

--- a/packages/app/src/server/service/slack-command-handler/search.js
+++ b/packages/app/src/server/service/slack-command-handler/search.js
@@ -2,9 +2,10 @@ import loggerFactory from '~/utils/logger';
 
 const logger = loggerFactory('growi:service:SlackCommandHandler:search');
 
-const { markdownSectionBlock, divider, respond } = require('@growi/slack');
+const {
+  markdownSectionBlock, divider, respond, deleteOriginal,
+} = require('@growi/slack');
 const { formatDistanceStrict } = require('date-fns');
-const axios = require('axios');
 const SlackbotError = require('../../models/vo/slackbot-error');
 
 const PAGINGLIMIT = 10;
@@ -318,7 +319,7 @@ module.exports = (crowi) => {
   handler.dismissSearchResults = async function(client, payload) {
     const { response_url: responseUrl } = payload;
 
-    return axios.post(responseUrl, {
+    return deleteOriginal(responseUrl, {
       delete_original: true,
     });
   };

--- a/packages/app/src/server/service/slack-command-handler/slack-command-handler.js
+++ b/packages/app/src/server/service/slack-command-handler/slack-command-handler.js
@@ -8,17 +8,12 @@ class BaseSlackCommandHandler {
   /**
    * Handle /commands endpoint
    */
-  handleCommand(client, body, ...opt) { throw new Error('Implement this') }
+  handleCommand(growiCommand, client, body) { throw new Error('Implement this') }
 
   /**
-   * Handle /interactions endpoint 'block_actions'
+   * Handle interactions
    */
-  handleBlockActions(client, payload, handlerMethodName) { throw new Error('Implement this') }
-
-  /**
-   * Handle /interactions endpoint 'view_submission'
-   */
-  handleViewSubmission(client, payload, handlerMethodName) { throw new Error('Implement this') }
+  handleInteractions(client, payload, handlerMethodName) { throw new Error('Implement this') }
 
 }
 

--- a/packages/app/src/server/service/slack-command-handler/togetter.js
+++ b/packages/app/src/server/service/slack-command-handler/togetter.js
@@ -2,7 +2,7 @@ import loggerFactory from '~/utils/logger';
 
 const logger = loggerFactory('growi:service:SlackBotService:togetter');
 const {
-  inputBlock, actionsBlock, buttonElement, markdownSectionBlock, divider,
+  inputBlock, actionsBlock, buttonElement, markdownSectionBlock, divider, respond,
 } = require('@growi/slack');
 const { parse, format } = require('date-fns');
 const axios = require('axios');
@@ -15,7 +15,7 @@ module.exports = (crowi) => {
   const handler = new BaseSlackCommandHandler();
 
   handler.handleCommand = async function(growiCommand, client, body) {
-    await axios.post(growiCommand.responseUrl, {
+    await respond(growiCommand.responseUrl, {
       text: 'Select messages to use.',
       blocks: this.togetterMessageBlocks(),
     });

--- a/packages/app/src/server/service/slack-command-handler/togetter.js
+++ b/packages/app/src/server/service/slack-command-handler/togetter.js
@@ -3,6 +3,7 @@ import loggerFactory from '~/utils/logger';
 const logger = loggerFactory('growi:service:SlackBotService:togetter');
 const {
   inputBlock, actionsBlock, buttonElement, markdownSectionBlock, divider, respond,
+  deleteOriginal,
 } = require('@growi/slack');
 const { parse, format } = require('date-fns');
 const axios = require('axios');
@@ -28,7 +29,7 @@ module.exports = (crowi) => {
 
   handler.cancel = async function(client, payload) {
     const responseUrl = payload.response_url;
-    await axios.post(responseUrl, {
+    await deleteOriginal(responseUrl, {
       delete_original: true,
     });
   };
@@ -171,7 +172,7 @@ module.exports = (crowi) => {
       });
       // dismiss message
       const responseUrl = payload.response_url;
-      axios.post(responseUrl, {
+      await deleteOriginal(responseUrl, {
         delete_original: true,
       });
     }

--- a/packages/app/src/server/service/slack-command-handler/togetter.js
+++ b/packages/app/src/server/service/slack-command-handler/togetter.js
@@ -14,29 +14,21 @@ module.exports = (crowi) => {
   const BaseSlackCommandHandler = require('./slack-command-handler');
   const handler = new BaseSlackCommandHandler();
 
-  handler.handleCommand = async function(client, body, args, limit = 10) {
-    // TODO GW-6721 Get the time from args
-    const result = await client.conversations.history({
-      channel: body.channel_id,
-      limit,
-    });
-      // Return Checkbox Message
-    client.chat.postEphemeral({
-      channel: body.channel_id,
-      user: body.user_id,
+  handler.handleCommand = async function(growiCommand, client, body) {
+    await axios.post(growiCommand.responseUrl, {
       text: 'Select messages to use.',
-      blocks: this.togetterMessageBlocks(result.messages, body, args, limit),
+      blocks: this.togetterMessageBlocks(),
     });
     return;
   };
 
-  handler.handleBlockActions = async function(client, payload, handlerMethodName) {
+  handler.handleInteractions = async function(client, payload, handlerMethodName) {
     await this[handlerMethodName](client, payload);
   };
 
   handler.cancel = async function(client, payload) {
     const responseUrl = payload.response_url;
-    axios.post(responseUrl, {
+    await axios.post(responseUrl, {
       delete_original: true,
     });
   };
@@ -194,7 +186,7 @@ module.exports = (crowi) => {
     }
   };
 
-  handler.togetterMessageBlocks = function(messages, body, args, limit) {
+  handler.togetterMessageBlocks = function() {
     return [
       markdownSectionBlock('Select the oldest and newest datetime of the messages to use.'),
       inputBlock(this.plainTextInputElementWithInitialTime('oldest'), 'oldest', 'Oldest datetime'),

--- a/packages/app/src/server/service/slack-integration.ts
+++ b/packages/app/src/server/service/slack-integration.ts
@@ -4,7 +4,7 @@ import { IncomingWebhookSendArguments } from '@slack/webhook';
 import { ChatPostMessageArguments, WebClient } from '@slack/web-api';
 
 import {
-  generateWebClient, GrowiCommand, InteractionPayloadAccessor, markdownSectionBlock, SlackbotType,
+  generateWebClient, GrowiCommand, InteractionPayloadAccessor, markdownSectionBlock, respond, SlackbotType,
 } from '@growi/slack';
 
 // eslint-disable-next-line no-restricted-imports
@@ -285,7 +285,7 @@ export class SlackIntegrationService implements S2sMessageHandlable {
 
   async notCommand(growiCommand: GrowiCommand): Promise<void> {
     logger.error('Invalid first argument');
-    await axios.post(growiCommand.responseUrl, {
+    await respond(growiCommand.responseUrl, {
       text: 'No command',
       blocks: [
         markdownSectionBlock('*No command.*\n Hint\n `/growi [command] [keyword]`'),

--- a/packages/slack/src/middlewares/verify-slack-request.ts
+++ b/packages/slack/src/middlewares/verify-slack-request.ts
@@ -12,6 +12,7 @@ const logger = loggerFactory('@growi/slack:middlewares:verify-slack-request');
  * Verify if the request came from slack
  * See: https://api.slack.com/authentication/verifying-requests-from-slack
  */
+// TODO: do investigation and fix if needed GW-7519
 export const verifySlackRequest = (req: RequestFromSlack, res: Response, next: NextFunction): Record<string, any> | void => {
   const signingSecret = req.slackSigningSecret;
 

--- a/packages/slackbot-proxy/src/controllers/slack.ts
+++ b/packages/slackbot-proxy/src/controllers/slack.ts
@@ -353,17 +353,18 @@ export class SlackCtrl {
       allowedRelations, disallowedGrowiUrls, commandName, rejectedResults,
     } = permission;
 
-    try {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      await postEphemeralErrors(rejectedResults, interactionPayload.channel.id, interactionPayload.user.id, authorizeResult.botToken!);
-    }
-    catch (err) {
-      logger.error(err);
-    }
+    // TODO: FIX THIS GW-7508
+    // try {
+    //   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    //   await postEphemeralErrors(rejectedResults, interactionPayload.channel.id, interactionPayload.user.id, authorizeResult.botToken!);
+    // }
+    // catch (err) {
+    //   logger.error(err);
+    // }
 
-    if (relations.length === disallowedGrowiUrls.size) {
-      return postNotAllowedMessage(interactionPayloadAccessor.getResponseUrl(), disallowedGrowiUrls, commandName);
-    }
+    // if (relations.length === disallowedGrowiUrls.size) {
+    //   return postNotAllowedMessage(interactionPayloadAccessor.getResponseUrl(), disallowedGrowiUrls, commandName);
+    // }
 
     /*
      * forward to GROWI server

--- a/packages/slackbot-proxy/src/services/growi-uri-injector/block-elements/ButtonActionPayloadDelegator.ts
+++ b/packages/slackbot-proxy/src/services/growi-uri-injector/block-elements/ButtonActionPayloadDelegator.ts
@@ -37,7 +37,7 @@ export class ButtonActionPayloadDelegator implements GrowiUriInjector<TypedBlock
     // action.value = restoredData.originalData;
     // return restoredData;
 
-    return JSON.parse(action.value);
+    return JSON.parse(action.value || '{}');
   }
 
 


### PR DESCRIPTION
GW-7445 本体の /proxied/commands の処理を改修

を実装しました。

## コメント
* 可能な限り response_url を使うようにしました
* 簡単に修正できる箇所は修正しました
* with, without の両パターンで togetter, search で動作確認済みです
* 勢い余って interactions の範囲も少し改修してしまいました
    * メソッド名一部改名しました (interactions の部分)
    * axios.post(responseUrl, {}) はユーティリティを使うように書き換えました 
    * 改修に伴って togetter が正常動作するように改修

## 必要な後続タスクと理由
[GW-7519](https://youtrack.weseek.co.jp/agiles/84-39/current?issue=GW-7519) growi-uri-injector , verifySlackRequest など完全に動作するように改修
* interaction payload の actions 周りでバグがある可能性があるため 調査と必要があれば改修
* verifySlackRequest でバグがある可能性があるため 調査と必要があれば改修
* その他動作が全て正常に動くように修正