### PR TITLE
Imprv/7508 improve post ephemeral errors

### DIFF
--- a/packages/slack/src/utils/post-ephemeral-errors.ts
+++ b/packages/slack/src/utils/post-ephemeral-errors.ts
@@ -1,23 +1,16 @@
 import { WebAPICallResult } from '@slack/web-api';
+import { respond } from './response-url';
 
 import { markdownSectionBlock } from './block-kit-builder';
-import { generateWebClient } from './webclient-factory';
 
 export const postEphemeralErrors = async(
     rejectedResults: PromiseRejectedResult[],
-    channelId: string,
-    userId: string,
-    botToken: string,
+    responseUrl: string,
 ): Promise<WebAPICallResult|void> => {
 
   if (rejectedResults.length > 0) {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const client = generateWebClient(botToken);
-
-    return client.chat.postEphemeral({
+    await respond(responseUrl, {
       text: 'Error occured.',
-      channel: channelId,
-      user: userId,
       blocks: [
         markdownSectionBlock('*Error occured:*'),
         ...rejectedResults.map((rejectedResult) => {

--- a/packages/slack/src/utils/post-ephemeral-errors.ts
+++ b/packages/slack/src/utils/post-ephemeral-errors.ts
@@ -3,7 +3,7 @@ import { respond } from './response-url';
 
 import { markdownSectionBlock } from './block-kit-builder';
 
-export const postEphemeralErrors = async(
+export const respondRejectedErrors = async(
     rejectedResults: PromiseRejectedResult[],
     responseUrl: string,
 ): Promise<WebAPICallResult|void> => {

--- a/packages/slackbot-proxy/src/controllers/slack.ts
+++ b/packages/slackbot-proxy/src/controllers/slack.ts
@@ -9,7 +9,7 @@ import { Installation } from '@slack/oauth';
 
 
 import {
-  markdownSectionBlock, GrowiCommand, parseSlashCommand, postEphemeralErrors, generateWebClient,
+  markdownSectionBlock, GrowiCommand, parseSlashCommand, respondRejectedErrors, generateWebClient,
   InvalidGrowiCommandError, requiredScopes, postWelcomeMessage, REQUEST_TIMEOUT_FOR_PTOG,
   parseSlackInteractionRequest, verifySlackRequest,
   respond,
@@ -121,7 +121,7 @@ export class SlackCtrl {
     const rejectedResults: PromiseRejectedResult[] = results.filter((result): result is PromiseRejectedResult => result.status === 'rejected');
 
     try {
-      return postEphemeralErrors(rejectedResults, growiCommand.responseUrl);
+      return respondRejectedErrors(rejectedResults, growiCommand.responseUrl);
     }
     catch (err) {
       logger.error(err);
@@ -342,7 +342,7 @@ export class SlackCtrl {
     } = permission;
 
     try {
-      await postEphemeralErrors(rejectedResults, interactionPayloadAccessor.getResponseUrl());
+      await respondRejectedErrors(rejectedResults, interactionPayloadAccessor.getResponseUrl());
     }
     catch (err) {
       logger.error(err);


### PR DESCRIPTION
GW-7508 [proxy 側]postEphemeralErrors などのその他の処理 改修 [竹ラスト]

を実装しました。

## 改修箇所
- postEphemeralErrors を response_url に対応した
