### PR TITLE
fix: Unfurl permission

### DIFF
--- a/packages/app/resource/locales/en_US/admin/admin.json
+++ b/packages/app/resource/locales/en_US/admin/admin.json
@@ -345,7 +345,7 @@
       "single_growi_command": "Commands that could be sent to single GROWI instance at a time",
       "allowed_channels_description": "Input allowed channels for \"{{keyName}}\" command. Separate each channel with \",\" . Users can will be able to use \"{{keyName}}\" command from channels written here.",
       "unfurl_description": "Show GROWI page contents when page links have been shared on Slack",
-      "unfurl_allowed_channels_description": "Input allowed channels for \"unfurl\" . Separate each channel with \",\" . GROWI public page links or permanent links sent in specified channels will show the content in the message.",
+      "unfurl_allowed_channels_description": "Input allowed channel IDs for \"unfurl\" . Separate each channel with \",\" . GROWI public page links or permanent links sent in specified channels will show the content in the message.",
       "allow_all": "Allow all",
       "deny_all": "Deny all",
       "allow_specified": "Allow specified",

--- a/packages/app/resource/locales/ja_JP/admin/admin.json
+++ b/packages/app/resource/locales/ja_JP/admin/admin.json
@@ -344,7 +344,7 @@
       "single_growi_command": "一つのGROWIに対して送信できるコマンド",
       "allowed_channels_description": "\"{{keyName}}\" コマンドの使用を許可するチャンネルを \",\" 区切りで入力してください。ユーザーはここに記入されているチャンネルから \"{{keyName}}\" コマンドを使用することができます。",
       "unfurl_description": "Slack で GROWI のリンクを共有したときにページの内容を表示する",
-      "unfurl_allowed_channels_description": "\"unfurl\" の使用を許可するチャンネルを \",\" 区切りで入力してください。ここに記入されているチャンネルで GROWI の ページリンクを共有するとページの内容が表示されます。",
+      "unfurl_allowed_channels_description": "\"unfurl\" の使用を許可するチャンネルの ID を \",\" 区切りで入力してください。ここに記入されているチャンネルで GROWI の ページリンクを共有するとページの内容が表示されます。",
       "allow_all": "全てのチャンネルを許可",
       "deny_all": "全てのチャンネルを拒否",
       "allow_specified": "特定のチャンネルを許可",

--- a/packages/app/resource/locales/zh_CN/admin/admin.json
+++ b/packages/app/resource/locales/zh_CN/admin/admin.json
@@ -354,7 +354,7 @@
       "single_growi_command": "可以一次发送到一个 GROWI 实例的命令",
       "allowed_channels_description": "为 \"{{keyName}}\" 命令输入允许的通道。每个通道之间用 \",\" 隔开。用户可以从这里写入的通道中使用 \"{{keyName}}\"。",
       "unfurl_description": "在 Slack 中共享 GROWI 链接时显示页面内容",
-      "unfurl_allowed_channels_description": "输入使用 Unfurl 权限的频道，以 \"unfurl\" 分隔。在此处列出的频道上分享 GROWI 的公共永久链接，看看发生了什么。",
+      "unfurl_allowed_channels_description": "为 \"unfurl\" 输入允许的通道ID。每个频道用 \",\"分开。在指定频道中发送的GROWI公共页面链接或永久链接将显示消息中的内容。",
       "allow_all": "允许所有",
       "deny_all": "拒绝所有",
       "allow_specified": "允许指定",

--- a/packages/app/src/server/service/slack-event-handler/link-shared.ts
+++ b/packages/app/src/server/service/slack-event-handler/link-shared.ts
@@ -26,11 +26,11 @@ export class LinkSharedEventHandler implements SlackEventHandler<UnfurlRequestEv
 
     const unfurlPermission = permission.get('unfurl');
 
-    if (Array.isArray(unfurlPermission) && unfurlPermission.length === 0) {
-      return false;
+    if (!Array.isArray(unfurlPermission)) {
+      return unfurlPermission as boolean;
     }
 
-    return (Array.isArray(unfurlPermission) && unfurlPermission.includes(channel)) || unfurlPermission as boolean;
+    return unfurlPermission.includes(channel);
   }
 
   async handleEvent(client: WebClient, growiBotEvent: GrowiBotEvent<UnfurlRequestEvent>, data?: {origin: string}): Promise<void> {

--- a/packages/app/src/server/service/slack-event-handler/link-shared.ts
+++ b/packages/app/src/server/service/slack-event-handler/link-shared.ts
@@ -25,6 +25,11 @@ export class LinkSharedEventHandler implements SlackEventHandler<UnfurlRequestEv
     if (eventType !== 'link_shared') return false;
 
     const unfurlPermission = permission.get('unfurl');
+
+    if (Array.isArray(unfurlPermission) && unfurlPermission.length === 0) {
+      return false;
+    }
+
     return (Array.isArray(unfurlPermission) && unfurlPermission.includes(channel)) || unfurlPermission as boolean;
   }
 

--- a/packages/app/src/server/service/slack-integration.ts
+++ b/packages/app/src/server/service/slack-integration.ts
@@ -312,7 +312,7 @@ export class SlackIntegrationService implements S2sMessageHandlable {
 
   async handleEventsRequest(client: WebClient, growiBotEvent: GrowiBotEvent<any>, permission: EventActionsPermission, data?: any): Promise<void> {
     const { eventType } = growiBotEvent;
-    const { channel = '' } = growiBotEvent.event;
+    const { channel = '' } = growiBotEvent.event; // only channelId
 
     if (this.linkSharedHandler.shouldHandle(eventType, permission, channel)) {
       return this.linkSharedHandler.handleEvent(client, growiBotEvent, data);


### PR DESCRIPTION
Redmine: https://redmine.weseek.co.jp/issues/82042

Unfurl の権限を channelId のみに対応して修正しました
それに伴って admin 画面の文言も修正しました