### PR TITLE
fix: Migration for slackbot configurations without proxy

### DIFF
--- a/packages/app/src/migrations/20211005131430-config-without-proxy-command-permission-for-renaming.js
+++ b/packages/app/src/migrations/20211005131430-config-without-proxy-command-permission-for-renaming.js
@@ -20,8 +20,12 @@ module.exports = {
 
     const commandPermission = JSON.parse(commandPermissionValue._doc.value);
 
-    const newCommandPermission = {};
-    Object.entries(commandPermission).forEach((key, value) => {
+    const newCommandPermission = {
+      note: false,
+      keep: false,
+    };
+    Object.entries(commandPermission).forEach((entry) => {
+      const [key, value] = entry;
       switch (key) {
         case 'create':
           newCommandPermission.note = value;
@@ -59,8 +63,12 @@ module.exports = {
 
     const commandPermission = JSON.parse(commandPermissionValue._doc.value);
 
-    const newCommandPermission = {};
-    Object.entries(commandPermission).forEach((key, value) => {
+    const newCommandPermission = {
+      create: false,
+      togetter: false,
+    };
+    Object.entries(commandPermission).forEach((entry) => {
+      const [key, value] = entry;
       switch (key) {
         case 'note':
           newCommandPermission.create = value;


### PR DESCRIPTION
Object.entries と forEach の組み合わせで使い方が間違ってる部分を修正しました