### PR TITLE
get search results including comments

### DIFF
--- a/packages/app/src/server/service/search-delegator/elasticsearch.js
+++ b/packages/app/src/server/service/search-delegator/elasticsearch.js
@@ -604,7 +604,7 @@ class ElasticsearchDelegator {
   }
 
   createSearchQuerySortedByScore(option) {
-    let fields = ['path', 'bookmark_count', 'comment_count', 'updated_at', 'tag_names'];
+    let fields = ['path', 'bookmark_count', 'comment_count', 'updated_at', 'tag_names', 'comments'];
     if (option) {
       fields = option.fields || fields;
     }
@@ -660,7 +660,7 @@ class ElasticsearchDelegator {
         multi_match: {
           query: parsedKeywords.match.join(' '),
           type: 'most_fields',
-          fields: ['path.ja^2', 'path.en^2', 'body.ja', 'body.en'],
+          fields: ['path.ja^2', 'path.en^2', 'body.ja', 'body.en', 'comments.ja', 'comments.en'],
         },
       };
       query.body.query.bool.must.push(q);
@@ -670,7 +670,7 @@ class ElasticsearchDelegator {
       const q = {
         multi_match: {
           query: parsedKeywords.not_match.join(' '),
-          fields: ['path.ja', 'path.en', 'body.ja', 'body.en'],
+          fields: ['path.ja', 'path.en', 'body.ja', 'body.en', 'comments.ja', 'comments.en'],
           operator: 'or',
         },
       };

--- a/packages/app/src/server/service/search-delegator/elasticsearch.js
+++ b/packages/app/src/server/service/search-delegator/elasticsearch.js
@@ -682,12 +682,13 @@ class ElasticsearchDelegator {
       parsedKeywords.phrase.forEach((phrase) => {
         phraseQueries.push({
           multi_match: {
-            query: phrase, // each phrase is quoteted words
+            query: phrase, // each phrase is quoteted words like "This is GROWI"
             type: 'phrase',
             fields: [
               // Not use "*.ja" fields here, because we want to analyze (parse) search words
               'path.raw^2',
               'body',
+              'comments',
             ],
           },
         });


### PR DESCRIPTION
## Task
- [#80702](https://redmine.weseek.co.jp/issues/80702) 検索結果のresultsにコメントを含むことができる

## Note
- 検索した時に、コメントも検索結果のresultsに含まれるようにしました。
- 「検索結果でのコメントの**表示**」は、検索結果画面改修の方でスコープに入るので、ここでは触れていません。

### リビルドインデックス
「インデックスのリビルド」も検証済み。元々あるコメントもリビルドすれば、検索対象に入ることを確認してあります。
順番は以下の通りです。

1. リビルドインデックスしようとすると、以下のようなトーストエラーが出るのと、「インデックスの状態」が「破損」のラベルになる。
<img width="379" alt="Screen Shot 2021-11-18 at 1 59 55" src="https://user-images.githubusercontent.com/59536731/142249765-4e6b6d58-3686-48a6-9193-2b2d915f2145.png">
<img width="1301" alt="Screen Shot 2021-11-18 at 2 03 07" src="https://user-images.githubusercontent.com/59536731/142249807-94f0a334-215c-44cd-b4e9-78f676d939e8.png">
2.  インデックスの正規化
3.  再度「インデックスのリビルド」を行いました。


## Screen Recording
https://user-images.githubusercontent.com/59536731/142247895-68f5c942-e491-4bc7-a24b-bab93116f5b6.mov


