### PR TITLE
Imprv/81019 time notation

### DIFF
--- a/packages/app/src/components/FormattedDistanceDate.jsx
+++ b/packages/app/src/components/FormattedDistanceDate.jsx
@@ -14,7 +14,7 @@ const FormattedDistanceDate = (props) => {
   const dateFormatted = format(date, 'yyyy/MM/dd HH:mm');
 
   const diff = Math.abs(differenceInSeconds(date, baseDate));
-  if (diff > props.differenceForAvoidingFormat) {
+  if (props.isEnabledShowDate && diff > props.differenceForAvoidingFormat) {
     return <>{dateFormatted}</>;
   }
 
@@ -35,10 +35,12 @@ FormattedDistanceDate.propTypes = {
   // the number(sec) from 'baseDate' to avoid format
   differenceForAvoidingFormat: PropTypes.number,
   isShowTooltip: PropTypes.bool,
+  isEnabledShowDate: PropTypes.bool,
 };
 FormattedDistanceDate.defaultProps = {
   differenceForAvoidingFormat: 86400 * 3,
   isShowTooltip: true,
+  isEnabledShowDate: true,
 };
 
 export default FormattedDistanceDate;

--- a/packages/app/src/components/FormattedDistanceDate.jsx
+++ b/packages/app/src/components/FormattedDistanceDate.jsx
@@ -14,7 +14,7 @@ const FormattedDistanceDate = (props) => {
   const dateFormatted = format(date, 'yyyy/MM/dd HH:mm');
 
   const diff = Math.abs(differenceInSeconds(date, baseDate));
-  if (props.isEnabledShowDate && diff > props.differenceForAvoidingFormat) {
+  if (!props.isNotShowDate && diff > props.differenceForAvoidingFormat) {
     return <>{dateFormatted}</>;
   }
 
@@ -35,12 +35,12 @@ FormattedDistanceDate.propTypes = {
   // the number(sec) from 'baseDate' to avoid format
   differenceForAvoidingFormat: PropTypes.number,
   isShowTooltip: PropTypes.bool,
-  isEnabledShowDate: PropTypes.bool,
+  isNotShowDate: PropTypes.bool,
 };
 FormattedDistanceDate.defaultProps = {
   differenceForAvoidingFormat: 86400 * 3,
   isShowTooltip: true,
-  isEnabledShowDate: true,
+  isNotShowDate: false,
 };
 
 export default FormattedDistanceDate;

--- a/packages/app/src/components/InAppNotification/InAppNotificationElm.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationElm.tsx
@@ -101,7 +101,12 @@ const InAppNotificationElm = (props: Props): JSX.Element => {
             <b>{actionUsers}</b> {actionMsg} <PagePathLabel page={pagePath} />
           </div>
           <i className={`${actionIcon} mr-2`} />
-          <FormattedDistanceDate id={notification._id} date={notification.createdAt} isShowTooltip={false} />
+          <FormattedDistanceDate
+            id={notification._id}
+            date={notification.createdAt}
+            differenceForAvoidingFormat={notification.createdAt}
+            isShowTooltip={false}
+          />
         </div>
       </div>
     </div>

--- a/packages/app/src/components/InAppNotification/InAppNotificationElm.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationElm.tsx
@@ -104,8 +104,8 @@ const InAppNotificationElm = (props: Props): JSX.Element => {
           <FormattedDistanceDate
             id={notification._id}
             date={notification.createdAt}
-            differenceForAvoidingFormat={notification.createdAt}
             isShowTooltip={false}
+            isEnabledShowDate={false}
           />
         </div>
       </div>

--- a/packages/app/src/components/InAppNotification/InAppNotificationElm.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationElm.tsx
@@ -101,12 +101,7 @@ const InAppNotificationElm = (props: Props): JSX.Element => {
             <b>{actionUsers}</b> {actionMsg} <PagePathLabel page={pagePath} />
           </div>
           <i className={`${actionIcon} mr-2`} />
-          <FormattedDistanceDate
-            id={notification._id}
-            date={notification.createdAt}
-            isShowTooltip={false}
-            isEnabledShowDate={false}
-          />
+          <FormattedDistanceDate id={notification._id} date={notification.createdAt} isShowTooltip={false} isNotShowDate />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Task
[#81019](https://redmine.weseek.co.jp/issues/81019) 時間表記の改善

## Memo 
1つの Notification ドキュメントに対する Activity が行われた時間がそれぞれ異なるため、具体的な時間表記（2021/11/11 21:18）を避け、曖昧な時間表記（3days）で表示できるようにしました。

<img width="292" alt="スクリーンショット 2021-11-12 15 37 46" src="https://user-images.githubusercontent.com/34241526/141421729-425da8ec-a48e-4680-9153-9322b7cacc7b.png">
  