### PR TITLE
Imprv/#77896 remove child activities

### DIFF
--- a/packages/app/src/server/models/activity.ts
+++ b/packages/app/src/server/models/activity.ts
@@ -98,7 +98,7 @@ activitySchema.statics.removeByParameters = async function(parameters) {
 };
 
 /**
-   * @param {Comment} comment
+   * @param {Array.<Comment>} comments array of comment documents
    * @return {Promise}
    */
 activitySchema.statics.createByPageComment = function(comment) {

--- a/packages/app/src/server/models/comment.js
+++ b/packages/app/src/server/models/comment.js
@@ -109,16 +109,9 @@ module.exports = function(crowi) {
         [{ replyTo: this._id }, { _id: this._id }]),
     });
 
-    console.log('commentsHoge', comments);
-
     const relatedCommentIds = comments.map((comment) => { return comment._id });
 
     await Comment.deleteMany({ _id: { $in: relatedCommentIds } });
-
-    // await Comment.remove({
-    //   $or: (
-    //     [{ replyTo: this._id }, { _id: this._id }]),
-    // });
 
     await commentEvent.emit('remove', comments);
     return;

--- a/packages/app/src/server/models/comment.js
+++ b/packages/app/src/server/models/comment.js
@@ -100,16 +100,27 @@ module.exports = function(crowi) {
     await commentEvent.emit('remove', savedComment);
   });
 
-  commentSchema.methods.removeWithReplies = async function(comment) {
+  commentSchema.methods.removeWithReplies = async function() {
     const Comment = crowi.model('Comment');
     const commentEvent = crowi.event('comment');
 
-    await Comment.remove({
+    const comments = await Comment.find({
       $or: (
         [{ replyTo: this._id }, { _id: this._id }]),
     });
 
-    await commentEvent.emit('remove', comment);
+    console.log('commentsHoge', comments);
+
+    const relatedCommentIds = comments.map((comment) => { return comment._id });
+
+    await Comment.deleteMany({ _id: { $in: relatedCommentIds } });
+
+    // await Comment.remove({
+    //   $or: (
+    //     [{ replyTo: this._id }, { _id: this._id }]),
+    // });
+
+    await commentEvent.emit('remove', comments);
     return;
   };
 

--- a/packages/app/src/server/routes/comment.js
+++ b/packages/app/src/server/routes/comment.js
@@ -439,7 +439,7 @@ module.exports = function(crowi, app) {
         throw new Error('Current user is not accessible to this page.');
       }
 
-      await comment.removeWithReplies(comment);
+      await comment.removeWithReplies();
       await Page.updateCommentCount(comment.page);
     }
     catch (err) {

--- a/packages/app/src/server/service/activity.ts
+++ b/packages/app/src/server/service/activity.ts
@@ -24,7 +24,7 @@ class ActivityService {
    * @param {Comment} comment
    * @return {Promise}
    */
-  removeByPageCommentDelete = async function(comments) {
+  removeByPageCommentDeleteWithReplies = async function(comments) {
     await comments.map(async(comment) => {
       const parameters = {
         user: comment.creator,

--- a/packages/app/src/server/service/activity.ts
+++ b/packages/app/src/server/service/activity.ts
@@ -24,18 +24,19 @@ class ActivityService {
    * @param {Comment} comment
    * @return {Promise}
    */
-  removeByPageCommentDelete = async function(comment) {
-    const parameters = await {
-      user: comment.creator,
-      targetModel: ActivityDefine.MODEL_PAGE,
-      target: comment.page,
-      eventModel: ActivityDefine.MODEL_COMMENT,
-      event: comment._id,
-      action: ActivityDefine.ACTION_COMMENT,
-    };
-
-    await Activity.removeByParameters(parameters);
-    return;
+  removeByPageCommentDelete = async function(comments) {
+    await comments.map(async(comment) => {
+      const parameters = {
+        user: comment.creator,
+        targetModel: ActivityDefine.MODEL_PAGE,
+        target: comment.page,
+        eventModel: ActivityDefine.MODEL_COMMENT,
+        event: comment._id,
+        action: ActivityDefine.ACTION_COMMENT,
+      };
+      await Activity.removeByParameters(parameters);
+      return;
+    });
   };
 
 }

--- a/packages/app/src/server/service/comment.ts
+++ b/packages/app/src/server/service/comment.ts
@@ -55,7 +55,7 @@ class CommentService {
 
       try {
         // TODO: Able to remove child activities of comment by GW-7510
-        await activityService.removeByPageCommentDelete(comments);
+        await activityService.removeByPageCommentDeleteWithReplies(comments);
       }
       catch (err) {
         logger.error(err);

--- a/packages/app/src/server/service/comment.ts
+++ b/packages/app/src/server/service/comment.ts
@@ -54,7 +54,6 @@ class CommentService {
       const { activityService } = this.crowi;
 
       try {
-        // TODO: Able to remove child activities of comment by GW-7510
         await activityService.removeByPageCommentDeleteWithReplies(comments);
       }
       catch (err) {

--- a/packages/app/src/server/service/comment.ts
+++ b/packages/app/src/server/service/comment.ts
@@ -48,14 +48,14 @@ class CommentService {
     });
 
     // remove
-    this.commentEvent.on('remove', async(comment) => {
+    this.commentEvent.on('remove', async(comments) => {
       this.commentEvent.onRemove();
 
       const { activityService } = this.crowi;
 
       try {
         // TODO: Able to remove child activities of comment by GW-7510
-        await activityService.removeByPageCommentDelete(comment);
+        await activityService.removeByPageCommentDelete(comments);
       }
       catch (err) {
         logger.error(err);


### PR DESCRIPTION
## Task
- コメントが削除された時に、その子供のコメントのActivityも削除できるようにする
https://estoc.weseek.co.jp/redmine/issues/77964

## Memo
※ Activity を Audit log 的なものとして記録する案があるので、却下対応不要になる可能性あり


