### PR TITLE
remove @types/mongoose-paginate-v2 to avoid typescript errors

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -162,7 +162,6 @@
     "@handsontable/react": "=2.1.0",
     "@types/compression": "^1.7.0",
     "@types/express": "^4.17.11",
-    "@types/mongoose-paginate-v2": "1.3.9",
     "@types/multer": "^1.4.5",
     "@types/react-dom": "^17.0.9",
     "autoprefixer": "^9.0.0",

--- a/packages/app/src/components/InAppNotification/InAppNotificationList.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationList.tsx
@@ -1,13 +1,14 @@
 import React, { FC } from 'react';
 
-import { PaginateResult } from 'mongoose';
 import { useTranslation } from 'react-i18next';
 import { IInAppNotification } from '../../interfaces/in-app-notification';
 import InAppNotificationElm from './InAppNotificationElm';
 
 
 type Props = {
-  inAppNotificationData: PaginateResult<IInAppNotification> | undefined;
+  // TODO: import @types/mongoose-paginate-v2 and use PaginateResult as a type after upgrading mongoose v6.0.0
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  inAppNotificationData: any;
 };
 
 const InAppNotificationList: FC<Props> = (props: Props) => {

--- a/packages/app/src/components/InAppNotification/InAppNotificationList.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationList.tsx
@@ -1,14 +1,12 @@
 import React, { FC } from 'react';
 
 import { useTranslation } from 'react-i18next';
-import { IInAppNotification } from '../../interfaces/in-app-notification';
+import { IInAppNotification, PaginateResult } from '../../interfaces/in-app-notification';
 import InAppNotificationElm from './InAppNotificationElm';
 
 
 type Props = {
-  // TODO: import @types/mongoose-paginate-v2 and use PaginateResult as a type after upgrading mongoose v6.0.0
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  inAppNotificationData: any;
+  inAppNotificationData?: PaginateResult<IInAppNotification>;
 };
 
 const InAppNotificationList: FC<Props> = (props: Props) => {

--- a/packages/app/src/interfaces/in-app-notification.ts
+++ b/packages/app/src/interfaces/in-app-notification.ts
@@ -13,9 +13,9 @@ export interface IInAppNotification {
 /*
 * Note:
 * Need to use mongoose PaginateResult as a type after upgrading mongoose v6.0.0.
-* Until then, use the original "PagenateResult".
+* Until then, use the original "PaginateResult".
 */
-export interface PagenateResult<T> {
+export interface PaginateResult<T> {
   docs: T[];
   hasNextPage: boolean;
   hasPrevPage: boolean;

--- a/packages/app/src/interfaces/in-app-notification.ts
+++ b/packages/app/src/interfaces/in-app-notification.ts
@@ -9,3 +9,22 @@ export interface IInAppNotification {
   actionUsers: any[] /* Need to set "User[]" as a type" */
   createdAt: string
 }
+
+/*
+* Note:
+* Need to use mongoose PaginateResult as a type after upgrading mongoose v6.0.0.
+* Until then, use the original "PagenateResult".
+*/
+export interface PagenateResult<T> {
+  docs: T[];
+  hasNextPage: boolean;
+  hasPrevPage: boolean;
+  limit: number;
+  nextPage: number | null;
+  offset: number;
+  page: number;
+  pagingCounter: number;
+  prevPage: number | null;
+  totalDocs: number;
+  totalPages: number;
+}

--- a/packages/app/src/server/models/in-app-notification-settings.ts
+++ b/packages/app/src/server/models/in-app-notification-settings.ts
@@ -6,7 +6,7 @@ import { IInAppNotificationSettings, subscribeRuleNames } from '../../interfaces
 export interface InAppNotificationSettingsDocument extends IInAppNotificationSettings, Document {}
 export type InAppNotificationSettingsModel = Model<InAppNotificationSettingsDocument>
 
-const inAppNotificationSettingsSchema = new Schema<IInAppNotificationSettings>({
+const inAppNotificationSettingsSchema = new Schema<InAppNotificationSettingsDocument>({
   userId: { type: Schema.Types.ObjectId },
   subscribeRules: [
     {

--- a/packages/app/src/server/models/in-app-notification-settings.ts
+++ b/packages/app/src/server/models/in-app-notification-settings.ts
@@ -6,7 +6,7 @@ import { IInAppNotificationSettings, subscribeRuleNames } from '../../interfaces
 export interface InAppNotificationSettingsDocument extends IInAppNotificationSettings, Document {}
 export type InAppNotificationSettingsModel = Model<InAppNotificationSettingsDocument>
 
-const inAppNotificationSettingsSchema = new Schema<InAppNotificationSettingsDocument>({
+const inAppNotificationSettingsSchema = new Schema<InAppNotificationSettingsDocument, InAppNotificationSettingsModel>({
   userId: { type: Schema.Types.ObjectId },
   subscribeRules: [
     {

--- a/packages/app/src/server/models/in-app-notification.ts
+++ b/packages/app/src/server/models/in-app-notification.ts
@@ -1,5 +1,5 @@
 import {
-  Types, Document, PaginateModel, Schema, /* , Query */
+  Types, Document, Schema, Model,
 } from 'mongoose';
 import mongoosePaginate from 'mongoose-paginate-v2';
 
@@ -24,7 +24,7 @@ export interface InAppNotificationDocument extends Document {
 }
 
 
-export interface InAppNotificationModel extends PaginateModel<InAppNotificationDocument> {
+export interface InAppNotificationModel extends Model<InAppNotificationDocument> {
   findLatestInAppNotificationsByUser(user: Types.ObjectId, skip: number, offset: number)
   getUnreadCountByUser(user: Types.ObjectId): Promise<number | undefined>
   open(user, id: Types.ObjectId): Promise<InAppNotificationDocument | null>

--- a/packages/app/src/server/service/in-app-notification.ts
+++ b/packages/app/src/server/service/in-app-notification.ts
@@ -1,4 +1,4 @@
-import { Types, PaginateResult } from 'mongoose';
+import { Types } from 'mongoose';
 import { subDays } from 'date-fns';
 import Crowi from '../crowi';
 import {
@@ -86,11 +86,15 @@ export default class InAppNotificationService {
   getLatestNotificationsByUser = async(
       userId: Types.ObjectId,
       queryOptions: {offset: number, limit: number},
-  ): Promise<PaginateResult<InAppNotificationDocument>> => {
+  // TODO: import @types/mongoose-paginate-v2 and use PaginateResult as a type after upgrading mongoose v6.0.0
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ): Promise<any> => {
     const { limit, offset } = queryOptions;
 
     try {
-      const paginationResult = await InAppNotification.paginate(
+      // TODO: import @types/mongoose-paginate-v2 and use PaginateResult as a type after upgrading mongoose v6.0.0
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const paginationResult = await (InAppNotification as any).paginate(
         { user: userId },
         {
           sort: { createdAt: -1 },

--- a/packages/app/src/server/service/in-app-notification.ts
+++ b/packages/app/src/server/service/in-app-notification.ts
@@ -5,6 +5,7 @@ import {
   InAppNotification, STATUS_UNREAD, STATUS_UNOPENED, STATUS_OPENED,
   InAppNotificationDocument,
 } from '~/server/models/in-app-notification';
+import { PaginateResult } from '../../interfaces/in-app-notification';
 
 import { ActivityDocument } from '~/server/models/activity';
 import InAppNotificationSettings from '~/server/models/in-app-notification-settings';
@@ -86,9 +87,7 @@ export default class InAppNotificationService {
   getLatestNotificationsByUser = async(
       userId: Types.ObjectId,
       queryOptions: {offset: number, limit: number},
-  // TODO: import @types/mongoose-paginate-v2 and use PaginateResult as a type after upgrading mongoose v6.0.0
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ): Promise<any> => {
+  ): Promise<PaginateResult<InAppNotificationDocument>> => {
     const { limit, offset } = queryOptions;
 
     try {

--- a/packages/app/src/stores/in-app-notification.ts
+++ b/packages/app/src/stores/in-app-notification.ts
@@ -1,15 +1,15 @@
 import useSWR, { SWRResponse } from 'swr';
 
-import { PaginateResult } from 'mongoose';
 import { apiv3Get } from '../client/util/apiv3-client';
-import { IInAppNotification } from '../interfaces/in-app-notification';
 
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const useSWRxInAppNotifications = <Data, Error>(
   limit: number,
   offset?: number,
-): SWRResponse<PaginateResult<IInAppNotification>, Error> => {
+// TODO: import @types/mongoose-paginate-v2 and use PaginateResult as a type after upgrading mongoose v6.0.0
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+): SWRResponse<any, Error> => {
   return useSWR(
     ['/in-app-notification/list', limit, offset],
     endpoint => apiv3Get(endpoint, { limit, offset }).then(response => response.data),

--- a/packages/app/src/stores/in-app-notification.ts
+++ b/packages/app/src/stores/in-app-notification.ts
@@ -1,15 +1,13 @@
 import useSWR, { SWRResponse } from 'swr';
 
 import { apiv3Get } from '../client/util/apiv3-client';
-
+import { IInAppNotification, PaginateResult } from '../interfaces/in-app-notification';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const useSWRxInAppNotifications = <Data, Error>(
   limit: number,
   offset?: number,
-// TODO: import @types/mongoose-paginate-v2 and use PaginateResult as a type after upgrading mongoose v6.0.0
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-): SWRResponse<any, Error> => {
+): SWRResponse<PaginateResult<IInAppNotification>, Error> => {
   return useSWR(
     ['/in-app-notification/list', limit, offset],
     endpoint => apiv3Get(endpoint, { limit, offset }).then(response => response.data),

--- a/yarn.lock
+++ b/yarn.lock
@@ -3141,20 +3141,6 @@
     "@types/bson" "*"
     "@types/node" "*"
 
-"@types/mongoose-paginate-v2@1.3.9":
-  version "1.3.9"
-  resolved "https://registry.yarnpkg.com/@types/mongoose-paginate-v2/-/mongoose-paginate-v2-1.3.9.tgz#a211bf0da49473e9e1f1a65d3aacbd5d5ff0408c"
-  integrity sha512-NHqTgOZRmi7gd/IkRJ2VXo88m0efKatLFrG63VEcAB98nO6nzbeRaXPUUgEFJ2Le6vleTE0WqvAuL0gO5IQF5A==
-  dependencies:
-    "@types/mongoose" "*"
-
-"@types/mongoose@*":
-  version "5.11.97"
-  resolved "https://registry.yarnpkg.com/@types/mongoose/-/mongoose-5.11.97.tgz#80b0357f3de6807eb597262f52e49c3e13ee14d8"
-  integrity sha512-cqwOVYT3qXyLiGw7ueU2kX9noE8DPGRY6z8eUxudhXY8NZ7DMKYAxyZkLSevGfhCX3dO/AoX5/SO9lAzfjon0Q==
-  dependencies:
-    mongoose "*"
-
 "@types/multer@^1.4.5":
   version "1.4.5"
   resolved "https://registry.yarnpkg.com/@types/multer/-/multer-1.4.5.tgz#db0557562307e9adb6661a9500c334cd7ddd0cd9"


### PR DESCRIPTION
## Task
- [#81697](https://redmine.weseek.co.jp/issues/81697) マスターからトピックブランチのマージによるmongoose-paginate関連のエラー調査 / 修正