### PR TITLE
docs(page): Add docs to /page/info api

### DIFF
--- a/packages/app/src/server/routes/apiv3/page.js
+++ b/packages/app/src/server/routes/apiv3/page.js
@@ -112,6 +112,52 @@ const ErrorV3 = require('../../models/vo/error-apiv3');
  *          bool:
  *            type: boolean
  *            description: boolean for like status
+ *
+ *      PageInfo:
+ *        description: PageInfo
+ *        type: object
+ *        required:
+ *          - isSeen
+ *          - sumOfLikers
+ *          - likerIds
+ *          - sumOfSeenUsers
+ *          - seenUserIds
+ *        properties:
+ *          isSeen:
+ *            type: boolean
+ *            description: Whether the page has ever been seen
+ *          isLiked:
+ *            type: boolean
+ *            description: Whether the page is liked by the logged in user
+ *          sumOfLikers:
+ *            type: number
+ *            description: Number of users who have liked the page
+ *          likerIds:
+ *            type: array
+ *            items:
+ *              type: string
+ *            description: Ids of users who have liked the page
+ *            example: ["5e07345972560e001761fa63"]
+ *          sumOfSeenUsers:
+ *            type: number
+ *            description: Number of users who have seen the page
+ *          seenUserIds:
+ *            type: array
+ *            items:
+ *              type: string
+ *            description: Ids of users who have seen the page
+ *            example: ["5e07345972560e001761fa63"]
+ *
+ *      PageParams:
+ *        description: PageParams
+ *        type: object
+ *        required:
+ *          - pageId
+ *        properties:
+ *          pageId:
+ *            type: string
+ *            description: page ID
+ *            example: 5e07345972560e001761fa63
  */
 module.exports = (crowi) => {
   const accessTokenParser = require('../../middlewares/access-token-parser')(crowi);
@@ -208,6 +254,30 @@ module.exports = (crowi) => {
     }
   });
 
+  /**
+   * @swagger
+   *
+   *    /page/info:
+   *      get:
+   *        tags: [Page]
+   *        summary: /page/info
+   *        description: Retrieve current page info
+   *        operationId: getPageInfo
+   *        requestBody:
+   *          content:
+   *            application/json:
+   *              schema:
+   *                $ref: '#/components/schemas/PageParams'
+   *        responses:
+   *          200:
+   *            description: Successfully retrieved current page info.
+   *            content:
+   *              application/json:
+   *                schema:
+   *                  $ref: '#/components/schemas/PageInfo'
+   *          500:
+   *            description: Internal server error.
+   */
   router.get(('/info', loginRequired), async(req, res) => {
 
     try {


### PR DESCRIPTION
@yuki-takei Added docs to /page/info api that I wrote in #4346.

Screenshot of the docs locally:
![image](https://user-images.githubusercontent.com/34886045/138584172-eafa03f0-f2c1-4801-8c88-bff0f6f0e163.png)

### Notes
`/page/likes` api docs
```js
/**
 *       properties:
 *          liker:
 *            type: array
 *            items:
 *              type: string
 *              description: user ID
 *            example: []
 *          seenUsers:
 *            type: array
 *            items:
 *              type: string
 *              description: user ID
 *            example: ["5ae5fccfc5577b0004dbd8ab"]
 */
```
`/page/info` api docs
```js
/**
 *        properties:
 *          likerIds:
 *            type: array
 *            items:
 *              type: string
 *            example: ["5e07345972560e001761fa63"]
 *          seenUserIds:
 *            type: array
 *            items:
 *              type: string
 *            example: ["5e07345972560e001761fa63"]
 */
```
I've omitted unrelated properties for brevity.

I noticed that the `/page/likes` api returns some of the same properties as the `/page/info` api. When I wrote `/page/info`, I renamed some of the properties in the response to be a bit clearer (e.g. liker -> likerIds and seenUsers -> seenUserIds) but now there are two ways to refer to the same object (e.g. `liker`, `likerIds`), which can be confusing.

### Suggested solution
I'm thinking I can remap the properties in the `/page/likes` api response to match the ones I wrote as they are clearer but then they become inconsistent with the database schema (I think that this would still improve the codebase).

### Alternative solutions
- I rename `likerIds` -> `liker` and `seenUserIds` -> `seenUser` in the `page/info` api response to be more consistent with the database schema.
- Leave it as it is.


This is unrelated but is there a reason why `seenUsers` doesn't show up on the `/page/likes` [api docs](https://docs.growi.org/en/api/rest-v3.html) even when it is in the [swagger documentation](https://github.com/weseek/growi/blob/0e6957f27804488e4d4c830d41b399efa4d6f6fb/packages/app/src/server/routes/apiv3/page.js#L83-L89) for `/page/likes`?
