### PR TITLE
Imprv/7446 growi side interactions process

### DIFF
--- a/packages/app/src/server/service/slack-command-handler/create-page-service.js
+++ b/packages/app/src/server/service/slack-command-handler/create-page-service.js
@@ -1,7 +1,7 @@
 import loggerFactory from '~/utils/logger';
 
 const logger = loggerFactory('growi:service:CreatePageService');
-const { reshapeContentsBody } = require('@growi/slack');
+const { reshapeContentsBody, respond, markdownSectionBlock } = require('@growi/slack');
 const mongoose = require('mongoose');
 const pathUtils = require('growi-commons').pathUtils;
 const SlackbotError = require('../../models/vo/slackbot-error');
@@ -12,7 +12,7 @@ class CreatePageService {
     this.crowi = crowi;
   }
 
-  async createPageInGrowi(client, payload, path, channelId, contentsBody) {
+  async createPageInGrowi(interactionPayloadAccessor, path, contentsBody) {
     const Page = this.crowi.model('Page');
     const reshapedContentsBody = reshapeContentsBody(contentsBody);
     try {
@@ -27,10 +27,11 @@ class CreatePageService {
       // Send a message when page creation is complete
       const growiUri = this.crowi.appService.getSiteUrl();
       // TODO: FIX THIS GW-7446
-      await client.chat.postEphemeral({
-        channel: channelId,
-        user: payload.user.id,
-        text: `The page <${decodeURI(`${growiUri}/${page._id} | ${decodeURI(growiUri + normalizedPath)}`)}> has been created.`,
+      await respond(interactionPayloadAccessor.getResponseUrl(), {
+        text: 'Page has been created',
+        blocks: [
+          markdownSectionBlock(`The page <${decodeURI(`${growiUri}/${page._id} | ${decodeURI(growiUri + normalizedPath)}`)}> has been created.`),
+        ],
       });
     }
     catch (err) {

--- a/packages/app/src/server/service/slack-command-handler/search.js
+++ b/packages/app/src/server/service/slack-command-handler/search.js
@@ -15,10 +15,10 @@ module.exports = (crowi) => {
   const handler = new BaseSlackCommandHandler(crowi);
 
   handler.handleCommand = async function(growiCommand, client, body) {
-    const { growiCommandArgs } = growiCommand;
+    const { responseUrl, growiCommandArgs } = growiCommand;
     let searchResult;
     try {
-      searchResult = await this.retrieveSearchResults(client, body, growiCommandArgs);
+      searchResult = await this.retrieveSearchResults(responseUrl, client, body, growiCommandArgs);
     }
     catch (err) {
       logger.error('Failed to get search results.', err);
@@ -42,14 +42,18 @@ module.exports = (crowi) => {
 
     let searchResultsDesc;
 
-    // TODO: handle correctly when case 0 GW-7446
     switch (resultsTotal) {
       case 0:
-        return; // do something GW-7446
+        await respond(responseUrl, {
+          text: 'No page found.',
+          blocks: [
+            markdownSectionBlock('Please try with other keywords.'),
+          ],
+        });
+        return;
       case 1:
         searchResultsDesc = `*${resultsTotal}* page is found.`;
         break;
-
       default:
         searchResultsDesc = `*${resultsTotal}* pages are found.`;
         break;
@@ -130,33 +134,42 @@ module.exports = (crowi) => {
     }
     blocks.push(actionBlocks);
 
-    await respond(growiCommand.responseUrl, {
+    await respond(responseUrl, {
       text: 'Successed To Search',
       blocks,
     });
   };
 
-  handler.handleInteractions = async function(client, payload, handlerMethodName) {
-    await this[handlerMethodName](client, payload);
+  handler.handleInteractions = async function(client, interactionPayload, interactionPayloadAccessor, handlerMethodName) {
+    await this[handlerMethodName](client, interactionPayload, interactionPayloadAccessor);
   };
 
-  handler.shareSinglePageResult = async function(client, payload) {
-    const { channel, user, actions } = payload;
+  handler.shareSinglePageResult = async function(client, payload, interactionPayloadAccessor) {
+    const { channel, user } = payload;
+    const responseUrl = interactionPayloadAccessor.getResponseUrl();
 
     const appUrl = crowi.appService.getSiteUrl();
     const appTitle = crowi.appService.getAppTitle();
 
     const channelId = channel.id;
-    const action = actions[0]; // shareSinglePage action must have button action
+    const value = interactionPayloadAccessor.firstAction()?.value; // shareSinglePage action must have button action
+    if (value) {
+      await respond(responseUrl, {
+        text: 'Error occurred',
+        blocks: [
+          markdownSectionBlock('Failed to share the result.'),
+        ],
+      });
+      return;
+    }
 
     // restore page data from value
-    const { page, href, pathname } = JSON.parse(action.value);
+    const { page, href, pathname } = JSON.parse(value);
     const { updatedAt, commentCount } = page;
 
     // share
     const now = new Date();
-    return client.chat.postMessage({
-      channel: channelId,
+    return respond(responseUrl, {
       blocks: [
         { type: 'divider' },
         markdownSectionBlock(`${this.appendSpeechBaloon(`*${this.generatePageLinkMrkdwn(pathname, href)}*`, commentCount)}`),
@@ -173,14 +186,26 @@ module.exports = (crowi) => {
     });
   };
 
-  handler.showNextResults = async function(client, payload) {
-    const parsedValue = JSON.parse(payload.actions[0].value);
+  handler.showNextResults = async function(client, payload, interactionPayloadAccessor) {
+    const responseUrl = interactionPayloadAccessor.getResponseUrl();
+
+    const value = interactionPayloadAccessor.firstAction()?.value;
+    if (value == null) {
+      await respond(responseUrl, {
+        text: 'Error occurred',
+        blocks: [
+          markdownSectionBlock('Failed to share the result.'),
+        ],
+      });
+      return;
+    }
+    const parsedValue = JSON.parse(value);
 
     const { body, args, offset: offsetNum } = parsedValue;
     const newOffsetNum = offsetNum + 10;
     let searchResult;
     try {
-      searchResult = await this.retrieveSearchResults(client, body, args, newOffsetNum);
+      searchResult = await this.retrieveSearchResults(responseUrl, client, body, args, newOffsetNum);
     }
     catch (err) {
       logger.error('Failed to get search results.', err);
@@ -204,15 +229,18 @@ module.exports = (crowi) => {
 
     let searchResultsDesc;
 
-    // TODO: FIX THIS when case 0 GW-7446
     switch (resultsTotal) {
       case 0:
+        await respond(responseUrl, {
+          text: 'No page found.',
+          blocks: [
+            markdownSectionBlock('Please try with other keywords.'),
+          ],
+        });
         return;
-
       case 1:
         searchResultsDesc = `*${resultsTotal}* page is found.`;
         break;
-
       default:
         searchResultsDesc = `*${resultsTotal}* pages are found.`;
         break;
@@ -263,21 +291,6 @@ module.exports = (crowi) => {
       contextBlock,
     ];
 
-    // DEFAULT show "Share" button
-    // const actionBlocks = {
-    //   type: 'actions',
-    //   elements: [
-    //     {
-    //       type: 'button',
-    //       text: {
-    //         type: 'plain_text',
-    //         text: 'Share',
-    //       },
-    //       style: 'primary',
-    //       action_id: 'shareSearchResults',
-    //     },
-    //   ],
-    // };
     const actionBlocks = {
       type: 'actions',
       elements: [
@@ -308,9 +321,7 @@ module.exports = (crowi) => {
     }
     blocks.push(actionBlocks);
 
-    await client.chat.postEphemeral({
-      channel: body.channel_id,
-      user: body.user_id,
+    await respond(responseUrl, {
       text: 'Successed To Search',
       blocks,
     });
@@ -324,12 +335,10 @@ module.exports = (crowi) => {
     });
   };
 
-  handler.retrieveSearchResults = async function(client, body, args, offset = 0) {
+  handler.retrieveSearchResults = async function(responseUrl, client, body, args, offset = 0) {
     const firstKeyword = args[0];
     if (firstKeyword == null) {
-      client.chat.postEphemeral({
-        channel: body.channel_id,
-        user: body.user_id,
+      await respond(responseUrl, {
         text: 'Input keywords',
         blocks: [
           markdownSectionBlock('*Input keywords.*\n Hint\n `/growi search [keyword]`'),
@@ -348,9 +357,7 @@ module.exports = (crowi) => {
     // no search results
     if (results.data.length === 0) {
       logger.info(`No page found with "${keywords}"`);
-      client.chat.postEphemeral({
-        channel: body.channel_id,
-        user: body.user_id,
+      await respond(responseUrl, {
         text: `No page found with "${keywords}"`,
         blocks: [
           markdownSectionBlock(`*No page that matches your keyword(s) "${keywords}".*`),

--- a/packages/app/src/server/service/slack-command-handler/slack-command-handler.js
+++ b/packages/app/src/server/service/slack-command-handler/slack-command-handler.js
@@ -13,7 +13,7 @@ class BaseSlackCommandHandler {
   /**
    * Handle interactions
    */
-  handleInteractions(client, payload, handlerMethodName) { throw new Error('Implement this') }
+  handleInteractions(client, interactionPayload, interactionPayloadAccessor, handlerMethodName) { throw new Error('Implement this') }
 
 }
 

--- a/packages/app/src/server/service/slack-command-handler/togetter.js
+++ b/packages/app/src/server/service/slack-command-handler/togetter.js
@@ -23,31 +23,31 @@ module.exports = (crowi) => {
     return;
   };
 
-  handler.handleInteractions = async function(client, payload, handlerMethodName) {
-    await this[handlerMethodName](client, payload);
+  handler.handleInteractions = async function(client, interactionPayload, interactionPayloadAccessor, handlerMethodName) {
+    await this[handlerMethodName](client, interactionPayload, interactionPayloadAccessor);
   };
 
-  handler.cancel = async function(client, payload) {
-    const responseUrl = payload.response_url;
-    await deleteOriginal(responseUrl, {
+  handler.cancel = async function(client, payload, interactionPayloadAccessor) {
+    await deleteOriginal(interactionPayloadAccessor.getResponseUrl(), {
       delete_original: true,
     });
   };
 
-  handler.createPage = async function(client, payload) {
+  handler.createPage = async function(client, payload, interactionPayloadAccessor) {
     let result = [];
-    const channel = payload.channel.id;
+    const channelId = payload.channel.id; // this must exist since the type is always block_actions
+    const userChannelId = payload.user.id;
     try {
       // validate form
-      const { path, oldest, newest } = await this.togetterValidateForm(client, payload);
+      const { path, oldest, newest } = await this.togetterValidateForm(client, payload, interactionPayloadAccessor);
       // get messages
-      result = await this.togetterGetMessages(client, payload, channel, path, newest, oldest);
+      result = await this.togetterGetMessages(client, channelId, newest, oldest);
       // clean messages
       const cleanedContents = await this.togetterCleanMessages(result.messages);
 
       const contentsBody = cleanedContents.join('');
       // create and send url message
-      await this.togetterCreatePageAndSendPreview(client, payload, path, channel, contentsBody);
+      await this.togetterCreatePageAndSendPreview(client, interactionPayloadAccessor, path, userChannelId, contentsBody);
     }
     catch (err) {
       logger.error('Error occured by togetter.');
@@ -55,14 +55,14 @@ module.exports = (crowi) => {
     }
   };
 
-  handler.togetterValidateForm = async function(client, payload) {
+  handler.togetterValidateForm = async function(client, payload, interactionPayloadAccessor) {
     const grwTzoffset = crowi.appService.getTzoffset() * 60;
-    const path = payload.state.values.page_path.page_path.value;
-    let oldest = payload.state.values.oldest.oldest.value;
-    let newest = payload.state.values.newest.newest.value;
+    const path = interactionPayloadAccessor.getStateValues()?.page_path.page_path.value;
+    let oldest = interactionPayloadAccessor.getStateValues()?.oldest.oldest.value;
+    let newest = interactionPayloadAccessor.getStateValues()?.newest.newest.value;
     oldest = oldest.trim();
     newest = newest.trim();
-    if (!path) {
+    if (path == null) {
       throw new SlackbotError({
         method: 'postMessage',
         to: 'dm',
@@ -108,9 +108,9 @@ module.exports = (crowi) => {
     return { path, oldest, newest };
   };
 
-  handler.togetterGetMessages = async function(client, payload, channel, path, newest, oldest) {
+  handler.togetterGetMessages = async function(client, channelId, newest, oldest) {
     const result = await client.conversations.history({
-      channel,
+      channel: channelId,
       newest,
       oldest,
       limit: 100,
@@ -118,7 +118,7 @@ module.exports = (crowi) => {
     });
 
     // return if no message found
-    if (!result.messages.length) {
+    if (result.messages.length === 0) {
       throw new SlackbotError({
         method: 'postMessage',
         to: 'dm',
@@ -156,12 +156,19 @@ module.exports = (crowi) => {
     return cleanedContents;
   };
 
-  handler.togetterCreatePageAndSendPreview = async function(client, payload, path, channel, contentsBody) {
+  handler.togetterCreatePageAndSendPreview = async function(client, interactionPayloadAccessor, path, userChannelId, contentsBody) {
     try {
-      await createPageService.createPageInGrowi(client, payload, path, channel, contentsBody);
+      await createPageService.createPageInGrowi(interactionPayloadAccessor, path, contentsBody);
+    }
+    catch (err) {
+      logger.error('Error occurred while creating a page.');
+      throw err;
+    }
+
+    try {
       // send preview to dm
       await client.chat.postMessage({
-        channel: payload.user.id,
+        channel: userChannelId,
         text: 'Preview from togetter command',
         blocks: [
           markdownSectionBlock('*Preview*'),
@@ -169,11 +176,6 @@ module.exports = (crowi) => {
           markdownSectionBlock(contentsBody),
           divider(),
         ],
-      });
-      // dismiss message
-      const responseUrl = payload.response_url;
-      await deleteOriginal(responseUrl, {
-        delete_original: true,
       });
     }
     catch (err) {

--- a/packages/app/src/server/service/slack-command-handler/togetter.js
+++ b/packages/app/src/server/service/slack-command-handler/togetter.js
@@ -177,6 +177,10 @@ module.exports = (crowi) => {
           divider(),
         ],
       });
+      // dismiss
+      await deleteOriginal(interactionPayloadAccessor.getResponseUrl(), {
+        delete_original: true,
+      });
     }
     catch (err) {
       logger.error('Error occurred while creating a page.', err);

--- a/packages/app/src/server/service/slack-integration.ts
+++ b/packages/app/src/server/service/slack-integration.ts
@@ -7,8 +7,6 @@ import {
   generateWebClient, GrowiCommand, InteractionPayloadAccessor, markdownSectionBlock, respond, SlackbotType,
 } from '@growi/slack';
 
-// eslint-disable-next-line no-restricted-imports
-import axios from 'axios';
 import loggerFactory from '~/utils/logger';
 
 import S2sMessage from '../models/vo/s2s-message';
@@ -260,7 +258,7 @@ export class SlackIntegrationService implements S2sMessageHandlable {
     const module = `./slack-command-handler/${commandName}`;
     try {
       const handler = require(module)(this.crowi);
-      await handler.handleInteractions(client, interactionPayload, handlerMethodName);
+      await handler.handleInteractions(client, interactionPayload, interactionPayloadAccessor, handlerMethodName);
     }
     catch (err) {
       throw err;
@@ -275,7 +273,7 @@ export class SlackIntegrationService implements S2sMessageHandlable {
     const module = `./slack-command-handler/${commandName}`;
     try {
       const handler = require(module)(this.crowi);
-      await handler.handleInteractions(client, interactionPayload, handlerMethodName);
+      await handler.handleInteractions(client, interactionPayload, interactionPayloadAccessor, handlerMethodName);
     }
     catch (err) {
       throw err;

--- a/packages/slack/src/utils/response-url.ts
+++ b/packages/slack/src/utils/response-url.ts
@@ -4,6 +4,7 @@ import { RespondBodyForResponseUrl } from '../interfaces/response-url';
 
 export async function respond(responseUrl: string, body: RespondBodyForResponseUrl): Promise<void> {
   return axios.post(responseUrl, {
+    replace_original: false,
     text: body.text,
     blocks: body.blocks,
   });


### PR DESCRIPTION
GW-7446 本体の /proxied/interactions の処理を改修

を実装しました。

## コメント
- 改名箇所が結構ありますが、以下の方針で改名しました
    - 抽象クラスのメソッドの仮引数が改名された場合は、実装箇所も改名した
    - 中身の形に変更があるものは改名した
    - コードを読んでいてわかりにくい箇所は改名した (channel -> channelId OR userChannelId)
- search, togetter で正常動作を確認しています
- user の dm にメッセージを送る場合は client.chat.postMessage を継続して使用しています
- search の検索結果 0 の時に発生していたバグを修正しました