### PR TITLE
Imprv/81702 add category tabs

### DIFF
--- a/packages/app/resource/locales/en_US/translation.json
+++ b/packages/app/resource/locales/en_US/translation.json
@@ -259,7 +259,9 @@
   "in_app_notification": {
     "notification_list": "In-App Notification List",
     "see_all": "See All",
-    "no_notification": "You don't have any notificatios."
+    "no_notification": "You don't have any notificatios.",
+    "all": "All",
+    "unopend": "Unread"
   },
   "in_app_notification_settings": {
     "in_app_notification_settings": "In-App Notification Settings",

--- a/packages/app/resource/locales/ja_JP/translation.json
+++ b/packages/app/resource/locales/ja_JP/translation.json
@@ -261,7 +261,7 @@
   "in_app_notification": {
     "notification_list": "アプリ内通知一覧",
     "see_all": "通知一覧を見る",
-    "no_notification": "通知は一つもありません。",
+    "no_notification": "通知はありません",
     "all": "全て",
     "unopend": "未読",
     "mark_all_as_read": "全て既読にする"

--- a/packages/app/resource/locales/ja_JP/translation.json
+++ b/packages/app/resource/locales/ja_JP/translation.json
@@ -261,7 +261,9 @@
   "in_app_notification": {
     "notification_list": "アプリ内通知一覧",
     "see_all": "通知一覧を見る",
-    "no_notification": "通知は一つもありません。"
+    "no_notification": "通知は一つもありません。",
+    "all": "全て",
+    "unopend": "未読"
   },
   "in_app_notification_settings": {
     "in_app_notification_settings": "アプリ内通知設定",

--- a/packages/app/resource/locales/zh_CN/translation.json
+++ b/packages/app/resource/locales/zh_CN/translation.json
@@ -240,7 +240,9 @@
   "in_app_notification": {
     "notification_list": "应用内通知列表",
     "see_all": "查看通知列表",
-    "no_notification": "您没有任何通知"
+    "no_notification": "您没有任何通知",
+    "all": "全部",
+    "unopend": "未读"
   },
   "in_app_notification_settings": {
     "in_app_notification_settings": "在应用程序通知设置",

--- a/packages/app/src/client/app.jsx
+++ b/packages/app/src/client/app.jsx
@@ -8,7 +8,7 @@ import { SWRConfig } from 'swr';
 import loggerFactory from '~/utils/logger';
 import { swrGlobalConfiguration } from '~/utils/swr-utils';
 
-import AllInAppNotifications from '../components/InAppNotification/AllInAppNotifications';
+import InAppNotificationPage from '../components/InAppNotification/InAppNotificationPage';
 import ErrorBoundary from '../components/ErrorBoudary';
 import Sidebar from '../components/Sidebar';
 import SearchPage from '../components/SearchPage';
@@ -87,7 +87,7 @@ Object.assign(componentMappings, {
   'grw-sidebar-wrapper': <Sidebar />,
 
   'search-page': <SearchPage crowi={appContainer} />,
-  'all-in-app-notifications': <AllInAppNotifications />,
+  'all-in-app-notifications': <InAppNotificationPage />,
 
   // 'revision-history': <PageHistory pageId={pageId} />,
   'tags-page': <TagsList crowi={appContainer} />,

--- a/packages/app/src/components/InAppNotification/AllInAppNotifications.tsx
+++ b/packages/app/src/components/InAppNotification/AllInAppNotifications.tsx
@@ -17,24 +17,6 @@ const AllInAppNotifications: FC = () => {
   const { data: inAppNotificationData } = useSWRxInAppNotifications(limit, offset);
   const { t } = useTranslation();
 
-
-  const navTabMapping = useMemo(() => {
-    return {
-      user_infomation: {
-        Icon: () => <i className="icon-fw icon-user"></i>,
-        Content: UserSettings,
-        i18n: t('User Information'),
-        index: 0,
-      },
-      external_accounts: {
-        Icon: () => <i className="icon-fw icon-share-alt"></i>,
-        Content: PasswordSettings,
-        i18n: t('admin:user_management.external_accounts'),
-        index: 1,
-      },
-    };
-  }, [t]);
-
   if (inAppNotificationData == null) {
     return (
       <div className="wiki">
@@ -52,9 +34,41 @@ const AllInAppNotifications: FC = () => {
     setOffset(offset);
   };
 
+  const InAppNotificationListContent = () => {
+    return (
+      <>
+        <InAppNotificationList inAppNotificationData={inAppNotificationData} />
+        <PaginationWrapper
+          activePage={activePage}
+          changePage={setPageNumber}
+          totalItemsCount={inAppNotificationData.totalDocs}
+          pagingLimit={inAppNotificationData.limit}
+          align="center"
+          size="sm"
+        />
+      </>
+    );
+  };
+
+  const navTabMapping = {
+    user_infomation: {
+      Icon: () => <i className="icon-fw icon-user"></i>,
+      Content: InAppNotificationListContent,
+      i18n: t('User Information'),
+      index: 0,
+    },
+    external_accounts: {
+      Icon: () => <i className="icon-fw icon-share-alt"></i>,
+      Content: PasswordSettings,
+      i18n: t('admin:user_management.external_accounts'),
+      index: 1,
+    },
+  };
+
   return (
     <>
       <CustomNavAndContents navTabMapping={navTabMapping} />
+      {/* <InAppNotificationListContent /> */}
       {/* <InAppNotificationList inAppNotificationData={inAppNotificationData} />
       <PaginationWrapper
         activePage={activePage}

--- a/packages/app/src/components/InAppNotification/AllInAppNotifications.tsx
+++ b/packages/app/src/components/InAppNotification/AllInAppNotifications.tsx
@@ -1,8 +1,13 @@
-import React, { FC, useState } from 'react';
+import React, { FC, useState, useMemo } from 'react';
 
+import { useTranslation } from 'react-i18next';
 import InAppNotificationList from './InAppNotificationList';
 import { useSWRxInAppNotifications } from '../../stores/in-app-notification';
 import PaginationWrapper from '../PaginationWrapper';
+import CustomNavAndContents from '../CustomNavigation/CustomNavAndContents';
+
+import UserSettings from '../Me/UserSettings';
+import PasswordSettings from '../Me/PasswordSettings';
 
 
 const AllInAppNotifications: FC = () => {
@@ -10,6 +15,25 @@ const AllInAppNotifications: FC = () => {
   const [offset, setOffset] = useState(0);
   const limit = 10;
   const { data: inAppNotificationData } = useSWRxInAppNotifications(limit, offset);
+  const { t } = useTranslation();
+
+
+  const navTabMapping = useMemo(() => {
+    return {
+      user_infomation: {
+        Icon: () => <i className="icon-fw icon-user"></i>,
+        Content: UserSettings,
+        i18n: t('User Information'),
+        index: 0,
+      },
+      external_accounts: {
+        Icon: () => <i className="icon-fw icon-share-alt"></i>,
+        Content: PasswordSettings,
+        i18n: t('admin:user_management.external_accounts'),
+        index: 1,
+      },
+    };
+  }, [t]);
 
   if (inAppNotificationData == null) {
     return (
@@ -21,6 +45,7 @@ const AllInAppNotifications: FC = () => {
     );
   }
 
+
   const setPageNumber = (selectedPageNumber): void => {
     setActivePage(selectedPageNumber);
     const offset = (selectedPageNumber - 1) * limit;
@@ -29,7 +54,8 @@ const AllInAppNotifications: FC = () => {
 
   return (
     <>
-      <InAppNotificationList inAppNotificationData={inAppNotificationData} />
+      <CustomNavAndContents navTabMapping={navTabMapping} />
+      {/* <InAppNotificationList inAppNotificationData={inAppNotificationData} />
       <PaginationWrapper
         activePage={activePage}
         changePage={setPageNumber}
@@ -37,7 +63,7 @@ const AllInAppNotifications: FC = () => {
         pagingLimit={inAppNotificationData.limit}
         align="center"
         size="sm"
-      />
+      /> */}
     </>
   );
 };

--- a/packages/app/src/components/InAppNotification/AllInAppNotifications.tsx
+++ b/packages/app/src/components/InAppNotification/AllInAppNotifications.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState, useMemo } from 'react';
+import React, { FC, useState } from 'react';
 
 import { useTranslation } from 'react-i18next';
 import InAppNotificationList from './InAppNotificationList';
@@ -6,7 +6,6 @@ import { useSWRxInAppNotifications } from '../../stores/in-app-notification';
 import PaginationWrapper from '../PaginationWrapper';
 import CustomNavAndContents from '../CustomNavigation/CustomNavAndContents';
 
-import UserSettings from '../Me/UserSettings';
 import PasswordSettings from '../Me/PasswordSettings';
 
 
@@ -34,7 +33,7 @@ const AllInAppNotifications: FC = () => {
     setOffset(offset);
   };
 
-  const InAppNotificationListContent = () => {
+  const AllInAppNotificationList = () => {
     return (
       <>
         <InAppNotificationList inAppNotificationData={inAppNotificationData} />
@@ -53,7 +52,7 @@ const AllInAppNotifications: FC = () => {
   const navTabMapping = {
     user_infomation: {
       Icon: () => <i className="icon-fw icon-user"></i>,
-      Content: InAppNotificationListContent,
+      Content: AllInAppNotificationList,
       i18n: t('User Information'),
       index: 0,
     },
@@ -66,19 +65,7 @@ const AllInAppNotifications: FC = () => {
   };
 
   return (
-    <>
-      <CustomNavAndContents navTabMapping={navTabMapping} />
-      {/* <InAppNotificationListContent /> */}
-      {/* <InAppNotificationList inAppNotificationData={inAppNotificationData} />
-      <PaginationWrapper
-        activePage={activePage}
-        changePage={setPageNumber}
-        totalItemsCount={inAppNotificationData.totalDocs}
-        pagingLimit={inAppNotificationData.limit}
-        align="center"
-        size="sm"
-      /> */}
-    </>
+    <CustomNavAndContents navTabMapping={navTabMapping} />
   );
 };
 

--- a/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
@@ -9,7 +9,7 @@ import CustomNavAndContents from '../CustomNavigation/CustomNavAndContents';
 import PasswordSettings from '../Me/PasswordSettings';
 
 
-const AllInAppNotifications: FC = () => {
+const InAppNotificationPage: FC = () => {
   const [activePage, setActivePage] = useState(1);
   const [offset, setOffset] = useState(0);
   const limit = 10;
@@ -69,4 +69,4 @@ const AllInAppNotifications: FC = () => {
   );
 };
 
-export default AllInAppNotifications;
+export default InAppNotificationPage;

--- a/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
@@ -51,13 +51,13 @@ const InAppNotificationPage: FC = () => {
 
   const navTabMapping = {
     user_infomation: {
-      Icon: () => <i className="icon-fw icon-user"></i>,
+      Icon: () => <></>,
       Content: AllInAppNotificationList,
       i18n: t('in_app_notification.all'),
       index: 0,
     },
     external_accounts: {
-      Icon: () => <i className="icon-fw icon-share-alt"></i>,
+      Icon: () => <></>,
       Content: PasswordSettings,
       i18n: t('in_app_notification.unopend'),
       index: 1,

--- a/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
@@ -53,13 +53,13 @@ const InAppNotificationPage: FC = () => {
     user_infomation: {
       Icon: () => <i className="icon-fw icon-user"></i>,
       Content: AllInAppNotificationList,
-      i18n: t('User Information'),
+      i18n: t('in_app_notification.all'),
       index: 0,
     },
     external_accounts: {
       Icon: () => <i className="icon-fw icon-share-alt"></i>,
       Content: PasswordSettings,
-      i18n: t('admin:user_management.external_accounts'),
+      i18n: t('in_app_notification.unopend'),
       index: 1,
     },
   };

--- a/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
@@ -1,15 +1,23 @@
 import React, { FC, useState } from 'react';
 
 import { useTranslation } from 'react-i18next';
+import PropTypes from 'prop-types';
+import AppContainer from '~/client/services/AppContainer';
+import { withUnstatedContainers } from '../UnstatedUtils';
 import InAppNotificationList from './InAppNotificationList';
 import { useSWRxInAppNotifications } from '../../stores/in-app-notification';
 import PaginationWrapper from '../PaginationWrapper';
 import CustomNavAndContents from '../CustomNavigation/CustomNavAndContents';
 
 
-const InAppNotificationPage: FC = () => {
+type Props = {
+  appContainer: AppContainer
+}
+
+const InAppNotificationPageBody: FC<Props> = (props) => {
+  const { appContainer } = props;
+  const limit = appContainer.config.pageLimitationXL;
   const [activePage, setActivePage] = useState(1);
-  const limit = 10;
   const offset = (activePage - 1) * limit;
   const { data: inAppNotificationData } = useSWRxInAppNotifications(limit, offset);
   const { t } = useTranslation();
@@ -95,4 +103,9 @@ const InAppNotificationPage: FC = () => {
   );
 };
 
+const InAppNotificationPage = withUnstatedContainers(InAppNotificationPageBody, [AppContainer]);
 export default InAppNotificationPage;
+
+InAppNotificationPageBody.propTypes = {
+  appContainer: PropTypes.instanceOf(AppContainer).isRequired,
+};

--- a/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
@@ -6,8 +6,6 @@ import { useSWRxInAppNotifications } from '../../stores/in-app-notification';
 import PaginationWrapper from '../PaginationWrapper';
 import CustomNavAndContents from '../CustomNavigation/CustomNavAndContents';
 
-import PasswordSettings from '../Me/PasswordSettings';
-
 
 const InAppNotificationPage: FC = () => {
   const [activePage, setActivePage] = useState(1);
@@ -56,9 +54,10 @@ const InAppNotificationPage: FC = () => {
       i18n: t('in_app_notification.all'),
       index: 0,
     },
+    // TODO: show unopend notification list by 81945
     external_accounts: {
       Icon: () => <></>,
-      Content: PasswordSettings,
+      Content: AllInAppNotificationList,
       i18n: t('in_app_notification.unopend'),
       index: 1,
     },

--- a/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
@@ -9,8 +9,8 @@ import CustomNavAndContents from '../CustomNavigation/CustomNavAndContents';
 
 const InAppNotificationPage: FC = () => {
   const [activePage, setActivePage] = useState(1);
-  const [offset, setOffset] = useState(0);
   const limit = 10;
+  const offset = (activePage - 1) * limit;
   const { data: inAppNotificationData } = useSWRxInAppNotifications(limit, offset);
   const { t } = useTranslation();
 
@@ -27,8 +27,6 @@ const InAppNotificationPage: FC = () => {
 
   const setPageNumber = (selectedPageNumber): void => {
     setActivePage(selectedPageNumber);
-    const offset = (selectedPageNumber - 1) * limit;
-    setOffset(offset);
   };
 
   // commonize notification lists by 81953

--- a/packages/app/src/server/models/config.ts
+++ b/packages/app/src/server/models/config.ts
@@ -235,6 +235,7 @@ schema.statics.getLocalconfig = function(crowi) {
     isSearchServiceReachable: crowi.searchService.isReachable,
     isMailerSetup: crowi.mailService.isMailerSetup,
     globalLang: crowi.configManager.getConfig('crowi', 'app:globalLang'),
+    pageLimitationXL: crowi.configManager.getConfig('crowi', 'customize:showPageLimitationXL'),
   };
 
   return localConfig;


### PR DESCRIPTION
## Task
- [#81702](https://redmine.weseek.co.jp/issues/81702) 全ての通知一覧ページにカテゴリー分けするタグを追加する

## Note
### やったこと
- AllInAppNotifications.tsx -> InAppNotificationPage にrename
- CustomNavの追加

現状、タブ内でのカテゴリーわけは未対応です。
未読の通知一覧の表示は、以下の後続タスクで着手します。
- [#81945](https://redmine.weseek.co.jp/issues/81945) 未読のカテゴリーにリストを表示させることができる
## Screen Recording

https://user-images.githubusercontent.com/59536731/142571186-70bf6619-6af1-42fc-a4d1-9f17a5ad9d31.mov


