### PR TITLE
improve: notification view

### DIFF
--- a/packages/app/src/components/InAppNotification/InAppNotificationElm.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationElm.tsx
@@ -94,7 +94,7 @@ const InAppNotificationElm = (props: Props): JSX.Element => {
   return (
     <div className="dropdown-item d-flex flex-row mb-3">
       <div className="p-2 mr-2 d-flex align-items-center">
-        <span className={`${notification.status === 'UNOPENED' && 'grw-unopend-notification'} rounded-circle mr-3`}></span>
+        <span className={`${notification.status === 'UNOPENED' ? 'grw-unopend-notification' : 'ml-2'} rounded-circle mr-3`}></span>
         {renderActionUserPictures()}
       </div>
       <div className="p-2">


### PR DESCRIPTION
## Task
- [#81863](https://redmine.weseek.co.jp/issues/81863) UNOPENDの印によってズレた通知一覧の表示を整える

## Note
### 前回のFB
- [#4690](https://github.com/weseek/growi/pull/4690#issuecomment-971498133)
ドロップダウン内のボタンが楕円になってしまう問題はどのように修正すればいいかまだわかっていませんが、ここで時間かけすぎるのも良くないと判断したので、別のタスクを優先させることにします。

## View
### Before
<img width="787" alt="Screen Shot 2021-11-19 at 15 23 27" src="https://user-images.githubusercontent.com/59536731/142575395-f1366425-9c68-4eb3-b28d-ad74f880c8d0.png">


### After
<img width="728" alt="Screen Shot 2021-11-19 at 15 22 06" src="https://user-images.githubusercontent.com/59536731/142575162-ce161954-c43a-479e-ad33-d610717afc73.png">


