### PR TITLE
Imprv/81701 add marks for each unopened notification

### DIFF
--- a/packages/app/src/components/InAppNotification/InAppNotificationDropdown.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationDropdown.tsx
@@ -73,7 +73,7 @@ const InAppNotificationDropdown: FC<Props> = (props: Props) => {
   const badge = count > 0 ? <span className="badge badge-pill badge-danger grw-notification-badge">{count}</span> : '';
 
   return (
-    <Dropdown className="notification-wrapper grw-in-app-notification-dropdown" isOpen={isOpen} toggle={toggleDropdownHandler}>
+    <Dropdown className="notification-wrapper" isOpen={isOpen} toggle={toggleDropdownHandler}>
       <DropdownToggle tag="a">
         <button type="button" className="nav-link border-0 bg-transparent waves-effect waves-light">
           <i className="icon-bell mr-2" /> {badge}

--- a/packages/app/src/components/InAppNotification/InAppNotificationDropdown.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationDropdown.tsx
@@ -73,7 +73,7 @@ const InAppNotificationDropdown: FC<Props> = (props: Props) => {
   const badge = count > 0 ? <span className="badge badge-pill badge-danger grw-notification-badge">{count}</span> : '';
 
   return (
-    <Dropdown className="notification-wrapper" isOpen={isOpen} toggle={toggleDropdownHandler}>
+    <Dropdown className="notification-wrapper grw-in-app-notification-dropdown" isOpen={isOpen} toggle={toggleDropdownHandler}>
       <DropdownToggle tag="a">
         <button type="button" className="nav-link border-0 bg-transparent waves-effect waves-light">
           <i className="icon-bell mr-2" /> {badge}

--- a/packages/app/src/components/InAppNotification/InAppNotificationElm.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationElm.tsx
@@ -90,6 +90,7 @@ const InAppNotificationElm = (props: Props): JSX.Element => {
   return (
     <div className="dropdown-item d-flex flex-row mb-3">
       <div className="p-2 mr-2 d-flex align-items-center">
+        <span className="grw-unread-notification rounded-circle mr-3"></span>
         {renderActionUserPictures()}
       </div>
       <div className="p-2">

--- a/packages/app/src/components/InAppNotification/InAppNotificationElm.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationElm.tsx
@@ -90,7 +90,7 @@ const InAppNotificationElm = (props: Props): JSX.Element => {
   return (
     <div className="dropdown-item d-flex flex-row mb-3">
       <div className="p-2 mr-2 d-flex align-items-center">
-        <span className="grw-unread-notification rounded-circle mr-3"></span>
+        <span className={`${notification.status === 'UNOPENED' && 'grw-unopend-notification'} rounded-circle mr-3`}></span>
         {renderActionUserPictures()}
       </div>
       <div className="p-2">

--- a/packages/app/src/server/models/in-app-notification.ts
+++ b/packages/app/src/server/models/in-app-notification.ts
@@ -65,7 +65,7 @@ const inAppNotificationSchema = new Schema<InAppNotificationDocument, InAppNotif
   status: {
     type: String,
     default: STATUS_UNREAD,
-    enum: [STATUS_UNREAD, STATUS_UNOPENED, STATUS_OPENED],
+    enum: InAppNotificationStatuses,
     index: true,
     require: true,
   },

--- a/packages/app/src/styles/theme/_apply-colors.scss
+++ b/packages/app/src/styles/theme/_apply-colors.scss
@@ -681,10 +681,8 @@ mark.rbt-highlight-text {
 /*
   In App Notification
 */
-.grw-in-app-notification-dropdown {
-  .grw-unread-notification {
-    width: 7px;
-    height: 7px;
-    background-color: $primary;
-  }
+.grw-unopend-notification {
+  width: 7px;
+  height: 7px;
+  background-color: $primary;
 }

--- a/packages/app/src/styles/theme/_apply-colors.scss
+++ b/packages/app/src/styles/theme/_apply-colors.scss
@@ -677,3 +677,14 @@ mark.rbt-highlight-text {
     width: 20px;
   }
 }
+
+/*
+  In App Notification
+*/
+.grw-in-app-notification-dropdown {
+  .grw-unread-notification {
+    width: 7px;
+    height: 7px;
+    background-color: $primary;
+  }
+}


### PR DESCRIPTION
## Task
- [#81701](https://redmine.weseek.co.jp/issues/81701) UNOPENDの通知に、印をつける


## ScreenRecording
- `.dropdown-menu` のpaddingのせいで、dropdown内の`UNOPEND`の形が楕円になってしまうのですが、どうしましょう。

https://user-images.githubusercontent.com/59536731/142188100-c5e9213f-b028-4bd5-8bd5-e9196faec07b.mov


<img width="227" alt="Screen Shot 2021-11-17 at 19 52 44" src="https://user-images.githubusercontent.com/59536731/142187933-21683f49-5db8-48d5-a54f-c5378c7342b4.png">

