### PR TITLE
Imprv/syncing comment data with elasticsearch db

### DIFF
--- a/packages/app/resource/search/mappings.json
+++ b/packages/app/resource/search/mappings.json
@@ -65,6 +65,20 @@
             }
           }
         },
+        "comment": {
+          "type": "text",
+          "fields": {
+            "ja": {
+              "type": "text",
+              "analyzer": "japanese"
+            },
+            "en": {
+              "type": "text",
+              "analyzer": "english_edge_ngram",
+              "search_analyzer": "standard"
+            }
+          }
+        },
         "username": {
           "type": "keyword"
         },

--- a/packages/app/resource/search/mappings.json
+++ b/packages/app/resource/search/mappings.json
@@ -65,7 +65,7 @@
             }
           }
         },
-        "comment": {
+        "comments": {
           "type": "text",
           "fields": {
             "ja": {

--- a/packages/app/src/server/crowi/index.js
+++ b/packages/app/src/server/crowi/index.js
@@ -81,6 +81,7 @@ function Crowi() {
     user: new (require('../events/user'))(this),
     page: new (require('../events/page'))(this),
     bookmark: new (require('../events/bookmark'))(this),
+    comment: new (require('../events/comment'))(this),
     tag: new (require('../events/tag'))(this),
     admin: new (require('../events/admin'))(this),
   };

--- a/packages/app/src/server/events/comment.ts
+++ b/packages/app/src/server/events/comment.ts
@@ -1,0 +1,17 @@
+
+import util from 'util';
+
+const events = require('events');
+
+function CommentEvent(crowi) {
+  this.crowi = crowi;
+
+  events.EventEmitter.call(this);
+}
+util.inherits(CommentEvent, events.EventEmitter);
+
+CommentEvent.prototype.onCreate = function(comment) {};
+CommentEvent.prototype.onUpdate = function(comment) {};
+CommentEvent.prototype.onDelete = function(comment) {};
+
+module.exports = CommentEvent;

--- a/packages/app/src/server/models/comment.js
+++ b/packages/app/src/server/models/comment.js
@@ -53,7 +53,7 @@ module.exports = function(crowi) {
 
 
   /**
-   * @return {object} key: page._id, value: comment
+   * @return {object} key: page._id, value: comments
    */
   commentSchema.statics.getPageIdToCommentMap = async function(pageIds) {
     const results = await this.aggregate()

--- a/packages/app/src/server/models/comment.js
+++ b/packages/app/src/server/models/comment.js
@@ -58,7 +58,8 @@ module.exports = function(crowi) {
   commentSchema.statics.getPageIdToCommentMap = async function(pageIds) {
     const results = await this.aggregate()
       .match({ page: { $in: pageIds } })
-      .group({ _id: '$page', count: { $sum: 1 } });
+      .group({ _id: '$page', commentIds: { $push: '$comment' } });
+
 
     // convert to map
     const idToCommenttMap = {};

--- a/packages/app/src/server/models/comment.js
+++ b/packages/app/src/server/models/comment.js
@@ -58,16 +58,16 @@ module.exports = function(crowi) {
   commentSchema.statics.getPageIdToCommentMap = async function(pageIds) {
     const results = await this.aggregate()
       .match({ page: { $in: pageIds } })
-      .group({ _id: '$page', commentIds: { $push: '$comment' } });
+      .group({ _id: '$page', comments: { $push: '$comment' } });
 
 
     // convert to map
-    const idToCommenttMap = {};
-    results.forEach((result) => {
-      idToCommenttMap[result._id] = result.comment;
+    const idToCommentMap = {};
+    results.forEach((result, i) => {
+      idToCommentMap[result._id] = result.comments;
     });
 
-    return idToCommenttMap;
+    return idToCommentMap;
   };
 
   commentSchema.statics.countCommentByPageId = function(page) {

--- a/packages/app/src/server/models/comment.js
+++ b/packages/app/src/server/models/comment.js
@@ -60,7 +60,6 @@ module.exports = function(crowi) {
       .match({ page: { $in: pageIds } })
       .group({ _id: '$page', comments: { $push: '$comment' } });
 
-
     // convert to map
     const idToCommentMap = {};
     results.forEach((result, i) => {

--- a/packages/app/src/server/models/comment.js
+++ b/packages/app/src/server/models/comment.js
@@ -51,6 +51,24 @@ module.exports = function(crowi) {
     return this.find({ revision: id }).sort({ createdAt: -1 });
   };
 
+
+  /**
+   * @return {object} key: page._id, value: comment
+   */
+  commentSchema.statics.getPageIdToCommentMap = async function(pageIds) {
+    const results = await this.aggregate()
+      .match({ page: { $in: pageIds } })
+      .group({ _id: '$page', count: { $sum: 1 } });
+
+    // convert to map
+    const idToCommenttMap = {};
+    results.forEach((result) => {
+      idToCommenttMap[result._id] = result.comment;
+    });
+
+    return idToCommenttMap;
+  };
+
   commentSchema.statics.countCommentByPageId = function(page) {
     const self = this;
 

--- a/packages/app/src/server/routes/comment.js
+++ b/packages/app/src/server/routes/comment.js
@@ -231,6 +231,7 @@ module.exports = function(crowi, app) {
     const position = commentForm.comment_position || -1;
     const isMarkdown = commentForm.is_markdown;
     const replyTo = commentForm.replyTo;
+    const commentEvent = crowi.event('comment');
 
     // check whether accessible
     const isAccessible = await Page.isAccessiblePageByViewer(pageId, req.user);
@@ -241,6 +242,7 @@ module.exports = function(crowi, app) {
     let createdComment;
     try {
       createdComment = await Comment.create(pageId, req.user._id, revisionId, comment, position, isMarkdown, replyTo);
+      commentEvent.emit('create', createdComment);
     }
     catch (err) {
       logger.error(err);

--- a/packages/app/src/server/routes/comment.js
+++ b/packages/app/src/server/routes/comment.js
@@ -347,6 +347,8 @@ module.exports = function(crowi, app) {
     const commentId = commentForm.comment_id;
     const revision = commentForm.revision_id;
 
+    const commentEvent = crowi.event('comment');
+
     if (commentStr === '') {
       return res.json(ApiResponse.error('Comment text is required'));
     }
@@ -377,6 +379,7 @@ module.exports = function(crowi, app) {
         { _id: commentId },
         { $set: { comment: commentStr, isMarkdown, revision } },
       );
+      commentEvent.emit('create', updatedComment);
     }
     catch (err) {
       logger.error(err);
@@ -430,6 +433,8 @@ module.exports = function(crowi, app) {
    * @apiParam {String} comment_id Comment Id.
    */
   api.remove = async function(req, res) {
+    const commentEvent = crowi.event('comment');
+
     const commentId = req.body.comment_id;
     if (!commentId) {
       return Promise.resolve(res.json(ApiResponse.error('\'comment_id\' is undefined')));
@@ -454,6 +459,7 @@ module.exports = function(crowi, app) {
 
       await comment.removeWithReplies();
       await Page.updateCommentCount(comment.page);
+      commentEvent.emit('delete', comment);
     }
     catch (err) {
       return res.json(ApiResponse.error(err));

--- a/packages/app/src/server/service/search-delegator/elasticsearch.js
+++ b/packages/app/src/server/service/search-delegator/elasticsearch.js
@@ -449,7 +449,7 @@ class ElasticsearchDelegator {
           .filter(doc => idsHavingComment.includes(doc._id.toString()))
           .forEach((doc) => {
             // append comment from idToCommentMap
-            doc.bookmarkCount = idToCommentMap[doc._id.toString()];
+            doc.comment = idToCommentMap[doc._id.toString()];
           });
 
         this.push(chunk);

--- a/packages/app/src/server/service/search-delegator/elasticsearch.js
+++ b/packages/app/src/server/service/search-delegator/elasticsearch.js
@@ -436,12 +436,9 @@ class ElasticsearchDelegator {
     const appendCommentStream = new Transform({
       objectMode: true,
       async transform(chunk, encoding, callback) {
-        console.log('chunkHoge', chunk);
         const pageIds = chunk.map(doc => doc._id);
 
         const idToCommentMap = await Comment.getPageIdToCommentMap(pageIds);
-
-        console.log('idToCommentMap', idToCommentMap);
         const idsHavingComment = Object.keys(idToCommentMap);
 
         // append count

--- a/packages/app/src/server/service/search-delegator/elasticsearch.js
+++ b/packages/app/src/server/service/search-delegator/elasticsearch.js
@@ -449,7 +449,7 @@ class ElasticsearchDelegator {
           .filter(doc => idsHavingComment.includes(doc._id.toString()))
           .forEach((doc) => {
             // append comment from idToCommentMap
-            doc.comment = idToCommentMap[doc._id.toString()];
+            doc.comments = idToCommentMap[doc._id.toString()];
           });
 
         this.push(chunk);

--- a/packages/app/src/server/service/search-delegator/elasticsearch.js
+++ b/packages/app/src/server/service/search-delegator/elasticsearch.js
@@ -1049,7 +1049,6 @@ class ElasticsearchDelegator {
   }
 
   async syncCommentChanged(comment) {
-    console.log('syncCommentChanged実行されてる?', comment);
     logger.debug('SearchClient.syncCommentChanged', comment);
 
     return this.updateOrInsertPageById(comment.page);

--- a/packages/app/src/server/service/search-delegator/elasticsearch.js
+++ b/packages/app/src/server/service/search-delegator/elasticsearch.js
@@ -314,6 +314,7 @@ class ElasticsearchDelegator {
       body: page.revision.body,
       // username: page.creator?.username, // available Node.js v14 and above
       username: page.creator != null ? page.creator.username : null,
+      comments: page.comments,
       comment_count: page.commentCount,
       bookmark_count: bookmarkCount,
       like_count: page.liker.length || 0,

--- a/packages/app/src/server/service/search-delegator/elasticsearch.js
+++ b/packages/app/src/server/service/search-delegator/elasticsearch.js
@@ -442,11 +442,11 @@ class ElasticsearchDelegator {
         const idToCommentMap = await Comment.getPageIdToCommentMap(pageIds);
         const idsHavingComment = Object.keys(idToCommentMap);
 
-        // append count
+        // append comments
         chunk
           .filter(doc => idsHavingComment.includes(doc._id.toString()))
           .forEach((doc) => {
-            // append comment from idToCommentMap
+            // append comments from idToCommentMap
             doc.comments = idToCommentMap[doc._id.toString()];
           });
 

--- a/packages/app/src/server/service/search.js
+++ b/packages/app/src/server/service/search.js
@@ -75,6 +75,8 @@ class SearchService {
 
     const commentEvent = this.crowi.event('comment');
     commentEvent.on('create', this.delegator.syncCommentChanged.bind(this.delegator));
+    commentEvent.on('update', this.delegator.syncCommentChanged.bind(this.delegator));
+    commentEvent.on('delete', this.delegator.syncCommentChanged.bind(this.delegator));
 
     const tagEvent = this.crowi.event('tag');
     tagEvent.on('update', this.delegator.syncTagChanged.bind(this.delegator));

--- a/packages/app/src/server/service/search.js
+++ b/packages/app/src/server/service/search.js
@@ -73,6 +73,9 @@ class SearchService {
     bookmarkEvent.on('create', this.delegator.syncBookmarkChanged.bind(this.delegator));
     bookmarkEvent.on('delete', this.delegator.syncBookmarkChanged.bind(this.delegator));
 
+    const commentEvent = this.crowi.event('comment');
+    commentEvent.on('create', this.delegator.syncCommentChanged.bind(this.delegator));
+
     const tagEvent = this.crowi.event('tag');
     tagEvent.on('update', this.delegator.syncTagChanged.bind(this.delegator));
   }


### PR DESCRIPTION
## Task
[#78947](https://estoc.weseek.co.jp/redmine/issues/78947) mappings.jsonにコメント用のブロックを追加し、コメントの追加・更新・削除をElasticsearchのDBに反映させることができる

## Screen Recording
- コメントの追加・更新・削除を行っています。

https://user-images.githubusercontent.com/59536731/136723161-eedf1b6d-a178-41c3-afe3-ce350d64405f.mov



- 同じキーワードが複数ページにある場合


![Screen Shot 2021-10-11 at 3 01 30](https://user-images.githubusercontent.com/59536731/136707830-49b47232-5683-43d2-a9a2-5fe5ee2cfab3.png)


