### PR TITLE
feat: 81679 81700 create notification when page is renamed

### DIFF
--- a/packages/app/src/components/InAppNotification/InAppNotificationElm.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationElm.tsx
@@ -77,6 +77,10 @@ const InAppNotificationElm = (props: Props): JSX.Element => {
       actionMsg = 'updated on';
       actionIcon = 'ti-agenda';
       break;
+    case 'PAGE_RENAME':
+      actionMsg = 'renamed';
+      actionIcon = 'ti-agenda';
+      break;
     case 'COMMENT_CREATE':
       actionMsg = 'commented on';
       actionIcon = 'icon-bubble';

--- a/packages/app/src/components/InAppNotification/InAppNotificationElm.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationElm.tsx
@@ -79,7 +79,7 @@ const InAppNotificationElm = (props: Props): JSX.Element => {
       break;
     case 'PAGE_RENAME':
       actionMsg = 'renamed';
-      actionIcon = 'ti-agenda';
+      actionIcon = 'icon-action-redo';
       break;
     case 'COMMENT_CREATE':
       actionMsg = 'commented on';

--- a/packages/app/src/server/service/page.js
+++ b/packages/app/src/server/service/page.js
@@ -31,7 +31,6 @@ class PageService {
     // create
     this.pageEvent.on('create', async(page, user) => {
       this.pageEvent.onCreate();
-      console.log('ページが作成されました');
     });
 
     // update
@@ -48,8 +47,7 @@ class PageService {
     });
 
     // rename
-    this.pageEvent.on('rename', async(page, renamedPage, user) => {
-      console.log('ページがリネームされました');
+    this.pageEvent.on('rename', async(page, user) => {
       try {
         await this.createAndSendNotifications(page, user, ActivityDefine.ACTION_PAGE_RENAME);
       }
@@ -140,9 +138,7 @@ class PageService {
       await Page.create(path, body, user, { redirectTo: newPagePath });
     }
 
-    // this.pageEvent.emit('delete', page, user);
-    // this.pageEvent.emit('create', renamedPage, user);
-    this.pageEvent.emit('rename', page, renamedPage, user);
+    this.pageEvent.emit('rename', page, user);
 
     return renamedPage;
   }

--- a/packages/app/src/server/service/page.js
+++ b/packages/app/src/server/service/page.js
@@ -29,7 +29,10 @@ class PageService {
 
   initPageEvent() {
     // create
-    this.pageEvent.on('create', this.pageEvent.onCreate);
+    this.pageEvent.on('create', async(page, user) => {
+      this.pageEvent.onCreate();
+      console.log('ページが作成されました');
+    });
 
     // update
     this.pageEvent.on('update', async(page, user) => {
@@ -42,6 +45,12 @@ class PageService {
       catch (err) {
         logger.error(err);
       }
+    });
+
+    // rename
+    this.pageEvent.on('rename', async(page, renamedPage, user) => {
+      console.log('ページがリネームされました');
+      console.log(page, renamedPage, user);
     });
 
 
@@ -127,8 +136,9 @@ class PageService {
       await Page.create(path, body, user, { redirectTo: newPagePath });
     }
 
-    this.pageEvent.emit('delete', page, user);
-    this.pageEvent.emit('create', renamedPage, user);
+    // this.pageEvent.emit('delete', page, user);
+    // this.pageEvent.emit('create', renamedPage, user);
+    this.pageEvent.emit('rename', page, renamedPage, user);
 
     return renamedPage;
   }

--- a/packages/app/src/server/service/page.js
+++ b/packages/app/src/server/service/page.js
@@ -29,9 +29,7 @@ class PageService {
 
   initPageEvent() {
     // create
-    this.pageEvent.on('create', async(page, user) => {
-      this.pageEvent.onCreate();
-    });
+    this.pageEvent.on('create', this.pageEvent.onCreate);
 
     // update
     this.pageEvent.on('update', async(page, user) => {
@@ -140,6 +138,8 @@ class PageService {
       await Page.create(path, body, user, { redirectTo: newPagePath });
     }
 
+    this.pageEvent.emit('delete', page, user);
+    this.pageEvent.emit('create', renamedPage, user);
     this.pageEvent.emit('rename', page, user);
 
     return renamedPage;

--- a/packages/app/src/server/service/page.js
+++ b/packages/app/src/server/service/page.js
@@ -56,6 +56,8 @@ class PageService {
       }
     });
 
+    // TODO 81841
+
     // createMany
     this.pageEvent.on('createMany', this.pageEvent.onCreateMany);
   }

--- a/packages/app/src/server/service/page.js
+++ b/packages/app/src/server/service/page.js
@@ -40,7 +40,7 @@ class PageService {
       this.pageEvent.onUpdate();
 
       try {
-        await this.createAndSendNotifications(page, user);
+        await this.createAndSendNotifications(page, user, ActivityDefine.ACTION_PAGE_UPDATE);
       }
       catch (err) {
         logger.error(err);
@@ -50,9 +50,13 @@ class PageService {
     // rename
     this.pageEvent.on('rename', async(page, renamedPage, user) => {
       console.log('ページがリネームされました');
-      console.log(page, renamedPage, user);
+      try {
+        await this.createAndSendNotifications(page, user, ActivityDefine.ACTION_PAGE_RENAME);
+      }
+      catch (err) {
+        logger.error(err);
+      }
     });
-
 
     // createMany
     this.pageEvent.on('createMany', this.pageEvent.onCreateMany);
@@ -770,7 +774,7 @@ class PageService {
     }
   }
 
-  createAndSendNotifications = async function(page, user) {
+  createAndSendNotifications = async function(page, user, action) {
 
     const { activityService, inAppNotificationService } = this.crowi;
 
@@ -779,7 +783,7 @@ class PageService {
       user: user._id,
       targetModel: ActivityDefine.MODEL_PAGE,
       target: page,
-      action: ActivityDefine.ACTION_PAGE_UPDATE,
+      action,
     };
     const activity = await activityService.createByParameters(parameters);
 

--- a/packages/app/src/server/util/activityDefine.ts
+++ b/packages/app/src/server/util/activityDefine.ts
@@ -2,6 +2,7 @@ const MODEL_PAGE = 'Page';
 const MODEL_COMMENT = 'Comment';
 
 const ACTION_PAGE_UPDATE = 'PAGE_UPDATE';
+const ACTION_PAGE_RENAME = 'PAGE_RENAME';
 const ACTION_COMMENT_CREATE = 'COMMENT_CREATE';
 const ACTION_COMMENT_UPDATE = 'COMMENT_UPDATE';
 
@@ -16,6 +17,7 @@ const getSupportEventModelNames = () => {
 const getSupportActionNames = () => {
   return [
     ACTION_PAGE_UPDATE,
+    ACTION_PAGE_RENAME,
     ACTION_COMMENT_CREATE,
     ACTION_COMMENT_UPDATE,
   ];
@@ -26,6 +28,7 @@ const activityDefine = {
   MODEL_COMMENT,
 
   ACTION_PAGE_UPDATE,
+  ACTION_PAGE_RENAME,
   ACTION_COMMENT_CREATE,
   ACTION_COMMENT_UPDATE,
 


### PR DESCRIPTION
## Task
- [#81700](https://redmine.weseek.co.jp/issues/81700) ページをリネームしたときにイベントを受け取れるようにする
- [#81679](https://redmine.weseek.co.jp/issues/81679) ページ名が変更されたときにに Activityドキュメント, Notificationドキュメントを作成し、socket.Io を通じてフロント側で通知を受け取ることができる


## Memo
通知のドロップダウンのアイコンは、`移動/名前変更` に使われている `icon-action-redo` を利用しました。

<img width="168" alt="スクリーンショット 2021-11-18 15 38 31" src="https://user-images.githubusercontent.com/34241526/142365177-4b23bed3-0b00-4a5d-9fa1-50d3934717b0.png">

<img width="273" alt="スクリーンショット 2021-11-18 15 36 59" src="https://user-images.githubusercontent.com/34241526/142365082-28aa8fe2-7101-4217-99e9-22ad15b6e294.png">

