### PR TITLE
feat: Switch pathlink and permalink

### DIFF
--- a/packages/app/src/server/models/obsolete-page.js
+++ b/packages/app/src/server/models/obsolete-page.js
@@ -561,31 +561,6 @@ export const getPageSchema = (crowi) => {
    * @param {User} user User instance
    * @param {UserGroup[]} userGroups List of UserGroup instances
    */
-  pageSchema.statics.findByPathAndViewer = async function(path, user, userGroups) {
-    if (path == null) {
-      throw new Error('path is required.');
-    }
-
-    const baseQuery = this.findOne({ path });
-
-    let relatedUserGroups = userGroups;
-    if (user != null && relatedUserGroups == null) {
-      validateCrowi();
-      const UserGroupRelation = crowi.model('UserGroupRelation');
-      relatedUserGroups = await UserGroupRelation.findAllUserGroupIdsRelatedToUser(user);
-    }
-
-    const queryBuilder = new PageQueryBuilder(baseQuery);
-    queryBuilder.addConditionToFilteringByViewer(user, relatedUserGroups, true);
-
-    return await queryBuilder.query.exec();
-  };
-
-  /**
-   * @param {string} path Page path
-   * @param {User} user User instance
-   * @param {UserGroup[]} userGroups List of UserGroup instances
-   */
   pageSchema.statics.findAncestorByPathAndViewer = async function(path, user, userGroups) {
     if (path == null) {
       throw new Error('path is required.');

--- a/packages/app/src/server/models/page.ts
+++ b/packages/app/src/server/models/page.ts
@@ -157,10 +157,12 @@ schema.statics.getParentIdAndFillAncestors = async function(path: string): Promi
   return parentId;
 };
 
-schema.statics.findByPathAndViewerV5 = async function(path: string | null, user, userGroups): Promise<IPage[]> {
+schema.statics.findByPathAndViewer = async function(path: string | null, user, userGroups, useFindOne = true): Promise<IPage[]> {
   if (path == null) {
     throw new Error('path is required.');
   }
+
+  const baseQuery = useFindOne ? this.findOne({ path }) : this.find({ path });
 
   let relatedUserGroups = userGroups;
   if (user != null && relatedUserGroups == null) {
@@ -168,7 +170,7 @@ schema.statics.findByPathAndViewerV5 = async function(path: string | null, user,
     relatedUserGroups = await UserGroupRelation.findAllUserGroupIdsRelatedToUser(user);
   }
 
-  const queryBuilder = new PageQueryBuilder(this.find({ path }));
+  const queryBuilder = new PageQueryBuilder(baseQuery);
   queryBuilder.addConditionToFilteringByViewer(user, relatedUserGroups, true);
 
   return queryBuilder.query.exec();

--- a/packages/app/src/server/models/page.ts
+++ b/packages/app/src/server/models/page.ts
@@ -10,7 +10,7 @@ import nodePath from 'path';
 import { getOrCreateModel, pagePathUtils } from '@growi/core';
 import loggerFactory from '../../utils/logger';
 import Crowi from '../crowi';
-import { IPage } from '~/interfaces/page';
+import { IPage } from '../../interfaces/page';
 import { getPageSchema, PageQueryBuilder } from './obsolete-page';
 
 const { isTopPage } = pagePathUtils;
@@ -157,12 +157,32 @@ schema.statics.getParentIdAndFillAncestors = async function(path: string): Promi
   return parentId;
 };
 
+schema.statics.findByPathAndViewerV5 = async function(path: string | null, user, userGroups): Promise<IPage[]> {
+  if (path == null) {
+    throw new Error('path is required.');
+  }
+
+  let relatedUserGroups = userGroups;
+  if (user != null && relatedUserGroups == null) {
+    const UserGroupRelation: any = mongoose.model('UserGroupRelation');
+    relatedUserGroups = await UserGroupRelation.findAllUserGroupIdsRelatedToUser(user);
+  }
+
+  const queryBuilder = new PageQueryBuilder(this.find({ path }));
+  queryBuilder.addConditionToFilteringByViewer(user, relatedUserGroups, true);
+
+  return queryBuilder.query.exec();
+};
+
+
+/*
+ * Merge obsolete page model methods and define new methods which depend on crowi instance
+ */
 export default (crowi: Crowi): any => {
   // add old page schema methods
   const pageSchema = getPageSchema(crowi);
   schema.methods = { ...pageSchema.methods, ...schema.methods };
   schema.statics = { ...pageSchema.statics, ...schema.statics };
-
 
   return getOrCreateModel<PageDocument, PageModel>('Page', schema);
 };

--- a/packages/app/src/server/routes/index.js
+++ b/packages/app/src/server/routes/index.js
@@ -139,7 +139,7 @@ module.exports = function(crowi, app) {
   // my drafts
   app.get('/me/drafts'                , loginRequiredStrictly, me.drafts.list);
 
-  app.get('/:id([0-9a-z]{24})'       , loginRequired , page.redirector);
+  app.get('/:id([0-9a-z]{24})'       , loginRequired , page.showPage);
   app.get('/_r/:id([0-9a-z]{24})'    , loginRequired , page.redirector); // alias
   app.get('/attachment/:id([0-9a-z]{24})' , certifySharedFile , loginRequired, attachment.api.get);
   app.get('/attachment/profile/:id([0-9a-z]{24})' , loginRequired, attachment.api.get);
@@ -196,7 +196,7 @@ module.exports = function(crowi, app) {
 
   app.get('/share/:linkId', page.showSharedPage);
 
-  app.get('/*/$'                   , loginRequired , page.showPageWithEndOfSlash, page.notFound);
-  app.get('/*'                     , loginRequired , autoReconnectToSearch, page.showPage, page.notFound);
+  app.get('/*/$'                   , loginRequired , page.redirectorWithEndOfSlash, page.notFound);
+  app.get('/*'                     , loginRequired , autoReconnectToSearch, page.redirector, page.notFound);
 
 };

--- a/packages/app/src/server/routes/page.js
+++ b/packages/app/src/server/routes/page.js
@@ -280,10 +280,10 @@ module.exports = function(crowi, app) {
   }
 
   async function showPageForPresentation(req, res, next) {
-    const path = getPathFromRequest(req);
+    const id = req.params.id;
     const { revisionId } = req.query;
 
-    let page = await Page.findByPathAndViewer(path, req.user);
+    let page = await Page.findByIdAndViewer(id, req.user);
 
     if (page == null) {
       next();

--- a/packages/app/src/server/routes/page.js
+++ b/packages/app/src/server/routes/page.js
@@ -564,16 +564,17 @@ module.exports = function(crowi, app) {
    */
   async function redirector(req, res, next, path) {
     const pages = await Page.findByPathAndViewer(path, req.user, null, false);
-    let query = '';
-    Object.entries(req.query).forEach(([key, value], i) => {
-      query += i === 0 ? `?${key}=${value}` : `&${key}=${value}`;
-    });
 
     if (pages.length >= 2) {
       // TODO: return res.render('layout-growi/select_same_path_page', renderVars);
       // TODO: put redirectFrom into renderVars
       return res.send('Two or more pages found.');
     }
+
+    let query = '';
+    Object.entries(req.query).forEach(([key, value], i) => {
+      query += i === 0 ? `?${key}=${value}` : `&${key}=${value}`;
+    });
 
     if (pages.length === 1) {
       return res.safeRedirect(`/${pages[0]._id}${query}`);

--- a/packages/app/src/server/routes/page.js
+++ b/packages/app/src/server/routes/page.js
@@ -563,9 +563,11 @@ module.exports = function(crowi, app) {
    * redirector
    */
   async function redirector(req, res, next, path) {
-    const pages = await Page.findByPathAndViewerV5(path, req.user);
-    const { redirectFrom } = req.query;
-    const query = redirectFrom == null ? '' : `?redirectFrom=${redirectFrom}`;
+    const pages = await Page.findByPathAndViewer(path, req.user, null, false);
+    let query = '';
+    Object.entries(req.query).forEach(([key, value], i) => {
+      query += i === 0 ? `?${key}=${value}` : `&${key}=${value}`;
+    });
 
     if (pages.length >= 2) {
       // TODO: return res.render('layout-growi/select_same_path_page', renderVars);
@@ -574,7 +576,7 @@ module.exports = function(crowi, app) {
     }
 
     if (pages.length === 1) {
-      return res.redirect(`/${pages[0]._id}${query}`);
+      return res.safeRedirect(`/${pages[0]._id}${query}`);
     }
 
     return next(); // to page.notFound

--- a/packages/app/src/server/routes/page.js
+++ b/packages/app/src/server/routes/page.js
@@ -571,13 +571,13 @@ module.exports = function(crowi, app) {
       return res.send('Two or more pages found.');
     }
 
-    let query = '';
+    const queryParams = new URLSearchParams();
     Object.entries(req.query).forEach(([key, value], i) => {
-      query += i === 0 ? `?${key}=${value}` : `&${key}=${value}`;
+      queryParams.append(key, value);
     });
 
     if (pages.length === 1) {
-      return res.safeRedirect(`/${pages[0]._id}${query}`);
+      return res.safeRedirect(`/${pages[0]._id}?${queryParams.toString()}`);
     }
 
     return next(); // to page.notFound


### PR DESCRIPTION
Redmine(２つ): https://estoc.weseek.co.jp/redmine/issues/80349, https://estoc.weseek.co.jp/redmine/issues/80350

パス付きリンクとパーマリンクを入れ替えました。



## redirectTo がある場合の動作例
1. `redirectTo` が `/A` であるページ `/B` にアクセス
2. `res.redirect('/A?redirectFrom=/B');`
3. `/A` からページ探す
  - １つしかない場合 => `'/Aのid?redirectFrom=/B'` にリダイレクト
  - ２つ以上ある場合 => `redirectFrom = /B` を `renderVars` に入れた上でページ遷移先選択ページを render (後続で実装)
    - 選択した遷移先 URL に `?redirectFrom=` を添加
  - ない場合 => `page.notFound` の挙動

## コメント
`pageSchema.statics.findByPathAndViewer` は path がユニーク前提で findOne していたので、一旦新規に `findByPathAndViewerV5` を追加して find するようにしました

## 後続タスクについて
- 複数のページが見つかった時に遷移先選択ページをレンダーするようにします。(UI はほぼ白紙)

## RC リリース以降にやること
- `findByPathAndViewer` が使われているところが正常に動くように改修して、最終的に `findByPathAndViewerV5` を `findByPathAndViewer` にマージします
  - duplicate や移動などの時にやる必要があると思う