### PR TITLE
Fix/80297 subscription status when scrolled

### DIFF
--- a/packages/app/src/client/services/PageContainer.js
+++ b/packages/app/src/client/services/PageContainer.js
@@ -53,6 +53,7 @@ export default class PageContainer extends Container {
       tocHtml: '',
       isLiked: false,
       isBookmarked: false,
+      isSubscribed: false,
       seenUsers: [],
       seenUserIds: mainContent.getAttribute('data-page-ids-of-seen-users'),
       countOfSeenUsers: mainContent.getAttribute('data-page-count-of-seen-users'),
@@ -120,6 +121,7 @@ export default class PageContainer extends Container {
       this.retrieveSeenUsers();
       this.retrieveLikeInfo();
       this.retrieveBookmarkInfo();
+      this.retrieveSubscribeInfo();
     }
 
     this.setTocHtml = this.setTocHtml.bind(this);
@@ -301,6 +303,21 @@ export default class PageContainer extends Container {
     const bool = !this.state.isBookmarked;
     await this.appContainer.apiv3Put('/bookmarks', { pageId: this.state.pageId, bool });
     return this.retrieveBookmarkInfo();
+  }
+
+  async retrieveSubscribeInfo() {
+    const res = await this.appContainer.apiv3Get('/page/subscribe', { pageId: this.state.pageId });
+    const { subscribing } = res.data;
+
+    this.setState({
+      isSubscribed: subscribing,
+    });
+  }
+
+  async toggleSubscribe() {
+    const bool = !this.state.isSubscribed;
+    await this.appContainer.apiv3Put('page/subscribe', { pageId: this.state.pageId, status: bool });
+    return this.retrieveSubscribeInfo();
   }
 
   async checkAndUpdateImageUrlCached(users) {

--- a/packages/app/src/client/services/PageContainer.js
+++ b/packages/app/src/client/services/PageContainer.js
@@ -307,10 +307,10 @@ export default class PageContainer extends Container {
 
   async retrieveSubscribeInfo() {
     const res = await this.appContainer.apiv3Get('/page/subscribe', { pageId: this.state.pageId });
-    const { subscribing } = res.data;
+    const { isSubscribed } = res.data;
 
     this.setState({
-      isSubscribed: subscribing,
+      isSubscribed,
     });
   }
 

--- a/packages/app/src/client/services/PageContainer.js
+++ b/packages/app/src/client/services/PageContainer.js
@@ -53,7 +53,7 @@ export default class PageContainer extends Container {
       tocHtml: '',
       isLiked: false,
       isBookmarked: false,
-      isSubscribed: false,
+      isSubscribed: null,
       seenUsers: [],
       seenUserIds: mainContent.getAttribute('data-page-ids-of-seen-users'),
       countOfSeenUsers: mainContent.getAttribute('data-page-count-of-seen-users'),

--- a/packages/app/src/components/Navbar/SubNavButtons.jsx
+++ b/packages/app/src/components/Navbar/SubNavButtons.jsx
@@ -15,7 +15,7 @@ const PageReactionButtons = ({ pageContainer }) => {
   return (
     <>
       <span>
-        <SubscribeButton pageId={pageContainer.state.pageId} />
+        <SubscribeButton />
       </span>
       {pageContainer.isAbleToShowLikeButton && (
         <span>

--- a/packages/app/src/components/SubscribeButton.tsx
+++ b/packages/app/src/components/SubscribeButton.tsx
@@ -1,6 +1,4 @@
-import React, {
-  FC, useState, useCallback, useEffect,
-} from 'react';
+import React, { FC } from 'react';
 
 import { useTranslation } from 'react-i18next';
 import { UncontrolledTooltip } from 'reactstrap';
@@ -13,65 +11,29 @@ import PageContainer from '~/client/services/PageContainer';
 type Props = {
   appContainer: AppContainer,
   pageContainer: PageContainer,
-  pageId: string,
 };
 
 const SubscribeButton: FC<Props> = (props: Props) => {
   const { t } = useTranslation();
 
-  const { appContainer, pageContainer, pageId } = props;
+  const { appContainer, pageContainer } = props;
   const { isSubscribed } = pageContainer.state;
-  // const [isSubscribing, setIsSubscribing] = useState<boolean | null>(null);
 
   const buttonClass = `${isSubscribed ? 'active' : ''} ${appContainer.isGuestUser ? 'disabled' : ''}`;
   const iconClass = isSubscribed || isSubscribed == null ? 'fa fa-eye' : 'fa fa-eye-slash';
-  // const buttonClass = `${isSubscribing ? 'active' : ''} ${appContainer.isGuestUser ? 'disabled' : ''}`;
-  // const iconClass = isSubscribing || isSubscribing == null ? 'fa fa-eye' : 'fa fa-eye-slash';
 
   const handleClick = async() => {
     if (appContainer.isGuestUser) {
-      console.log('isGuestUser', appContainer.isGuestUser);
       return;
     }
 
     try {
       pageContainer.toggleSubscribe();
-      // const res = await appContainer.apiv3Put('page/subscribe', { pageId, status: !isSubscribing });
-      // if (res) {
-      //   const { subscription } = res.data;
-      //   console.log('handleClick_subscription.status', subscription.status);
-
-      //   setIsSubscribing(subscription.status === 'SUBSCRIBE');
-      // }
     }
     catch (err) {
       toastError(err);
     }
   };
-
-  // const fetchSubscriptionStatus = useCallback(async() => {
-  //   if (appContainer.isGuestUser) {
-  //     return;
-  //   }
-
-  //   try {
-  //     const res = await appContainer.apiv3Get('page/subscribe', { pageId });
-  //     const { subscribing } = res.data;
-  //     if (subscribing == null) {
-  //       setIsSubscribing(null);
-  //     }
-  //     else {
-  //       setIsSubscribing(subscribing);
-  //     }
-  //   }
-  //   catch (err) {
-  //     toastError(err);
-  //   }
-  // }, [appContainer, pageId]);
-
-  // useEffect(() => {
-  //   fetchSubscriptionStatus();
-  // }, [fetchSubscriptionStatus]);
 
   return (
     <>

--- a/packages/app/src/components/SubscribeButton.tsx
+++ b/packages/app/src/components/SubscribeButton.tsx
@@ -12,58 +12,66 @@ import PageContainer from '~/client/services/PageContainer';
 
 type Props = {
   appContainer: AppContainer,
+  pageContainer: PageContainer,
   pageId: string,
 };
 
 const SubscribeButton: FC<Props> = (props: Props) => {
   const { t } = useTranslation();
 
-  const { appContainer, pageId } = props;
-  const [isSubscribing, setIsSubscribing] = useState<boolean | null>(null);
+  const { appContainer, pageContainer, pageId } = props;
+  const { isSubscribed } = pageContainer.state;
+  // const [isSubscribing, setIsSubscribing] = useState<boolean | null>(null);
 
-  const buttonClass = `${isSubscribing ? 'active' : ''} ${appContainer.isGuestUser ? 'disabled' : ''}`;
-  const iconClass = isSubscribing || isSubscribing == null ? 'fa fa-eye' : 'fa fa-eye-slash';
+  const buttonClass = `${isSubscribed ? 'active' : ''} ${appContainer.isGuestUser ? 'disabled' : ''}`;
+  const iconClass = isSubscribed || isSubscribed == null ? 'fa fa-eye' : 'fa fa-eye-slash';
+  // const buttonClass = `${isSubscribing ? 'active' : ''} ${appContainer.isGuestUser ? 'disabled' : ''}`;
+  // const iconClass = isSubscribing || isSubscribing == null ? 'fa fa-eye' : 'fa fa-eye-slash';
 
   const handleClick = async() => {
     if (appContainer.isGuestUser) {
+      console.log('isGuestUser', appContainer.isGuestUser);
       return;
     }
 
     try {
-      const res = await appContainer.apiv3Put('page/subscribe', { pageId, status: !isSubscribing });
-      if (res) {
-        const { subscription } = res.data;
-        setIsSubscribing(subscription.status === 'SUBSCRIBE');
-      }
+      pageContainer.toggleSubscribe();
+      // const res = await appContainer.apiv3Put('page/subscribe', { pageId, status: !isSubscribing });
+      // if (res) {
+      //   const { subscription } = res.data;
+      //   console.log('handleClick_subscription.status', subscription.status);
+
+      //   setIsSubscribing(subscription.status === 'SUBSCRIBE');
+      // }
     }
     catch (err) {
       toastError(err);
     }
   };
 
-  const fetchSubscriptionStatus = useCallback(async() => {
-    if (appContainer.isGuestUser) {
-      return;
-    }
+  // const fetchSubscriptionStatus = useCallback(async() => {
+  //   if (appContainer.isGuestUser) {
+  //     return;
+  //   }
 
-    try {
-      const res = await appContainer.apiv3Get('page/subscribe', { pageId });
-      const { subscribing } = res.data;
-      if (subscribing == null) {
-        setIsSubscribing(null);
-      }
-      else {
-        setIsSubscribing(subscribing);
-      }
-    }
-    catch (err) {
-      toastError(err);
-    }
-  }, [appContainer, pageId]);
+  //   try {
+  //     const res = await appContainer.apiv3Get('page/subscribe', { pageId });
+  //     const { subscribing } = res.data;
+  //     if (subscribing == null) {
+  //       setIsSubscribing(null);
+  //     }
+  //     else {
+  //       setIsSubscribing(subscribing);
+  //     }
+  //   }
+  //   catch (err) {
+  //     toastError(err);
+  //   }
+  // }, [appContainer, pageId]);
 
-  useEffect(() => {
-    fetchSubscriptionStatus();
-  }, [fetchSubscriptionStatus]);
+  // useEffect(() => {
+  //   fetchSubscriptionStatus();
+  // }, [fetchSubscriptionStatus]);
 
   return (
     <>

--- a/packages/app/src/server/routes/apiv3/page.js
+++ b/packages/app/src/server/routes/apiv3/page.js
@@ -546,8 +546,8 @@ module.exports = (crowi) => {
 
     try {
       const subscription = await Subscription.findByUserIdAndTargetId(userId, pageId);
-      const subscribing = subscription ? subscription.isSubscribing() : null;
-      return res.apiv3({ subscribing });
+      const isSubscribed = subscription ? subscription.isSubscribing() : null;
+      return res.apiv3({ isSubscribed });
     }
     catch (err) {
       logger.error('Failed to ge subscribe status', err);


### PR DESCRIPTION
## Task
- [#80297](https://estoc.weseek.co.jp/redmine/issues/80297) 【並行】スクロールした時に subscription status の値が異なってしまう問題の修正

## Description
- 問題点
nav bar と subnav bar での subscriptionのボタンがそれぞれ固有のstatusを参照しており、ページを下にスクロールした時にsubscription status の値が異なってしまっていた
- 修正内容
 pageContainerにstate(isSubscribed)を追加し、どのコンポーネントからもそれを参照するように変更しました。

## Q
pageContainerを使わずに修正すべきですかね......?