### PR TITLE
Fix email auth error page [7568]

### DIFF
--- a/packages/app/resource/locales/en_US/translation.json
+++ b/packages/app/resource/locales/en_US/translation.json
@@ -837,7 +837,8 @@
     "unable_to_use_this_user":"Unable to use this user.",
     "complete_to_install1":"Complete to Install GROWI ! Please login as admin account.",
     "complete_to_install2":"Complete to Install GROWI ! Please check each settings on this page first.",
-    "failed_to_create_admin_user":"Failed to create admin user. {{errMessage}}"
+    "failed_to_create_admin_user":"Failed to create admin user. {{errMessage}}",
+    "incorrect_token_or_expired_url": "The token is incorrect or the URL has expired."
   },
   "grid_edit":{
     "create_bootstrap_4_grid":"Create Bootstrap 4 Grid",

--- a/packages/app/resource/locales/ja_JP/translation.json
+++ b/packages/app/resource/locales/ja_JP/translation.json
@@ -831,7 +831,8 @@
     "unable_to_use_this_user":"利用できないユーザーIDです。",
     "complete_to_install1":"GROWI のインストールが完了しました！管理者アカウントでログインしてください。",
     "complete_to_install2":"GROWI のインストールが完了しました！はじめに、このページで各種設定を確認してください。",
-    "failed_to_create_admin_user":"管理ユーザーの作成に失敗しました。{{errMessage}}"
+    "failed_to_create_admin_user":"管理ユーザーの作成に失敗しました。{{errMessage}}",
+    "incorrect_token_or_expired_url":"トークンが正しくないか、URLの有効期限が切れています。"
   },
   "grid_edit":{
     "create_bootstrap_4_grid":"Bootstrap 4 グリッドを作成",

--- a/packages/app/resource/locales/zh_CN/translation.json
+++ b/packages/app/resource/locales/zh_CN/translation.json
@@ -842,7 +842,8 @@
 		"unable_to_use_this_user": "无法使用此用户。",
 		"complete_to_install1": "完成安装GROWI！请以管理员帐户登录。",
 		"complete_to_install2": "完成安装GROWI！请先检查此页上的每个设置。",
-		"failed_to_create_admin_user": "无法创建管理用户。{{errMessage}"
+		"failed_to_create_admin_user": "无法创建管理用户。{{errMessage}",
+    "incorrect_token_or_expired_url":"令牌不正确或 URL 已过期。"
 	},
   "grid_edit":{
     "create_bootstrap_4_grid":"创建Bootstrap 4网格",

--- a/packages/app/src/server/routes/index.js
+++ b/packages/app/src/server/routes/index.js
@@ -198,7 +198,7 @@ module.exports = function(crowi, app) {
 
   app.use('/user-activation', express.Router()
     .get('/:token', apiLimiter, applicationInstalled, injectUserRegistrationOrderByTokenMiddleware, userActivation.form)
-    .use(userActivation.handleHttpErrosMiddleware));
+    .use(userActivation.tokenErrorHandlerMiddeware));
   app.post('/user-activation/complete-registartion', apiLimiter, applicationInstalled, injectUserRegistrationOrderByTokenMiddleware, csrf, userActivation.completeRegistrationRules(), userActivation.validateCompleteRegistrationForm, userActivation.completeRegistrationAction(crowi));
   app.post('/user-activation/register', apiLimiter, applicationInstalled, csrf, userActivation.registerRules(), userActivation.validateRegisterForm, userActivation.registerAction(crowi));
 

--- a/packages/app/src/server/routes/user-activation.ts
+++ b/packages/app/src/server/routes/user-activation.ts
@@ -1,6 +1,3 @@
-import {
-  NextFunction, Request, RequestHandler, Response,
-} from 'express';
 import path from 'path';
 import { body, validationResult } from 'express-validator';
 import UserRegistrationOrder from '~/server/models/user-registration-order';
@@ -149,8 +146,8 @@ export const completeRegistrationAction = (crowi) => {
 };
 
 // middleware to handle error
-export const handleHttpErrosMiddleware = (error: Error & { code: string }, req: Request, res: Response, next: NextFunction): Promise<RequestHandler> | void => {
-  if (error != null) {
+export const handleHttpErrosMiddleware = (err, req, res, next) => {
+  if (err != null) {
     req.flash('errorMessage', req.t('message.incorrect_token_or_expired_url'));
     return res.redirect('/login#register');
   }

--- a/packages/app/src/server/routes/user-activation.ts
+++ b/packages/app/src/server/routes/user-activation.ts
@@ -151,8 +151,8 @@ export const completeRegistrationAction = (crowi) => {
 // middleware to handle error
 export const handleHttpErrosMiddleware = (error: Error & { code: string }, req: Request, res: Response, next: NextFunction): Promise<RequestHandler> | void => {
   if (error != null) {
-    // TODO: GW7335 - make custom view
-    return res.render('forgot-password/error', { key: error.code });
+    req.flash('errorMessage', req.t('message.incorrect_token_or_expired_url'));
+    return res.redirect('/login#register');
   }
   next();
 };

--- a/packages/app/src/server/routes/user-activation.ts
+++ b/packages/app/src/server/routes/user-activation.ts
@@ -146,7 +146,7 @@ export const completeRegistrationAction = (crowi) => {
 };
 
 // middleware to handle error
-export const handleHttpErrosMiddleware = (err, req, res, next) => {
+export const tokenErrorHandlerMiddeware = (err, req, res, next) => {
   if (err != null) {
     req.flash('errorMessage', req.t('message.incorrect_token_or_expired_url'));
     return res.redirect('/login#register');


### PR DESCRIPTION
https://youtrack.weseek.co.jp/issue/GW-7568
- Add incorrect_token_or_expired_url translation en_US, ja_JP, zh_CN
- Change redirection to /login#register instead of render forgot-password-error view
- Fix lint errors 'Cant find method' for flash and t methods