### PR TITLE
feat: adjust tags page

### DIFF
--- a/packages/app/src/components/TagsList.jsx
+++ b/packages/app/src/components/TagsList.jsx
@@ -68,26 +68,32 @@ class TagsList extends React.Component {
     const messageForNoTag = this.state.tagData.length ? null : <h3>{ t('You have no tag, You can set tags on pages') }</h3>;
 
     return (
-      <div className="row text-center">
-        <div className="col-12 mb-5 px-5">
-          <TagCloudBox tags={this.state.tagData} minSize={20} />
+      <>
+        <header className="py-0">
+          <h1 className="title text-center mt-5 mb-3 font-weight-bold">{`${t('Tags')}(${this.state.totalTags})`}</h1>
+        </header>
+        <div className="row text-center">
+          <div className="col-12 mb-5 px-5">
+            <TagCloudBox tags={this.state.tagData} minSize={20} />
+          </div>
+          <div className="col-12 tag-list mb-4">
+            <ul className="list-group text-left">
+              {this.generateTagList(this.state.tagData)}
+            </ul>
+            {messageForNoTag}
+          </div>
+          <div className="col-12 tag-list-pagination">
+            <PaginationWrapper
+              activePage={this.state.activePage}
+              changePage={this.handlePage}
+              totalItemsCount={this.state.totalTags}
+              pagingLimit={this.state.pagingLimit}
+              align="center"
+              size="md"
+            />
+          </div>
         </div>
-        <div className="col-12 tag-list">
-          <ul className="list-group text-left">
-            {this.generateTagList(this.state.tagData)}
-          </ul>
-          {messageForNoTag}
-        </div>
-        <div className="tag-list-pagination">
-          <PaginationWrapper
-            activePage={this.state.activePage}
-            changePage={this.handlePage}
-            totalItemsCount={this.state.totalTags}
-            pagingLimit={this.state.pagingLimit}
-            size="sm"
-          />
-        </div>
-      </div>
+      </>
     );
   }
 

--- a/packages/app/src/server/views/tags.html
+++ b/packages/app/src/server/views/tags.html
@@ -5,10 +5,6 @@
 {% block html_base_css %}tags-page{% endblock %}
 
 {% block layout_main %}
-<header class="py-0">
-  <h1 class="title text-center mt-5 font-weight-bold">{{ t('Tags') }}</h1>
-</header>
-
 <div class="container-fluid">
   <div class="row">
     <div id="main" class="main mt-3 col-md-12 tags-page">


### PR DESCRIPTION
## タスク

https://estoc.weseek.co.jp/redmine/issues/80469

## デザインの目安となる画像

画像の右側

![画面 (4)](https://user-images.githubusercontent.com/83065937/140270247-da9b839a-ed4f-459c-a1d9-3044278031ce.jpg)

## やったこと

以下のように /tags ページを整えました（配置しました）。

XDなどはないので、デザインやUI的な部分は既存の状態から大きく変更はしていません。


詳細

- タグの総数の出力 Tags(37) 
- ページネーションの位置調整とサイズ調整

![tags page image](https://user-images.githubusercontent.com/83065937/140262650-94258ee4-c0a5-4eb2-9e17-d0b237d7d390.PNG)


