### PR TITLE
feat: Pt fetch initial data (client)

### DIFF
--- a/packages/app/src/client/services/PageContainer.js
+++ b/packages/app/src/client/services/PageContainer.js
@@ -82,6 +82,7 @@ export default class PageContainer extends Container {
       templateTagData: mainContent.getAttribute('data-template-tags') || null,
       shareLinksNumber: mainContent.getAttribute('data-share-links-number'),
       shareLinkId: JSON.parse(mainContent.getAttribute('data-share-link-id') || null),
+      targetAndAncestors: JSON.parse(mainContent.getAttribute('data-target-and-ancestors') || null),
 
       // latest(on remote) information
       remoteRevisionId: revisionId,

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -10,9 +10,7 @@ interface ItemProps {
 const Item = memo<ItemProps>((props: ItemProps) => {
   const { itemNode, isOpen = false } = props;
 
-  const { page, children, isPartialChildren } = itemNode;
-
-  // TODO: fetch children if isPartialChildren
+  const { page, children } = itemNode;
 
   if (page == null) {
     return null;
@@ -31,7 +29,7 @@ const Item = memo<ItemProps>((props: ItemProps) => {
       {
         itemNode.hasChildren() && (children as ItemNode[]).map(node => (
           <Item
-            key={node.page.path}
+            key={node.page._id}
             itemNode={node}
             isOpen={false}
           />

--- a/packages/app/src/components/Sidebar/PageTree/ItemNode.ts
+++ b/packages/app/src/components/Sidebar/PageTree/ItemNode.ts
@@ -1,6 +1,6 @@
 import { IPage } from '~/interfaces/page';
 
-type IPageForItem = Partial<IPage> & {isTarget?: boolean};
+type IPageForItem = Partial<IPage> & { _id?: string, isTarget?: boolean };
 
 export class ItemNode {
 
@@ -8,16 +8,17 @@ export class ItemNode {
 
   children?: ItemNode[];
 
-  isPartialChildren?: boolean;
-
-  constructor(page: IPageForItem, children: ItemNode[] = [], isPartialChildren = false) {
+  constructor(page: IPageForItem, children: ItemNode[] = []) {
     this.page = page;
     this.children = children;
-    this.isPartialChildren = isPartialChildren;
   }
 
   hasChildren(): boolean {
     return this.children != null && this.children?.length > 0;
+  }
+
+  static generateNodesFromPages(pages: IPageForItem[]): ItemNode[] {
+    return pages.map(page => new ItemNode(page));
   }
 
 }

--- a/packages/app/src/components/Sidebar/PageTree/ItemNode.ts
+++ b/packages/app/src/components/Sidebar/PageTree/ItemNode.ts
@@ -1,6 +1,6 @@
 import { IPage } from '~/interfaces/page';
 
-type IPageForItem = Partial<IPage> & { isTarget?: boolean };
+type IPageForItem = Partial<IPage> & {isTarget?: boolean};
 
 export class ItemNode {
 

--- a/packages/app/src/components/Sidebar/PageTree/ItemNode.ts
+++ b/packages/app/src/components/Sidebar/PageTree/ItemNode.ts
@@ -1,6 +1,6 @@
 import { IPage } from '~/interfaces/page';
 
-type IPageForItem = Partial<IPage> & { _id?: string, isTarget?: boolean };
+type IPageForItem = Partial<IPage> & { isTarget?: boolean };
 
 export class ItemNode {
 

--- a/packages/app/src/components/Sidebar/PageTree/ItemNode.ts
+++ b/packages/app/src/components/Sidebar/PageTree/ItemNode.ts
@@ -1,6 +1,7 @@
-import { IPage } from '~/interfaces/page';
+import { IPage } from '../../../interfaces/page';
+import { HasObjectId } from '../../../interfaces/has-object-id';
 
-type IPageForItem = Partial<IPage> & {isTarget?: boolean};
+type IPageForItem = Partial<IPage & {isTarget?: boolean} & HasObjectId>;
 
 export class ItemNode {
 

--- a/packages/app/src/components/Sidebar/PageTree/ItemsTree.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/ItemsTree.tsx
@@ -3,72 +3,25 @@ import React, { FC } from 'react';
 import { IPage } from '../../../interfaces/page';
 import { ItemNode } from './ItemNode';
 import Item from './Item';
-
-/*
- * Mock data
- */
-const ancestors: (Partial<IPage> & {isTarget?: boolean})[] = [
-  {
-    path: '/',
-    isEmpty: false,
-    grant: 1,
-  },
-  {
-    path: '/A',
-    isEmpty: false,
-    grant: 1,
-  },
-  {
-    path: '/A/B',
-    isEmpty: false,
-    grant: 1,
-  },
-];
-
-/*
- * Mock data
- */
-const targetAndSiblings: (Partial<IPage> & {isTarget?: boolean})[] = [
-  {
-    path: '/A/B/C',
-    isEmpty: false,
-    grant: 1,
-    isTarget: true,
-  },
-  {
-    path: '/A/B/C2',
-    isEmpty: false,
-    grant: 1,
-  },
-  {
-    path: '/A/B/C3',
-    isEmpty: false,
-    grant: 1,
-  },
-  {
-    path: '/A/B/C4',
-    isEmpty: false,
-    grant: 1,
-  },
-];
+import { useSWRxPageSiblings, useSWRxPageAncestors } from '../../../stores/page-listing';
 
 
 /*
  * Utility to generate node tree and return the root node
  */
 const generateInitialTreeFromAncestors = (ancestors: Partial<IPage>[], siblings: Partial<IPage>[]): ItemNode => {
-  const rootPage = ancestors[0];
+  const rootPage = ancestors[ancestors.length - 1];
   if (rootPage?.path !== '/') throw Error('/ not exist in ancestors');
 
-  const ancestorNodes = ancestors.map((page, i, array): ItemNode => {
-    if (i === array.length - 1) {
+  const ancestorNodes = ancestors.map((page, i): ItemNode => {
+    if (i === 0) {
       const siblingNodes = siblings.map(page => new ItemNode(page));
       return new ItemNode(page, siblingNodes);
     }
     return new ItemNode(page, [], true);
   });
 
-  const rootNode = ancestorNodes.reverse().reduce((child, parent) => {
+  const rootNode = ancestorNodes.reduce((child, parent) => {
     parent.children = [child];
     return parent;
   });
@@ -80,8 +33,23 @@ const generateInitialTreeFromAncestors = (ancestors: Partial<IPage>[], siblings:
  * ItemsTree
  */
 const ItemsTree: FC = () => {
-  // TODO: fetch ancestors, siblings using swr
-  if (ancestors == null) return null;
+  // TODO: get from props
+  const path = '/Sandbox/Bootstrap4';
+  const id = '6181188ae38676152e464fc2';
+
+  const { data: ancestorsData, error: error1 } = useSWRxPageAncestors(path, id);
+  const { data: siblingsData, error: error2 } = useSWRxPageSiblings(path);
+
+  if (error1 != null || error2 != null) {
+    return null;
+  }
+
+  if (ancestorsData == null || siblingsData == null) {
+    return null;
+  }
+
+  const { ancestors } = ancestorsData;
+  const { targetAndSiblings } = siblingsData;
 
   // create node tree
   const rootNode = generateInitialTreeFromAncestors(ancestors, targetAndSiblings);

--- a/packages/app/src/components/Sidebar/SidebarContents.jsx
+++ b/packages/app/src/components/Sidebar/SidebarContents.jsx
@@ -5,6 +5,7 @@ import { withTranslation } from 'react-i18next';
 
 import { withUnstatedContainers } from '../UnstatedUtils';
 import NavigationContainer from '~/client/services/NavigationContainer';
+import { useTargetAndAncestors } from '../../stores/context';
 
 import RecentChanges from './RecentChanges';
 import CustomSidebar from './CustomSidebar';
@@ -12,6 +13,12 @@ import PageTree from './PageTree';
 
 const SidebarContents = (props) => {
   const { navigationContainer, isSharedUser } = props;
+
+  const pageContainer = navigationContainer.getPageContainer();
+
+  const { targetAndAncestors } = pageContainer.state;
+
+  useTargetAndAncestors(targetAndAncestors);
 
   if (isSharedUser) {
     return null;

--- a/packages/app/src/interfaces/has-object-id.ts
+++ b/packages/app/src/interfaces/has-object-id.ts
@@ -1,0 +1,3 @@
+export interface HasObjectId {
+  _id: string,
+}

--- a/packages/app/src/interfaces/page-listing-results.ts
+++ b/packages/app/src/interfaces/page-listing-results.ts
@@ -1,10 +1,16 @@
 import { IPage } from './page';
 
-export interface SiblingsResult {
-  targetAndSiblings: Partial<IPage>[]
+export interface ChildrenResult {
+  pages: Partial<IPage>[]
 }
 
 
-export interface AncestorsResult {
-  ancestors: Partial<IPage>[]
+type ParentPath = string;
+export interface AncestorsChildrenResult {
+  ancestorsChildren: Record<ParentPath, Partial<IPage>[]>
+}
+
+
+export interface TargetAndAncestorsResult {
+  targetAndAncestors: Partial<IPage>[]
 }

--- a/packages/app/src/interfaces/page-listing-results.ts
+++ b/packages/app/src/interfaces/page-listing-results.ts
@@ -1,0 +1,10 @@
+import { IPage } from './page';
+
+export interface SiblingsResult {
+  targetAndSiblings: Partial<IPage>[]
+}
+
+
+export interface AncestorsResult {
+  ancestors: Partial<IPage>[]
+}

--- a/packages/app/src/interfaces/page-listing-results.ts
+++ b/packages/app/src/interfaces/page-listing-results.ts
@@ -1,9 +1,5 @@
 import { IPage } from './page';
 
-export interface ChildrenResult {
-  pages: Partial<IPage>[]
-}
-
 
 type ParentPath = string;
 export interface AncestorsChildrenResult {

--- a/packages/app/src/interfaces/page-listing-results.ts
+++ b/packages/app/src/interfaces/page-listing-results.ts
@@ -1,12 +1,10 @@
 import { IPage } from './page';
+import { HasObjectId } from './has-object-id';
 
 
 type ParentPath = string;
 export interface AncestorsChildrenResult {
-  ancestorsChildren: Record<ParentPath, Partial<IPage>[]>
+  ancestorsChildren: Record<ParentPath, Partial<IPage & HasObjectId>[]>
 }
 
-
-export interface TargetAndAncestorsResult {
-  targetAndAncestors: Partial<IPage>[]
-}
+export type TargetAndAncestors = Partial<IPage & HasObjectId>[];

--- a/packages/app/src/interfaces/page.ts
+++ b/packages/app/src/interfaces/page.ts
@@ -5,6 +5,7 @@ import { ITag } from './tag';
 
 
 export type IPage = {
+  _id?: string,
   path: string,
   status: string,
   revision: Ref<IRevision>,

--- a/packages/app/src/interfaces/page.ts
+++ b/packages/app/src/interfaces/page.ts
@@ -5,7 +5,6 @@ import { ITag } from './tag';
 
 
 export type IPage = {
-  _id?: string,
   path: string,
   status: string,
   revision: Ref<IRevision>,

--- a/packages/app/src/server/models/obsolete-page.js
+++ b/packages/app/src/server/models/obsolete-page.js
@@ -228,6 +228,12 @@ export class PageQueryBuilder {
     return this;
   }
 
+  addConditionToMinimizeDataForRendering() {
+    this.query = this.query.select('_id path isEmpty grant');
+
+    return this;
+  }
+
   addConditionToListByPathsArray(paths) {
     this.query = this.query
       .and({

--- a/packages/app/src/server/models/page.ts
+++ b/packages/app/src/server/models/page.ts
@@ -31,7 +31,7 @@ const PAGE_GRANT_ERROR = 1;
 const STATUS_PUBLISHED = 'published';
 const STATUS_DELETED = 'deleted';
 
-export interface PageDocument extends Omit<IPage, '_id'>, Document {}
+export interface PageDocument extends IPage, Document {}
 
 export interface PageModel extends Model<PageDocument> {
   createEmptyPagesByPaths(paths: string[]): Promise<void>
@@ -246,7 +246,7 @@ schema.statics.findTargetAndAncestorsByPathOrId = async function(pathOrId: strin
   if (!hasSlash(pathOrId)) {
     const _id = pathOrId;
     const page = await this.findOne({ _id });
-    if (page == null) throw Error('Page not found.');
+    if (page == null) throw new Error('Page not found.');
 
     path = page.path;
   }
@@ -261,6 +261,7 @@ schema.statics.findTargetAndAncestorsByPathOrId = async function(pathOrId: strin
   const queryBuilder = new PageQueryBuilder(this.find());
   const _ancestors: PageDocument[] = await queryBuilder
     .addConditionToListByPathsArray(ancestorPaths)
+    .addConditionToMinimizeDataForRendering()
     .addConditionToSortAncestorPages()
     .query
     .lean()

--- a/packages/app/src/server/routes/apiv3/page-listing.ts
+++ b/packages/app/src/server/routes/apiv3/page-listing.ts
@@ -1,5 +1,4 @@
 import express, { Request, Router } from 'express';
-import { pagePathUtils } from '@growi/core';
 import { query, oneOf } from 'express-validator';
 
 import { PageDocument, PageModel } from '../../models/page';
@@ -7,8 +6,6 @@ import ErrorV3 from '../../models/vo/error-apiv3';
 import loggerFactory from '../../../utils/logger';
 import Crowi from '../../crowi';
 import { ApiV3Response } from './interfaces/apiv3-response';
-
-const { isTopPage } = pagePathUtils;
 
 const logger = loggerFactory('growi:routes:apiv3:page-tree');
 
@@ -53,31 +50,6 @@ export default (crowi: Crowi): Router => {
     const ancestorsChildren: Record<string, PageDocument[]> = await Page.findAncestorsChildrenByPathAndViewer(path as string, req.user);
 
     return res.apiv3({ ancestorsChildren });
-  });
-
-  /*
-   * In most cases, using path should be prioritized
-   */
-  // eslint-disable-next-line max-len
-  router.get('/target-ancestors', accessTokenParser, loginRequiredStrictly, validator.pageIdOrPathRequired, apiV3FormValidator, async(req: AuthorizedRequest, res: ApiV3Response): Promise<any> => {
-    const { id, path } = req.query;
-
-    const Page: PageModel = crowi.model('Page');
-
-    let targetAndAncestors: PageDocument[];
-    try {
-      targetAndAncestors = await Page.findTargetAndAncestorsByPathOrId((path || id) as string);
-
-      if (targetAndAncestors.length === 0 && !isTopPage(path as string)) {
-        throw Error('Ancestors must have at least one page.');
-      }
-    }
-    catch (err) {
-      logger.error('Error occurred while finding pages.', err);
-      return res.apiv3Err(new ErrorV3('Error occurred while finding pages.'));
-    }
-
-    return res.apiv3({ targetAndAncestors });
   });
 
   /*

--- a/packages/app/src/server/views/widget/page_content.html
+++ b/packages/app/src/server/views/widget/page_content.html
@@ -27,6 +27,7 @@
   data-page-user="{% if pageUser %}{{ pageUser|json }}{% else %}null{% endif %}"
   data-share-links-number="{% if page %}{{ sharelinksNumber }}{% endif %}"
   data-share-link-id="{% if sharelink %}{{ sharelink._id|json }}{% endif %}"
+  data-target-and-ancestors="{% if targetAndAncestors %}{{ targetAndAncestors|json }}{% endif %}"
   >
 {% else %}
 <div id="content-main" class="content-main d-flex"

--- a/packages/app/src/stores/context.tsx
+++ b/packages/app/src/stores/context.tsx
@@ -1,0 +1,8 @@
+import { SWRResponse } from 'swr';
+import { useStaticSWR } from './use-static-swr';
+
+import { TargetAndAncestors } from '../interfaces/page-listing-results';
+
+export const useTargetAndAncestors = (initialData?: TargetAndAncestors): SWRResponse<TargetAndAncestors, Error> => {
+  return useStaticSWR<TargetAndAncestors, Error>('targetAndAncestors', initialData);
+};

--- a/packages/app/src/stores/page-listing.tsx
+++ b/packages/app/src/stores/page-listing.tsx
@@ -1,7 +1,7 @@
 import useSWR, { SWRResponse } from 'swr';
 
 import { apiv3Get } from '../client/util/apiv3-client';
-import { ChildrenResult, TargetAndAncestorsResult, AncestorsChildrenResult } from '../interfaces/page-listing-results';
+import { TargetAndAncestorsResult, AncestorsChildrenResult } from '../interfaces/page-listing-results';
 
 
 export const useSWRxPageAncestorsChildren = (
@@ -31,16 +31,3 @@ export const useSWRxPageAncestors = (
   );
 };
 
-
-export const useSWRxPageChildren = (
-    path: string | null,
-): SWRResponse<ChildrenResult, Error> => {
-  return useSWR(
-    path ? `/page-listing/children?path=${path}` : null,
-    endpoint => apiv3Get(endpoint).then((response) => {
-      return {
-        pages: response.data.pages,
-      };
-    }),
-  );
-};

--- a/packages/app/src/stores/page-listing.tsx
+++ b/packages/app/src/stores/page-listing.tsx
@@ -30,4 +30,3 @@ export const useSWRxPageAncestors = (
     }),
   );
 };
-

--- a/packages/app/src/stores/page-listing.tsx
+++ b/packages/app/src/stores/page-listing.tsx
@@ -1,32 +1,45 @@
 import useSWR, { SWRResponse } from 'swr';
 
 import { apiv3Get } from '../client/util/apiv3-client';
-import { SiblingsResult, AncestorsResult } from '../interfaces/page-listing-results';
+import { ChildrenResult, TargetAndAncestorsResult, AncestorsChildrenResult } from '../interfaces/page-listing-results';
 
 
-export const useSWRxPageSiblings = (
+export const useSWRxPageAncestorsChildren = (
     path: string,
-): SWRResponse<SiblingsResult, Error> => {
+): SWRResponse<AncestorsChildrenResult, Error> => {
   return useSWR(
-    `/page-listing/siblings?path=${path}`,
+    `/page-listing/ancestors-children?path=${path}`,
     endpoint => apiv3Get(endpoint).then((response) => {
       return {
-        targetAndSiblings: response.data.targetAndSiblings,
+        ancestorsChildren: response.data.ancestorsChildren,
+      };
+    }),
+  );
+};
+
+export const useSWRxPageAncestors = (
+    path: string,
+    id: string,
+): SWRResponse<TargetAndAncestorsResult, Error> => {
+  return useSWR(
+    `/page-listing/target-ancestors?path=${path}&id=${id}`,
+    endpoint => apiv3Get(endpoint).then((response) => {
+      return {
+        targetAndAncestors: response.data.targetAndAncestors,
       };
     }),
   );
 };
 
 
-export const useSWRxPageAncestors = (
-    path: string,
-    id: string,
-): SWRResponse<AncestorsResult, Error> => {
+export const useSWRxPageChildren = (
+    path: string | null,
+): SWRResponse<ChildrenResult, Error> => {
   return useSWR(
-    `/page-listing/ancestors?path=${path}&id=${id}`,
+    path ? `/page-listing/children?path=${path}` : null,
     endpoint => apiv3Get(endpoint).then((response) => {
       return {
-        ancestors: response.data.ancestors,
+        pages: response.data.pages,
       };
     }),
   );

--- a/packages/app/src/stores/page-listing.tsx
+++ b/packages/app/src/stores/page-listing.tsx
@@ -1,0 +1,33 @@
+import useSWR, { SWRResponse } from 'swr';
+
+import { apiv3Get } from '../client/util/apiv3-client';
+import { SiblingsResult, AncestorsResult } from '../interfaces/page-listing-results';
+
+
+export const useSWRxPageSiblings = (
+    path: string,
+): SWRResponse<SiblingsResult, Error> => {
+  return useSWR(
+    `/page-listing/siblings?path=${path}`,
+    endpoint => apiv3Get(endpoint).then((response) => {
+      return {
+        targetAndSiblings: response.data.targetAndSiblings,
+      };
+    }),
+  );
+};
+
+
+export const useSWRxPageAncestors = (
+    path: string,
+    id: string,
+): SWRResponse<AncestorsResult, Error> => {
+  return useSWR(
+    `/page-listing/ancestors?path=${path}&id=${id}`,
+    endpoint => apiv3Get(endpoint).then((response) => {
+      return {
+        ancestors: response.data.ancestors,
+      };
+    }),
+  );
+};

--- a/packages/app/src/stores/page-listing.tsx
+++ b/packages/app/src/stores/page-listing.tsx
@@ -5,10 +5,10 @@ import { TargetAndAncestorsResult, AncestorsChildrenResult } from '../interfaces
 
 
 export const useSWRxPageAncestorsChildren = (
-    path: string,
+    path: string | null,
 ): SWRResponse<AncestorsChildrenResult, Error> => {
   return useSWR(
-    `/page-listing/ancestors-children?path=${path}`,
+    path ? `/page-listing/ancestors-children?path=${path}` : null,
     endpoint => apiv3Get(endpoint).then((response) => {
       return {
         ancestorsChildren: response.data.ancestorsChildren,

--- a/packages/app/src/stores/page-listing.tsx
+++ b/packages/app/src/stores/page-listing.tsx
@@ -1,7 +1,7 @@
 import useSWR, { SWRResponse } from 'swr';
 
 import { apiv3Get } from '../client/util/apiv3-client';
-import { TargetAndAncestorsResult, AncestorsChildrenResult } from '../interfaces/page-listing-results';
+import { AncestorsChildrenResult } from '../interfaces/page-listing-results';
 
 
 export const useSWRxPageAncestorsChildren = (
@@ -12,20 +12,6 @@ export const useSWRxPageAncestorsChildren = (
     endpoint => apiv3Get(endpoint).then((response) => {
       return {
         ancestorsChildren: response.data.ancestorsChildren,
-      };
-    }),
-  );
-};
-
-export const useSWRxPageAncestors = (
-    path: string,
-    id: string,
-): SWRResponse<TargetAndAncestorsResult, Error> => {
-  return useSWR(
-    `/page-listing/target-ancestors?path=${path}&id=${id}`,
-    endpoint => apiv3Get(endpoint).then((response) => {
-      return {
-        targetAndAncestors: response.data.targetAndAncestors,
       };
     }),
   );

--- a/packages/app/src/stores/use-static-swr.tsx
+++ b/packages/app/src/stores/use-static-swr.tsx
@@ -1,0 +1,27 @@
+import useSWR, {
+  Key, SWRResponse, mutate, useSWRConfig,
+} from 'swr';
+import { Fetcher } from 'swr/dist/types';
+
+
+export const useStaticSWR = <Data, Error>(
+  key: Key,
+  updateData?: Data | Fetcher<Data>,
+  initialData?: Data | Fetcher<Data>,
+): SWRResponse<Data, Error> => {
+  const { cache } = useSWRConfig();
+
+  if (updateData == null) {
+    if (cache.get(key) == null && initialData != null) {
+      mutate(key, initialData, false);
+    }
+  }
+  else {
+    mutate(key, updateData);
+  }
+
+  return useSWR(key, null, {
+    revalidateOnFocus: false,
+    revalidateOnReconnect: false,
+  });
+};


### PR DESCRIPTION
Redmine: https://estoc.weseek.co.jp/redmine/issues/80791

## 変更内容
- isPartialChildren は不要になったので削除しました
- １回目の SWR で ancestors のみを取得していたのを target と ancestors 両方を取得するように書き換えました
- ２回目の SWR で target 以外の node の children をサーバーから取得し、各 node を更新してからレンダリングするようにしました
- ancestors-children API はハリボテです

## ItemsTree のレンダリング
- 正しく動けば計３回 ItemsTree がレンダリングされるようになっています (null, target & ancestors, target & ancestors & ancestors-children)

## 後続について
- ancestors-children API を実装します
- ItemsTree コンポーネントに props で path と id を渡すようにします