### PR TITLE
Fix/79430 subscribe button position

### DIFF
--- a/packages/app/src/styles/_subnav.scss
+++ b/packages/app/src/styles/_subnav.scss
@@ -85,7 +85,8 @@
     }
 
     .btn-like,
-    .btn-bookmark {
+    .btn-bookmark,
+    .btn-subscribe {
       @extend .btn-sm;
 
       height: 30px;


### PR DESCRIPTION
## Task
[79430 subscription ボタンの位置の修正](https://estoc.weseek.co.jp/redmine/issues/79430)

## View
before
<img width="187" alt="スクリーンショット 2021-10-25 14 01 32" src="https://user-images.githubusercontent.com/34241526/138637098-09efeb0e-7e63-4b5f-bb12-626a1e9db233.png">

afte
<img width="186" alt="スクリーンショット 2021-10-25 14 02 38" src="https://user-images.githubusercontent.com/34241526/138637157-26d0e894-d65e-4353-a063-4094b187a56d.png">
