### PR TITLE
Imprv/7519 normalize behaviors

### DIFF
--- a/packages/app/src/server/routes/apiv3/slack-integration.js
+++ b/packages/app/src/server/routes/apiv3/slack-integration.js
@@ -5,7 +5,9 @@ const express = require('express');
 const mongoose = require('mongoose');
 const urljoin = require('url-join');
 
-const { verifySlackRequest, parseSlashCommand, InteractionPayloadAccessor } = require('@growi/slack');
+const {
+  verifySlackRequest, parseSlashCommand, InteractionPayloadAccessor, respond,
+} = require('@growi/slack');
 
 const logger = loggerFactory('growi:routes:apiv3:slack-integration');
 const router = express.Router();
@@ -57,45 +59,41 @@ module.exports = (crowi) => {
 
   // REFACTORIMG THIS MIDDLEWARE GW-7441
   async function checkCommandsPermission(req, res, next) {
-    if (req.body.text == null) return next(); // when /relation-test
     const tokenPtoG = req.headers['x-growi-ptog-tokens'];
     const extractPermissions = await extractPermissionsCommands(tokenPtoG);
+    const fromChannel = req.body.channel_name;
+    const siteUrl = crowi.appService.getSiteUrl();
 
     let commandPermission;
     if (extractPermissions != null) { // with proxy
+      const { growiCommand } = req.body;
       const { permissionsForBroadcastUseCommands, permissionsForSingleUseCommands } = extractPermissions;
       commandPermission = Object.fromEntries([...permissionsForBroadcastUseCommands, ...permissionsForSingleUseCommands]);
+      const isPermitted = checkPermission(commandPermission, growiCommand.growiCommandType, fromChannel);
+      if (isPermitted) return next();
+      return res.status(403).send(`It is not allowed to send \`/growi ${growiCommand.growiCommandType}\` command to this GROWI: ${siteUrl}`);
     }
-    else { // without proxy
-      commandPermission = JSON.parse(configManager.getConfig('crowi', 'slackbot:withoutProxy:commandPermission'));
-    }
-
+    // without proxy
     const growiCommand = parseSlashCommand(req.body);
-    const fromChannel = req.body.channel_name;
+    commandPermission = JSON.parse(configManager.getConfig('crowi', 'slackbot:withoutProxy:commandPermission'));
     const isPermitted = checkPermission(commandPermission, growiCommand.growiCommandType, fromChannel);
     if (isPermitted) return next();
-
-    // IT IS NOT WORKING. FIX THIS GW-7441
-    return res.status(403).send('It is not allowed to run the command to this GROWI.');
+    await respond(growiCommand.response_url, {
+      text: 'Command forbidden',
+      blocks: [
+        markdownSectionBlock(`It is not allowed to send \`/growi ${growiCommand.growiCommandType}\` command to this GROWI: ${siteUrl}`),
+      ],
+    });
   }
 
   // REFACTORIMG THIS MIDDLEWARE GW-7441
   async function checkInteractionsPermission(req, res, next) {
-    const payload = JSON.parse(req.body.payload);
-    if (payload == null) return next(); // when /relation-test
+    const { interactionPayload, interactionPayloadAccessor } = req;
+    const siteUrl = crowi.appService.getSiteUrl();
 
-    let actionId = '';
-    let callbackId = '';
-    let fromChannel = '';
-
-    if (payload.actions) { // when request is to /interactions && block_actions
-      actionId = payload.actions[0].action_id;
-      fromChannel = payload.channel.name;
-    }
-    else { // when request is to /interactions && view_submission
-      callbackId = payload.view.callback_id;
-      fromChannel = JSON.parse(payload.view.private_metadata).channelName;
-    }
+    const { actionId, callbackId } = interactionPayloadAccessor.getActionIdAndCallbackIdFromPayLoad();
+    const callbacIdkOrActionId = callbackId || actionId;
+    const fromChannel = interactionPayloadAccessor.getChannelName();
 
     const tokenPtoG = req.headers['x-growi-ptog-tokens'];
     const extractPermissions = await extractPermissionsCommands(tokenPtoG);
@@ -103,17 +101,22 @@ module.exports = (crowi) => {
     if (extractPermissions != null) { // with proxy
       const { permissionsForBroadcastUseCommands, permissionsForSingleUseCommands } = extractPermissions;
       commandPermission = Object.fromEntries([...permissionsForBroadcastUseCommands, ...permissionsForSingleUseCommands]);
-    }
-    else { // without proxy
-      commandPermission = JSON.parse(configManager.getConfig('crowi', 'slackbot:withoutProxy:commandPermission'));
-    }
+      const isPermitted = checkPermission(commandPermission, callbacIdkOrActionId, fromChannel);
+      if (isPermitted) return next();
 
-    const callbacIdkOrActionId = callbackId || actionId;
+      return res.status(403).send(`This interaction is forbidden on this GROWI: ${siteUrl}`);
+    }
+    // without proxy
+    commandPermission = JSON.parse(configManager.getConfig('crowi', 'slackbot:withoutProxy:commandPermission'));
     const isPermitted = checkPermission(commandPermission, callbacIdkOrActionId, fromChannel);
     if (isPermitted) return next();
 
-    // IT IS NOT WORKING FIX. THIS GW-7441
-    return res.status(403).send('It is not allowed to run the command to this GROWI.');
+    await respond(interactionPayloadAccessor.getResponseUrl(), {
+      text: 'Interaction forbidden',
+      blocks: [
+        markdownSectionBlock(`This interaction is forbidden on this GROWI: ${siteUrl}`),
+      ],
+    });
   }
 
   const addSigningSecretToReq = (req, res, next) => {

--- a/packages/app/src/server/routes/apiv3/slack-integration.js
+++ b/packages/app/src/server/routes/apiv3/slack-integration.js
@@ -183,7 +183,7 @@ module.exports = (crowi) => {
   }
 
   // TODO: do investigation and fix if needed GW-7519
-  router.post('/commands', addSigningSecretToReq, /* verifySlackRequest, */checkCommandsPermission, async(req, res) => {
+  router.post('/commands', addSigningSecretToReq, verifySlackRequest, checkCommandsPermission, async(req, res) => {
     const client = await slackIntegrationService.generateClientForCustomBotWithoutProxy();
     return handleCommands(req, res, client);
   });
@@ -239,7 +239,7 @@ module.exports = (crowi) => {
   }
 
   // TODO: do investigation and fix if needed GW-7519
-  router.post('/interactions', addSigningSecretToReq, /* verifySlackRequest, */ parseSlackInteractionRequest, checkInteractionsPermission, async(req, res) => {
+  router.post('/interactions', addSigningSecretToReq, verifySlackRequest, parseSlackInteractionRequest, checkInteractionsPermission, async(req, res) => {
     const client = await slackIntegrationService.generateClientForCustomBotWithoutProxy();
     return handleInteractionsRequest(req, res, client);
   });

--- a/packages/app/src/server/service/slack-command-handler/create-page-service.js
+++ b/packages/app/src/server/service/slack-command-handler/create-page-service.js
@@ -26,7 +26,6 @@ class CreatePageService {
 
       // Send a message when page creation is complete
       const growiUri = this.crowi.appService.getSiteUrl();
-      // TODO: FIX THIS GW-7446
       await respond(interactionPayloadAccessor.getResponseUrl(), {
         text: 'Page has been created',
         blocks: [

--- a/packages/app/src/server/service/slack-command-handler/create.js
+++ b/packages/app/src/server/service/slack-command-handler/create.js
@@ -1,6 +1,8 @@
 import loggerFactory from '~/utils/logger';
 
-const { markdownSectionBlock, inputSectionBlock, respond } = require('@growi/slack');
+const {
+  markdownSectionBlock, inputSectionBlock, respond, inputBlock,
+} = require('@growi/slack');
 
 const logger = loggerFactory('growi:service:SlackCommandHandler:create');
 
@@ -9,6 +11,12 @@ module.exports = (crowi) => {
   const createPageService = new CreatePageService(crowi);
   const BaseSlackCommandHandler = require('./slack-command-handler');
   const handler = new BaseSlackCommandHandler();
+  const conversationsSelectElement = {
+    action_id: 'conversation',
+    type: 'conversations_select',
+    response_url_enabled: true,
+    default_to_current_conversation: true,
+  };
 
   handler.handleCommand = async(growiCommand, client, body) => {
     await client.views.open({
@@ -31,6 +39,7 @@ module.exports = (crowi) => {
         },
         blocks: [
           markdownSectionBlock('Create new page.'),
+          inputBlock(conversationsSelectElement, 'conversation', 'Channel name to display in the page to be created'),
           inputSectionBlock('path', 'Path', 'path_input', false, '/path'),
           inputSectionBlock('contents', 'Contents', 'contents_input', true, 'Input with Markdown...'),
         ],

--- a/packages/app/src/server/service/slack-command-handler/search.js
+++ b/packages/app/src/server/service/slack-command-handler/search.js
@@ -42,7 +42,7 @@ module.exports = (crowi) => {
 
     let searchResultsDesc;
 
-    if (resultsTotal === 0) {
+    if (resultsTotal === 0 || resultsTotal == null) {
       await respond(responseUrl, {
         text: 'No page found.',
         blocks: [
@@ -229,7 +229,7 @@ module.exports = (crowi) => {
 
     let searchResultsDesc;
 
-    if (resultsTotal === 0) {
+    if (resultsTotal === 0 || resultsTotal == null) {
       await respond(responseUrl, {
         text: 'No page found.',
         blocks: [

--- a/packages/slack/src/middlewares/verify-slack-request.ts
+++ b/packages/slack/src/middlewares/verify-slack-request.ts
@@ -12,7 +12,6 @@ const logger = loggerFactory('@growi/slack:middlewares:verify-slack-request');
  * Verify if the request came from slack
  * See: https://api.slack.com/authentication/verifying-requests-from-slack
  */
-// TODO: do investigation and fix if needed GW-7519
 export const verifySlackRequest = (req: RequestFromSlack, res: Response, next: NextFunction): Record<string, any> | void => {
   const signingSecret = req.slackSigningSecret;
 

--- a/packages/slackbot-proxy/src/controllers/slack.ts
+++ b/packages/slackbot-proxy/src/controllers/slack.ts
@@ -291,7 +291,7 @@ export class SlackCtrl {
 
 
   @Post('/interactions')
-  @UseBefore(/* AddSigningSecretToReq, verifySlackRequest, */ parseSlackInteractionRequest, AuthorizeInteractionMiddleware, ExtractGrowiUriFromReq)
+  @UseBefore(AddSigningSecretToReq, verifySlackRequest, parseSlackInteractionRequest, AuthorizeInteractionMiddleware, ExtractGrowiUriFromReq)
   async handleInteraction(@Req() req: SlackOauthReq, @Res() res: Res): Promise<void|string|Res|WebAPICallResult> {
     logger.info('receive interaction', req.authorizeResult);
     logger.debug('receive interaction', req.body);

--- a/packages/slackbot-proxy/src/controllers/slack.ts
+++ b/packages/slackbot-proxy/src/controllers/slack.ts
@@ -129,6 +129,7 @@ export class SlackCtrl {
     // catch (err) {
     //   logger.error(err);
     // }
+    // The code below is temporary. It will be fixed as well GW-7508
     if (rejectedResults.length > 0) {
       logger.error('Growi command failed: No installation found.');
       await respond(growiCommand.responseUrl, {
@@ -263,7 +264,7 @@ export class SlackCtrl {
       const growiDocsLink = 'https://docs.growi.org/en/admin-guide/upgrading/43x.html';
 
       return respond(growiCommand.responseUrl, {
-        text: 'Error occured.',
+        text: 'Command not permitted.',
         blocks: [
           markdownSectionBlock('*None of GROWI permitted the command.*'),
           markdownSectionBlock(`*'${growiCommand.growiCommandType}'* command was not allowed.`),

--- a/packages/slackbot-proxy/src/services/SelectGrowiService.ts
+++ b/packages/slackbot-proxy/src/services/SelectGrowiService.ts
@@ -144,7 +144,7 @@ export class SelectGrowiService implements GrowiCommandProcessor<SelectGrowiComm
 
     const selectGrowiValue = interactionPayloadAccessor.firstAction()?.value;
     if (selectGrowiValue == null) {
-      logger.error('Growi command failed: growiCommand and body params are required in private_metadata.');
+      logger.error('Growi command failed: The first action element must have the value parameter.');
       await respond(responseUrl, {
         text: 'Growi command failed',
         blocks: [
@@ -157,7 +157,7 @@ export class SelectGrowiService implements GrowiCommandProcessor<SelectGrowiComm
 
 
     if (growiCommand == null) {
-      logger.error('Growi command failed: growiCommand and body params are required in private_metadata.');
+      logger.error('Growi command failed: The first action value must have growiCommand parameter.');
       await respond(responseUrl, {
         text: 'Growi command failed',
         blocks: [

--- a/packages/slackbot-proxy/src/services/UnregisterService.ts
+++ b/packages/slackbot-proxy/src/services/UnregisterService.ts
@@ -4,7 +4,7 @@ import { MultiStaticSelect } from '@slack/web-api';
 import {
   actionsBlock, buttonElement, getInteractionIdRegexpFromCommandName,
   GrowiCommand, GrowiCommandProcessor, GrowiInteractionProcessor,
-  inputBlock, InteractionHandledResult, markdownSectionBlock, respond, InteractionPayloadAccessor,
+  inputBlock, InteractionHandledResult, markdownSectionBlock, respond, InteractionPayloadAccessor, replaceOriginal,
 } from '@growi/slack';
 import { AuthorizeResult } from '@slack/oauth';
 import { DeleteResult } from 'typeorm';
@@ -171,7 +171,7 @@ export class UnregisterService implements GrowiCommandProcessor, GrowiInteractio
       return;
     }
 
-    await respond(responseUrl, {
+    await replaceOriginal(responseUrl, {
       text: 'Unregistration completed',
       blocks: [
         markdownSectionBlock(`Unregistered *${deleteResult.affected}* GROWI from this workspace.`),

--- a/packages/slackbot-proxy/src/services/growi-uri-injector/block-elements/ButtonActionPayloadDelegator.ts
+++ b/packages/slackbot-proxy/src/services/growi-uri-injector/block-elements/ButtonActionPayloadDelegator.ts
@@ -33,11 +33,13 @@ export class ButtonActionPayloadDelegator implements GrowiUriInjector<TypedBlock
   }
 
   extract(action: ButtonActionPayload): GrowiUriWithOriginalData {
-    // TODO: FIX THIS GW-7508
-    // action.value = restoredData.originalData;
-    // return restoredData;
+    const restoredData: GrowiUriWithOriginalData = JSON.parse(action.value || '{}');
 
-    return JSON.parse(action.value || '{}');
+    if (restoredData.originalData != null) {
+      action.value = restoredData.originalData;
+    }
+
+    return restoredData;
   }
 
 


### PR DESCRIPTION
GW-7519 growi-uri-injector , verifySlackRequest など完全に動作するように改修
GW-7466 [本体側] checkInteractionsPermission で権限エラーの時適切に     res.status(403).send('It is not allowed to run  command to this GROWI.'); を返答することができる

を実装しました。

## 修正一覧
- with, without で権限設定も含めて全てのコマンドが正常に動くようになった
- search コマンドの検索結果なしの時のバグを修正
- エラーメッセージをわかりやすく修正
- ButtonActionPayloadDelegator の value がない場合に対応 (dismiss のときなどは value を意識しないため)
- 本体の checkHogePermission 系ミドルウェアを正常化 & リファクタ

## 次のタスクについて
- postEphemeralErrors で　response_url を使うように改修したら再提出できます