### PR TITLE
Feat/81294 change the icon depending on the type of notification

### DIFF
--- a/packages/app/src/components/InAppNotification/InAppNotificationElm.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationElm.tsx
@@ -73,16 +73,20 @@ const InAppNotificationElm = (props: Props): JSX.Element => {
 
   const actionType: string = notification.action;
   let actionMsg: string;
+  let actionIcon: string;
 
   switch (actionType) {
     case 'PAGE_UPDATE':
       actionMsg = 'updated on';
+      actionIcon = 'fa-file-o';
       break;
     case 'COMMENT_CREATE':
       actionMsg = 'commented on';
+      actionIcon = 'fa-comment-o';
       break;
     default:
       actionMsg = '';
+      actionIcon = '';
   }
 
 
@@ -96,7 +100,7 @@ const InAppNotificationElm = (props: Props): JSX.Element => {
           <div>
             <b>{actionUsers}</b> {actionMsg} <PagePathLabel page={pagePath} />
           </div>
-          <i className="fa fa-file-o mr-2" />
+          <i className={`fa ${actionIcon} mr-2`} />
           <FormattedDistanceDate id={notification._id} date={notification.createdAt} isShowTooltip={false} />
         </div>
       </div>


### PR DESCRIPTION
## Task
[#81294](https://estoc.weseek.co.jp/redmine/issues/81294) 通知の種類によってアイコンを変更する

## View
<img width="282" alt="スクリーンショット 2021-11-11 18 21 26" src="https://user-images.githubusercontent.com/34241526/141272729-9db99257-ec90-4c34-bb54-0b2ed3606a6d.png">

