### PR TITLE
feat: 79579 81032 change codemirror modal

### DIFF
--- a/packages/app/src/components/PageEditor/CodeMirrorEditor.jsx
+++ b/packages/app/src/components/PageEditor/CodeMirrorEditor.jsx
@@ -625,11 +625,14 @@ export default class CodeMirrorEditor extends AbstractEditor {
   }
 
   renderCheatsheetModalButton() {
-    return (
-      <button type="button" className="btn-link gfm-cheatsheet-modal-link small" onClick={() => { this.markdownHelpButtonClickedHandler() }}>
-        <i className="icon-question" /> Markdown
-      </button>
-    );
+    const isMarkDownButtonHidden = this.props.isConflictMode && this.props.readOnly;
+    if (!isMarkDownButtonHidden) {
+      return (
+        <button type="button" className="btn-link gfm-cheatsheet-modal-link small" onClick={() => { this.markdownHelpButtonClickedHandler() }}>
+          <i className="icon-question" /> Markdown
+        </button>
+      );
+    }
   }
 
   renderCheatsheetOverlay() {

--- a/packages/app/src/components/PageEditor/CodeMirrorEditor.jsx
+++ b/packages/app/src/components/PageEditor/CodeMirrorEditor.jsx
@@ -109,6 +109,7 @@ export default class CodeMirrorEditor extends AbstractEditor {
     this.state = {
       value: this.props.value,
       isGfmMode: this.props.isGfmMode,
+      isConflictMode: this.props.isConflict,
       isEnabledEmojiAutoComplete: false,
       isLoadingKeymap: false,
       isSimpleCheatsheetShown: this.props.isGfmMode && this.props.value.length === 0,
@@ -882,7 +883,17 @@ export default class CodeMirrorEditor extends AbstractEditor {
     const mode = this.state.isGfmMode ? 'gfm-growi' : undefined;
     const lint = this.props.isTextlintEnabled ? this.codemirrorLintConfig : false;
     const additionalClasses = Array.from(this.state.additionalClassSet).join(' ');
-    const placeholder = this.state.isGfmMode ? 'Input with Markdown..' : 'Input with Plain Text..';
+    let placeholder;
+
+    if (this.state.isGfmMode) {
+      placeholder = 'Input with Markdown..';
+    }
+    else if (this.state.isConflictMode) {
+      placeholder = 'Please select revision body..';
+    }
+    else {
+      placeholder = 'Input with Plain Text..';
+    }
 
     const gutters = [];
     if (this.props.lineNumbers != null) {
@@ -919,6 +930,7 @@ export default class CodeMirrorEditor extends AbstractEditor {
             placeholder,
             matchBrackets: true,
             matchTags: { bothTags: true },
+            readOnly: (this.props.readOnly || false),
             // folding
             foldGutter: this.props.lineNumbers,
             gutters,

--- a/packages/app/src/components/PageEditor/CodeMirrorEditor.jsx
+++ b/packages/app/src/components/PageEditor/CodeMirrorEditor.jsx
@@ -625,14 +625,11 @@ export default class CodeMirrorEditor extends AbstractEditor {
   }
 
   renderCheatsheetModalButton() {
-    const isMarkDownButtonHidden = this.props.isConflictMode && this.props.readOnly;
-    if (!isMarkDownButtonHidden) {
-      return (
-        <button type="button" className="btn-link gfm-cheatsheet-modal-link small" onClick={() => { this.markdownHelpButtonClickedHandler() }}>
-          <i className="icon-question" /> Markdown
-        </button>
-      );
-    }
+    return (
+      <button type="button" className="btn-link gfm-cheatsheet-modal-link small" onClick={() => { this.markdownHelpButtonClickedHandler() }}>
+        <i className="icon-question" /> Markdown
+      </button>
+    );
   }
 
   renderCheatsheetOverlay() {
@@ -886,6 +883,8 @@ export default class CodeMirrorEditor extends AbstractEditor {
     const mode = this.state.isGfmMode ? 'gfm-growi' : undefined;
     const lint = this.props.isTextlintEnabled ? this.codemirrorLintConfig : false;
     const additionalClasses = Array.from(this.state.additionalClassSet).join(' ');
+    const isMarkDownButtonHidden = this.props.isConflictMode && this.props.readOnly;
+
     let placeholder;
 
     if (this.state.isGfmMode) {
@@ -969,7 +968,7 @@ export default class CodeMirrorEditor extends AbstractEditor {
 
         { this.renderLoadingKeymapOverlay() }
 
-        { this.renderCheatsheetOverlay() }
+        { !isMarkDownButtonHidden && this.renderCheatsheetOverlay() }
 
         <GridEditModal
           ref={this.gridEditModal}

--- a/packages/app/src/components/PageEditor/CodeMirrorEditor.jsx
+++ b/packages/app/src/components/PageEditor/CodeMirrorEditor.jsx
@@ -5,7 +5,7 @@ import urljoin from 'url-join';
 import * as codemirror from 'codemirror';
 
 import { Button } from 'reactstrap';
-import { UnControlled as ReactCodeMirrorUncontroled, Controlled as ReactCodeMirrorControlled } from 'react-codemirror2';
+import { UnControlled as ReactCodeMirrorUncontrolled, Controlled as ReactCodeMirrorControlled } from 'react-codemirror2';
 
 import { JSHINT } from 'jshint';
 
@@ -878,7 +878,7 @@ export default class CodeMirrorEditor extends AbstractEditor {
     ];
   }
 
-  renderReactCideMirror() {
+  renderReactCodeMirror() {
     const mode = this.state.isGfmMode ? 'gfm-growi' : undefined;
     const lint = this.props.isTextlintEnabled ? this.codemirrorLintConfig : false;
     const additionalClasses = Array.from(this.state.additionalClassSet).join(' ');
@@ -968,7 +968,7 @@ export default class CodeMirrorEditor extends AbstractEditor {
     }
 
     return (
-      <ReactCodeMirrorUncontroled
+      <ReactCodeMirrorUncontrolled
         ref={(c) => { this.cm = c }}
         className={additionalClasses}
         placeholder="search"
@@ -1036,7 +1036,7 @@ export default class CodeMirrorEditor extends AbstractEditor {
     return (
       <React.Fragment>
 
-        { this.renderReactCideMirror() }
+        { this.renderReactCodeMirror() }
 
         { this.renderLoadingKeymapOverlay() }
 

--- a/packages/app/src/components/PageEditor/CodeMirrorEditor.jsx
+++ b/packages/app/src/components/PageEditor/CodeMirrorEditor.jsx
@@ -883,7 +883,7 @@ export default class CodeMirrorEditor extends AbstractEditor {
     const mode = this.state.isGfmMode ? 'gfm-growi' : undefined;
     const lint = this.props.isTextlintEnabled ? this.codemirrorLintConfig : false;
     const additionalClasses = Array.from(this.state.additionalClassSet).join(' ');
-    const isMarkDownButtonHidden = this.props.isConflictMode && this.props.readOnly;
+    const isMarkDownButtonHidden = this.props.isConflictMode;
 
     let placeholder;
 

--- a/packages/app/src/components/PageEditor/ConflictDiffModal.tsx
+++ b/packages/app/src/components/PageEditor/ConflictDiffModal.tsx
@@ -77,6 +77,7 @@ export const ConflictDiffModal: FC<ConflictDiffModalProps> = (props) => {
                     <p className="my-0">{format(parseISO(request.createdAt), 'yyyy/MM/dd HH:mm:ss')}</p>
                   </div>
                 </div>
+                {/* TODO: replace: RevisionDiff and adjust design */}
                 <CodeMirrorEditor
                   indentSize={editorContainer.state.indentSize}
                   editorOptions={editorContainer.state.editorOptions}
@@ -85,7 +86,6 @@ export const ConflictDiffModal: FC<ConflictDiffModalProps> = (props) => {
                   value={request.revisionBody}
                   isConflict
                   readOnly
-                  // options={codeMirrorRevisionOption}
                 />
                 <div className="text-center my-4">
                   <button
@@ -121,7 +121,6 @@ export const ConflictDiffModal: FC<ConflictDiffModalProps> = (props) => {
                   value={origin.revisionBody}
                   isConflict
                   readOnly
-                  // options={codeMirrorRevisionOption}
                 />
                 <div className="text-center my-4">
                   <button
@@ -156,7 +155,6 @@ export const ConflictDiffModal: FC<ConflictDiffModalProps> = (props) => {
                   value={latest.revisionBody}
                   isConflict
                   readOnly
-                  // options={codeMirrorRevisionOption}
                 />
                 <div className="text-center my-4">
                   <button

--- a/packages/app/src/components/PageEditor/ConflictDiffModal.tsx
+++ b/packages/app/src/components/PageEditor/ConflictDiffModal.tsx
@@ -9,6 +9,7 @@ import { useTranslation } from 'react-i18next';
 import { UnControlled as CodeMirrorAny } from 'react-codemirror2';
 import PageContainer from '../../client/services/PageContainer';
 import EditorContainer from '../../client/services/EditorContainer';
+import CodeMirrorEditor from './CodeMirrorEditor';
 
 require('codemirror/mode/htmlmixed/htmlmixed');
 const DMP = require('diff_match_patch');
@@ -86,9 +87,15 @@ export const ConflictDiffModal: FC<ConflictDiffModalProps> = (props) => {
                     <p className="my-0">{format(parseISO(request.createdAt), 'yyyy/MM/dd HH:mm:ss')}</p>
                   </div>
                 </div>
-                <CodeMirror
+                <CodeMirrorEditor
+                  indentSize={editorContainer.state.indentSize}
+                  editorOptions={editorContainer.state.editorOptions}
+                  isTextlintEnabled={editorContainer.state.isTextlintEnabled}
+                  textlintRules={editorContainer.state.textlintRules}
                   value={request.revisionBody}
-                  options={codeMirrorRevisionOption}
+                  isConflictMode
+                  readOnly
+                  // options={codeMirrorRevisionOption}
                 />
                 <div className="text-center my-4">
                   <button
@@ -115,9 +122,15 @@ export const ConflictDiffModal: FC<ConflictDiffModalProps> = (props) => {
                     <p className="my-0">{format(parseISO(origin.createdAt), 'yyyy/MM/dd HH:mm:ss')}</p>
                   </div>
                 </div>
-                <CodeMirror
+                <CodeMirrorEditor
+                  indentSize={editorContainer.state.indentSize}
+                  editorOptions={editorContainer.state.editorOptions}
+                  isTextlintEnabled={editorContainer.state.isTextlintEnabled}
+                  textlintRules={editorContainer.state.textlintRules}
                   value={origin.revisionBody}
-                  options={codeMirrorRevisionOption}
+                  isConflictMode
+                  readOnly
+                  // options={codeMirrorRevisionOption}
                 />
                 <div className="text-center my-4">
                   <button
@@ -144,9 +157,15 @@ export const ConflictDiffModal: FC<ConflictDiffModalProps> = (props) => {
                     <p className="my-0">{format(parseISO(latest.createdAt), 'yyyy/MM/dd HH:mm:ss')}</p>
                   </div>
                 </div>
-                <CodeMirror
+                <CodeMirrorEditor
+                  indentSize={editorContainer.state.indentSize}
+                  editorOptions={editorContainer.state.editorOptions}
+                  isTextlintEnabled={editorContainer.state.isTextlintEnabled}
+                  textlintRules={editorContainer.state.textlintRules}
                   value={latest.revisionBody}
-                  options={codeMirrorRevisionOption}
+                  isConflictMode
+                  readOnly
+                  // options={codeMirrorRevisionOption}
                 />
                 <div className="text-center my-4">
                   <button
@@ -164,6 +183,7 @@ export const ConflictDiffModal: FC<ConflictDiffModalProps> = (props) => {
               </div>
               <div className="col-12 border border-dark">
                 <h3 className="font-weight-bold my-2">{t('modal_resolve_conflict.selected_editable_revision')}</h3>
+                {/*
                 <CodeMirror
                   value={resolvedRevision.current}
                   options={{
@@ -177,6 +197,15 @@ export const ConflictDiffModal: FC<ConflictDiffModalProps> = (props) => {
                     if (pageBody === '') setIsRevisionSelected(false);
                     resolvedRevision.current = pageBody;
                   }}
+                />
+                */}
+                <CodeMirrorEditor
+                  indentSize={editorContainer.state.indentSize}
+                  editorOptions={editorContainer.state.editorOptions}
+                  isTextlintEnabled={editorContainer.state.isTextlintEnabled}
+                  textlintRules={editorContainer.state.textlintRules}
+                  value={latest.revisionBody}
+                  // options={codeMirrorRevisionOption}
                 />
               </div>
             </div>

--- a/packages/app/src/server/routes/page.js
+++ b/packages/app/src/server/routes/page.js
@@ -830,7 +830,7 @@ module.exports = function(crowi, app) {
     // check revision
     const Revision = crowi.model('Revision');
     let page = await Page.findByIdAndViewer(pageId, req.user);
-    if (page != null && revisionId != null && !page.isUpdatable('')) {
+    if (page != null && revisionId != null && !page.isUpdatable(revisionId)) {
       const populatedFields = 'name imageUrlCached';
       // when isUpdatable is false, originRevisionId is a reqested revisionId
       const originRevision = await Revision.findById(revisionId).populate('author', populatedFields);

--- a/packages/app/src/server/routes/page.js
+++ b/packages/app/src/server/routes/page.js
@@ -830,7 +830,7 @@ module.exports = function(crowi, app) {
     // check revision
     const Revision = crowi.model('Revision');
     let page = await Page.findByIdAndViewer(pageId, req.user);
-    if (page != null && revisionId != null && !page.isUpdatable(revisionId)) {
+    if (page != null && revisionId != null && !page.isUpdatable('')) {
       const populatedFields = 'name imageUrlCached';
       // when isUpdatable is false, originRevisionId is a reqested revisionId
       const originRevision = await Revision.findById(revisionId).populate('author', populatedFields);


### PR DESCRIPTION
## タスク

https://redmine.weseek.co.jp/issues/81032

## 画像

![codemirroreditor](https://user-images.githubusercontent.com/83065937/142807314-376f0aef-f5b7-467f-900e-8e3655cc94f5.PNG)

## 行ったこと

コンフリクト解消モーダルで使用されている reactcodemirror を CodeMirrorEditor に共通化しました。

共通化背景↓

https://redmine.weseek.co.jp/issues/81032

## 共通化に関して

-  CodeMirrorEditor に共通化しましたが、既存の  CodeMirrorEditor 内の reactcodemirror では、意図した挙動にすることができなかったため、 CodeMirrorEditor 内でやや無理やり共通化しました
- CodeMirrorEditor 内の reactcodemirror をリファクタすることは困難（デグレやバグが発生する可能性が高くほかの箇所も改修が必要）でした


## 後続タスク

差分がある行数を表示するために、RevisionDiff.jsx を改修し、 3column で使用できるようにする予定です。

