### PR TITLE
Extract context before rendering other components

### DIFF
--- a/packages/app/src/client/app.jsx
+++ b/packages/app/src/client/app.jsx
@@ -155,23 +155,42 @@ if (pageContainer.state.path != null) {
   });
 }
 
-Object.keys(componentMappings).forEach((key) => {
-  const elem = document.getElementById(key);
-  if (elem) {
-    ReactDOM.render(
-      <I18nextProvider i18n={i18n}>
-        <ErrorBoundary>
-          <SWRConfig value={swrGlobalConfiguration}>
-            <Provider inject={injectableContainers}>
-              {componentMappings[key]}
-            </Provider>
-          </SWRConfig>
-        </ErrorBoundary>
-      </I18nextProvider>,
-      elem,
-    );
-  }
-});
+const renderMainComponents = () => {
+  Object.keys(componentMappings).forEach((key) => {
+    const elem = document.getElementById(key);
+    if (elem) {
+      ReactDOM.render(
+        <I18nextProvider i18n={i18n}>
+          <ErrorBoundary>
+            <SWRConfig value={swrGlobalConfiguration}>
+              <Provider inject={injectableContainers}>
+                {componentMappings[key]}
+              </Provider>
+            </SWRConfig>
+          </ErrorBoundary>
+        </I18nextProvider>,
+        elem,
+      );
+    }
+  });
+};
+
+// extract context before rendering main components
+const elem = document.getElementById('page-context');
+ReactDOM.render(
+  <I18nextProvider i18n={i18n}>
+    <ErrorBoundary>
+      <SWRConfig value={swrGlobalConfiguration}>
+        <Provider inject={injectableContainers}>
+          {componentMappings['page-context']}
+        </Provider>
+      </SWRConfig>
+    </ErrorBoundary>
+  </I18nextProvider>,
+  elem,
+  renderMainComponents,
+);
+
 
 // initialize scrollpos-styler
 ScrollPosStyler.init();

--- a/packages/app/src/stores/context.tsx
+++ b/packages/app/src/stores/context.tsx
@@ -7,8 +7,8 @@ import { useStaticSWR } from './use-static-swr';
 
 type Nullable<T> = T | null;
 
-export const useCurrentUser = (initialData?: IUser): SWRResponse<Nullable<IUser>, any> => {
-  return useStaticSWR<Nullable<any>, Error>('currentUser', initialData);
+export const useCurrentUser = (initialData?: IUser): SWRResponse<Nullable<IUser>, Error> => {
+  return useStaticSWR<Nullable<IUser>, Error>('currentUser', initialData || null);
 };
 
 export const useRevisionId = (initialData?: Nullable<any>): SWRResponse<Nullable<any>, Error> => {


### PR DESCRIPTION
Redmine: https://redmine.weseek.co.jp/issues/81481

```
Warning: Cannot update a component (`SidebarNav`) while rendering a different component (`ContextExtractor`). To locate the bad setState() call inside `ContextExtractor`, follow the stack trace as described in https://fb.me/setstate-in-render
```

このエラーを解消しました

ContextExtractor の render のコールバックにその他のコンポーネントの render を入れました。