### PR TITLE
Feat: implement trash button

### DIFF
--- a/packages/app/resource/locales/en_US/translation.json
+++ b/packages/app/resource/locales/en_US/translation.json
@@ -477,6 +477,7 @@
   },
   "toaster": {
     "update_successed": "Succeeded to update {{target}}",
+    "remove_successed": "Succeeded to remove {{target}}",
     "initialize_successed": "Succeeded to initialize {{target}}",
     "give_user_admin": "Succeeded to give {{username}} admin",
     "remove_user_admin": "Succeeded to remove {{username}} admin",

--- a/packages/app/resource/locales/ja_JP/translation.json
+++ b/packages/app/resource/locales/ja_JP/translation.json
@@ -478,6 +478,7 @@
   },
   "toaster": {
     "update_successed": "{{target}}を更新しました",
+    "remove_successed": "{{target}}を削除しました",
     "initialize_successed": "{{target}}を初期化しました",
     "give_user_admin": "{{username}}を管理者に設定しました",
     "remove_user_admin": "{{username}}を管理者から外しました",

--- a/packages/app/resource/locales/zh_CN/translation.json
+++ b/packages/app/resource/locales/zh_CN/translation.json
@@ -456,6 +456,7 @@
   },
 	"toaster": {
 		"update_successed": "Succeeded to update {{target}}",
+    "remove_successed": "Succeeded to remove {{target}}",
     "initialize_successed": "Succeeded to initialize {{target}}",
 		"give_user_admin": "Succeeded to give {{username}} admin",
     "remove_user_admin": "Succeeded to remove {{username}} admin ",

--- a/packages/app/src/components/SearchPage.jsx
+++ b/packages/app/src/components/SearchPage.jsx
@@ -141,6 +141,7 @@ class SearchPage extends React.Component {
         selectedPages={this.state.selectedPages}
         onClickInvoked={this.selectPage}
         onChangedInvoked={this.toggleCheckBox}
+        appContainer={this.props.appContainer}
       >
       </SearchResultList>
     );

--- a/packages/app/src/components/SearchPage/DeleteButton.tsx
+++ b/packages/app/src/components/SearchPage/DeleteButton.tsx
@@ -1,0 +1,40 @@
+import React, { FC, useState } from 'react';
+import PageDeleteOneModal from './PageDeleteOneModal';
+import AppContainer from '../../client/services/AppContainer';
+
+type Props = {
+  path: string
+  pageId: string
+  revisionId: string
+  appContainer: AppContainer,
+}
+
+const DeleteButton: FC <Props> = (props: Props) => {
+
+  const [isShown, setIsShown] = useState(false);
+
+  return (
+    <>
+      <button
+        type="button"
+        className="btn btn-link p-0 text-decoration-none"
+        value={props.path}
+        onClick={() => {
+          setIsShown(true);
+        }}
+      >
+        <i className="icon-trash text-danger" />
+      </button>
+      <PageDeleteOneModal
+        isOpen={isShown}
+        onClose={() => setIsShown(false)}
+        path={props.path}
+        pageId={props.pageId}
+        revisionId={props.revisionId}
+        appContainer={props.appContainer}
+      />
+    </>
+  );
+};
+
+export default DeleteButton;

--- a/packages/app/src/components/SearchPage/PageDeleteOneModal.tsx
+++ b/packages/app/src/components/SearchPage/PageDeleteOneModal.tsx
@@ -1,0 +1,97 @@
+import React, { FC, useState } from 'react';
+import {
+  Button, Modal, ModalHeader, ModalBody, ModalFooter,
+} from 'reactstrap';
+
+import { useTranslation } from 'react-i18next';
+import AppContainer from '../../client/services/AppContainer';
+import { toastSuccess } from '../../client/util/apiNotification';
+
+
+type Props = {
+  isOpen: boolean
+  onClose: (() => void) | null
+  path: string
+  pageId: string
+  revisionId: string
+  appContainer: AppContainer,
+}
+
+
+const PageDeleteOneModal: FC <Props> = (props: Props) => {
+
+  const {
+    isOpen, path, pageId, revisionId, appContainer,
+  } = props;
+  const { t } = useTranslation('');
+  const [isDeleteCompletely, setIsDeleteCompletely] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
+
+  const onClose = () => {
+    if (props.onClose != null) {
+      props.onClose();
+    }
+  };
+
+  const onDeleteInvoked = () => {
+    return new Promise<void>((resolve, reject) => {
+      appContainer.apiPost('/pages.remove', { page_id: pageId, revision_id: revisionId, completely: isDeleteCompletely || null })
+        .then((res) => {
+          if (res.ok) {
+            onClose();
+            toastSuccess(t('toaster.remove_successed', { target: 'the page' }));
+            // TODO: reload or update page list by using state
+            // https://estoc.weseek.co.jp/redmine/issues/79786
+            return resolve();
+          }
+          return reject();
+        })
+        .catch((err) => {
+          setErrorMessage(err.message);
+          return reject();
+        });
+    });
+  };
+
+  return (
+    <Modal isOpen={isOpen} toggle={onClose} className="page-list-delete-modal">
+      <ModalHeader tag="h4" toggle={onClose} className="bg-danger text-light">
+        {t('search_result.deletion_modal_header')}
+      </ModalHeader>
+      <ModalBody>
+        <p>{path}</p>
+      </ModalBody>
+      <ModalFooter>
+        <div className="d-flex justify-content-between">
+          {errorMessage.length > 0
+            && <span className="text-danger">{errorMessage}</span>
+          }
+          <span className="d-flex align-items-center">
+            <div className="custom-control custom-checkbox custom-checkbox-danger mr-2">
+              <input
+                type="checkbox"
+                className="custom-control-input"
+                id="customCheck-delete-completely"
+                checked={isDeleteCompletely}
+                onChange={() => setIsDeleteCompletely(!isDeleteCompletely)}
+              />
+              <label
+                className="custom-control-label text-danger"
+                htmlFor="customCheck-delete-completely"
+              >
+                {t('search_result.delete_completely')}
+              </label>
+            </div>
+            <Button color={isDeleteCompletely ? 'danger' : 'light'} onClick={() => onDeleteInvoked()}>
+              <i className="icon-trash"></i>
+              {t('search_result.delete')}
+            </Button>
+          </span>
+        </div>
+      </ModalFooter>
+    </Modal>
+  );
+
+};
+
+export default PageDeleteOneModal;

--- a/packages/app/src/components/SearchPage/SearchResultList.jsx
+++ b/packages/app/src/components/SearchPage/SearchResultList.jsx
@@ -2,76 +2,94 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Page from '../PageList/Page';
 import loggerFactory from '~/utils/logger';
+import DeleteButton from './DeleteButton';
+import AppContainer from '../../client/services/AppContainer';
 
 const logger = loggerFactory('growi:searchResultList');
 class SearchResultList extends React.Component {
 
   render() {
-    return this.props.pages.map((page) => {
-      // Add prefix 'id_' in pageId, because scrollspy of bootstrap doesn't work when the first letter of id attr of target component is numeral.
-      const pageId = `#${page._id}`;
-      return (
-        <li key={page._id} className="nav-item page-list-li w-100 m-0 border-bottom">
-          <a
-            className="nav-link page-list-link d-flex align-items-baseline"
-            href={pageId}
-            onClick={() => {
-              try {
-                if (this.props.onClickInvoked == null) { throw new Error('onClickInvoked is null') }
-                this.props.onClickInvoked(page._id);
-              }
-              catch (error) {
-                logger.error(error);
-              }
-            }}
-          >
-            <div className="form-check my-auto">
-              <input className="form-check-input my-auto" type="checkbox" value="" id="flexCheckDefault" />
-            </div>
-            {/* TODO: remove dummy snippet and adjust style */}
-            <div className="d-block">
-              <Page page={page} noLink />
-              <div className="border-gray mt-5">{page.snippet}</div>
-            </div>
-            <div className="ml-auto d-flex">
-              {this.props.deletionMode && (
-                <div className="custom-control custom-checkbox custom-checkbox-danger">
-                  <input
-                    type="checkbox"
-                    id={`page-delete-check-${page._id}`}
-                    className="custom-control-input search-result-list-delete-checkbox"
-                    value={pageId}
-                    checked={this.props.selectedPages.has(page)}
-                    onChange={() => {
+    return (
+      <>
+        {
+          this.props.pages.map((page) => {
+            // Add prefix 'id_' in pageId, because scrollspy of bootstrap doesn't work when the first letter of id attr of target component is numeral.
+            const pageId = `#${page._id}`;
+            return (
+              <>
+                <li key={page._id} className="nav-item page-list-li w-100 m-0 border-bottom">
+                  <a
+                    className="nav-link page-list-link d-flex align-items-baseline"
+                    href={pageId}
+                    onClick={() => {
                       try {
-                        if (this.props.onChangeInvoked == null) { throw new Error('onChnageInvoked is null') }
-                        return this.props.onChangeInvoked(page);
+                        if (this.props.onClickInvoked == null) { throw new Error('onClickInvoked is null') }
+                        this.props.onClickInvoked(page._id);
                       }
                       catch (error) {
                         logger.error(error);
                       }
                     }}
-                  />
-                  <label className="custom-control-label" htmlFor={`page-delete-check-${page._id}`}></label>
-                </div>
-              )}
-              <div className="page-list-option">
-                <button
-                  type="button"
-                  className="btn btn-link p-0"
-                  value={page.path}
-                  onClick={(e) => {
-                    window.location.href = e.currentTarget.value;
-                  }}
-                >
-                  <i className="icon-login" />
-                </button>
-              </div>
-            </div>
-          </a>
-        </li>
-      );
-    });
+                  >
+                    <div className="form-check my-auto">
+                      <input className="form-check-input my-auto" type="checkbox" value="" id="flexCheckDefault" />
+                    </div>
+                    {/* TODO: remove dummy snippet and adjust style */}
+                    <div className="d-block">
+                      <Page page={page} noLink />
+                      <div className="border-gray mt-5">{page.snippet}</div>
+                    </div>
+                    <div className="ml-auto d-flex">
+                      {this.props.deletionMode && (
+                        <div className="custom-control custom-checkbox custom-checkbox-danger">
+                          <input
+                            type="checkbox"
+                            id={`page-delete-check-${page._id}`}
+                            className="custom-control-input search-result-list-delete-checkbox"
+                            value={pageId}
+                            checked={this.props.selectedPages.has(page)}
+                            onChange={() => {
+                              try {
+                                if (this.props.onChangeInvoked == null) { throw new Error('onChnageInvoked is null') }
+                                return this.props.onChangeInvoked(page);
+                              }
+                              catch (error) {
+                                logger.error(error);
+                              }
+                            }}
+                          />
+                          <label className="custom-control-label" htmlFor={`page-delete-check-${page._id}`}></label>
+                        </div>
+                      )}
+                      <div className="page-list-option">
+                        <DeleteButton
+                          path={page.path}
+                          pageId={page._id}
+                          revisionId={page.revision}
+                          appContainer={this.props.appContainer}
+                        />
+                      </div>
+                      <div className="page-list-option">
+                        <button
+                          type="button"
+                          className="btn btn-link p-0"
+                          value={page.path}
+                          onClick={(e) => {
+                            window.location.href = e.currentTarget.value;
+                          }}
+                        >
+                          <i className="icon-login" />
+                        </button>
+                      </div>
+                    </div>
+                  </a>
+                </li>
+              </>
+            );
+          })
+        }
+      </>
+    );
   }
 
 }
@@ -83,6 +101,7 @@ SearchResultList.propTypes = {
   selectedPages: PropTypes.array.isRequired,
   onClickInvoked: PropTypes.func,
   onChangeInvoked: PropTypes.func,
+  appContainer: PropTypes.instanceOf(AppContainer).isRequired,
 };
 
 


### PR DESCRIPTION
## やったこと

以下の画像のように、ページごとに trash ボタンを追加しました。

後続タスクで、ページ削除後のページ表示の変更を行います。（state を変更して、削除されたページは表示しなくなるなどの挙動）

![delete page modal](https://user-images.githubusercontent.com/83065937/138070138-45866a60-c0f8-4ab9-bc45-ccb0ac30b453.PNG)
![remove page](https://user-images.githubusercontent.com/83065937/138070167-e9738212-d329-4edc-a705-0c06a5a3b0e3.png)

