### PR TITLE
imprv: Save in-app-notification when an activity is created

### DIFF
--- a/packages/app/src/server/crowi/index.js
+++ b/packages/app/src/server/crowi/index.js
@@ -84,6 +84,7 @@ function Crowi() {
     tag: new (require('../events/tag'))(this),
     admin: new (require('../events/admin'))(this),
     comment: new (require('../events/comment'))(this),
+    activity: new (require('../events/activity'))(),
   };
 }
 

--- a/packages/app/src/server/events/activity.ts
+++ b/packages/app/src/server/events/activity.ts
@@ -10,4 +10,10 @@ export default class ActivityEvent extends EventEmitter {
     logger.info('onRemove activity event fired');
   }
 
+  onCreate(action: string, activity: any): void {
+    logger.info('onCreate activity event fired');
+  }
+
 }
+
+module.exports = ActivityEvent;

--- a/packages/app/src/server/models/activity.ts
+++ b/packages/app/src/server/models/activity.ts
@@ -13,6 +13,8 @@ import Watcher from './watcher';
 
 const logger = loggerFactory('growi:models:activity');
 
+const mongoose = require('mongoose');
+
 export interface ActivityDocument extends Document {
   _id: Types.ObjectId
   user: Types.ObjectId | any
@@ -195,14 +197,11 @@ activitySchema.methods.getNotificationTargetUsers = async function() {
   return activeNotificationUsers;
 };
 
-/**
-   * saved hook   TODO: getNotificationTargetUsers by GW-7346
-   */
 activitySchema.post('save', async(savedActivity: ActivityDocument) => {
   try {
-    // const notificationUsers = await savedActivity.getNotificationTargetUsers();
-
-    // await Promise.all(notificationUsers.map(user => InAppNotification.upsertByActivity(user, savedActivity)));
+    const targetUsers = await savedActivity.getNotificationTargetUsers();
+    const InAppNotification = mongoose.model('InAppNotification');
+    await InAppNotification.upsertByActivity(targetUsers, savedActivity);
     return;
   }
   catch (err) {

--- a/packages/app/src/server/models/activity.ts
+++ b/packages/app/src/server/models/activity.ts
@@ -2,6 +2,7 @@ import { DeleteWriteOpResultObject } from 'mongodb';
 import {
   Types, Document, Model, Schema,
 } from 'mongoose';
+import Crowi from '../crowi';
 
 import { getOrCreateModel, getModelSafely } from '../util/mongoose-utils';
 import loggerFactory from '../../utils/logger';
@@ -9,7 +10,6 @@ import ActivityDefine from '../util/activityDefine';
 
 import Watcher from './watcher';
 // import { InAppNotification } from './in-app-notification';
-import ActivityEvent from '../events/activity';
 
 const logger = loggerFactory('growi:models:activity');
 
@@ -39,177 +39,180 @@ export interface ActivityModel extends Model<ActivityDocument> {
   getActionUsersFromActivities(activities: ActivityDocument[]): any[]
 }
 
-// TODO: add revision id
-const activitySchema = new Schema<ActivityDocument, ActivityModel>({
-  user: {
-    type: Schema.Types.ObjectId,
-    ref: 'User',
-    index: true,
-    require: true,
-  },
-  targetModel: {
-    type: String,
-    require: true,
-    enum: ActivityDefine.getSupportTargetModelNames(),
-  },
-  target: {
-    type: Schema.Types.ObjectId,
-    refPath: 'targetModel',
-    require: true,
-  },
-  action: {
-    type: String,
-    require: true,
-    enum: ActivityDefine.getSupportActionNames(),
-  },
-  event: {
-    type: Schema.Types.ObjectId,
-    refPath: 'eventModel',
-  },
-  eventModel: {
-    type: String,
-    enum: ActivityDefine.getSupportEventModelNames(),
-  },
-  createdAt: {
-    type: Date,
-    default: Date.now,
-  },
-});
-activitySchema.index({ target: 1, action: 1 });
-activitySchema.index({
-  user: 1, target: 1, action: 1, createdAt: 1,
-}, { unique: true });
+module.exports = function(crowi: Crowi) {
+  const activityEvent = crowi.event('activity');
 
-/**
-   * @param {object} parameters
-   * @return {Promise}
-   */
-activitySchema.statics.createByParameters = function(parameters) {
-  return this.create(parameters);
-};
+  // TODO: add revision id
+  const activitySchema = new Schema<ActivityDocument, ActivityModel>({
+    user: {
+      type: Schema.Types.ObjectId,
+      ref: 'User',
+      index: true,
+      require: true,
+    },
+    targetModel: {
+      type: String,
+      require: true,
+      enum: ActivityDefine.getSupportTargetModelNames(),
+    },
+    target: {
+      type: Schema.Types.ObjectId,
+      refPath: 'targetModel',
+      require: true,
+    },
+    action: {
+      type: String,
+      require: true,
+      enum: ActivityDefine.getSupportActionNames(),
+    },
+    event: {
+      type: Schema.Types.ObjectId,
+      refPath: 'eventModel',
+    },
+    eventModel: {
+      type: String,
+      enum: ActivityDefine.getSupportEventModelNames(),
+    },
+    createdAt: {
+      type: Date,
+      default: Date.now,
+    },
+  });
+  activitySchema.index({ target: 1, action: 1 });
+  activitySchema.index({
+    user: 1, target: 1, action: 1, createdAt: 1,
+  }, { unique: true });
 
-/**
-   * @param {object} parameters
-   */
-activitySchema.statics.removeByParameters = async function(parameters) {
-  const activityEvent = new ActivityEvent();
-  const activity = await this.findOne(parameters);
-  activityEvent.emit('remove', activity);
-
-  return this.deleteMany(parameters).exec();
-};
-
-/**
-   * @param {Comment} comment
-   * @return {Promise}
-   */
-activitySchema.statics.createByPageComment = function(comment) {
-  const parameters = {
-    user: comment.creator,
-    targetModel: ActivityDefine.MODEL_PAGE,
-    target: comment.page,
-    eventModel: ActivityDefine.MODEL_COMMENT,
-    event: comment._id,
-    action: ActivityDefine.ACTION_COMMENT,
+  /**
+     * @param {object} parameters
+     * @return {Promise}
+     */
+  activitySchema.statics.createByParameters = function(parameters) {
+    return this.create(parameters);
   };
 
-  return this.createByParameters(parameters);
-};
+  /**
+     * @param {object} parameters
+     */
+  activitySchema.statics.removeByParameters = async function(parameters) {
+    const activity = await this.findOne(parameters);
+    activityEvent.emit('remove', activity);
 
-/**
-   * @param {Page} page
-   * @param {User} user
-   * @return {Promise}
-   */
-activitySchema.statics.createByPageLike = function(page, user) {
-  const parameters = {
-    user: user._id,
-    targetModel: ActivityDefine.MODEL_PAGE,
-    target: page,
-    action: ActivityDefine.ACTION_LIKE,
+    return this.deleteMany(parameters).exec();
   };
 
-  return this.createByParameters(parameters);
-};
+  /**
+     * @param {Comment} comment
+     * @return {Promise}
+     */
+  activitySchema.statics.createByPageComment = function(comment) {
+    const parameters = {
+      user: comment.creator,
+      targetModel: ActivityDefine.MODEL_PAGE,
+      target: comment.page,
+      eventModel: ActivityDefine.MODEL_COMMENT,
+      event: comment._id,
+      action: ActivityDefine.ACTION_COMMENT,
+    };
 
-/**
-   * @param {Page} page
-   * @param {User} user
-   * @return {Promise}
-   */
-activitySchema.statics.removeByPageUnlike = function(page, user) {
-  const parameters = {
-    user,
-    targetModel: ActivityDefine.MODEL_PAGE,
-    target: page,
-    action: ActivityDefine.ACTION_LIKE,
+    return this.createByParameters(parameters);
   };
 
-  return this.removeByParameters(parameters);
-};
+  /**
+     * @param {Page} page
+     * @param {User} user
+     * @return {Promise}
+     */
+  activitySchema.statics.createByPageLike = function(page, user) {
+    const parameters = {
+      user: user._id,
+      targetModel: ActivityDefine.MODEL_PAGE,
+      target: page,
+      action: ActivityDefine.ACTION_LIKE,
+    };
 
-/**
-   * @param {Page} page
-   *
-   * @return {Promise}
-   */
-activitySchema.statics.removeByPage = async function(page) {
-  // const activityEvent = new ActivityEvent();
-  const activities = await this.find({ target: page });
-  for (const activity of activities) {
-    // TODO: implement removeActivity when page deleted by GW-7481
-    // activityEvent.emit('remove', activity);
-  }
-  return this.deleteMany({ target: page }).exec();
-};
-
-/**
-   * @param {User} user
-   * @return {Promise}
-   */
-activitySchema.statics.findByUser = function(user) {
-  return this.find({ user }).sort({ createdAt: -1 }).exec();
-};
-
-activitySchema.statics.getActionUsersFromActivities = function(activities) {
-  return activities.map(({ user }) => user).filter((user, i, self) => self.indexOf(user) === i);
-};
-
-activitySchema.methods.getNotificationTargetUsers = async function() {
-  const User = getModelSafely('User') || require('~/server/models/user')();
-  const { user: actionUser, targetModel, target } = this;
-
-  const model: any = await this.model(targetModel).findById(target);
-  const [targetUsers, watchUsers, ignoreUsers] = await Promise.all([
-    model.getNotificationTargetUsers(),
-    Watcher.getWatchers((target as any) as Types.ObjectId),
-    Watcher.getIgnorers((target as any) as Types.ObjectId),
-  ]);
-
-  const unique = array => Object.values(array.reduce((objects, object) => ({ ...objects, [object.toString()]: object }), {}));
-  const filter = (array, pull) => {
-    const ids = pull.map(object => object.toString());
-    return array.filter(object => !ids.includes(object.toString()));
+    return this.createByParameters(parameters);
   };
-  const notificationUsers = filter(unique([...targetUsers, ...watchUsers]), [...ignoreUsers, actionUser]);
-  const activeNotificationUsers = await User.find({
-    _id: { $in: notificationUsers },
-    status: User.STATUS_ACTIVE,
-  }).distinct('_id');
-  return activeNotificationUsers;
+
+  /**
+     * @param {Page} page
+     * @param {User} user
+     * @return {Promise}
+     */
+  activitySchema.statics.removeByPageUnlike = function(page, user) {
+    const parameters = {
+      user,
+      targetModel: ActivityDefine.MODEL_PAGE,
+      target: page,
+      action: ActivityDefine.ACTION_LIKE,
+    };
+
+    return this.removeByParameters(parameters);
+  };
+
+  /**
+     * @param {Page} page
+     *
+     * @return {Promise}
+     */
+  activitySchema.statics.removeByPage = async function(page) {
+    // const activityEvent = new ActivityEvent();
+    const activities = await this.find({ target: page });
+    for (const activity of activities) {
+      // TODO: implement removeActivity when page deleted by GW-7481
+      // activityEvent.emit('remove', activity);
+    }
+    return this.deleteMany({ target: page }).exec();
+  };
+
+  /**
+     * @param {User} user
+     * @return {Promise}
+     */
+  activitySchema.statics.findByUser = function(user) {
+    return this.find({ user }).sort({ createdAt: -1 }).exec();
+  };
+
+  activitySchema.statics.getActionUsersFromActivities = function(activities) {
+    return activities.map(({ user }) => user).filter((user, i, self) => self.indexOf(user) === i);
+  };
+
+  activitySchema.methods.getNotificationTargetUsers = async function() {
+    const User = getModelSafely('User') || require('~/server/models/user')();
+    const { user: actionUser, targetModel, target } = this;
+
+    const model: any = await this.model(targetModel).findById(target);
+    const [targetUsers, watchUsers, ignoreUsers] = await Promise.all([
+      model.getNotificationTargetUsers(),
+      Watcher.getWatchers((target as any) as Types.ObjectId),
+      Watcher.getIgnorers((target as any) as Types.ObjectId),
+    ]);
+
+    const unique = array => Object.values(array.reduce((objects, object) => ({ ...objects, [object.toString()]: object }), {}));
+    const filter = (array, pull) => {
+      const ids = pull.map(object => object.toString());
+      return array.filter(object => !ids.includes(object.toString()));
+    };
+    const notificationUsers = filter(unique([...targetUsers, ...watchUsers]), [...ignoreUsers, actionUser]);
+    const activeNotificationUsers = await User.find({
+      _id: { $in: notificationUsers },
+      status: User.STATUS_ACTIVE,
+    }).distinct('_id');
+    return activeNotificationUsers;
+  };
+
+  activitySchema.post('save', async(savedActivity: ActivityDocument) => {
+    let targetUsers: Types.ObjectId[] = [];
+    try {
+      targetUsers = await savedActivity.getNotificationTargetUsers();
+    }
+    catch (err) {
+      logger.error(err);
+    }
+
+    activityEvent.emit('create', targetUsers, savedActivity);
+  });
+
+  return getOrCreateModel<ActivityDocument, ActivityModel>('Activity', activitySchema);
+
 };
-
-activitySchema.post('save', async(savedActivity: ActivityDocument) => {
-  try {
-    const targetUsers = await savedActivity.getNotificationTargetUsers();
-    const InAppNotification = mongoose.model('InAppNotification');
-    await InAppNotification.upsertByActivity(targetUsers, savedActivity);
-    return;
-  }
-  catch (err) {
-    logger.error(err);
-  }
-});
-
-const Activity = getOrCreateModel<ActivityDocument, ActivityModel>('Activity', activitySchema);
-export { Activity };

--- a/packages/app/src/server/models/comment.js
+++ b/packages/app/src/server/models/comment.js
@@ -102,6 +102,10 @@ module.exports = function(crowi) {
     });
   };
 
+  commentSchema.statics.findCreatorsByPage = async function(page) {
+    return this.distinct('creator', { page }).exec();
+  };
+
   /**
    * post save hook
    */

--- a/packages/app/src/server/models/comment.js
+++ b/packages/app/src/server/models/comment.js
@@ -1,7 +1,3 @@
-// disable no-return-await for model functions
-/* eslint-disable no-return-await */
-import { Activity } from './activity';
-
 module.exports = function(crowi) {
   const debug = require('debug')('growi:models:comment');
   const mongoose = require('mongoose');

--- a/packages/app/src/server/models/page.js
+++ b/packages/app/src/server/models/page.js
@@ -1149,6 +1149,16 @@ module.exports = function(crowi) {
     return pageData.save();
   };
 
+  pageSchema.methods.getNotificationTargetUsers = async function() {
+    const Comment = mongoose.model('Comment');
+    const Revision = mongoose.model('Revision');
+
+    const [commentCreators, revisionAuthors] = await Promise.all([Comment.findCreatorsByPage(this), Revision.findAuthorsByPage(this)]);
+
+    const targetUsers = new Set([this.creator].concat(commentCreators, revisionAuthors));
+    return Array.from(targetUsers);
+  };
+
   pageSchema.statics.getHistories = function() {
     // TODO
 

--- a/packages/app/src/server/models/revision.js
+++ b/packages/app/src/server/models/revision.js
@@ -90,5 +90,10 @@ module.exports = function(crowi) {
     }));
   };
 
+  revisionSchema.statics.findAuthorsByPage = async function(page) {
+    const result = await this.distinct('author', { path: page.path }).exec();
+    return result;
+  };
+
   return mongoose.model('Revision', revisionSchema);
 };

--- a/packages/app/src/server/service/activity.ts
+++ b/packages/app/src/server/service/activity.ts
@@ -1,23 +1,47 @@
+import { Types } from 'mongoose';
+import Crowi from '../crowi';
 import loggerFactory from '../../utils/logger';
 
-import { Activity } from '../models/activity';
+import { ActivityDocument } from '../models/activity';
 
 import ActivityDefine from '../util/activityDefine';
+import { getModelSafely } from '../util/mongoose-utils';
 
 
 const logger = loggerFactory('growi:service:ActivityService');
 
 class ActivityService {
 
-  crowi: any;
+  crowi!: Crowi;
 
-  inAppNotificationService: any;
+  inAppNotificationService!: any;
+
+  activityEvent!: any;
 
   // commentEvent!: any;
 
-  constructor(crowi) {
+  constructor(crowi: Crowi) {
     this.crowi = crowi;
     this.inAppNotificationService = crowi.inAppNotificationService;
+    this.activityEvent = crowi.event('activity');
+
+    this.setUpEventListeners();
+  }
+
+  setUpEventListeners() {
+    this.initActivityEventListeners();
+  }
+
+  initActivityEventListeners() {
+    this.activityEvent.on('create', async(targetUsers: Types.ObjectId[], activity: ActivityDocument) => {
+      try {
+        await this.inAppNotificationService.upsertByActivity(targetUsers, activity);
+      }
+      catch (err) {
+        logger.error('Error occurred while saving InAppNotification');
+        throw err;
+      }
+    });
   }
 
   /**
@@ -34,6 +58,7 @@ class ActivityService {
       action: ActivityDefine.ACTION_COMMENT,
     };
 
+    const Activity = getModelSafely('Activity') || require('../models/activity')(this.crowi);
     await Activity.removeByParameters(parameters);
     return;
   };

--- a/packages/app/src/server/service/comment.ts
+++ b/packages/app/src/server/service/comment.ts
@@ -1,6 +1,5 @@
 import loggerFactory from '../../utils/logger';
-
-import { Activity } from '../models/activity';
+import { getModelSafely } from '../util/mongoose-utils';
 
 const InAppNotificationService = require('./in-app-notification');
 const ActivityService = require('./activity');
@@ -30,6 +29,7 @@ class CommentService {
       this.commentEvent.onCreate();
 
       try {
+        const Activity = getModelSafely('Activity') || require('../models/activity')(this.crowi);
         const activityLog = await Activity.createByPageComment(savedComment);
         logger.info('Activity created', activityLog);
       }

--- a/packages/app/src/server/service/in-app-notification.ts
+++ b/packages/app/src/server/service/in-app-notification.ts
@@ -1,24 +1,29 @@
+import { Types } from 'mongoose';
+import { subDays } from 'date-fns';
 import Crowi from '../crowi';
-import { InAppNotification } from '~/server/models/in-app-notification';
-import { Activity } from '~/server/models/activity';
+import { InAppNotification, InAppNotificationDocument, STATUS_UNREAD } from '~/server/models/in-app-notification';
+import { ActivityDocument } from '~/server/models/activity';
 
 import loggerFactory from '~/utils/logger';
 
 const logger = loggerFactory('growi:service:inAppNotification');
 
 
-class InAppNotificationService {
+export default class InAppNotificationService {
 
-  crowi!: any;
+  crowi!: Crowi;
 
   socketIoService!: any;
 
   commentEvent!: any;
 
+  activityEvent!: any;
+
 
   constructor(crowi: Crowi) {
     this.crowi = crowi;
     this.socketIoService = crowi.socketIoService;
+    this.activityEvent = crowi.event('activity');
   }
 
 
@@ -26,6 +31,41 @@ class InAppNotificationService {
     if (this.socketIoService.isInitialized) {
       await this.socketIoService.getDefaultSocket().emit('comment updated', { user });
     }
+  }
+
+  upsertByActivity = async function(
+      users: Types.ObjectId[], activity: ActivityDocument, createdAt?: Date | null,
+  ): Promise<void> {
+    const {
+      _id: activityId, targetModel, target, action,
+    } = activity;
+    const now = createdAt || Date.now();
+    const lastWeek = subDays(now, 7);
+    const operations = users.map((user) => {
+      const filter = {
+        user, target, action, createdAt: { $gt: lastWeek },
+      };
+      const parameters = {
+        user,
+        targetModel,
+        target,
+        action,
+        status: STATUS_UNREAD,
+        createdAt: now,
+        $addToSet: { activities: activityId },
+      };
+      return {
+        updateOne: {
+          filter,
+          update: parameters,
+          upsert: true,
+        },
+      };
+    });
+
+    await InAppNotification.bulkWrite(operations);
+    logger.info('InAppNotification bulkWrite has run');
+    return;
   }
 
 }


### PR DESCRIPTION
Activity のデータが作られる時に同時に InAppNotification を生成 OR 更新 するようにしました。

## コメント
- export 方法変えた時にネストが一段深くなったのでコード変更量が多くなってしまいました
- モデル層のリファクタ & 不要なコードの精査・削除は後続の 77970 で最後の方でやります
- InAppNotification の取り扱いについては一旦 crowi の仕様と合わせました
    - 7日単位で一つの InAppNotification に activity を溜め込んでいく
    - InAppNotification の対象ユーザーは、対象オブジェクト(今はPageのみ)に編集 or コメントしたユーザーかつ Activity のもととなる actionUser でも ignoreUser でもないユーザー

 