### PR TITLE
feat: page migration remove unique constraint

### DIFF
--- a/packages/app/src/client/services/AdminAppContainer.js
+++ b/packages/app/src/client/services/AdminAppContainer.js
@@ -452,7 +452,7 @@ export default class AdminAppContainer extends Container {
   /**
    * Start v5 page migration
    * @memberOf AdminAppContainer
-   * @property action takes only 'upgrade' for now. 'upgrade' will start or resume migration
+   * @property action takes only 'initialMigration' for now. 'initialMigration' will start or resume migration
    */
   async v5PageMigrationHandler(action) {
     const response = await this.appContainer.apiv3.post('/pages/v5-schema-migration', { action });

--- a/packages/app/src/components/Admin/App/V5PageMigration.tsx
+++ b/packages/app/src/components/Admin/App/V5PageMigration.tsx
@@ -17,7 +17,7 @@ const V5PageMigration: FC<Props> = (props: Props) => {
   const onConfirm = async() => {
     setIsV5PageMigrationModalShown(false);
     try {
-      const { isV5Compatible } = await adminAppContainer.v5PageMigrationHandler('upgrade');
+      const { isV5Compatible } = await adminAppContainer.v5PageMigrationHandler('initialMigration');
       if (isV5Compatible) {
 
         return toastSuccess(t('admin:v5_page_migration.already_upgraded'));

--- a/packages/app/src/server/models/page.js
+++ b/packages/app/src/server/models/page.js
@@ -72,7 +72,7 @@ pageSchema.plugin(mongoosePaginate);
 pageSchema.plugin(uniqueValidator);
 
 // TODO: test this after modifying Page.create
-// ensure v4 compatibility
+// ensure v4 compatibility using partial index
 pageSchema.index({ path: 1 }, { unique: true, partialFilterExpression: { parent: null } });
 
 /**

--- a/packages/app/src/server/models/page.js
+++ b/packages/app/src/server/models/page.js
@@ -42,7 +42,7 @@ const pageSchema = new mongoose.Schema({
   },
   isEmpty: { type: Boolean, default: false },
   path: {
-    type: String, required: true, index: true, unique: true,
+    type: String, required: true,
   },
   revision: { type: ObjectId, ref: 'Revision' },
   redirectTo: { type: String, index: true },
@@ -71,8 +71,9 @@ const pageSchema = new mongoose.Schema({
 pageSchema.plugin(mongoosePaginate);
 pageSchema.plugin(uniqueValidator);
 
+// TODO: test this after modifying Page.create
 // ensure v5 clean install compatibility
-pageSchema.index({ path: 1 }, { partialFilterExpression: { parent: null } });
+pageSchema.index({ path: 1 }, { unique: true, partialFilterExpression: { parent: null } });
 
 /**
  * return an array of ancestors paths that is extracted from specified pagePath

--- a/packages/app/src/server/models/page.js
+++ b/packages/app/src/server/models/page.js
@@ -72,7 +72,7 @@ pageSchema.plugin(mongoosePaginate);
 pageSchema.plugin(uniqueValidator);
 
 // TODO: test this after modifying Page.create
-// ensure v5 clean install compatibility
+// ensure v4 compatibility
 pageSchema.index({ path: 1 }, { unique: true, partialFilterExpression: { parent: null } });
 
 /**

--- a/packages/app/src/server/models/page.js
+++ b/packages/app/src/server/models/page.js
@@ -71,6 +71,8 @@ const pageSchema = new mongoose.Schema({
 pageSchema.plugin(mongoosePaginate);
 pageSchema.plugin(uniqueValidator);
 
+// ensure v5 clean install compatibility
+pageSchema.index({ path: 1 }, { partialFilterExpression: { parent: null } });
 
 /**
  * return an array of ancestors paths that is extracted from specified pagePath

--- a/packages/app/src/server/routes/apiv3/pages.js
+++ b/packages/app/src/server/routes/apiv3/pages.js
@@ -684,30 +684,27 @@ module.exports = (crowi) => {
 
   });
 
-  // TODO: use socket conn to show progress
   router.post('/v5-schema-migration', accessTokenParser, loginRequired, adminRequired, csrf, validator.v5PageMigration, apiV3FormValidator, async(req, res) => {
     const { action } = req.body;
     const isV5Compatible = crowi.configManager.getConfig('crowi', 'app:isV5Compatible');
 
-    switch (action) {
-      case 'upgrade':
-        try {
+    try {
+      switch (action) {
+        case 'upgrade':
           if (!isV5Compatible) {
             const Page = crowi.model('Page');
-            // not await
-            crowi.pageService.v5RecursiveMigration(Page.GRANT_PUBLIC);
+            // this method throws and emit socketIo event when error occurs
+            crowi.pageService.v5Migration(Page.GRANT_PUBLIC); // not await
           }
-        }
-        catch (err) {
-          // websocket で通知する
-          logger.error('Error\n', err);
-          return res.apiv3Err(new ErrorV3('Failed to migrate pages. Please try again.', 'v5_migration_failed'), 500);
-        }
-        break;
+          break;
 
-      default:
-        logger.error(`${action} action is not supported.`);
-        return res.apiv3Err(new ErrorV3('This action is not supported.', 'not_supported'), 400);
+        default:
+          logger.error(`${action} action is not supported.`);
+          return res.apiv3Err(new ErrorV3('This action is not supported.', 'not_supported'), 400);
+      }
+    }
+    catch (err) {
+      return res.apiv3Err(new ErrorV3(`Failed to migrate pages: ${err.message}`), 500);
     }
 
     return res.apiv3({ isV5Compatible });

--- a/packages/app/src/server/routes/apiv3/pages.js
+++ b/packages/app/src/server/routes/apiv3/pages.js
@@ -687,14 +687,16 @@ module.exports = (crowi) => {
   // TODO: use socket conn to show progress
   router.post('/v5-schema-migration', accessTokenParser, loginRequired, adminRequired, csrf, validator.v5PageMigration, apiV3FormValidator, async(req, res) => {
     const { action } = req.body;
+    const isV5Compatible = crowi.configManager.getConfig('crowi', 'app:isV5Compatible');
 
     switch (action) {
       case 'upgrade':
-
         try {
-          const Page = crowi.model('Page');
-          // not await
-          crowi.pageService.v5RecursiveMigration(Page.GRANT_PUBLIC);
+          if (!isV5Compatible) {
+            const Page = crowi.model('Page');
+            // not await
+            crowi.pageService.v5RecursiveMigration(Page.GRANT_PUBLIC);
+          }
         }
         catch (err) {
           logger.error('Error\n', err);
@@ -707,7 +709,6 @@ module.exports = (crowi) => {
         return res.apiv3Err(new ErrorV3('This action is not supported.', 'not_supported'), 400);
     }
 
-    const isV5Compatible = crowi.configManager.getConfig('crowi', 'app:isV5Compatible');
     return res.apiv3({ isV5Compatible });
   });
 

--- a/packages/app/src/server/routes/apiv3/pages.js
+++ b/packages/app/src/server/routes/apiv3/pages.js
@@ -699,6 +699,7 @@ module.exports = (crowi) => {
           }
         }
         catch (err) {
+          // websocket で通知する
           logger.error('Error\n', err);
           return res.apiv3Err(new ErrorV3('Failed to migrate pages. Please try again.', 'v5_migration_failed'), 500);
         }

--- a/packages/app/src/server/routes/apiv3/pages.js
+++ b/packages/app/src/server/routes/apiv3/pages.js
@@ -694,7 +694,7 @@ module.exports = (crowi) => {
           if (!isV5Compatible) {
             const Page = crowi.model('Page');
             // this method throws and emit socketIo event when error occurs
-            crowi.pageService.v5Migration(Page.GRANT_PUBLIC); // not await
+            crowi.pageService.v5InitialMigration(Page.GRANT_PUBLIC); // not await
           }
           break;
 

--- a/packages/app/src/server/routes/apiv3/pages.js
+++ b/packages/app/src/server/routes/apiv3/pages.js
@@ -690,7 +690,7 @@ module.exports = (crowi) => {
 
     try {
       switch (action) {
-        case 'upgrade':
+        case 'initialMigration':
           if (!isV5Compatible) {
             const Page = crowi.model('Page');
             // this method throws and emit socketIo event when error occurs

--- a/packages/app/src/server/service/page.js
+++ b/packages/app/src/server/service/page.js
@@ -749,6 +749,38 @@ class PageService {
 
       throw err;
     }
+
+    const Page = this.crowi.model('Page');
+    const indexStatus = await Page.aggregate([{ $indexStats: {} }]);
+    const pathIndexStatus = indexStatus.filter(status => status.name === 'path_1')?.[0];
+    const isUnique = pathIndexStatus?.spec?.unique;
+
+    if (isUnique === false) {
+      return this._setIsV5CompatibleTrue();
+    }
+
+    try {
+      await this._v5ModifyPagePathIndex(isUnique);
+    }
+    catch (err) {
+      logger.error('V5 index modification failed.', err);
+      socket.emit('v5IndexModificationFailed', { error: err.message });
+
+      throw err;
+    }
+  }
+
+  async _setIsV5CompatibleTrue() {
+    try {
+      await this.crowi.configManager.updateConfigsInTheSameNamespace('crowi', {
+        'app:isV5Compatible': true,
+      });
+      logger.info('Successfully migrated all public pages.');
+    }
+    catch (err) {
+      logger.warn('Failed to update app:isV5Compatible to true.');
+      throw err;
+    }
   }
 
   // TODO: use websocket to show progress
@@ -872,51 +904,31 @@ class PageService {
       return this.v5RecursiveMigration(grant, rootPath);
     }
 
-    /*
-     * After completed migration
-     */
-    if (grant !== Page.GRANT_PUBLIC) {
-      return;
-    }
+  }
 
+  async _v5ModifyPagePathIndex(isUnique) {
     const collection = mongoose.connection.collection('pages');
-    const indexStatus = await Page.aggregate([{ $indexStats: {} }]);
-    const pathIndexStatus = indexStatus.filter(status => status.name === 'path_1')?.[0]?.spec?.unique;
+    const Page = this.crowi.model('Page');
 
-    // skip index modification if path is unique
-    if (pathIndexStatus == null || pathIndexStatus === true) {
-      // drop only when true. this condition is for in case createIndex failed but dropIndex succeeded before
-      if (pathIndexStatus) {
-        try {
-          // drop pages.path_1 indexes
-          await collection.dropIndex('path_1');
-          logger.info('Succeeded to drop unique indexes from pages.path.');
-        }
-        catch (err) {
-          logger.warn('Failed to drop unique indexes from pages.path.', err);
-          throw err;
-        }
-      }
-
+    if (isUnique) {
       try {
-        // create indexes without
-        await collection.createIndex({ path: 1 }, { unique: false });
-        logger.info('Succeeded to create non-unique indexes on pages.path.');
+        // drop pages.path_1 indexes
+        await collection.dropIndex('path_1');
+        logger.info('Succeeded to drop unique indexes from pages.path.');
       }
       catch (err) {
-        logger.warn('Failed to create non-unique indexes on pages.path.', err);
+        logger.warn('Failed to drop unique indexes from pages.path.', err);
         throw err;
       }
     }
 
     try {
-      await this.crowi.configManager.updateConfigsInTheSameNamespace('crowi', {
-        'app:isV5Compatible': true,
-      });
-      logger.info('Successfully migrated all public pages.');
+      // create indexes without
+      await collection.createIndex({ path: 1 }, { unique: false });
+      logger.info('Succeeded to create non-unique indexes on pages.path.');
     }
     catch (err) {
-      logger.warn('Failed to update app:isV5Compatible to true.');
+      logger.warn('Failed to create non-unique indexes on pages.path.', err);
       throw err;
     }
   }

--- a/packages/app/src/server/service/page.js
+++ b/packages/app/src/server/service/page.js
@@ -753,21 +753,22 @@ class PageService {
     const Page = this.crowi.model('Page');
     const indexStatus = await Page.aggregate([{ $indexStats: {} }]);
     const pathIndexStatus = indexStatus.filter(status => status.name === 'path_1')?.[0];
-    const isUnique = pathIndexStatus?.spec?.unique;
+    const isPathIndexExists = pathIndexStatus != null;
+    const isUnique = isPathIndexExists && pathIndexStatus.spec?.unique === true;
 
-    if (isUnique === false) {
-      return this._setIsV5CompatibleTrue();
+    if (isUnique || !isPathIndexExists) {
+      try {
+        await this._v5NormalizeIndex(isPathIndexExists);
+      }
+      catch (err) {
+        logger.error('V5 index normalization failed.', err);
+        socket.emit('v5IndexNormalizationFailed', { error: err.message });
+
+        throw err;
+      }
     }
 
-    try {
-      await this._v5ModifyPagePathIndex(isUnique);
-    }
-    catch (err) {
-      logger.error('V5 index modification failed.', err);
-      socket.emit('v5IndexModificationFailed', { error: err.message });
-
-      throw err;
-    }
+    await this._setIsV5CompatibleTrue();
   }
 
   async _setIsV5CompatibleTrue() {
@@ -906,10 +907,10 @@ class PageService {
 
   }
 
-  async _v5ModifyPagePathIndex(isUnique) {
+  async _v5NormalizeIndex(isPathIndexExists) {
     const collection = mongoose.connection.collection('pages');
 
-    if (isUnique) {
+    if (isPathIndexExists) {
       try {
         // drop pages.path_1 indexes
         await collection.dropIndex('path_1');

--- a/packages/app/src/server/service/page.js
+++ b/packages/app/src/server/service/page.js
@@ -738,14 +738,14 @@ class PageService {
     }
   }
 
-  async v5Migration(grant, rootPath = null) {
+  async v5InitialMigration(grant) {
     const socket = this.crowicrowi.socketIoService.getAdminSocket();
     try {
-      await this._v5RecursiveMigration(grant, rootPath);
+      await this._v5RecursiveMigration(grant);
     }
     catch (err) {
-      logger.error('V5 miration failed.', err);
-      socket.emit('v5MirationFailed', { error: err.message });
+      logger.error('V5 initial miration failed.', err);
+      socket.emit('v5InitialMirationFailed', { error: err.message });
 
       throw err;
     }

--- a/packages/app/src/server/service/page.js
+++ b/packages/app/src/server/service/page.js
@@ -908,7 +908,6 @@ class PageService {
 
   async _v5ModifyPagePathIndex(isUnique) {
     const collection = mongoose.connection.collection('pages');
-    const Page = this.crowi.model('Page');
 
     if (isUnique) {
       try {

--- a/packages/app/src/server/service/page.js
+++ b/packages/app/src/server/service/page.js
@@ -856,6 +856,17 @@ class PageService {
     }
 
     try {
+      // drop pages.path_1 indexes
+      const conn = mongoose.connection.collection('pages');
+      await conn.dropIndexes('path_1');
+      // then create non-unique indexes
+    }
+    catch (err) {
+      // return not to set app:isV5Compatible to true
+      return logger.error('Failed to drop unique indexes.', err);
+    }
+
+    try {
       await this.crowi.configManager.updateConfigsInTheSameNamespace('crowi', {
         'app:isV5Compatible': true,
       });

--- a/packages/app/src/server/service/page.js
+++ b/packages/app/src/server/service/page.js
@@ -868,7 +868,7 @@ class PageService {
 
     // skip index modification if path is unique
     if (pathIndexStatus == null || pathIndexStatus === true) {
-      // drop only when true
+      // drop only when true. this condition is for in case createIndex failed but dropIndex succeeded before
       if (pathIndexStatus) {
         try {
           // drop pages.path_1 indexes


### PR DESCRIPTION
Redmine: https://estoc.weseek.co.jp/redmine/issues/80257

マイグレーション完了後にユニーク制約を取り除く処理を実装しました

## 後続について
Page スキーマの以下の部分についての動作確認は Page.create の改修後の方が楽なのでそのタスクの時におこないます

```typescript
// TODO: test this after modifying Page.create
// ensure v4 compatibility using partial index
pageSchema.index({ path: 1 }, { unique: true, partialFilterExpression: { parent: null } });
```