### PR TITLE
fix: CSRF Token not sent with request

### DIFF
--- a/packages/app/src/server/middlewares/csrf.js
+++ b/packages/app/src/server/middlewares/csrf.js
@@ -5,7 +5,7 @@ const logger = loggerFactory('growi:middleware:csrf');
 module.exports = (crowi) => {
 
   return async(req, res, next) => {
-    const token = req.body._csrf || req.query._csrf || null;
+    const token = req.body._csrf || req.query._csrf || req.csrfToken || null;
     const csrfKey = (req.session && req.session.id) || 'anon';
 
     logger.debug('req.skipCsrfVerify', req.skipCsrfVerify);


### PR DESCRIPTION
## タスク
https://estoc.weseek.co.jp/redmine/issues/80510

## 概要
CSRF Tokenがリクエストに含まれていないためリクエストが失敗するバグを修正しいました。
![Capture](https://user-images.githubusercontent.com/66785624/139637948-48495cc6-9fda-4b1c-b961-095e1cd967b6.PNG)
