### PR TITLE
Imprv/80107 add pagination to all in app notifications

### DIFF
--- a/packages/app/src/components/InAppNotification/AllInAppNotifications.tsx
+++ b/packages/app/src/components/InAppNotification/AllInAppNotifications.tsx
@@ -1,15 +1,42 @@
-import React, { FC } from 'react';
+import React, { FC, useState } from 'react';
 
 import InAppNotificationList from './InAppNotificationList';
 import { useSWRxInAppNotifications } from '../../stores/in-app-notification';
+import PaginationWrapper from '../PaginationWrapper';
 
 
 const AllInAppNotifications: FC = () => {
   const limit = 6;
+  const [activePage, setActivePage] = useState(1);
   const { data: inAppNotificationData } = useSWRxInAppNotifications(limit);
 
+
+  if (inAppNotificationData == null) {
+    return (
+      <div className="wiki">
+        <div className="text-muted text-center">
+          <i className="fa fa-2x fa-spinner fa-pulse mr-1"></i>
+        </div>
+      </div>
+    );
+  }
+
+  function setPageNumber(selectedPageNumber): void {
+    setActivePage(selectedPageNumber);
+  }
+
   return (
-    <InAppNotificationList inAppNotificationData={inAppNotificationData} />
+    <>
+      <InAppNotificationList inAppNotificationData={inAppNotificationData} />
+      <PaginationWrapper
+        activePage={activePage}
+        changePage={setPageNumber}
+        totalItemsCount={inAppNotificationData.totalDocs}
+        pagingLimit={inAppNotificationData.limit}
+        align="center"
+        size="sm"
+      />
+    </>
   );
 };
 

