### PR TITLE
Imprv/79920 display two action user images

### DIFF
--- a/packages/app/src/components/InAppNotification/InAppNotification.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotification.tsx
@@ -77,7 +77,7 @@ export const InAppNotification = (props: Props): JSX.Element => {
   return (
     <>
       <div className="dropdown-item d-flex flex-row mb-3">
-        <div className="p-2 d-flex align-items-center">
+        <div className="p-2 mr-2 d-flex align-items-center">
           {renderUserPicture()}
         </div>
         <div className="p-2">


### PR DESCRIPTION
## Task
 [#79920](https://estoc.weseek.co.jp/redmine/issues/79920) actionUsersが複数いる場合、画像も複数表示させることができる

## Description
 actionUsersが二人以上の場合、アイコンはactionUsersの最初の2人が表示されるようにしました。


## View
![Screen Shot 2021-10-29 at 0 27 05](https://user-images.githubusercontent.com/59536731/139287462-23825200-bd55-4606-a79b-3b8d2df34a46.png)

