### PR TITLE
Fix/80942 hit api multi times when page scrolled

### DIFF
--- a/packages/app/src/components/Navbar/SubNavButtons.jsx
+++ b/packages/app/src/components/Navbar/SubNavButtons.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import AppContainer from '~/client/services/AppContainer';
 import NavigationContainer from '~/client/services/NavigationContainer';

--- a/packages/app/src/components/Navbar/SubNavButtons.jsx
+++ b/packages/app/src/components/Navbar/SubNavButtons.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import AppContainer from '~/client/services/AppContainer';
 import NavigationContainer from '~/client/services/NavigationContainer';
@@ -10,7 +10,7 @@ import LikeButtons from '../LikeButtons';
 import SubscribeButton from '../SubscribeButton';
 import PageManagement from '../Page/PageManagement';
 
-const SubnavButtons = (props) => {
+const SubnavButtons = React.memo((props) => {
   const {
     appContainer, navigationContainer, pageContainer, isCompactMode,
   } = props;
@@ -49,7 +49,7 @@ const SubnavButtons = (props) => {
       )}
     </>
   );
-};
+});
 
 /**
  * Wrapper component for using unstated

--- a/packages/app/src/components/SubscribeButton.tsx
+++ b/packages/app/src/components/SubscribeButton.tsx
@@ -1,12 +1,9 @@
-import React, {
-  FC, useState, useCallback, useEffect,
-} from 'react';
+import React, { FC } from 'react';
 
 
 import { Types } from 'mongoose';
 import { useTranslation } from 'react-i18next';
 import { UncontrolledTooltip } from 'reactstrap';
-import { SubscribeStatuses } from '~/interfaces/in-app-notification-settings';
 import { withUnstatedContainers } from './UnstatedUtils';
 import { useSWRxSubscribeButton } from '../stores/page';
 
@@ -22,35 +19,8 @@ type Props = {
 
 const SubscribeButton: FC<Props> = (props: Props) => {
   const { t } = useTranslation();
-
   const { appContainer, pageId } = props;
-  // const [isSubscribing, setIsSubscribing] = useState<boolean | null>(null);
   const { data: subscriptionData, mutate } = useSWRxSubscribeButton(pageId);
-  console.log('subscriptionData', subscriptionData);
-
-  const fetchSubscriptionStatus = useCallback(async() => {
-    if (appContainer.isGuestUser) {
-      return;
-    }
-
-    try {
-      const res = await appContainer.apiv3Get('page/subscribe', { pageId });
-      const { subscribing } = res.data;
-      if (subscribing == null) {
-        // setIsSubscribing(null);
-      }
-      else {
-        // setIsSubscribing(subscribing);
-      }
-    }
-    catch (err) {
-      toastError(err);
-    }
-  }, [appContainer, pageId]);
-
-  useEffect(() => {
-    fetchSubscriptionStatus();
-  }, [fetchSubscriptionStatus]);
 
   if (subscriptionData == null) {
     return <></>;
@@ -74,10 +44,7 @@ const SubscribeButton: FC<Props> = (props: Props) => {
       console.log('subscriptionData_handleclick', subscriptionData.status);
       const res = await appContainer.apiv3Put('page/subscribe', { pageId, status: !isSubscribing });
       if (res) {
-        console.log('res.data', res.data);
         mutate();
-        const { subscription } = res.data;
-        // setIsSubscribing(subscription.status === 'SUBSCRIBE');
       }
     }
     catch (err) {

--- a/packages/app/src/components/SubscribeButton.tsx
+++ b/packages/app/src/components/SubscribeButton.tsx
@@ -2,9 +2,11 @@ import React, {
   FC, useState, useCallback, useEffect,
 } from 'react';
 
+
 import { Types } from 'mongoose';
 import { useTranslation } from 'react-i18next';
 import { UncontrolledTooltip } from 'reactstrap';
+import { SubscribeStatuses } from '~/interfaces/in-app-notification-settings';
 import { withUnstatedContainers } from './UnstatedUtils';
 import { useSWRxSubscribeButton } from '../stores/page';
 
@@ -22,35 +24,9 @@ const SubscribeButton: FC<Props> = (props: Props) => {
   const { t } = useTranslation();
 
   const { appContainer, pageId } = props;
-  const [isSubscribing, setIsSubscribing] = useState<boolean | null>(null);
+  // const [isSubscribing, setIsSubscribing] = useState<boolean | null>(null);
   const { data: subscriptionData, mutate } = useSWRxSubscribeButton(pageId);
   console.log('subscriptionData', subscriptionData);
-
-  if (subscriptionData == null) {
-    console.log('hoge');
-  }
-
-
-  const buttonClass = `${isSubscribing ? 'active' : ''} ${appContainer.isGuestUser ? 'disabled' : ''}`;
-  const iconClass = isSubscribing || isSubscribing == null ? 'fa fa-eye' : 'fa fa-eye-slash';
-
-  const handleClick = async() => {
-    if (appContainer.isGuestUser) {
-      return;
-    }
-
-    try {
-      const res = await appContainer.apiv3Put('page/subscribe', { pageId, status: !isSubscribing });
-      if (res) {
-        const { subscription } = res.data;
-        setIsSubscribing(subscription.status === 'SUBSCRIBE');
-        mutate();
-      }
-    }
-    catch (err) {
-      toastError(err);
-    }
-  };
 
   const fetchSubscriptionStatus = useCallback(async() => {
     if (appContainer.isGuestUser) {
@@ -61,10 +37,10 @@ const SubscribeButton: FC<Props> = (props: Props) => {
       const res = await appContainer.apiv3Get('page/subscribe', { pageId });
       const { subscribing } = res.data;
       if (subscribing == null) {
-        setIsSubscribing(null);
+        // setIsSubscribing(null);
       }
       else {
-        setIsSubscribing(subscribing);
+        // setIsSubscribing(subscribing);
       }
     }
     catch (err) {
@@ -75,6 +51,35 @@ const SubscribeButton: FC<Props> = (props: Props) => {
   useEffect(() => {
     fetchSubscriptionStatus();
   }, [fetchSubscriptionStatus]);
+
+  if (subscriptionData == null) {
+    return <></>;
+  }
+
+  const isSubscribing = subscriptionData.status === SubscribeStatuses.STATUS_SUBSCRIBE;
+
+  const buttonClass = `${isSubscribing ? 'active' : ''} ${appContainer.isGuestUser ? 'disabled' : ''}`;
+  const iconClass = isSubscribing || isSubscribing == null ? 'fa fa-eye' : 'fa fa-eye-slash';
+
+  const handleClick = async() => {
+    if (appContainer.isGuestUser) {
+      return;
+    }
+
+    try {
+      console.log('subscriptionData_handleclick', subscriptionData.status);
+      const res = await appContainer.apiv3Put('page/subscribe', { pageId, status: !isSubscribing });
+      if (res) {
+        console.log('res.data', res.data);
+        mutate();
+        const { subscription } = res.data;
+        // setIsSubscribing(subscription.status === 'SUBSCRIBE');
+      }
+    }
+    catch (err) {
+      toastError(err);
+    }
+  };
 
   return (
     <>

--- a/packages/app/src/components/SubscribeButton.tsx
+++ b/packages/app/src/components/SubscribeButton.tsx
@@ -36,7 +36,7 @@ const SubscribeButton: FC<Props> = (props: Props) => {
     );
   }
 
-  let isSubscribing;
+  let isSubscribing = false;
 
   if (subscriptionData.status) {
     isSubscribing = true;

--- a/packages/app/src/components/SubscribeButton.tsx
+++ b/packages/app/src/components/SubscribeButton.tsx
@@ -41,7 +41,6 @@ const SubscribeButton: FC<Props> = (props: Props) => {
     }
 
     try {
-      console.log('subscriptionData_handleclick', subscriptionData.status);
       const res = await appContainer.apiv3Put('page/subscribe', { pageId, status: !isSubscribing });
       if (res) {
         mutate();

--- a/packages/app/src/components/SubscribeButton.tsx
+++ b/packages/app/src/components/SubscribeButton.tsx
@@ -23,7 +23,7 @@ const SubscribeButton: FC<Props> = (props: Props) => {
 
   const { appContainer, pageId } = props;
   const [isSubscribing, setIsSubscribing] = useState<boolean | null>(null);
-  const { data: subscriptionData } = useSWRxSubscribeButton(pageId);
+  const { data: subscriptionData, mutate } = useSWRxSubscribeButton(pageId);
   console.log('subscriptionData', subscriptionData);
 
   if (subscriptionData == null) {

--- a/packages/app/src/components/SubscribeButton.tsx
+++ b/packages/app/src/components/SubscribeButton.tsx
@@ -36,21 +36,21 @@ const SubscribeButton: FC<Props> = (props: Props) => {
     );
   }
 
-  let isSubscribing;
+  let isSubscribed;
 
   switch (subscriptionData.status) {
     case true:
-      isSubscribing = true;
+      isSubscribed = true;
       break;
     case false:
-      isSubscribing = false;
+      isSubscribed = false;
       break;
     default:
-      isSubscribing = null;
+      isSubscribed = null;
   }
 
-  const buttonClass = `${isSubscribing ? 'active' : ''} ${appContainer.isGuestUser ? 'disabled' : ''}`;
-  const iconClass = isSubscribing || isSubscribing == null ? 'fa fa-eye' : 'fa fa-eye-slash';
+  const buttonClass = `${isSubscribed ? 'active' : ''} ${appContainer.isGuestUser ? 'disabled' : ''}`;
+  const iconClass = isSubscribed || isSubscribed == null ? 'fa fa-eye' : 'fa fa-eye-slash';
 
   const handleClick = async() => {
     if (appContainer.isGuestUser) {
@@ -58,7 +58,7 @@ const SubscribeButton: FC<Props> = (props: Props) => {
     }
 
     try {
-      const res = await appContainer.apiv3Put('page/subscribe', { pageId, status: !isSubscribing });
+      const res = await appContainer.apiv3Put('page/subscribe', { pageId, status: !isSubscribed });
       if (res) {
         mutate();
       }

--- a/packages/app/src/components/SubscribeButton.tsx
+++ b/packages/app/src/components/SubscribeButton.tsx
@@ -56,7 +56,11 @@ const SubscribeButton: FC<Props> = (props: Props) => {
     return <></>;
   }
 
-  const isSubscribing = subscriptionData.status === SubscribeStatuses.STATUS_SUBSCRIBE;
+  let isSubscribing;
+
+  if (subscriptionData.status) {
+    isSubscribing = true;
+  }
 
   const buttonClass = `${isSubscribing ? 'active' : ''} ${appContainer.isGuestUser ? 'disabled' : ''}`;
   const iconClass = isSubscribing || isSubscribing == null ? 'fa fa-eye' : 'fa fa-eye-slash';

--- a/packages/app/src/components/SubscribeButton.tsx
+++ b/packages/app/src/components/SubscribeButton.tsx
@@ -22,23 +22,9 @@ const SubscribeButton: FC<Props> = (props: Props) => {
   const { appContainer, pageId } = props;
   const { data: subscriptionData, mutate } = useSWRxSubscribeButton(pageId);
 
-  if (subscriptionData == null) {
-    // render default subscribe icon
-    return (
-      <>
-        <button
-          type="button"
-          className="btn btn-subscribe border-0"
-        >
-          <i className="fa fa-eye"></i>
-        </button>
-      </>
-    );
-  }
-
   let isSubscribed;
 
-  switch (subscriptionData.status) {
+  switch (subscriptionData?.status) {
     case true:
       isSubscribed = true;
       break;

--- a/packages/app/src/components/SubscribeButton.tsx
+++ b/packages/app/src/components/SubscribeButton.tsx
@@ -23,7 +23,17 @@ const SubscribeButton: FC<Props> = (props: Props) => {
   const { data: subscriptionData, mutate } = useSWRxSubscribeButton(pageId);
 
   if (subscriptionData == null) {
-    return <></>;
+    // render default subscribe icon
+    return (
+      <>
+        <button
+          type="button"
+          className="btn btn-subscribe border-0"
+        >
+          <i className="fa fa-eye"></i>
+        </button>
+      </>
+    );
   }
 
   let isSubscribing;

--- a/packages/app/src/components/SubscribeButton.tsx
+++ b/packages/app/src/components/SubscribeButton.tsx
@@ -44,6 +44,7 @@ const SubscribeButton: FC<Props> = (props: Props) => {
       if (res) {
         const { subscription } = res.data;
         setIsSubscribing(subscription.status === 'SUBSCRIBE');
+        mutate();
       }
     }
     catch (err) {

--- a/packages/app/src/components/SubscribeButton.tsx
+++ b/packages/app/src/components/SubscribeButton.tsx
@@ -2,9 +2,12 @@ import React, {
   FC, useState, useCallback, useEffect,
 } from 'react';
 
+import { Types } from 'mongoose';
 import { useTranslation } from 'react-i18next';
 import { UncontrolledTooltip } from 'reactstrap';
 import { withUnstatedContainers } from './UnstatedUtils';
+import { useSWRxSubscribeButton } from '../stores/page';
+
 
 import { toastError } from '~/client/util/apiNotification';
 import AppContainer from '~/client/services/AppContainer';
@@ -12,7 +15,7 @@ import PageContainer from '~/client/services/PageContainer';
 
 type Props = {
   appContainer: AppContainer,
-  pageId: string,
+  pageId: Types.ObjectId,
 };
 
 const SubscribeButton: FC<Props> = (props: Props) => {
@@ -20,6 +23,13 @@ const SubscribeButton: FC<Props> = (props: Props) => {
 
   const { appContainer, pageId } = props;
   const [isSubscribing, setIsSubscribing] = useState<boolean | null>(null);
+  const { data: subscriptionData } = useSWRxSubscribeButton(pageId);
+  console.log('subscriptionData', subscriptionData);
+
+  if (subscriptionData == null) {
+    console.log('hoge');
+  }
+
 
   const buttonClass = `${isSubscribing ? 'active' : ''} ${appContainer.isGuestUser ? 'disabled' : ''}`;
   const iconClass = isSubscribing || isSubscribing == null ? 'fa fa-eye' : 'fa fa-eye-slash';

--- a/packages/app/src/components/SubscribeButton.tsx
+++ b/packages/app/src/components/SubscribeButton.tsx
@@ -36,10 +36,17 @@ const SubscribeButton: FC<Props> = (props: Props) => {
     );
   }
 
-  let isSubscribing = false;
+  let isSubscribing;
 
-  if (subscriptionData.status) {
-    isSubscribing = true;
+  switch (subscriptionData.status) {
+    case true:
+      isSubscribing = true;
+      break;
+    case false:
+      isSubscribing = false;
+      break;
+    default:
+      isSubscribing = null;
   }
 
   const buttonClass = `${isSubscribing ? 'active' : ''} ${appContainer.isGuestUser ? 'disabled' : ''}`;

--- a/packages/app/src/interfaces/in-app-notification-settings.ts
+++ b/packages/app/src/interfaces/in-app-notification-settings.ts
@@ -7,6 +7,13 @@ export enum subscribeRuleNames {
 export enum SubscribeRuleDescriptions {
   PAGE_CREATE = 'in_app_notification_settings.default_subscribe_rules.page_create',
 }
+
+
+export enum SubscribeStatuses {
+  STATUS_SUBSCRIBE = 'SUBSCRIBE',
+  STATUS_UNSUBSCRIBE = 'UNSUBSCRIBE'
+}
+
 export interface ISubscribeRule {
   name: subscribeRuleNames;
   isEnabled: boolean;

--- a/packages/app/src/interfaces/in-app-notification-settings.ts
+++ b/packages/app/src/interfaces/in-app-notification-settings.ts
@@ -8,12 +8,6 @@ export enum SubscribeRuleDescriptions {
   PAGE_CREATE = 'in_app_notification_settings.default_subscribe_rules.page_create',
 }
 
-
-export enum SubscribeStatuses {
-  STATUS_SUBSCRIBE = 'SUBSCRIBE',
-  STATUS_UNSUBSCRIBE = 'UNSUBSCRIBE'
-}
-
 export interface ISubscribeRule {
   name: subscribeRuleNames;
   isEnabled: boolean;

--- a/packages/app/src/stores/page.tsx
+++ b/packages/app/src/stores/page.tsx
@@ -45,7 +45,7 @@ export const useSWRxSubscribeButton = <Data, Error>(
     endpoint => apiv3Get(endpoint, { pageId }).then((response) => {
       console.log(response);
       return {
-        status: response.data.status,
+        status: response.data.subscribing,
       };
     }),
   );

--- a/packages/app/src/stores/page.tsx
+++ b/packages/app/src/stores/page.tsx
@@ -39,7 +39,7 @@ export const useSWRxSubscribeButton = <Data, Error>(
 
 ): SWRResponse<{status: boolean | null}, Error> => {
   return useSWR(
-    '/page/subscribe',
+    ['/page/subscribe', pageId],
     endpoint => apiv3Get(endpoint, { pageId }).then((response) => {
       return {
         status: response.data.subscribing,

--- a/packages/app/src/stores/page.tsx
+++ b/packages/app/src/stores/page.tsx
@@ -40,7 +40,7 @@ export const useSWRxSubscribeButton = <Data, Error>(
 ): SWRResponse<{status: boolean | null}, Error> => {
   return useSWR(
     ['/page/subscribe', pageId],
-    endpoint => apiv3Get(endpoint, { pageId }).then((response) => {
+    (endpoint, pageId) => apiv3Get(endpoint, { pageId }).then((response) => {
       return {
         status: response.data.subscribing,
       };

--- a/packages/app/src/stores/page.tsx
+++ b/packages/app/src/stores/page.tsx
@@ -43,7 +43,6 @@ export const useSWRxSubscribeButton = <Data, Error>(
   return useSWR(
     'page/subscribe',
     endpoint => apiv3Get(endpoint, { pageId }).then((response) => {
-      console.log(response);
       return {
         status: response.data.subscribing,
       };

--- a/packages/app/src/stores/page.tsx
+++ b/packages/app/src/stores/page.tsx
@@ -1,6 +1,9 @@
 import useSWR, { SWRResponse } from 'swr';
 
+import { Types } from 'mongoose';
+
 import { apiv3Get } from '~/client/util/apiv3-client';
+import { SubscribeStatuses } from '~/interfaces/in-app-notification-settings';
 
 import { IPage } from '~/interfaces/page';
 import { IPagingResult } from '~/interfaces/paging-result';
@@ -27,6 +30,22 @@ export const useSWRxPageList = (
         items: response.data.pages,
         totalCount: response.data.totalCount,
         limit: response.data.limit,
+      };
+    }),
+  );
+};
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const useSWRxSubscribeButton = <Data, Error>(
+  pageId: Types.ObjectId,
+
+): SWRResponse<{status: SubscribeStatuses}, Error> => {
+  return useSWR(
+    'page/subscribe',
+    endpoint => apiv3Get(endpoint, { pageId }).then((response) => {
+      console.log(response);
+      return {
+        status: response.data.status,
       };
     }),
   );

--- a/packages/app/src/stores/page.tsx
+++ b/packages/app/src/stores/page.tsx
@@ -39,7 +39,7 @@ export const useSWRxSubscribeButton = <Data, Error>(
 
 ): SWRResponse<{status: boolean | null}, Error> => {
   return useSWR(
-    'page/subscribe',
+    '/page/subscribe',
     endpoint => apiv3Get(endpoint, { pageId }).then((response) => {
       return {
         status: response.data.subscribing,

--- a/packages/app/src/stores/page.tsx
+++ b/packages/app/src/stores/page.tsx
@@ -39,7 +39,7 @@ export const useSWRxPageList = (
 export const useSWRxSubscribeButton = <Data, Error>(
   pageId: Types.ObjectId,
 
-): SWRResponse<{status: SubscribeStatuses}, Error> => {
+): SWRResponse<{status: boolean | null}, Error> => {
   return useSWR(
     'page/subscribe',
     endpoint => apiv3Get(endpoint, { pageId }).then((response) => {

--- a/packages/app/src/stores/page.tsx
+++ b/packages/app/src/stores/page.tsx
@@ -1,9 +1,7 @@
 import useSWR, { SWRResponse } from 'swr';
 
 import { Types } from 'mongoose';
-
 import { apiv3Get } from '~/client/util/apiv3-client';
-import { SubscribeStatuses } from '~/interfaces/in-app-notification-settings';
 
 import { IPage } from '~/interfaces/page';
 import { IPagingResult } from '~/interfaces/paging-result';


### PR DESCRIPTION
## Task
- [#80942](https://redmine.weseek.co.jp/issues/80942) スクロール時にsubscribeのapiが複数叩かれることの修正

## Description
- `React.memo()`によって不要なレンダリングを防ぐ
- swrを使ってapiGetをする


## Screen Recording
[1]サブナビバーのsubscribe buttonのstatusが同じであることを確認

https://user-images.githubusercontent.com/59536731/141602817-6cca40a4-57a5-40d2-8652-1b902d67db87.mov

 [2]リロードした時の挙動
- statusの反映まで1テンポ遅れます。

https://user-images.githubusercontent.com/59536731/141602963-0c6e166c-f679-461f-86fa-49198fb82cb9.mov


 