### PR TITLE
Feat: 77797 get seen users

### DIFF
--- a/packages/app/resource/search/mappings.json
+++ b/packages/app/resource/search/mappings.json
@@ -74,6 +74,9 @@
         "bookmark_count": {
           "type": "integer"
         },
+        "seenUsers_count":{
+          "type": "integer"
+        },
         "like_count": {
           "type": "integer"
         },

--- a/packages/app/src/server/events/page.js
+++ b/packages/app/src/server/events/page.js
@@ -18,5 +18,8 @@ PageEvent.prototype.onUpdate = function(page, user) {
 PageEvent.prototype.onCreateMany = function(pages, user) {
   debug('onCreateMany event fired');
 };
-
+PageEvent.prototype.onAddSeenUsers = function(pages, user) {
+  console.log(22);
+  debug('onAddSeenUsers event fired');
+};
 module.exports = PageEvent;

--- a/packages/app/src/server/events/page.js
+++ b/packages/app/src/server/events/page.js
@@ -19,7 +19,6 @@ PageEvent.prototype.onCreateMany = function(pages, user) {
   debug('onCreateMany event fired');
 };
 PageEvent.prototype.onAddSeenUsers = function(pages, user) {
-  console.log(22);
   debug('onAddSeenUsers event fired');
 };
 module.exports = PageEvent;

--- a/packages/app/src/server/models/page.js
+++ b/packages/app/src/server/models/page.js
@@ -418,21 +418,27 @@ module.exports = function(crowi) {
     return saved;
   };
 
-  // pageSchema.statics.getPageIdToSeenUsersCount = async function(pageIds) {
-  //   console.log(pageIds, 423);
-  //   const results = await this.aggregate()
-  //     .match({ _id: { $in: pageIds } });
+  pageSchema.methods.eventFireAfterSeen = async function(page) {
+    // const pageEvent = crowi.event('page');
+    pageEvent.emit('addSeenUsers', page);
+    return;
+  };
+
+  pageSchema.statics.getPageIdToSeenUsersCount = async function(pageIds) {
+    console.log(pageIds, 423);
+    const results = await this.aggregate()
+      .match({ _id: { $in: pageIds } });
 
 
-  //   console.log(results, 425, 'getPageIdTO');
-  //   const idToCountMap = {};
-  //   results.forEach((result) => {
-  //     idToCountMap[result.id] = result.count;
-  //   });
+    console.log(results, 425, 'getPageIdTO');
+    const idToCountMap = {};
+    results.forEach((result) => {
+      idToCountMap[result.seenUsers] = result.seenUsers.length;
+    });
 
-  //   return idToCountMap;
+    return idToCountMap;
 
-  // };
+  };
 
   pageSchema.methods.updateSlackChannels = function(slackChannels) {
     this.slackChannels = slackChannels;

--- a/packages/app/src/server/models/page.js
+++ b/packages/app/src/server/models/page.js
@@ -413,16 +413,11 @@ module.exports = function(crowi) {
     const added = this.seenUsers.addToSet(userData._id);
     const saved = await this.save();
 
-    this.eventFireAfterSeen(saved);
+    pageEvent.emit('addSeenUsers', saved);
 
     debug('seenUsers updated!', added);
 
     return saved;
-  };
-
-  pageSchema.methods.eventFireAfterSeen = function(page) {
-    pageEvent.emit('addSeenUsers', page);
-    return;
   };
 
   pageSchema.statics.getPageIdToSeenUsersCount = async function(pageIds) {

--- a/packages/app/src/server/models/page.js
+++ b/packages/app/src/server/models/page.js
@@ -429,7 +429,6 @@ module.exports = function(crowi) {
     });
 
     return idToCountMap;
-
   };
 
   pageSchema.methods.updateSlackChannels = function(slackChannels) {

--- a/packages/app/src/server/models/page.js
+++ b/packages/app/src/server/models/page.js
@@ -413,24 +413,22 @@ module.exports = function(crowi) {
     const added = this.seenUsers.addToSet(userData._id);
     const saved = await this.save();
 
+    this.eventFireAfterSeen(saved);
+
     debug('seenUsers updated!', added);
 
     return saved;
   };
 
-  pageSchema.methods.eventFireAfterSeen = async function(page) {
-    // const pageEvent = crowi.event('page');
+  pageSchema.methods.eventFireAfterSeen = function(page) {
     pageEvent.emit('addSeenUsers', page);
     return;
   };
 
   pageSchema.statics.getPageIdToSeenUsersCount = async function(pageIds) {
-    console.log(pageIds, 423);
     const results = await this.aggregate()
       .match({ _id: { $in: pageIds } });
 
-
-    console.log(results, 425, 'getPageIdTO');
     const idToCountMap = {};
     results.forEach((result) => {
       idToCountMap[result.seenUsers] = result.seenUsers.length;

--- a/packages/app/src/server/models/page.js
+++ b/packages/app/src/server/models/page.js
@@ -288,6 +288,7 @@ module.exports = function(crowi) {
     pageEvent.on('create', pageEvent.onCreate);
     pageEvent.on('update', pageEvent.onUpdate);
     pageEvent.on('createMany', pageEvent.onCreateMany);
+    pageEvent.on('addSeenUsers', pageEvent.onAddSeenUsers);
   }
 
   function validateCrowi() {
@@ -416,6 +417,22 @@ module.exports = function(crowi) {
 
     return saved;
   };
+
+  // pageSchema.statics.getPageIdToSeenUsersCount = async function(pageIds) {
+  //   console.log(pageIds, 423);
+  //   const results = await this.aggregate()
+  //     .match({ _id: { $in: pageIds } });
+
+
+  //   console.log(results, 425, 'getPageIdTO');
+  //   const idToCountMap = {};
+  //   results.forEach((result) => {
+  //     idToCountMap[result.id] = result.count;
+  //   });
+
+  //   return idToCountMap;
+
+  // };
 
   pageSchema.methods.updateSlackChannels = function(slackChannels) {
     this.slackChannels = slackChannels;

--- a/packages/app/src/server/models/page.js
+++ b/packages/app/src/server/models/page.js
@@ -419,18 +419,6 @@ module.exports = function(crowi) {
     return saved;
   };
 
-  pageSchema.statics.getPageIdToSeenUsersCount = async function(pageIds) {
-    const results = await this.aggregate()
-      .match({ _id: { $in: pageIds } });
-
-    const idToCountMap = {};
-    results.forEach((result) => {
-      idToCountMap[result.seenUsers] = result.seenUsers.length;
-    });
-
-    return idToCountMap;
-  };
-
   pageSchema.methods.updateSlackChannels = function(slackChannels) {
     this.slackChannels = slackChannels;
 

--- a/packages/app/src/server/models/page.js
+++ b/packages/app/src/server/models/page.js
@@ -413,9 +413,8 @@ module.exports = function(crowi) {
     const added = this.seenUsers.addToSet(userData._id);
     const saved = await this.save();
 
-    pageEvent.emit('addSeenUsers', saved);
-
     debug('seenUsers updated!', added);
+    pageEvent.emit('addSeenUsers', saved);
 
     return saved;
   };

--- a/packages/app/src/server/routes/page.js
+++ b/packages/app/src/server/routes/page.js
@@ -362,9 +362,10 @@ module.exports = function(crowi, app) {
     if (req.user != null) {
       page = await page.seen(req.user);
       console.log(page, 364);
-      const pageEvent = crowi.event('page');
-      pageEvent.on('addSeenUsers', pageEvent.onAddSeenUsers);
+
+      await page.eventFireAfterSeen(page);
       console.log(367);
+
     }
 
     // populate

--- a/packages/app/src/server/routes/page.js
+++ b/packages/app/src/server/routes/page.js
@@ -361,11 +361,6 @@ module.exports = function(crowi, app) {
     // add user to seen users
     if (req.user != null) {
       page = await page.seen(req.user);
-      console.log(page, 364);
-
-      await page.eventFireAfterSeen(page);
-      console.log(367);
-
     }
 
     // populate

--- a/packages/app/src/server/routes/page.js
+++ b/packages/app/src/server/routes/page.js
@@ -361,6 +361,10 @@ module.exports = function(crowi, app) {
     // add user to seen users
     if (req.user != null) {
       page = await page.seen(req.user);
+      console.log(page, 364);
+      const pageEvent = crowi.event('page');
+      pageEvent.on('addSeenUsers', pageEvent.onAddSeenUsers);
+      console.log(367);
     }
 
     // populate

--- a/packages/app/src/server/service/page.js
+++ b/packages/app/src/server/service/page.js
@@ -25,6 +25,7 @@ class PageService {
     this.pageEvent.on('create', this.pageEvent.onCreate);
     this.pageEvent.on('update', this.pageEvent.onUpdate);
     this.pageEvent.on('createMany', this.pageEvent.onCreateMany);
+    this.pageEvent.on('addSeenUsers', this.pageEvent.onAddSeenUsers);
   }
 
   /**

--- a/packages/app/src/server/service/search-delegator/elasticsearch.js
+++ b/packages/app/src/server/service/search-delegator/elasticsearch.js
@@ -454,23 +454,6 @@ class ElasticsearchDelegator {
       },
     });
 
-    const appendSeenUsersCountStream = new Transform({
-      objectMode: true,
-      async transform(chunk, encoding, callback) {
-        const pageIds = chunk.map(doc => doc._id);
-
-        const idToSeenUsersCountMap = await Page.getPageIdToSeenUsersCount(pageIds);
-        const idsHavingCount = Object.keys(idToSeenUsersCountMap);
-        chunk
-          .filter(doc => idsHavingCount.includes(doc._id.toString()))
-          .forEach((doc) => {
-            doc.seenUsers = idToSeenUsersCountMap[doc._id.toString()];
-          });
-        this.push(chunk);
-        callback();
-      },
-    });
-
     let count = 0;
     const writeStream = new Writable({
       objectMode: true,
@@ -523,7 +506,6 @@ class ElasticsearchDelegator {
       .pipe(batchStream)
       .pipe(appendBookmarkCountStream)
       .pipe(appendTagNamesStream)
-      .pipe(appendSeenUsersCountStream)
       .pipe(writeStream);
 
     return streamToPromise(writeStream);

--- a/packages/app/src/server/service/search-delegator/elasticsearch.js
+++ b/packages/app/src/server/service/search-delegator/elasticsearch.js
@@ -418,6 +418,8 @@ class ElasticsearchDelegator {
       async transform(chunk, encoding, callback) {
         const pageIds = chunk.map(doc => doc._id);
 
+        console.log(pageIds, 420, 'updateOrInsertPages');
+
         const idToCountMap = await Bookmark.getPageIdToCountMap(pageIds);
         const idsHavingCount = Object.keys(idToCountMap);
 
@@ -460,17 +462,17 @@ class ElasticsearchDelegator {
       async transform(chunk, encoding, callback) {
         const pageIds = chunk.map(doc => doc._id);
 
-        const idToCountSeenUsersMap = await Page.getPageIdToSeenUsersCount(pageIds);
-        console.log(idToCountSeenUsersMap, 464);
+        const hoge = await Page.find({ _id: { $in: pageIds } });
+        console.log(hoge, 464);
 
-        const idsHavingCount = Object.keys(idToCountSeenUsersMap);
+        // const idsHavingCount = Object.keys(idToCountSeenUsersMap);
 
-        chunk
-          .filter(doc => idsHavingCount.includes(doc._id.toString()))
-          .forEach((doc) => {
-            doc.seenUsers = idToCountSeenUsersMap[doc.id.toString()];
-          });
-        this.push(chunk);
+        // chunk
+        //   .filter(doc => idsHavingCount.includes(doc._id.toString()))
+        //   .forEach((doc) => {
+        //     doc.seenUsers = idToCountSeenUsersMap[doc.id.toString()];
+        //   });
+        // this.push(chunk);
         callback();
       },
     });
@@ -994,7 +996,12 @@ class ElasticsearchDelegator {
     };
   }
 
+  // async syncPageSeen() {
+
+  // }
+
   async syncPageUpdated(page, user) {
+    console.log(page, 1004);
     logger.debug('SearchClient.syncPageUpdated', page.path);
 
     // delete if page should not indexed

--- a/packages/app/src/server/service/search-delegator/elasticsearch.js
+++ b/packages/app/src/server/service/search-delegator/elasticsearch.js
@@ -310,7 +310,7 @@ class ElasticsearchDelegator {
 
     const bookmarkCount = page.bookmarkCount || 0;
     const seenUsersCount = page.seenUsers.length || 0;
-    // console.log(seenUsersCount, 313);
+    console.log(seenUsersCount, 313);
     let document = {
       path: page.path,
       body: page.revision.body,
@@ -907,6 +907,7 @@ class ElasticsearchDelegator {
     const size = option.limit || null;
     const type = option.type || null;
     const query = this.createSearchQuerySortedByScore();
+    console.log(query, 910);
     this.appendCriteriaForQueryString(query, queryString);
 
     this.filterPagesByType(query, type);

--- a/packages/app/src/server/service/search-delegator/elasticsearch.js
+++ b/packages/app/src/server/service/search-delegator/elasticsearch.js
@@ -644,7 +644,6 @@ class ElasticsearchDelegator {
     if (!isInitialized(query.body.query.bool.must_not)) {
       query.body.query.bool.must_not = [];
     }
-
     return query;
   }
 
@@ -985,10 +984,6 @@ class ElasticsearchDelegator {
       not_tag: notTags,
     };
   }
-
-  // async syncPageSeen() {
-
-  // }
 
   async syncPageUpdated(page, user) {
     logger.debug('SearchClient.syncPageUpdated', page.path);

--- a/packages/app/src/server/service/search-delegator/elasticsearch.js
+++ b/packages/app/src/server/service/search-delegator/elasticsearch.js
@@ -421,8 +421,9 @@ class ElasticsearchDelegator {
         console.log(pageIds, 420, 'updateOrInsertPages');
 
         const idToCountMap = await Bookmark.getPageIdToCountMap(pageIds);
+        console.log(idToCountMap);
         const idsHavingCount = Object.keys(idToCountMap);
-
+        console.log(idsHavingCount);
         // append count
         chunk
           .filter(doc => idsHavingCount.includes(doc._id.toString()))
@@ -462,17 +463,17 @@ class ElasticsearchDelegator {
       async transform(chunk, encoding, callback) {
         const pageIds = chunk.map(doc => doc._id);
 
-        const hoge = await Page.find({ _id: { $in: pageIds } });
-        console.log(hoge, 464);
-
-        // const idsHavingCount = Object.keys(idToCountSeenUsersMap);
-
-        // chunk
-        //   .filter(doc => idsHavingCount.includes(doc._id.toString()))
-        //   .forEach((doc) => {
-        //     doc.seenUsers = idToCountSeenUsersMap[doc.id.toString()];
-        //   });
-        // this.push(chunk);
+        const idToSeenUsersCountMap = await Page.getPageIdToSeenUsersCount(pageIds);
+        console.log(idToSeenUsersCountMap);
+        const idsHavingCount = Object.keys(idToSeenUsersCountMap);
+        console.log(idsHavingCount);
+        chunk
+          .filter(doc => idsHavingCount.includes(doc._id.toString()))
+          .forEach((doc) => {
+            console.log(doc.seenUsers, 473);
+            doc.seenUsers = idToSeenUsersCountMap[doc._id.toString()];
+          });
+        this.push(chunk);
         callback();
       },
     });

--- a/packages/app/src/server/service/search-delegator/elasticsearch.js
+++ b/packages/app/src/server/service/search-delegator/elasticsearch.js
@@ -416,8 +416,10 @@ class ElasticsearchDelegator {
       objectMode: true,
       async transform(chunk, encoding, callback) {
         const pageIds = chunk.map(doc => doc._id);
+
         const idToCountMap = await Bookmark.getPageIdToCountMap(pageIds);
         const idsHavingCount = Object.keys(idToCountMap);
+
         // append count
         chunk
           .filter(doc => idsHavingCount.includes(doc._id.toString()))

--- a/packages/app/src/server/service/search-delegator/elasticsearch.js
+++ b/packages/app/src/server/service/search-delegator/elasticsearch.js
@@ -309,6 +309,8 @@ class ElasticsearchDelegator {
     };
 
     const bookmarkCount = page.bookmarkCount || 0;
+    const seenUsersCount = page.seenUsers.length || 0;
+    // console.log(seenUsersCount, 313);
     let document = {
       path: page.path,
       body: page.revision.body,
@@ -316,6 +318,7 @@ class ElasticsearchDelegator {
       username: page.creator != null ? page.creator.username : null,
       comment_count: page.commentCount,
       bookmark_count: bookmarkCount,
+      seenUsers_count: seenUsersCount,
       like_count: page.liker.length || 0,
       created_at: page.createdAt,
       updated_at: page.updatedAt,
@@ -452,6 +455,26 @@ class ElasticsearchDelegator {
       },
     });
 
+    const appendSeenUsersCountStream = new Transform({
+      objectMode: true,
+      async transform(chunk, encoding, callback) {
+        const pageIds = chunk.map(doc => doc._id);
+
+        const idToCountSeenUsersMap = await Page.getPageIdToSeenUsersCount(pageIds);
+        console.log(idToCountSeenUsersMap, 464);
+
+        const idsHavingCount = Object.keys(idToCountSeenUsersMap);
+
+        chunk
+          .filter(doc => idsHavingCount.includes(doc._id.toString()))
+          .forEach((doc) => {
+            doc.seenUsers = idToCountSeenUsersMap[doc.id.toString()];
+          });
+        this.push(chunk);
+        callback();
+      },
+    });
+
     let count = 0;
     const writeStream = new Writable({
       objectMode: true,
@@ -504,6 +527,7 @@ class ElasticsearchDelegator {
       .pipe(batchStream)
       .pipe(appendBookmarkCountStream)
       .pipe(appendTagNamesStream)
+      .pipe(appendSeenUsersCountStream)
       .pipe(writeStream);
 
     return streamToPromise(writeStream);
@@ -543,7 +567,8 @@ class ElasticsearchDelegator {
 
     // for debug
     logger.debug('ES result: ', result);
-
+    console.log(result.hits, 550, 'search resluts.hits');
+    console.log(result.hits.hits, 551, 'search results.hits.hits');
     return {
       meta: {
         took: result.took,
@@ -563,7 +588,7 @@ class ElasticsearchDelegator {
 
   createSearchQuerySortedByUpdatedAt(option) {
     // getting path by default is almost for debug
-    let fields = ['path', 'bookmark_count', 'comment_count', 'updated_at', 'tag_names'];
+    let fields = ['path', 'bookmark_count', 'comment_count', 'seenUsers_count', 'updated_at', 'tag_names'];
     if (option) {
       fields = option.fields || fields;
     }
@@ -584,7 +609,7 @@ class ElasticsearchDelegator {
   }
 
   createSearchQuerySortedByScore(option) {
-    let fields = ['path', 'bookmark_count', 'comment_count', 'updated_at', 'tag_names'];
+    let fields = ['path', 'bookmark_count', 'comment_count', 'seenUsers_count', 'updated_at', 'tag_names'];
     if (option) {
       fields = option.fields || fields;
     }
@@ -626,6 +651,8 @@ class ElasticsearchDelegator {
     if (!isInitialized(query.body.query.bool.must_not)) {
       query.body.query.bool.must_not = [];
     }
+
+    console.log(query, 635, 'initializeBoolQuery');
     return query;
   }
 

--- a/packages/app/src/server/service/search-delegator/elasticsearch.js
+++ b/packages/app/src/server/service/search-delegator/elasticsearch.js
@@ -310,7 +310,6 @@ class ElasticsearchDelegator {
 
     const bookmarkCount = page.bookmarkCount || 0;
     const seenUsersCount = page.seenUsers.length || 0;
-    console.log(seenUsersCount, 313);
     let document = {
       path: page.path,
       body: page.revision.body,
@@ -417,13 +416,8 @@ class ElasticsearchDelegator {
       objectMode: true,
       async transform(chunk, encoding, callback) {
         const pageIds = chunk.map(doc => doc._id);
-
-        console.log(pageIds, 420, 'updateOrInsertPages');
-
         const idToCountMap = await Bookmark.getPageIdToCountMap(pageIds);
-        console.log(idToCountMap);
         const idsHavingCount = Object.keys(idToCountMap);
-        console.log(idsHavingCount);
         // append count
         chunk
           .filter(doc => idsHavingCount.includes(doc._id.toString()))
@@ -464,13 +458,10 @@ class ElasticsearchDelegator {
         const pageIds = chunk.map(doc => doc._id);
 
         const idToSeenUsersCountMap = await Page.getPageIdToSeenUsersCount(pageIds);
-        console.log(idToSeenUsersCountMap);
         const idsHavingCount = Object.keys(idToSeenUsersCountMap);
-        console.log(idsHavingCount);
         chunk
           .filter(doc => idsHavingCount.includes(doc._id.toString()))
           .forEach((doc) => {
-            console.log(doc.seenUsers, 473);
             doc.seenUsers = idToSeenUsersCountMap[doc._id.toString()];
           });
         this.push(chunk);
@@ -570,8 +561,7 @@ class ElasticsearchDelegator {
 
     // for debug
     logger.debug('ES result: ', result);
-    console.log(result.hits, 550, 'search resluts.hits');
-    console.log(result.hits.hits, 551, 'search results.hits.hits');
+
     return {
       meta: {
         took: result.took,
@@ -655,7 +645,6 @@ class ElasticsearchDelegator {
       query.body.query.bool.must_not = [];
     }
 
-    console.log(query, 635, 'initializeBoolQuery');
     return query;
   }
 
@@ -907,7 +896,6 @@ class ElasticsearchDelegator {
     const size = option.limit || null;
     const type = option.type || null;
     const query = this.createSearchQuerySortedByScore();
-    console.log(query, 910);
     this.appendCriteriaForQueryString(query, queryString);
 
     this.filterPagesByType(query, type);
@@ -1003,7 +991,6 @@ class ElasticsearchDelegator {
   // }
 
   async syncPageUpdated(page, user) {
-    console.log(page, 1004);
     logger.debug('SearchClient.syncPageUpdated', page.path);
 
     // delete if page should not indexed

--- a/packages/app/src/server/service/search.js
+++ b/packages/app/src/server/service/search.js
@@ -68,6 +68,7 @@ class SearchService {
     pageEvent.on('delete', this.delegator.syncPageDeleted.bind(this.delegator));
     pageEvent.on('updateMany', this.delegator.syncPagesUpdated.bind(this.delegator));
     pageEvent.on('syncDescendants', this.delegator.syncDescendantsPagesUpdated.bind(this.delegator));
+    pageEvent.on('addSeenUsers', this.delegator.syncPageUpdated.bind(this.delegator));
 
     const bookmarkEvent = this.crowi.event('bookmark');
     bookmarkEvent.on('create', this.delegator.syncBookmarkChanged.bind(this.delegator));


### PR DESCRIPTION
## ゴール
- 検索した時に、elasticsearch から seenUsers を取得することができる

## 確認したこと
- 検索時
elasticsearch.js の search メソッド  の result に seenUsers が含まれることを確認
```
[
  {
...
    _source: {
      comment_count: 0,
      path: '/Sandbox/Math',
      updated_at: '2021-09-27T23:22:13.237Z',
      seenUsers_count: 1,
      bookmark_count: 1
    },
    highlight: {
      'path.en': [Array],
   ...
    }
  },
  {
...
    _source: {
      comment_count: 0,
      path: '/Sandbox',
      updated_at: '2021-09-27T23:22:13.228Z',
      seenUsers_count: 1,
      bookmark_count: 0
    },
...
```