### PR TITLE
Imprv/81945 show unopened notification list

### DIFF
--- a/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
@@ -8,6 +8,7 @@ import InAppNotificationList from './InAppNotificationList';
 import { useSWRxInAppNotifications } from '../../stores/in-app-notification';
 import PaginationWrapper from '../PaginationWrapper';
 import CustomNavAndContents from '../CustomNavigation/CustomNavAndContents';
+import { InAppNotificationStatuses } from '~/interfaces/in-app-notification';
 
 
 type Props = {
@@ -20,6 +21,7 @@ const InAppNotificationPageBody: FC<Props> = (props) => {
   const [activePage, setActivePage] = useState(1);
   const offset = (activePage - 1) * limit;
   const { data: inAppNotificationData } = useSWRxInAppNotifications(limit, offset);
+  const { data: unOpendinAppNotificationData } = useSWRxInAppNotifications(limit, offset, InAppNotificationStatuses.STATUS_UNOPENED);
   const { t } = useTranslation();
 
   if (inAppNotificationData == null) {
@@ -56,6 +58,11 @@ const InAppNotificationPageBody: FC<Props> = (props) => {
 
   // commonize notification lists by 81953
   const UnopenedInAppNotificationList = () => {
+    console.log('inAppNotificationData', unOpendinAppNotificationData);
+    // const unopendNotifications = inAppNotificationData.map((notification) => {
+
+    // });
+
     return (
       <>
         <div className="mb-2 d-flex justify-content-end">
@@ -69,7 +76,7 @@ const InAppNotificationPageBody: FC<Props> = (props) => {
           </button>
         </div>
         {/*  TODO: show only unopened notifications by 81945 */}
-        <InAppNotificationList inAppNotificationData={inAppNotificationData} />
+        <InAppNotificationList inAppNotificationData={unOpendinAppNotificationData} />
         <PaginationWrapper
           activePage={activePage}
           changePage={setPageNumber}

--- a/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
@@ -19,8 +19,8 @@ const InAppNotificationPageBody: FC<Props> = (props) => {
   const { appContainer } = props;
   const limit = appContainer.config.pageLimitationXL;
   const [activePageOfAllNotificationCat, setActivePage] = useState(1);
-  const offset = (activePageOfAllNotificationCat - 1) * limit;
-  const { data: allNotificationData } = useSWRxInAppNotifications(limit, offset);
+  const offsetOfAllNotificationCat = (activePageOfAllNotificationCat - 1) * limit;
+  const { data: allNotificationData } = useSWRxInAppNotifications(limit, offsetOfAllNotificationCat);
 
   const [activePageOfUnopenedNotificationCat, setActiveUnopenedNotificationPage] = useState(1);
   const offsetOfUnopenedNotificationCat = (activePageOfUnopenedNotificationCat - 1) * limit;

--- a/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
@@ -21,7 +21,11 @@ const InAppNotificationPageBody: FC<Props> = (props) => {
   const [activePage, setActivePage] = useState(1);
   const offset = (activePage - 1) * limit;
   const { data: inAppNotificationData } = useSWRxInAppNotifications(limit, offset);
-  const { data: unOpendinAppNotificationData } = useSWRxInAppNotifications(limit, offset, InAppNotificationStatuses.STATUS_UNOPENED);
+
+
+  const [activeUnopenedPage, setActiveUnopenedPage] = useState(1);
+  const UnopenedOffset = (activeUnopenedPage - 1) * limit;
+  const { data: unOpendinAppNotificationData } = useSWRxInAppNotifications(limit, UnopenedOffset, InAppNotificationStatuses.STATUS_UNOPENED);
   const { t } = useTranslation();
 
   if (inAppNotificationData == null) {
@@ -37,6 +41,10 @@ const InAppNotificationPageBody: FC<Props> = (props) => {
 
   const setPageNumber = (selectedPageNumber): void => {
     setActivePage(selectedPageNumber);
+  };
+
+  const setUnopenedPageNumber = (selectedPageNumber): void => {
+    setActiveUnopenedPage(selectedPageNumber);
   };
 
   // commonize notification lists by 81953
@@ -78,8 +86,8 @@ const InAppNotificationPageBody: FC<Props> = (props) => {
         {/*  TODO: show only unopened notifications by 81945 */}
         <InAppNotificationList inAppNotificationData={unOpendinAppNotificationData} />
         <PaginationWrapper
-          activePage={activePage}
-          changePage={setPageNumber}
+          activePage={activeUnopenedPage}
+          changePage={setUnopenedPageNumber}
           totalItemsCount={inAppNotificationData.totalDocs}
           pagingLimit={inAppNotificationData.limit}
           align="center"

--- a/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
@@ -25,7 +25,7 @@ const InAppNotificationPageBody: FC<Props> = (props) => {
 
   const [activeUnopenedPage, setActiveUnopenedPage] = useState(1);
   const UnopenedOffset = (activeUnopenedPage - 1) * limit;
-  const { data: unOpendinAppNotificationData } = useSWRxInAppNotifications(limit, UnopenedOffset, InAppNotificationStatuses.STATUS_UNOPENED);
+  const { data: unopendinAppNotificationData } = useSWRxInAppNotifications(limit, UnopenedOffset, InAppNotificationStatuses.STATUS_UNOPENED);
   const { t } = useTranslation();
 
   if (inAppNotificationData == null) {
@@ -66,11 +66,6 @@ const InAppNotificationPageBody: FC<Props> = (props) => {
 
   // commonize notification lists by 81953
   const UnopenedInAppNotificationList = () => {
-    console.log('inAppNotificationData', unOpendinAppNotificationData);
-    // const unopendNotifications = inAppNotificationData.map((notification) => {
-
-    // });
-
     return (
       <>
         <div className="mb-2 d-flex justify-content-end">
@@ -84,7 +79,7 @@ const InAppNotificationPageBody: FC<Props> = (props) => {
           </button>
         </div>
         {/*  TODO: show only unopened notifications by 81945 */}
-        <InAppNotificationList inAppNotificationData={unOpendinAppNotificationData} />
+        <InAppNotificationList inAppNotificationData={unopendinAppNotificationData} />
         <PaginationWrapper
           activePage={activeUnopenedPage}
           changePage={setUnopenedPageNumber}

--- a/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
@@ -78,7 +78,6 @@ const InAppNotificationPageBody: FC<Props> = (props) => {
             {t('in_app_notification.mark_all_as_read')}
           </button>
         </div>
-        {/*  TODO: show only unopened notifications by 81945 */}
         <InAppNotificationList inAppNotificationData={unopendinAppNotificationData} />
         <PaginationWrapper
           activePage={activeUnopenedPage}
@@ -99,7 +98,6 @@ const InAppNotificationPageBody: FC<Props> = (props) => {
       i18n: t('in_app_notification.all'),
       index: 0,
     },
-    // TODO: show unopend notification list by 81945
     external_accounts: {
       Icon: () => <></>,
       Content: UnopenedInAppNotificationList,

--- a/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
@@ -23,9 +23,9 @@ const InAppNotificationPageBody: FC<Props> = (props) => {
   const { data: inAppNotificationData } = useSWRxInAppNotifications(limit, offset);
 
 
-  const [activeUnopenedPage, setActiveUnopenedPage] = useState(1);
-  const UnopenedOffset = (activeUnopenedPage - 1) * limit;
-  const { data: unopendinAppNotificationData } = useSWRxInAppNotifications(limit, UnopenedOffset, InAppNotificationStatuses.STATUS_UNOPENED);
+  const [activeUnopenedNotificationPage, setActiveUnopenedPage] = useState(1);
+  const UnopenedNotificationOffset = (activeUnopenedNotificationPage - 1) * limit;
+  const { data: unopendNotificationData } = useSWRxInAppNotifications(limit, UnopenedNotificationOffset, InAppNotificationStatuses.STATUS_UNOPENED);
   const { t } = useTranslation();
 
   if (inAppNotificationData == null) {
@@ -78,9 +78,9 @@ const InAppNotificationPageBody: FC<Props> = (props) => {
             {t('in_app_notification.mark_all_as_read')}
           </button>
         </div>
-        <InAppNotificationList inAppNotificationData={unopendinAppNotificationData} />
+        <InAppNotificationList inAppNotificationData={unopendNotificationData} />
         <PaginationWrapper
-          activePage={activeUnopenedPage}
+          activePage={activeUnopenedNotificationPage}
           changePage={setUnopenedPageNumber}
           totalItemsCount={inAppNotificationData.totalDocs}
           pagingLimit={inAppNotificationData.limit}

--- a/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
@@ -17,25 +17,11 @@ type Props = {
 
 const InAppNotificationPageBody: FC<Props> = (props) => {
   const { appContainer } = props;
-  const limit = appContainer.config.pageLimitationXL;
-  const [activePageOfAllNotificationCat, setActivePage] = useState(1);
-  const offsetOfAllNotificationCat = (activePageOfAllNotificationCat - 1) * limit;
-  const { data: allNotificationData } = useSWRxInAppNotifications(limit, offsetOfAllNotificationCat);
-
-  const [activePageOfUnopenedNotificationCat, setActiveUnopenedNotificationPage] = useState(1);
-  const offsetOfUnopenedNotificationCat = (activePageOfUnopenedNotificationCat - 1) * limit;
-
   const { t } = useTranslation();
 
-  if (allNotificationData == null) {
-    return (
-      <div className="wiki">
-        <div className="text-muted text-center">
-          <i className="fa fa-2x fa-spinner fa-pulse mr-1"></i>
-        </div>
-      </div>
-    );
-  }
+  const limit = appContainer.config.pageLimitationXL;
+  const [activePageOfAllNotificationCat, setActivePage] = useState(1);
+  const [activePageOfUnopenedNotificationCat, setActiveUnopenedNotificationPage] = useState(1);
 
 
   const setAllNotificationPageNumber = (selectedPageNumber): void => {
@@ -48,6 +34,20 @@ const InAppNotificationPageBody: FC<Props> = (props) => {
 
   // commonize notification lists by 81953
   const AllInAppNotificationList = () => {
+    const offsetOfAllNotificationCat = (activePageOfAllNotificationCat - 1) * limit;
+    const { data: allNotificationData } = useSWRxInAppNotifications(limit, offsetOfAllNotificationCat);
+
+    if (allNotificationData == null) {
+      return (
+        <div className="wiki">
+          <div className="text-muted text-center">
+            <i className="fa fa-2x fa-spinner fa-pulse mr-1"></i>
+          </div>
+        </div>
+      );
+    }
+
+
     return (
       <>
         <InAppNotificationList inAppNotificationData={allNotificationData} />
@@ -65,6 +65,7 @@ const InAppNotificationPageBody: FC<Props> = (props) => {
 
   // commonize notification lists by 81953
   const UnopenedInAppNotificationList = () => {
+    const offsetOfUnopenedNotificationCat = (activePageOfUnopenedNotificationCat - 1) * limit;
     const { data: unopendNotificationData } = useSWRxInAppNotifications(limit, offsetOfUnopenedNotificationCat, InAppNotificationStatuses.STATUS_UNOPENED);
 
     if (unopendNotificationData == null) {

--- a/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
@@ -18,12 +18,12 @@ type Props = {
 const InAppNotificationPageBody: FC<Props> = (props) => {
   const { appContainer } = props;
   const limit = appContainer.config.pageLimitationXL;
-  const [activePage, setActivePage] = useState(1);
-  const offset = (activePage - 1) * limit;
+  const [activePageOfAllNotificationCat, setActivePage] = useState(1);
+  const offset = (activePageOfAllNotificationCat - 1) * limit;
   const { data: allNotificationData } = useSWRxInAppNotifications(limit, offset);
 
-  const [activeUnopenedNotificationPage, setActiveUnopenedNotificationPage] = useState(1);
-  const unopenedNotificationOffset = (activeUnopenedNotificationPage - 1) * limit;
+  const [activePageOfUnopenedNotificationCat, setActiveUnopenedNotificationPage] = useState(1);
+  const offsetOfUnopenedNotificationCat = (activePageOfUnopenedNotificationCat - 1) * limit;
 
   const { t } = useTranslation();
 
@@ -38,7 +38,7 @@ const InAppNotificationPageBody: FC<Props> = (props) => {
   }
 
 
-  const setPageNumber = (selectedPageNumber): void => {
+  const setAllNotificationPageNumber = (selectedPageNumber): void => {
     setActivePage(selectedPageNumber);
   };
 
@@ -52,8 +52,8 @@ const InAppNotificationPageBody: FC<Props> = (props) => {
       <>
         <InAppNotificationList inAppNotificationData={allNotificationData} />
         <PaginationWrapper
-          activePage={activePage}
-          changePage={setPageNumber}
+          activePage={activePageOfAllNotificationCat}
+          changePage={setAllNotificationPageNumber}
           totalItemsCount={allNotificationData.totalDocs}
           pagingLimit={allNotificationData.limit}
           align="center"
@@ -65,7 +65,7 @@ const InAppNotificationPageBody: FC<Props> = (props) => {
 
   // commonize notification lists by 81953
   const UnopenedInAppNotificationList = () => {
-    const { data: unopendNotificationData } = useSWRxInAppNotifications(limit, unopenedNotificationOffset, InAppNotificationStatuses.STATUS_UNOPENED);
+    const { data: unopendNotificationData } = useSWRxInAppNotifications(limit, offsetOfUnopenedNotificationCat, InAppNotificationStatuses.STATUS_UNOPENED);
 
     if (unopendNotificationData == null) {
       return (
@@ -91,7 +91,7 @@ const InAppNotificationPageBody: FC<Props> = (props) => {
         </div>
         <InAppNotificationList inAppNotificationData={unopendNotificationData} />
         <PaginationWrapper
-          activePage={activeUnopenedNotificationPage}
+          activePage={activePageOfUnopenedNotificationCat}
           changePage={setUnopenedPageNumber}
           totalItemsCount={unopendNotificationData.totalDocs}
           pagingLimit={unopendNotificationData.limit}

--- a/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
@@ -20,15 +20,14 @@ const InAppNotificationPageBody: FC<Props> = (props) => {
   const limit = appContainer.config.pageLimitationXL;
   const [activePage, setActivePage] = useState(1);
   const offset = (activePage - 1) * limit;
-  const { data: inAppNotificationData } = useSWRxInAppNotifications(limit, offset);
+  const { data: allNotificationData } = useSWRxInAppNotifications(limit, offset);
 
-
-  const [activeUnopenedNotificationPage, setActiveUnopenedPage] = useState(1);
+  const [activeUnopenedNotificationPage, setActiveUnopenedNotificationPage] = useState(1);
   const unopenedNotificationOffset = (activeUnopenedNotificationPage - 1) * limit;
-  const { data: unopendNotificationData } = useSWRxInAppNotifications(limit, unopenedNotificationOffset, InAppNotificationStatuses.STATUS_UNOPENED);
+
   const { t } = useTranslation();
 
-  if (inAppNotificationData == null || unopendNotificationData == null) {
+  if (allNotificationData == null) {
     return (
       <div className="wiki">
         <div className="text-muted text-center">
@@ -44,19 +43,19 @@ const InAppNotificationPageBody: FC<Props> = (props) => {
   };
 
   const setUnopenedPageNumber = (selectedPageNumber): void => {
-    setActiveUnopenedPage(selectedPageNumber);
+    setActiveUnopenedNotificationPage(selectedPageNumber);
   };
 
   // commonize notification lists by 81953
   const AllInAppNotificationList = () => {
     return (
       <>
-        <InAppNotificationList inAppNotificationData={inAppNotificationData} />
+        <InAppNotificationList inAppNotificationData={allNotificationData} />
         <PaginationWrapper
           activePage={activePage}
           changePage={setPageNumber}
-          totalItemsCount={inAppNotificationData.totalDocs}
-          pagingLimit={inAppNotificationData.limit}
+          totalItemsCount={allNotificationData.totalDocs}
+          pagingLimit={allNotificationData.limit}
           align="center"
           size="sm"
         />
@@ -66,6 +65,18 @@ const InAppNotificationPageBody: FC<Props> = (props) => {
 
   // commonize notification lists by 81953
   const UnopenedInAppNotificationList = () => {
+    const { data: unopendNotificationData } = useSWRxInAppNotifications(limit, unopenedNotificationOffset, InAppNotificationStatuses.STATUS_UNOPENED);
+
+    if (unopendNotificationData == null) {
+      return (
+        <div className="wiki">
+          <div className="text-muted text-center">
+            <i className="fa fa-2x fa-spinner fa-pulse mr-1"></i>
+          </div>
+        </div>
+      );
+    }
+
     return (
       <>
         <div className="mb-2 d-flex justify-content-end">

--- a/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
@@ -28,7 +28,7 @@ const InAppNotificationPageBody: FC<Props> = (props) => {
   const { data: unopendNotificationData } = useSWRxInAppNotifications(limit, UnopenedNotificationOffset, InAppNotificationStatuses.STATUS_UNOPENED);
   const { t } = useTranslation();
 
-  if (inAppNotificationData == null) {
+  if (inAppNotificationData == null || unopendNotificationData == null) {
     return (
       <div className="wiki">
         <div className="text-muted text-center">
@@ -82,8 +82,8 @@ const InAppNotificationPageBody: FC<Props> = (props) => {
         <PaginationWrapper
           activePage={activeUnopenedNotificationPage}
           changePage={setUnopenedPageNumber}
-          totalItemsCount={inAppNotificationData.totalDocs}
-          pagingLimit={inAppNotificationData.limit}
+          totalItemsCount={unopendNotificationData.totalDocs}
+          pagingLimit={unopendNotificationData.limit}
           align="center"
           size="sm"
         />

--- a/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
@@ -24,8 +24,8 @@ const InAppNotificationPageBody: FC<Props> = (props) => {
 
 
   const [activeUnopenedNotificationPage, setActiveUnopenedPage] = useState(1);
-  const UnopenedNotificationOffset = (activeUnopenedNotificationPage - 1) * limit;
-  const { data: unopendNotificationData } = useSWRxInAppNotifications(limit, UnopenedNotificationOffset, InAppNotificationStatuses.STATUS_UNOPENED);
+  const unopenedNotificationOffset = (activeUnopenedNotificationPage - 1) * limit;
+  const { data: unopendNotificationData } = useSWRxInAppNotifications(limit, unopenedNotificationOffset, InAppNotificationStatuses.STATUS_UNOPENED);
   const { t } = useTranslation();
 
   if (inAppNotificationData == null || unopendNotificationData == null) {

--- a/packages/app/src/server/routes/apiv3/in-app-notification.ts
+++ b/packages/app/src/server/routes/apiv3/in-app-notification.ts
@@ -29,9 +29,8 @@ module.exports = (crowi) => {
       limit,
     };
 
-    // get categorized notification list
+    // set in-app-notification status to categorize
     if (req.query.status) {
-      console.log('req.query.status');
       Object.assign(queryOptions, { status: req.query.status });
     }
 

--- a/packages/app/src/server/routes/apiv3/in-app-notification.ts
+++ b/packages/app/src/server/routes/apiv3/in-app-notification.ts
@@ -30,7 +30,7 @@ module.exports = (crowi) => {
     };
 
     // set in-app-notification status to categorize
-    if (req.query.status) {
+    if (req.query.status != null) {
       Object.assign(queryOptions, { status: req.query.status });
     }
 

--- a/packages/app/src/server/routes/apiv3/in-app-notification.ts
+++ b/packages/app/src/server/routes/apiv3/in-app-notification.ts
@@ -29,6 +29,11 @@ module.exports = (crowi) => {
       limit,
     };
 
+    // get categorized notification list
+    if (req.query.status) {
+      console.log('req.query.status');
+      Object.assign(queryOptions, { status: req.query.status });
+    }
 
     const paginationResult = await inAppNotificationService.getLatestNotificationsByUser(user._id, queryOptions);
 

--- a/packages/app/src/server/service/in-app-notification.ts
+++ b/packages/app/src/server/service/in-app-notification.ts
@@ -1,11 +1,12 @@
 import { Types } from 'mongoose';
 import { subDays } from 'date-fns';
+import { InAppNotificationStatuses, PaginateResult, InAppNotificationStatuses } from '~/interfaces/in-app-notification';
 import Crowi from '../crowi';
 import {
   InAppNotification,
   InAppNotificationDocument,
 } from '~/server/models/in-app-notification';
-import { PaginateResult, InAppNotificationStatuses } from '../../interfaces/in-app-notification';
+
 
 import { ActivityDocument } from '~/server/models/activity';
 import InAppNotificationSettings from '~/server/models/in-app-notification-settings';
@@ -88,15 +89,19 @@ export default class InAppNotificationService {
 
   getLatestNotificationsByUser = async(
       userId: Types.ObjectId,
-      queryOptions: {offset: number, limit: number},
+      queryOptions: {offset: number, limit: number, status?: InAppNotificationStatuses},
   ): Promise<PaginateResult<InAppNotificationDocument>> => {
-    const { limit, offset } = queryOptions;
+    const { limit, offset, status } = queryOptions;
 
     try {
+      const pagenateOptions = { user: userId };
+      if (status != null) {
+        Object.assign(pagenateOptions, { status });
+      }
       // TODO: import @types/mongoose-paginate-v2 and use PaginateResult as a type after upgrading mongoose v6.0.0
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const paginationResult = await (InAppNotification as any).paginate(
-        { user: userId },
+        pagenateOptions,
         {
           sort: { createdAt: -1 },
           limit,

--- a/packages/app/src/server/service/in-app-notification.ts
+++ b/packages/app/src/server/service/in-app-notification.ts
@@ -1,12 +1,11 @@
 import { Types } from 'mongoose';
 import { subDays } from 'date-fns';
-import { InAppNotificationStatuses, PaginateResult, InAppNotificationStatuses } from '~/interfaces/in-app-notification';
+import { InAppNotificationStatuses, PaginateResult } from '~/interfaces/in-app-notification';
 import Crowi from '../crowi';
 import {
   InAppNotification,
   InAppNotificationDocument,
 } from '~/server/models/in-app-notification';
-
 
 import { ActivityDocument } from '~/server/models/activity';
 import InAppNotificationSettings from '~/server/models/in-app-notification-settings';

--- a/packages/app/src/stores/in-app-notification.ts
+++ b/packages/app/src/stores/in-app-notification.ts
@@ -1,15 +1,17 @@
 import useSWR, { SWRResponse } from 'swr';
+import { InAppNotificationStatuses, IInAppNotification, PaginateResult } from '~/interfaces/in-app-notification';
 
 import { apiv3Get } from '../client/util/apiv3-client';
-import { IInAppNotification, PaginateResult } from '../interfaces/in-app-notification';
+
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const useSWRxInAppNotifications = <Data, Error>(
   limit: number,
   offset?: number,
+  status?: InAppNotificationStatuses,
 ): SWRResponse<PaginateResult<IInAppNotification>, Error> => {
   return useSWR(
-    ['/in-app-notification/list', limit, offset],
-    endpoint => apiv3Get(endpoint, { limit, offset }).then(response => response.data),
+    ['/in-app-notification/list', limit, offset, status],
+    endpoint => apiv3Get(endpoint, { limit, offset, status }).then(response => response.data),
   );
 };

--- a/packages/app/src/stores/in-app-notification.ts
+++ b/packages/app/src/stores/in-app-notification.ts
@@ -1,8 +1,6 @@
 import useSWR, { SWRResponse } from 'swr';
 import { InAppNotificationStatuses, IInAppNotification, PaginateResult } from '~/interfaces/in-app-notification';
-
 import { apiv3Get } from '../client/util/apiv3-client';
-
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const useSWRxInAppNotifications = <Data, Error>(


### PR DESCRIPTION
## Task
- [#81945](https://redmine.weseek.co.jp/issues/81945) 未読のカテゴリーリストを表示させることができる

## Note
### TODO
- [#81999](https://redmine.weseek.co.jp/issues/81999) 通知がひとつもない場合、「ページネーション」と「全て既読にする」ボタンが表示されないようにする

## Screen Recording

https://user-images.githubusercontent.com/59536731/142624083-960d066b-b58d-4ade-8f3e-92e18a53f0f5.mov


