### PR TITLE
wip: 81762 repalce grid with flex

### DIFF
--- a/packages/app/src/components/SearchPage/SearchPageLayout.tsx
+++ b/packages/app/src/components/SearchPage/SearchPageLayout.tsx
@@ -18,8 +18,8 @@ const SearchPageLayout: FC<Props> = (props: Props) => {
   const { SearchResultList, SearchControl, SearchResultContent } = props;
   return (
     <div className="content-main">
-      <div className="search-result row" id="search-result">
-        <div className="col-xl-6  page-list search-result-list pr-0" id="search-result-list">
+      <div className="search-result d-flex" id="search-result">
+        <div className="page-list search-result-list pr-0" id="search-result-list">
           <nav><SearchControl></SearchControl></nav>
           <div className="d-flex align-items-start justify-content-between mt-1">
             <div className="search-result-meta">
@@ -31,7 +31,7 @@ const SearchPageLayout: FC<Props> = (props: Props) => {
             <ul className="page-list-ul page-list-ul-flat nav nav-pills"><SearchResultList></SearchResultList></ul>
           </div>
         </div>
-        <div className="col-xl-6 d-none d-lg-block search-result-content">
+        <div className="w-50 flex-grow-1 d-none d-lg-block search-result-content">
           <SearchResultContent></SearchResultContent>
         </div>
       </div>

--- a/packages/app/src/components/SearchPage/SearchPageLayout.tsx
+++ b/packages/app/src/components/SearchPage/SearchPageLayout.tsx
@@ -19,7 +19,7 @@ const SearchPageLayout: FC<Props> = (props: Props) => {
   return (
     <div className="content-main">
       <div className="search-result d-flex" id="search-result">
-        <div className="page-list search-result-list pr-0" id="search-result-list">
+        <div className="w-50 flex-grow-1 page-list search-result-list pr-0" id="search-result-list">
           <nav><SearchControl></SearchControl></nav>
           <div className="d-flex align-items-start justify-content-between mt-1">
             <div className="search-result-meta">

--- a/packages/app/src/server/views/search.html
+++ b/packages/app/src/server/views/search.html
@@ -14,13 +14,7 @@
 {% block layout_main %}
 <div id="grw-fav-sticky-trigger" class="sticky-top"></div>
 
-<div class="container-fluid">
-
-  <div class="row">
-    <div id="main" class="main col-lg-12 search-page">
-      <div class="" id="search-page"></div>
-    </div>
-  </div>
-
-</div><!-- /.container-fluid -->
+<div id="main" class="search-page">
+  <div class="" id="search-page"></div>
+</div>
 {% endblock %} {# layout_main #}

--- a/packages/app/src/server/views/search.html
+++ b/packages/app/src/server/views/search.html
@@ -15,6 +15,6 @@
 <div id="grw-fav-sticky-trigger" class="sticky-top"></div>
 
 <div id="main" class="search-page">
-  <div class="" id="search-page"></div>
+  <div id="search-page"></div>
 </div>
 {% endblock %} {# layout_main #}


### PR DESCRIPTION
[#81762](https://redmine.weseek.co.jp/issues/81762)

# やったこと
- 左右ページを囲む .container-fluid の padding をなくすため、必須でないgrid を flex で置き換えて余白が当たらないよう変更
- 横幅半分の大きさを保ちつつ、余白ができたらその分埋まるように w-50 と flex-grow を適用
- .main にも上部余白が当たるようになっていたので削除

before
<img src="https://user-images.githubusercontent.com/35527421/142347060-e1af2a97-94f2-499d-aa98-c58b14044d4c.png" height="300"/>

after
<img src="https://user-images.githubusercontent.com/35527421/142177266-e62082c4-44f4-4bc4-a5ae-06894dd5226d.png" height="300"/>
