### PR TITLE
feat: create snippet

### DIFF
--- a/packages/app/src/server/service/search-delegator/elasticsearch.js
+++ b/packages/app/src/server/service/search-delegator/elasticsearch.js
@@ -864,9 +864,7 @@ class ElasticsearchDelegator {
         '*': {
           type: 'plain',
           fragment_size: 30,
-          // number_of_fragments: 3,
           fragmenter: 'simple',
-          // _source: fields,
         },
       },
     };
@@ -886,12 +884,11 @@ class ElasticsearchDelegator {
 
     this.appendFunctionScore(query, queryString);
     this.appendHighlight(query);
-    const hoge = await this.search(query);
-    console.log(hoge, 895, 'search した結果');
-    console.log(hoge.data[0].highlight, 895, '_sourceの中身');
-    console.log(hoge.data[1].highlight, 895, '_sourceの中身その2');
-    console.log(hoge.data[2].highlight, 895, '_sourceの中身その2');
-    return hoge;
+    return this.search(query);
+    // const hoge = await this.search(query);
+
+    // console.log(hoge.data[0].highlight, 895, '_sourceの中身その1');
+    // return hoge;
   }
 
   parseQueryString(queryString) {

--- a/packages/app/src/server/service/search-delegator/elasticsearch.js
+++ b/packages/app/src/server/service/search-delegator/elasticsearch.js
@@ -540,10 +540,11 @@ class ElasticsearchDelegator {
     }
 
     const result = await this.client.search(query);
+
     // for debug
     logger.debug('ES result: ', result);
-    return {
 
+    return {
       meta: {
         took: result.took,
         total: result.hits.total,

--- a/packages/app/src/server/service/search-delegator/elasticsearch.js
+++ b/packages/app/src/server/service/search-delegator/elasticsearch.js
@@ -543,7 +543,6 @@ class ElasticsearchDelegator {
 
     // for debug
     logger.debug('ES result: ', result);
-    // console.log(result.hits.hits[0].highlight, 'highlight');
     return {
       meta: {
         took: result.took,

--- a/packages/app/src/server/service/search-delegator/elasticsearch.js
+++ b/packages/app/src/server/service/search-delegator/elasticsearch.js
@@ -554,7 +554,7 @@ class ElasticsearchDelegator {
           _id: elm._id,
           _score: elm._score,
           _source: elm._source,
-          highlight: elm.highlight,
+          _highlight: elm.highlight,
         };
       }),
     };
@@ -864,7 +864,6 @@ class ElasticsearchDelegator {
     query.body.highlight = {
       fields: {
         '*': {
-          type: 'plain',
           fragment_size: 30,
           fragmenter: 'simple',
         },

--- a/packages/app/src/server/service/search-delegator/elasticsearch.js
+++ b/packages/app/src/server/service/search-delegator/elasticsearch.js
@@ -540,10 +540,10 @@ class ElasticsearchDelegator {
     }
 
     const result = await this.client.search(query);
-
     // for debug
     logger.debug('ES result: ', result);
     return {
+
       meta: {
         took: result.took,
         total: result.hits.total,

--- a/packages/app/src/server/service/search-delegator/elasticsearch.js
+++ b/packages/app/src/server/service/search-delegator/elasticsearch.js
@@ -552,7 +552,10 @@ class ElasticsearchDelegator {
       },
       data: result.hits.hits.map((elm) => {
         return {
-          _id: elm._id, _score: elm._score, _source: elm._source, highlight: elm.highlight,
+          _id: elm._id,
+          _score: elm._score,
+          _source: elm._source,
+          highlight: elm.highlight,
         };
       }),
     };
@@ -885,10 +888,6 @@ class ElasticsearchDelegator {
     this.appendFunctionScore(query, queryString);
     this.appendHighlight(query);
     return this.search(query);
-    // const hoge = await this.search(query);
-
-    // console.log(hoge.data[0].highlight, 895, '_sourceの中身その1');
-    // return hoge;
   }
 
   parseQueryString(queryString) {


### PR DESCRIPTION
## 概要
elasticsearch 側で highlight,snippet の設定をし、Highlight を含む snippet の取得をしています。

## 実行結果
hoge の検索結果
```
GET /_api/v3/pages/recent 304 137.889 ms - -
{
  'body.en': [
    '航空機売込みに絡んだ贈収賄事件（ロッキード事件）で逮捕収監され、<em>hoge</em>',
    '小学校卒業まで\n新潟県刈羽郡二田村大字坂田（現：柏崎市）に父・<em>hoge</em>',
    'しかし、<em>hoge</em>の中央工学校は専門学校として東京都から認可を受'
  ],
  'body.ja': [
    '航空機売込みに絡んだ贈収賄事件（ロッキード事件）で逮捕収監され、<em>hoge</em>',
    'などに強い影響力を持ち、政治家による官僚統制の象徴、族議員の<em>hoge</em>',
    '1972年8月7日の駐日<em>hoge</em>大使から本国への機密の報告書には',
    '小学校卒業まで\n新潟県刈羽郡二田村大字坂田（現：柏崎市）に父・<em>hoge</em>',
    'しかし、<em>hoge</em>の中央工学校は専門学校として東京都から認可を受'
  ]
} 
```
body が en と ja に分かれているため、body.en と body.ja で引っかかります。
調査したところ句読点やスペースの次に hoge がきた場合 body.en で検知されるようです。
こちらの対策は、 重複する内容を排除して本体に返すことを考えています。

また、path に hoge が含まれる場合 path.en と path.ja 双方に検索結果が引っかかっります。こちらはいずれか一方を取得しようと考えています。
```
  highlight: {
    'path.en': [ '/<em>hoge</em>' ],
    'body.en': [ 'ワイ松 <em>hoge</em>' ],
    'path.ja': [ '/<em>hoge</em>' ],
    'body.ja': [ 'ワイ松 <em>hoge</em>' ]
  }
```

