### PR TITLE
fix: draw.io editor dialog is closed by backdrop clicked

### DIFF
--- a/packages/app/src/components/PageEditor/DrawioModal.jsx
+++ b/packages/app/src/components/PageEditor/DrawioModal.jsx
@@ -135,7 +135,14 @@ class DrawioModal extends React.PureComponent {
 
   render() {
     return (
-      <Modal isOpen={this.state.show} toggle={this.cancel} className="drawio-modal" size="xl" keyboard={false}>
+      <Modal
+        isOpen={this.state.show}
+        toggle={this.cancel}
+        backdrop="static"
+        className="drawio-modal"
+        size="xl"
+        keyboard={false}
+      >
         <ModalBody className="p-0">
           {/* Loading spinner */}
           <div className="w-100 h-100 position-absolute d-flex">


### PR DESCRIPTION
#4586 の改修案です。

#3643 を参考にbackdrop="static"を適用しました。

draw.ioの編集ダイアログにてダイアログ外のクリックを実施し、閉じなくなった（表編集ダイアログと同じ挙動になった）ことを確認しています。