### PR TITLE
Feat/api get ancestors children

### DIFF
--- a/packages/app/src/components/Sidebar/PageTree/ItemsTree.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/ItemsTree.tsx
@@ -1,16 +1,19 @@
 import React, { FC, useState } from 'react';
+import { pagePathUtils } from '@growi/core';
 
 import { IPage } from '../../../interfaces/page';
 import { ItemNode } from './ItemNode';
 import Item from './Item';
 import { useSWRxPageAncestors, useSWRxPageAncestorsChildren } from '../../../stores/page-listing';
 
+const { isTopPage } = pagePathUtils;
+
 /*
  * Utility to generate initial node and return
  */
 const generateInitialNode = (targetAndAncestors: Partial<IPage>[]): ItemNode => {
   const rootPage = targetAndAncestors[targetAndAncestors.length - 1]; // the last item is the root
-  if (rootPage?.path !== '/') throw Error('/ not exist in ancestors');
+  if (!isTopPage(rootPage?.path as string)) throw Error('/ not exist in ancestors');
 
   const nodes = targetAndAncestors.map((page): ItemNode => {
     return new ItemNode(page, []);
@@ -25,64 +28,76 @@ const generateInitialNode = (targetAndAncestors: Partial<IPage>[]): ItemNode => 
   return rootNode;
 };
 
+const generateInitialNodeWithChildren = (ancestors: Partial<IPage>[], ancestorsChildren: Record<string, Partial<IPage>[]>): ItemNode => {
+  // create nodes
+  const nodes = ancestors.map((page): ItemNode => {
+    const children = ancestorsChildren[page.path as string].map(page => new ItemNode(page, []));
+    return new ItemNode(page, children);
+  });
+
+  // update children for each node
+  const rootNode = nodes.reduce((child, parent) => {
+    parent.children = [child];
+    return parent;
+  });
+
+  return rootNode;
+};
+
+// TODO: get from props
+const path = '/Sandbox/Bootstrap4';
+const id = '6181188ae38676152e464fc2';
+
 /*
  * ItemsTree
  */
 const ItemsTree: FC = () => {
-  // TODO: get from props
-  const path = '/Sandbox/Bootstrap4';
-  const id = '6181188ae38676152e464fc2';
-
   const [initialNode, setInitialNode] = useState<ItemNode | null>(null);
 
-  // initial request
-  const { data: ancestorsData, error } = useSWRxPageAncestors(path, id);
-
+  // initial request this is important
+  const { data: ancestorsChildrenData, error } = useSWRxPageAncestorsChildren(path);
   // secondary request
-  const { data: ancestorsChildrenData, error: error2 } = useSWRxPageAncestorsChildren(ancestorsData != null ? path : null);
+  const { data: ancestorsData, error: error2 } = useSWRxPageAncestors(path, id);
 
-  if (error != null || ancestorsData == null) {
+
+  if (error != null || error2 != null) {
     return null;
   }
 
-  const { targetAndAncestors } = ancestorsData;
-  const newInitialNode = generateInitialNode(targetAndAncestors);
-
-  if (error2 != null) {
+  if (ancestorsData == null) {
     return null;
   }
 
   /*
-   * when second SWR resolved
+   * When initial request is taking long
+   */
+  if (ancestorsChildrenData == null) {
+    const { targetAndAncestors } = ancestorsData;
+    const newInitialNode = generateInitialNode(targetAndAncestors);
+    setInitialNode(newInitialNode); // rerender
+  }
+
+  /*
+   * When initial request finishes
    */
   if (ancestorsChildrenData != null) {
     // increment initialNode
+    const { targetAndAncestors } = ancestorsData;
     const { ancestorsChildren } = ancestorsChildrenData;
+    const ancestors = targetAndAncestors.filter(page => page.path !== path);
 
-    // flatten ancestors
-    const partialChildren: ItemNode[] = [];
-    let currentNode = newInitialNode;
-    while (currentNode.hasChildren() && currentNode?.children?.[0] != null) {
-      const child = currentNode.children[0];
-      partialChildren.push(child);
-      currentNode = child;
-    }
-
-    // update children
-    partialChildren.forEach((node) => {
-      const childPages = ancestorsChildren[node.page.path as string];
-      node.children = ItemNode.generateNodesFromPages(childPages);
-    });
+    const newInitialNode = generateInitialNodeWithChildren(ancestors, ancestorsChildren);
+    setInitialNode(newInitialNode); // rerender
   }
 
-  setInitialNode(newInitialNode); // rerender
-
-  if (initialNode == null) return null;
+  if (initialNode == null) {
+    return null;
+  }
 
   const isOpen = true;
   return (
     <>
-      <Item key={initialNode.page.path} itemNode={initialNode} isOpen={isOpen} />
+      <Item key={(initialNode as ItemNode).page.path} itemNode={(initialNode as ItemNode)} isOpen={isOpen} />
     </>
   );
 };

--- a/packages/app/src/components/Sidebar/PageTree/ItemsTree.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/ItemsTree.tsx
@@ -48,6 +48,10 @@ const ItemsTree: FC = () => {
   const { targetAndAncestors } = ancestorsData;
   const newInitialNode = generateInitialNode(targetAndAncestors);
 
+  if (error2 != null) {
+    return null;
+  }
+
   /*
    * when second SWR resolved
    */
@@ -82,5 +86,10 @@ const ItemsTree: FC = () => {
     </>
   );
 };
+
+/*
+ * ItemsTree wrapper
+ */
+
 
 export default ItemsTree;

--- a/packages/app/src/components/Sidebar/PageTree/ItemsTree.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/ItemsTree.tsx
@@ -42,7 +42,7 @@ const generateInitialNodeAfterResponse = (ancestorsChildren: Record<string, Part
     currentNode.children = ItemNode.generateNodesFromPages(childPages);
 
     const nextNode = currentNode.children.filter((node) => {
-      return paths.includes(node.page.path);
+      return paths.includes(node.page.path as string);
     })[0];
     currentNode = nextNode;
   });
@@ -60,7 +60,7 @@ const ItemsTree: FC = () => {
 
   const { data: targetAndAncestors, error } = useTargetAndAncestors();
 
-  const { data: ancestorsChildrenData, error: error2 } = useSWRxPageAncestorsChildren(targetAndAncestors != null ? path : null);
+  const { data: ancestorsChildrenData, error: error2 } = useSWRxPageAncestorsChildren(path);
 
   if (error != null || error2 != null) {
     return null;

--- a/packages/app/src/interfaces/page-listing-results.ts
+++ b/packages/app/src/interfaces/page-listing-results.ts
@@ -7,4 +7,7 @@ export interface AncestorsChildrenResult {
   ancestorsChildren: Record<ParentPath, Partial<IPage & HasObjectId>[]>
 }
 
-export type TargetAndAncestors = Partial<IPage & HasObjectId>[];
+export type TargetAndAncestors = {
+  targetAndAncestors: Partial<IPage & HasObjectId>[]
+  rootPage: Partial<IPage & HasObjectId>,
+}

--- a/packages/app/src/server/models/page.ts
+++ b/packages/app/src/server/models/page.ts
@@ -281,7 +281,13 @@ schema.statics.findAncestorsChildrenByPathAndViewer = async function(path: strin
   // get pages at once
   const queryBuilder = new PageQueryBuilder(this.find({ path: { $in: regexps } }));
   await addViewerCondition(queryBuilder, user, userGroups);
-  const pages: PageDocument[] = await queryBuilder.query.lean().exec();
+  const _pages = await queryBuilder.query.lean().exec();
+  const pages = _pages.map((page: PageDocument & {isTarget?: boolean}) => {
+    if (page.path === path) {
+      page.isTarget = true;
+    }
+    return page;
+  });
 
   // make map
   const pathToChildren: Record<string, PageDocument[]> = {};

--- a/packages/app/src/server/models/page.ts
+++ b/packages/app/src/server/models/page.ts
@@ -84,9 +84,7 @@ schema.plugin(uniqueValidator);
  * Methods
  */
 const collectAncestorPaths = (path: string, ancestorPaths: string[] = []): string[] => {
-  if (isTopPage(path)) {
-    return ancestorPaths;
-  }
+  if (isTopPage(path)) return ancestorPaths;
 
   const parentPath = nodePath.dirname(path);
   ancestorPaths.push(parentPath);

--- a/packages/app/src/server/models/page.ts
+++ b/packages/app/src/server/models/page.ts
@@ -301,6 +301,7 @@ schema.statics.findAncestorsChildrenByPathAndViewer = async function(path: strin
     .query
     .lean()
     .exec();
+  // mark target
   const pages = _pages.map((page: PageDocument & {isTarget?: boolean}) => {
     if (page.path === path) {
       page.isTarget = true;

--- a/packages/app/src/server/routes/apiv3/page-listing.ts
+++ b/packages/app/src/server/routes/apiv3/page-listing.ts
@@ -50,9 +50,15 @@ export default (crowi: Crowi): Router => {
 
     const Page: PageModel = crowi.model('Page');
 
-    const ancestorsChildren: Record<string, PageDocument[]> = await Page.findAncestorsChildrenByPathAndViewer(path as string, req.user);
+    try {
+      const ancestorsChildren: Record<string, PageDocument[]> = await Page.findAncestorsChildrenByPathAndViewer(path as string, req.user);
+      return res.apiv3({ ancestorsChildren });
+    }
+    catch (err) {
+      logger.error('Failed to get ancestorsChildren.', err);
+      return res.apiv3Err(new ErrorV3('Failed to get ancestorsChildren.'));
+    }
 
-    return res.apiv3({ ancestorsChildren });
   });
 
   /*

--- a/packages/app/src/server/routes/apiv3/page-listing.ts
+++ b/packages/app/src/server/routes/apiv3/page-listing.ts
@@ -48,7 +48,7 @@ export default (crowi: Crowi): Router => {
     const Page: PageModel = crowi.model('Page');
 
     try {
-      const ancestorsChildren: Record<string, PageDocument[]> = await Page.findAncestorsChildrenByPathAndViewer(path as string, req.user);
+      const ancestorsChildren = await Page.findAncestorsChildrenByPathAndViewer(path as string, req.user);
       return res.apiv3({ ancestorsChildren });
     }
     catch (err) {

--- a/packages/app/src/server/routes/page.js
+++ b/packages/app/src/server/routes/page.js
@@ -265,13 +265,13 @@ module.exports = function(crowi, app) {
   }
 
   async function addRenderVarsForPageTree(renderVars, path) {
-    const targetAndAncestors = await Page.findTargetAndAncestorsByPathOrId(path);
+    const { targetAndAncestors, rootPage } = await Page.findTargetAndAncestorsByPathOrId(path);
 
     if (targetAndAncestors.length === 0 && !isTopPage(path)) {
       throw new Error('Ancestors must have at least one page.');
     }
 
-    renderVars.targetAndAncestors = targetAndAncestors;
+    renderVars.targetAndAncestors = { targetAndAncestors, rootPage };
   }
 
   function replacePlaceholdersOfTemplate(template, req) {

--- a/packages/app/src/stores/context.tsx
+++ b/packages/app/src/stores/context.tsx
@@ -4,5 +4,5 @@ import { useStaticSWR } from './use-static-swr';
 import { TargetAndAncestors } from '../interfaces/page-listing-results';
 
 export const useTargetAndAncestors = (initialData?: TargetAndAncestors): SWRResponse<TargetAndAncestors, Error> => {
-  return useStaticSWR<TargetAndAncestors, Error>('targetAndAncestors', initialData);
+  return useStaticSWR<TargetAndAncestors, Error>('targetAndAncestors', initialData || null);
 };

--- a/packages/app/src/stores/context.tsx
+++ b/packages/app/src/stores/context.tsx
@@ -4,5 +4,5 @@ import { useStaticSWR } from './use-static-swr';
 import { TargetAndAncestors } from '../interfaces/page-listing-results';
 
 export const useTargetAndAncestors = (initialData?: TargetAndAncestors): SWRResponse<TargetAndAncestors, Error> => {
-  return useStaticSWR<TargetAndAncestors, Error>('swr-targetAndAncestors', initialData);
+  return useStaticSWR<TargetAndAncestors, Error>('targetAndAncestors', initialData);
 };

--- a/packages/app/src/stores/context.tsx
+++ b/packages/app/src/stores/context.tsx
@@ -4,5 +4,5 @@ import { useStaticSWR } from './use-static-swr';
 import { TargetAndAncestors } from '../interfaces/page-listing-results';
 
 export const useTargetAndAncestors = (initialData?: TargetAndAncestors): SWRResponse<TargetAndAncestors, Error> => {
-  return useStaticSWR<TargetAndAncestors, Error>('swr-targetAndAncestors', null, initialData);
+  return useStaticSWR<TargetAndAncestors, Error>('swr-targetAndAncestors', initialData);
 };

--- a/packages/app/src/stores/context.tsx
+++ b/packages/app/src/stores/context.tsx
@@ -4,5 +4,5 @@ import { useStaticSWR } from './use-static-swr';
 import { TargetAndAncestors } from '../interfaces/page-listing-results';
 
 export const useTargetAndAncestors = (initialData?: TargetAndAncestors): SWRResponse<TargetAndAncestors, Error> => {
-  return useStaticSWR<TargetAndAncestors, Error>('targetAndAncestors', initialData);
+  return useStaticSWR<TargetAndAncestors, Error>('swr-targetAndAncestors', null, initialData);
 };

--- a/packages/app/src/stores/page-listing.tsx
+++ b/packages/app/src/stores/page-listing.tsx
@@ -5,10 +5,10 @@ import { TargetAndAncestorsResult, AncestorsChildrenResult } from '../interfaces
 
 
 export const useSWRxPageAncestorsChildren = (
-    path: string | null,
+    path: string,
 ): SWRResponse<AncestorsChildrenResult, Error> => {
   return useSWR(
-    path ? `/page-listing/ancestors-children?path=${path}` : null,
+    `/page-listing/ancestors-children?path=${path}`,
     endpoint => apiv3Get(endpoint).then((response) => {
       return {
         ancestorsChildren: response.data.ancestorsChildren,

--- a/packages/app/src/stores/page-listing.tsx
+++ b/packages/app/src/stores/page-listing.tsx
@@ -14,5 +14,6 @@ export const useSWRxPageAncestorsChildren = (
         ancestorsChildren: response.data.ancestorsChildren,
       };
     }),
+    { revalidateOnFocus: false },
   );
 };

--- a/packages/app/src/stores/use-static-swr.tsx
+++ b/packages/app/src/stores/use-static-swr.tsx
@@ -6,8 +6,8 @@ import { Fetcher } from 'swr/dist/types';
 
 export const useStaticSWR = <Data, Error>(
   key: Key,
-  updateData?: Data | Fetcher<Data>,
   initialData?: Data | Fetcher<Data>,
+  updateData?: Data | Fetcher<Data>,
 ): SWRResponse<Data, Error> => {
   const { cache } = useSWRConfig();
 

--- a/packages/app/src/stores/use-static-swr.tsx
+++ b/packages/app/src/stores/use-static-swr.tsx
@@ -1,27 +1,26 @@
-import useSWR, {
-  Key, SWRResponse, mutate, useSWRConfig,
+import {
+  Key, SWRConfiguration, SWRResponse, mutate,
 } from 'swr';
+import useSWRImmutable from 'swr/immutable';
 import { Fetcher } from 'swr/dist/types';
 
 
-export const useStaticSWR = <Data, Error>(
-  key: Key,
-  initialData?: Data | Fetcher<Data>,
-  updateData?: Data | Fetcher<Data>,
-): SWRResponse<Data, Error> => {
-  const { cache } = useSWRConfig();
+export function useStaticSWR<Data, Error>(key: Key): SWRResponse<Data, Error>;
+export function useStaticSWR<Data, Error>(key: Key, data: Data | Fetcher<Data> | null): SWRResponse<Data, Error>;
+export function useStaticSWR<Data, Error>(key: Key, data: Data | Fetcher<Data> | null,
+  configuration: SWRConfiguration<Data, Error> | undefined): SWRResponse<Data, Error>;
 
-  if (updateData == null) {
-    if (cache.get(key) == null && initialData != null) {
-      mutate(key, initialData, false);
-    }
-  }
-  else {
-    mutate(key, updateData);
+export function useStaticSWR<Data, Error>(
+    ...args: readonly [Key]
+    | readonly [Key, Data | Fetcher<Data> | null]
+    | readonly [Key, Data | Fetcher<Data> | null, SWRConfiguration<Data, Error> | undefined]
+): SWRResponse<Data, Error> {
+  const [key, fetcher, configuration] = args;
+
+  const fetcherFixed = fetcher || configuration?.fetcher;
+  if (fetcherFixed != null) {
+    mutate(key, fetcherFixed);
   }
 
-  return useSWR(key, null, {
-    revalidateOnFocus: false,
-    revalidateOnReconnect: false,
-  });
-};
+  return useSWRImmutable(key, null, configuration);
+}

--- a/packages/app/src/utils/swr-utils.ts
+++ b/packages/app/src/utils/swr-utils.ts
@@ -1,9 +1,8 @@
 import { SWRConfiguration } from 'swr';
 
-import axios from './axios';
 
 export const swrGlobalConfiguration: SWRConfiguration = {
-  fetcher: url => axios.get(url).then(res => res.data),
+  fetcher: null,
   revalidateOnFocus: false,
   errorRetryCount: 1,
 };

--- a/packages/app/src/utils/swr-utils.ts
+++ b/packages/app/src/utils/swr-utils.ts
@@ -2,7 +2,5 @@ import { SWRConfiguration } from 'swr';
 
 
 export const swrGlobalConfiguration: SWRConfiguration = {
-  fetcher: undefined,
-  revalidateOnFocus: false,
   errorRetryCount: 1,
 };

--- a/packages/app/src/utils/swr-utils.ts
+++ b/packages/app/src/utils/swr-utils.ts
@@ -2,7 +2,7 @@ import { SWRConfiguration } from 'swr';
 
 
 export const swrGlobalConfiguration: SWRConfiguration = {
-  fetcher: null,
+  fetcher: undefined,
   revalidateOnFocus: false,
   errorRetryCount: 1,
 };


### PR DESCRIPTION
Redmine: https://estoc.weseek.co.jp/redmine/issues/81120

最初の PT レンダリングができるところまで実装しました。

## 実装箇所
- ancestors-children API を実装しました
  - これに必要なメソッドを Page モデルに追加しました
- ItemsTree コンポーネントを最大２~３回レンダリングされるようにしました(想定は２だけど３になるので atlaskit 箇所改修後に再検証)
- mongoose で re2 が使えない箇所を RegExp で代用しました
- useStaticSWR で最初のレンダリングで必要なデータを cache から取れるようにしました
  - useStaticSWR の移植は前回の PR でやりました
  - fetcher の初期値を null にしました
    - こうしないと /key に GET リクエストが飛んでしまうため