### PR TITLE
fix: SAML setting says 'setup is not yet complete' even if setup properly

### DIFF
--- a/packages/app/src/components/Admin/Security/SamlSecuritySettingContents.jsx
+++ b/packages/app/src/components/Admin/Security/SamlSecuritySettingContents.jsx
@@ -65,7 +65,7 @@ class SamlSecurityManagementContents extends React.Component {
                 {t('security_setting.SAML.enable_saml')}
               </label>
             </div>
-            {(!adminGeneralSecurityContainer.state.setupStrategies.includes('ldap') && isSamlEnabled)
+            {(!adminGeneralSecurityContainer.state.setupStrategies.includes('saml') && isSamlEnabled)
               && <div className="badge badge-warning">{t('security_setting.setup_is_not_yet_complete')}</div>}
           </div>
         </div>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/58382232/134770175-f021abe5-9c91-4862-82de-ea4f0c2c68c2.png)

「セキュリティ設定」のSAML設定に関して、セットアップが完了して動作している状態でも「セットアップはまだ完了してません」のアラートが表示されている状況になっています。  
当初は「動いているけど設定は不完全なのだろう」と考えていたのですが、コードを確認していたところLDAPのセットアップ完了を誤ってチェックしているようでした。

本変更を実施して、仮の設定値を埋めてセットアップしたところ、アラートが表示されなくなることを確認できました。