### PR TITLE
Imprv/80940 change notification status read

### DIFF
--- a/packages/app/src/components/InAppNotification/NotificationContent.tsx
+++ b/packages/app/src/components/InAppNotification/NotificationContent.tsx
@@ -16,11 +16,11 @@ interface Props {
 const notificationClickHandler = async(notification: IInAppNotification) => {
 
   try {
-    window.location.href = notification.target.path;
     // set notification status "STATUS_OPEND"
     await apiv3Post('/in-app-notification/open', { id: notification._id });
+
     // jump to target page
-    console.log('path', notification.target.path);
+    window.location.href = notification.target.path;
   }
   catch (err) {
     logger.error(err);

--- a/packages/app/src/components/InAppNotification/NotificationContent.tsx
+++ b/packages/app/src/components/InAppNotification/NotificationContent.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { PagePathLabel } from '@growi/ui';
 import { IInAppNotification } from '../../interfaces/in-app-notification';
 import loggerFactory from '~/utils/logger';
+import { apiv3Post } from '../../client/util/apiv3-client';
 
 import FormattedDistanceDate from '../FormattedDistanceDate';
 
@@ -12,13 +13,14 @@ interface Props {
   notification: IInAppNotification
 }
 
-const notificationClickHandler = async(pagePath: string) => {
+const notificationClickHandler = async(notification: IInAppNotification) => {
 
   try {
-    // TODO: change notification status read by #80904
-    // await this.props.crowi.apiPost('/notification.open', { id: notification._id });
+    window.location.href = notification.target.path;
+    // set notification status "STATUS_OPEND"
+    await apiv3Post('/in-app-notification/open', { id: notification._id });
     // jump to target page
-    window.location.href = pagePath;
+    console.log('path', notification.target.path);
   }
   catch (err) {
     logger.error(err);
@@ -30,7 +32,7 @@ export const PageCommentNotification = (props: Props): JSX.Element => {
   const pagePath = { path: props.notification.target.path };
 
   return (
-    <div onClick={() => notificationClickHandler(pagePath.path)}>
+    <div onClick={() => notificationClickHandler(props.notification)}>
       <div>
         <b>{props.actionUsers}</b> commented on  <PagePathLabel page={pagePath} />
       </div>
@@ -45,7 +47,7 @@ export const PageUpdateNotification = (props: Props): JSX.Element => {
   const pagePath = { path: props.notification.target.path };
 
   return (
-    <div onClick={() => notificationClickHandler(pagePath.path)}>
+    <div onClick={() => notificationClickHandler(props.notification)}>
       <div>
         <b>{props.actionUsers}</b> page updated on <PagePathLabel page={pagePath} />
       </div>

--- a/packages/app/src/interfaces/has-object-id.ts
+++ b/packages/app/src/interfaces/has-object-id.ts
@@ -1,0 +1,3 @@
+export type HasObjectId = {
+  _id: string,
+};

--- a/packages/app/src/server/routes/apiv3/in-app-notification.ts
+++ b/packages/app/src/server/routes/apiv3/in-app-notification.ts
@@ -89,7 +89,7 @@ module.exports = (crowi) => {
     const id = req.body.id;
 
     try {
-      const notification = await InAppNotification.open(user, id);
+      const notification = await inAppNotificationService.open(user, id);
       const result = { notification };
       return res.apiv3(result);
     }

--- a/packages/app/src/server/service/in-app-notification.ts
+++ b/packages/app/src/server/service/in-app-notification.ts
@@ -2,8 +2,11 @@ import { Types } from 'mongoose';
 import { subDays } from 'date-fns';
 import Crowi from '../crowi';
 import {
-  InAppNotification, InAppNotificationDocument, STATUS_UNREAD, STATUS_UNOPENED,
+  InAppNotification, InAppNotificationDocument, STATUS_UNREAD, STATUS_UNOPENED, STATUS_OPENED,
 } from '~/server/models/in-app-notification';
+
+import { IUser } from '~/interfaces/user';
+import { HasObjectId } from '~/interfaces/has-object-id';
 import { ActivityDocument } from '~/server/models/activity';
 
 import loggerFactory from '~/utils/logger';
@@ -109,6 +112,15 @@ export default class InAppNotificationService {
 
     return;
   };
+
+  open = async function(user: IUser & HasObjectId, id: Types.ObjectId): Promise<void> {
+    const query = { _id: id, user: user._id };
+    const parameters = { status: STATUS_OPENED };
+    const options = { new: true };
+
+    await InAppNotification.findOneAndUpdate(query, parameters, options);
+    return;
+  }
 
   getUnreadCountByUser = async function(user: Types.ObjectId): Promise<number| undefined> {
     const query = { user, status: STATUS_UNREAD };


### PR DESCRIPTION
## Task
- [#80940](https://estoc.weseek.co.jp/redmine/issues/80940) 通知をクリックしたときに、apiを叩いて既読にすることができる

## DB

<img width="922" alt="Screen Shot 2021-11-09 at 14 17 52" src="https://user-images.githubusercontent.com/59536731/140866895-a96623a9-e3da-4a93-b1bd-6bbdc464720c.png">


## Note
通知listから特定の通知クリックして対象ページに遷移した時`STATUS_UNOPENE` -> `STATUS_OPENED` になるようにしました。



- notification のstatus
```
  STATUS_UNREAD: string // ベルマークに通知数が表示されている時
  STATUS_UNOPENED: string // 通知のpopupを表示させた時
  STATUS_OPENED: string // listから特定の通知クリックして対象ページに遷移した時
```