### PR TITLE
fix: SidebarSmall button does not keep selection on reload

### DIFF
--- a/packages/app/src/components/Sidebar/RecentChanges.jsx
+++ b/packages/app/src/components/Sidebar/RecentChanges.jsx
@@ -187,7 +187,7 @@ class RecentChanges extends React.Component {
               className="custom-control-input"
               type="checkbox"
               checked={this.state.isRecentChangesSidebarSmall}
-              onChange={e => this.setState({ isRecentChangesSidebarSmall: e.target.checked })}
+              onChange={this.changeSizeHandler}
             />
             <label className="custom-control-label" htmlFor="recentChangesResize">
             </label>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/58382232/134756407-87ec2c57-a9dc-4bc8-ab48-833388d0da41.png)

「最新の変更」サイドバーにあるS/L切り替えボタンについて、変更がlocalStorageに反映されておらずリロードのたびにデフォルト（L）に戻ってしまっていました。

localStorageへの保存を伴うハンドラーがchangeSizeHandlerとして既に用意されていたのでそちらを使うようにしたところ期待する動作となりました。  
→ 意図・懸念があって元コードの状態にしているようでしたらすみません（ご指摘ください）。

* localStorageを消去してページをリロードする
   * 「L」の状態で表示、OK
* 「S」に変更してページをリロードする
   * 「S」の状態で表示、OK
* 再度「L」に変更してページをリロードする
   * 「L」の状態で表示、OK