--- a/packages/app/src/components/InAppNotification/AllInAppNotifications.tsx
+++ b/packages/app/src/components/InAppNotification/AllInAppNotifications.tsx
@@ -8,7 +8,7 @@ import PaginationWrapper from '../PaginationWrapper';
 const AllInAppNotifications: FC = () => {
   const limit = 6;
   const [activePage, setActivePage] = useState(1);
-  const { data: inAppNotificationData } = useSWRxInAppNotifications(limit);
+  const { data: inAppNotificationData } = useSWRxInAppNotifications(limit, activePage);
 
 
   if (inAppNotificationData == null) {
@@ -21,9 +21,9 @@ const AllInAppNotifications: FC = () => {
     );
   }
 
-  function setPageNumber(selectedPageNumber): void {
+  const setPageNumber = (selectedPageNumber): void => {
     setActivePage(selectedPageNumber);
-  }
+  };
 
   return (
     <>

--- a/packages/app/src/components/InAppNotification/AllInAppNotifications.tsx
+++ b/packages/app/src/components/InAppNotification/AllInAppNotifications.tsx
@@ -6,9 +6,10 @@ import PaginationWrapper from '../PaginationWrapper';
 
 
 const AllInAppNotifications: FC = () => {
-  const limit = 6;
   const [activePage, setActivePage] = useState(1);
-  const { data: inAppNotificationData } = useSWRxInAppNotifications(limit, activePage);
+  const [offset, setOffset] = useState(0);
+  const limit = 10;
+  const { data: inAppNotificationData } = useSWRxInAppNotifications(limit, offset);
 
   if (inAppNotificationData == null) {
     return (
@@ -22,6 +23,8 @@ const AllInAppNotifications: FC = () => {
 
   const setPageNumber = (selectedPageNumber): void => {
     setActivePage(selectedPageNumber);
+    const offset = (selectedPageNumber - 1) * limit;
+    setOffset(offset);
   };
 
   return (

--- a/packages/app/src/components/InAppNotification/AllInAppNotifications.tsx
+++ b/packages/app/src/components/InAppNotification/AllInAppNotifications.tsx
@@ -10,7 +10,6 @@ const AllInAppNotifications: FC = () => {
   const [activePage, setActivePage] = useState(1);
   const { data: inAppNotificationData } = useSWRxInAppNotifications(limit, activePage);
 
-
   if (inAppNotificationData == null) {
     return (
       <div className="wiki">

--- a/packages/app/src/components/InAppNotification/InAppNotificationDropdown.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationDropdown.tsx
@@ -69,7 +69,6 @@ const InAppNotificationDropdown: FC<Props> = (props: Props) => {
 
   const badge = count > 0 ? <span className="badge badge-pill badge-danger grw-notification-badge">{count}</span> : '';
 
-
   return (
     <Dropdown className="notification-wrapper" isOpen={isOpen} toggle={toggleDropdownHandler}>
       <DropdownToggle tag="a">

--- a/packages/app/src/components/PaginationWrapper.tsx
+++ b/packages/app/src/components/PaginationWrapper.tsx
@@ -1,18 +1,21 @@
-import React, { useCallback, useMemo } from 'react';
-import PropTypes from 'prop-types';
+import React, {
+  FC, memo, useCallback, useMemo,
+} from 'react';
 
 import { Pagination, PaginationItem, PaginationLink } from 'reactstrap';
 
-/**
- *
- * @author Mikitaka Itizawa <itizawa@weseek.co.jp>
- *
- * @export
- * @class PaginationWrapper
- * @extends {React.Component}
- */
 
-const PaginationWrapper = React.memo((props) => {
+type Props = {
+  activePage: number,
+  changePage?: (number) => void,
+  totalItemsCount: number,
+  pagingLimit?: number,
+  align?: string,
+  size?: string,
+};
+
+
+const PaginationWrapper: FC<Props> = memo((props: Props) => {
   const {
     activePage, changePage, totalItemsCount, pagingLimit, align,
   } = props;
@@ -59,14 +62,14 @@ const PaginationWrapper = React.memo((props) => {
    * this function set << & <
    */
   const generateFirstPrev = useCallback(() => {
-    const paginationItems = [];
+    const paginationItems: JSX.Element[] = [];
     if (activePage !== 1) {
       paginationItems.push(
         <PaginationItem key="painationItemFirst">
-          <PaginationLink first onClick={() => { return changePage(1) }} />
+          <PaginationLink first onClick={() => { return changePage != null && changePage(1) }} />
         </PaginationItem>,
         <PaginationItem key="painationItemPrevious">
-          <PaginationLink previous onClick={() => { return changePage(activePage - 1) }} />
+          <PaginationLink previous onClick={() => { return changePage != null && changePage(activePage - 1) }} />
         </PaginationItem>,
       );
     }
@@ -89,11 +92,11 @@ const PaginationWrapper = React.memo((props) => {
    * this function set  numbers
    */
   const generatePaginations = useCallback(() => {
-    const paginationItems = [];
+    const paginationItems: JSX.Element[] = [];
     for (let number = paginationStart; number <= maxViewPageNum; number++) {
       paginationItems.push(
         <PaginationItem key={`paginationItem-${number}`} active={number === activePage}>
-          <PaginationLink onClick={() => { return changePage(number) }}>
+          <PaginationLink onClick={() => { return changePage != null && changePage(number) }}>
             {number}
           </PaginationLink>
         </PaginationItem>,
@@ -108,14 +111,14 @@ const PaginationWrapper = React.memo((props) => {
    * this function set > & >>
    */
   const generateNextLast = useCallback(() => {
-    const paginationItems = [];
+    const paginationItems: JSX.Element[] = [];
     if (totalPage !== activePage) {
       paginationItems.push(
         <PaginationItem key="painationItemNext">
-          <PaginationLink next onClick={() => { return changePage(activePage + 1) }} />
+          <PaginationLink next onClick={() => { return changePage != null && changePage(activePage + 1) }} />
         </PaginationItem>,
         <PaginationItem key="painationItemLast">
-          <PaginationLink last onClick={() => { return changePage(totalPage) }} />
+          <PaginationLink last onClick={() => { return changePage != null && changePage(totalPage) }} />
         </PaginationItem>,
       );
     }
@@ -133,7 +136,7 @@ const PaginationWrapper = React.memo((props) => {
   }, [activePage, changePage, totalPage]);
 
   const getListClassName = useMemo(() => {
-    const listClassNames = [];
+    const listClassNames: string[] = [];
 
     if (align === 'center') {
       listClassNames.push('justify-content-center');
@@ -156,15 +159,6 @@ const PaginationWrapper = React.memo((props) => {
   );
 
 });
-
-PaginationWrapper.propTypes = {
-  activePage: PropTypes.number.isRequired,
-  changePage: PropTypes.func.isRequired,
-  totalItemsCount: PropTypes.number.isRequired,
-  pagingLimit: PropTypes.number,
-  align: PropTypes.string,
-  size: PropTypes.string,
-};
 
 PaginationWrapper.defaultProps = {
   align: 'left',

--- a/packages/app/src/server/models/in-app-notification.ts
+++ b/packages/app/src/server/models/in-app-notification.ts
@@ -4,12 +4,8 @@ import {
 import mongoosePaginate from 'mongoose-paginate-v2';
 
 import { getOrCreateModel } from '@growi/core';
-import Activity, { ActivityDocument } from './activity';
+import { ActivityDocument } from './activity';
 import ActivityDefine from '../util/activityDefine';
-
-import loggerFactory from '../../utils/logger';
-
-const logger = loggerFactory('growi:models:inAppNotification');
 
 export const STATUS_UNREAD = 'UNREAD';
 export const STATUS_UNOPENED = 'UNOPENED';

--- a/packages/app/src/server/routes/apiv3/in-app-notification.ts
+++ b/packages/app/src/server/routes/apiv3/in-app-notification.ts
@@ -17,9 +17,12 @@ module.exports = (crowi) => {
   router.get('/list', accessTokenParser, loginRequiredStrictly, async(req, res) => {
     const user = req.user;
 
-    const limit = parseInt(req.query.limit) || await crowi.configManager.getConfig('crowi', 'customize:showPageLimitationS') || 10;
-    const page = req.query.page || 1;
-    const offset = (page - 1) * limit;
+    const limit = parseInt(req.query.limit) || 10;
+
+    let offset = 0;
+    if (req.query.offset) {
+      offset = parseInt(req.query.offset, 10);
+    }
 
     const queryOptions = {
       offset,

--- a/packages/app/src/server/routes/apiv3/in-app-notification.ts
+++ b/packages/app/src/server/routes/apiv3/in-app-notification.ts
@@ -17,19 +17,17 @@ module.exports = (crowi) => {
   router.get('/list', accessTokenParser, loginRequiredStrictly, async(req, res) => {
     const user = req.user;
 
-    let limit = 10;
-    if (req.query.limit) {
-      limit = parseInt(req.query.limit, 10);
-    }
+    const limit = parseInt(req.query.limit) || await crowi.configManager.getConfig('crowi', 'customize:showPageLimitationS') || 10;
+    const page = req.query.page || 1;
+    const offset = (page - 1) * limit;
 
-    let offset = 0;
-    if (req.query.offset) {
-      offset = parseInt(req.query.offset, 10);
-    }
+    const queryOptions = {
+      offset,
+      limit,
+    };
 
-    const requestLimit = limit + 1;
 
-    const paginationResult = await inAppNotificationService.getLatestNotificationsByUser(user._id, requestLimit, offset);
+    const paginationResult = await inAppNotificationService.getLatestNotificationsByUser(user._id, queryOptions);
 
 
     const getActionUsersFromActivities = function(activities) {

--- a/packages/app/src/server/service/in-app-notification.ts
+++ b/packages/app/src/server/service/in-app-notification.ts
@@ -3,8 +3,9 @@ import { subDays } from 'date-fns';
 import Crowi from '../crowi';
 import {
   InAppNotification, STATUS_UNREAD, STATUS_UNOPENED, STATUS_OPENED,
+  InAppNotificationDocument,
 } from '~/server/models/in-app-notification';
-import { IInAppNotification } from '../../interfaces/in-app-notification';
+
 import { ActivityDocument } from '~/server/models/activity';
 import InAppNotificationSettings from '~/server/models/in-app-notification-settings';
 import Subscription, { STATUS_SUBSCRIBE } from '~/server/models/subscription';
@@ -82,7 +83,10 @@ export default class InAppNotificationService {
     return;
   }
 
-  getLatestNotificationsByUser = async(userId: Types.ObjectId, queryOptions: {offset: number, limit: number}): Promise<PaginateResult<IInAppNotification>> => {
+  getLatestNotificationsByUser = async(
+      userId: Types.ObjectId,
+      queryOptions: {offset: number, limit: number},
+  ): Promise<PaginateResult<InAppNotificationDocument>> => {
     const { limit, offset } = queryOptions;
 
     try {

--- a/packages/app/src/server/service/in-app-notification.ts
+++ b/packages/app/src/server/service/in-app-notification.ts
@@ -79,7 +79,9 @@ export default class InAppNotificationService {
     return;
   }
 
-  getLatestNotificationsByUser = async(userId, limitNum, offset) => {
+  getLatestNotificationsByUser = async(userId, queryOptions) => {
+    const { offset } = queryOptions;
+    const limit = queryOptions.limit || 10;
 
     try {
       const paginationResult = await InAppNotification.paginate(
@@ -87,7 +89,7 @@ export default class InAppNotificationService {
         {
           sort: { createdAt: -1 },
           offset,
-          limit: limitNum || 10,
+          limit,
           populate: [
             { path: 'user' },
             { path: 'target' },

--- a/packages/app/src/server/service/in-app-notification.ts
+++ b/packages/app/src/server/service/in-app-notification.ts
@@ -82,15 +82,16 @@ export default class InAppNotificationService {
   }
 
   getLatestNotificationsByUser = async(userId, queryOptions) => {
-    const { offset, limit } = queryOptions;
+    const { limit } = queryOptions;
+    const offset = queryOptions.offset || 0;
 
     try {
       const paginationResult = await InAppNotification.paginate(
         { user: userId },
         {
           sort: { createdAt: -1 },
-          offset,
           limit,
+          offset,
           populate: [
             { path: 'user' },
             { path: 'target' },

--- a/packages/app/src/server/service/in-app-notification.ts
+++ b/packages/app/src/server/service/in-app-notification.ts
@@ -1,9 +1,10 @@
-import { Types } from 'mongoose';
+import { Types, PaginateResult } from 'mongoose';
 import { subDays } from 'date-fns';
 import Crowi from '../crowi';
 import {
   InAppNotification, STATUS_UNREAD, STATUS_UNOPENED, STATUS_OPENED,
 } from '~/server/models/in-app-notification';
+import { IInAppNotification } from '../../interfaces/in-app-notification';
 import { ActivityDocument } from '~/server/models/activity';
 import InAppNotificationSettings from '~/server/models/in-app-notification-settings';
 import Subscription, { STATUS_SUBSCRIBE } from '~/server/models/subscription';
@@ -81,9 +82,8 @@ export default class InAppNotificationService {
     return;
   }
 
-  getLatestNotificationsByUser = async(userId, queryOptions) => {
-    const { limit } = queryOptions;
-    const offset = queryOptions.offset || 0;
+  getLatestNotificationsByUser = async(userId: Types.ObjectId, queryOptions: {offset: number, limit: number}): Promise<PaginateResult<IInAppNotification>> => {
+    const { limit, offset } = queryOptions;
 
     try {
       const paginationResult = await InAppNotification.paginate(

--- a/packages/app/src/server/service/in-app-notification.ts
+++ b/packages/app/src/server/service/in-app-notification.ts
@@ -82,8 +82,7 @@ export default class InAppNotificationService {
   }
 
   getLatestNotificationsByUser = async(userId, queryOptions) => {
-    const { offset } = queryOptions;
-    const limit = queryOptions.limit || 10;
+    const { offset, limit } = queryOptions;
 
     try {
       const paginationResult = await InAppNotification.paginate(

--- a/packages/app/src/stores/in-app-notification.ts
+++ b/packages/app/src/stores/in-app-notification.ts
@@ -11,7 +11,7 @@ export const useSWRxInAppNotifications = <Data, Error>(
   offset?: number,
 ): SWRResponse<PaginateResult<IInAppNotification>, Error> => {
   return useSWR(
-    `/in-app-notification/list?limit=${limit}&offset=${offset}`,
-    endpoint => apiv3Get(endpoint).then(response => response.data),
+    ['/in-app-notification/list', limit, offset],
+    endpoint => apiv3Get(endpoint, { limit, offset }).then(response => response.data),
   );
 };

--- a/packages/app/src/stores/in-app-notification.ts
+++ b/packages/app/src/stores/in-app-notification.ts
@@ -8,7 +8,7 @@ import { IInAppNotification } from '../interfaces/in-app-notification';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const useSWRxInAppNotifications = <Data, Error>(
   limit: number,
-  page: number,
+  page?: number,
 ): SWRResponse<PaginateResult<IInAppNotification>, Error> => {
   return useSWR(
     `/in-app-notification/list?limit=${limit}&page=${page}`,

--- a/packages/app/src/stores/in-app-notification.ts
+++ b/packages/app/src/stores/in-app-notification.ts
@@ -8,7 +8,7 @@ import { IInAppNotification } from '../interfaces/in-app-notification';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const useSWRxInAppNotifications = <Data, Error>(
   limit: number,
-  offset: number,
+  offset?: number,
 ): SWRResponse<PaginateResult<IInAppNotification>, Error> => {
   return useSWR(
     `/in-app-notification/list?limit=${limit}&offset=${offset}`,

--- a/packages/app/src/stores/in-app-notification.ts
+++ b/packages/app/src/stores/in-app-notification.ts
@@ -10,7 +10,6 @@ export const useSWRxInAppNotifications = <Data, Error>(
   limit: number,
   page: number,
 ): SWRResponse<PaginateResult<IInAppNotification>, Error> => {
-  // const limitNum = limit;
   return useSWR(
     `/in-app-notification/list?limit=${limit}&page=${page}`,
     endpoint => apiv3Get(endpoint).then(response => response.data),

--- a/packages/app/src/stores/in-app-notification.ts
+++ b/packages/app/src/stores/in-app-notification.ts
@@ -7,11 +7,12 @@ import { IInAppNotification } from '../interfaces/in-app-notification';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const useSWRxInAppNotifications = <Data, Error>(
-  // TODO: apply pagination by 80107
   limit: number,
+  page: number,
 ): SWRResponse<PaginateResult<IInAppNotification>, Error> => {
+  // const limitNum = limit;
   return useSWR(
-    '/in-app-notification/list',
-    endpoint => apiv3Get(endpoint, { limit }).then(response => response.data),
+    `/in-app-notification/list?limit=${limit}&page=${page}`,
+    endpoint => apiv3Get(endpoint).then(response => response.data),
   );
 };

--- a/packages/app/src/stores/in-app-notification.ts
+++ b/packages/app/src/stores/in-app-notification.ts
@@ -8,10 +8,10 @@ import { IInAppNotification } from '../interfaces/in-app-notification';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const useSWRxInAppNotifications = <Data, Error>(
   limit: number,
-  page?: number,
+  offset: number,
 ): SWRResponse<PaginateResult<IInAppNotification>, Error> => {
   return useSWR(
-    `/in-app-notification/list?limit=${limit}&page=${page}`,
+    `/in-app-notification/list?limit=${limit}&offset=${offset}`,
     endpoint => apiv3Get(endpoint).then(response => response.data),
   );
 };


### PR DESCRIPTION
## Task
- [#80107](https://estoc.weseek.co.jp/redmine/issues/80107)「See All」の遷移先に、ページネーションを追加し、ページ遷移することができる

## Note
- `PagenationWrapper`はを以下のコミットを流用してtsx化しました。
     - [PaginationWrapper.tsx ](https://github.com/weseek/growi/pull/4614/commits/6c1197a90a083c6aabab4aae34bf29e976416581)

- 1ページあたりのリスト表示数を 6 -> 10に変更しました。

## Screen Recording
https://user-images.githubusercontent.com/59536731/141422549-a74212c3-256f-463b-87e3-4d4eb12035e9.mov



