### PR TITLE
hit in-app-notification api with mutate

### DIFF
--- a/packages/app/src/components/InAppNotification/InAppNotificationDropdown.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationDropdown.tsx
@@ -23,7 +23,7 @@ const InAppNotificationDropdown: FC<Props> = (props: Props) => {
   const [count, setCount] = useState(0);
   const [isOpen, setIsOpen] = useState(false);
   const limit = 6;
-  const { data: inAppNotificationData } = useSWRxInAppNotifications(limit);
+  const { data: inAppNotificationData, mutate } = useSWRxInAppNotifications(limit);
 
   useEffect(() => {
     initializeSocket(props);
@@ -59,11 +59,14 @@ const InAppNotificationDropdown: FC<Props> = (props: Props) => {
   };
 
   const toggleDropdownHandler = () => {
-    if (isOpen === false && count > 0) {
+    if (!isOpen && count > 0) {
       updateNotificationStatus();
     }
 
     const newIsOpenState = !isOpen;
+    if (newIsOpenState) {
+      mutate();
+    }
     setIsOpen(newIsOpenState);
   };
 


### PR DESCRIPTION
## Task
- [81245](https://estoc.weseek.co.jp/redmine/issues/81245) ベルマークを押したときに/listのapiが叩かれていないのを修正

dropdown buttonが isOpenの時に、`mutate()` でdataを再取得するようにしました。