### PR TITLE
Imprv/81907 update notification statuses by clicking on the "mark as read" button

### DIFF
--- a/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
@@ -19,8 +19,8 @@ const InAppNotificationPageBody: FC<Props> = (props) => {
   const { appContainer } = props;
   const limit = appContainer.config.pageLimitationXL;
   const [activePageOfAllNotificationCat, setActivePage] = useState(1);
-  const offset = (activePageOfAllNotificationCat - 1) * limit;
-  const { data: allNotificationData } = useSWRxInAppNotifications(limit, offset);
+  const offsetOfAllNotificationCat = (activePageOfAllNotificationCat - 1) * limit;
+  const { data: allNotificationData } = useSWRxInAppNotifications(limit, offsetOfAllNotificationCat);
 
   const [activePageOfUnopenedNotificationCat, setActiveUnopenedNotificationPage] = useState(1);
   const offsetOfUnopenedNotificationCat = (activePageOfUnopenedNotificationCat - 1) * limit;

--- a/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
@@ -9,6 +9,7 @@ import { useSWRxInAppNotifications } from '../../stores/in-app-notification';
 import PaginationWrapper from '../PaginationWrapper';
 import CustomNavAndContents from '../CustomNavigation/CustomNavAndContents';
 import { InAppNotificationStatuses } from '~/interfaces/in-app-notification';
+import { apiv3Put } from '~/client/util/apiv3-client';
 
 
 type Props = {
@@ -63,6 +64,10 @@ const InAppNotificationPageBody: FC<Props> = (props) => {
     );
   };
 
+  const updateUnopendNotificationStatusesToOpened = async() => {
+    await apiv3Put('/in-app-notification/all-statuses-open');
+  };
+
   // commonize notification lists by 81953
   const UnopenedInAppNotificationList = () => {
     const { data: unopendNotificationData } = useSWRxInAppNotifications(limit, offsetOfUnopenedNotificationCat, InAppNotificationStatuses.STATUS_UNOPENED);
@@ -83,8 +88,7 @@ const InAppNotificationPageBody: FC<Props> = (props) => {
           <button
             type="button"
             className="btn btn-outline-primary"
-            // TODO: set "UNOPENED" notification status "OPEND" by 81951
-            // onClick={}
+            onClick={updateUnopendNotificationStatusesToOpened}
           >
             {t('in_app_notification.mark_all_as_read')}
           </button>

--- a/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
@@ -21,7 +21,7 @@ const InAppNotificationPageBody: FC<Props> = (props) => {
   const limit = appContainer.config.pageLimitationXL;
   const [activePageOfAllNotificationCat, setActivePage] = useState(1);
   const offsetOfAllNotificationCat = (activePageOfAllNotificationCat - 1) * limit;
-  const { data: allNotificationData } = useSWRxInAppNotifications(limit, offsetOfAllNotificationCat);
+  const { data: allNotificationData, mutate } = useSWRxInAppNotifications(limit, offsetOfAllNotificationCat);
 
   const [activePageOfUnopenedNotificationCat, setActiveUnopenedNotificationPage] = useState(1);
   const offsetOfUnopenedNotificationCat = (activePageOfUnopenedNotificationCat - 1) * limit;
@@ -66,6 +66,7 @@ const InAppNotificationPageBody: FC<Props> = (props) => {
 
   const updateUnopendNotificationStatusesToOpened = async() => {
     await apiv3Put('/in-app-notification/all-statuses-open');
+    mutate();
   };
 
   // commonize notification lists by 81953

--- a/packages/app/src/server/routes/apiv3/in-app-notification.ts
+++ b/packages/app/src/server/routes/apiv3/in-app-notification.ts
@@ -104,19 +104,17 @@ module.exports = (crowi) => {
   });
 
   router.put('/all-statuses-open', accessTokenParser, loginRequiredStrictly, csrf, async(req, res) => {
-    // const user = req.user;
-    // const id = req.body.id;
-    console.log('api叩かれた');
+    const user = req.user;
 
-    // try {
-    //   // findする
-    //   const notifications = await inAppNotificationService.markAllNotificationsAsOpened(user);
-    //   const result = { notifications };
-    //   return res.apiv3(result);
-    // }
-    // catch (err) {
-    //   return res.apiv3Err(err);
-    // }
+    try {
+      const notifications = await inAppNotificationService.updateAllNotificationsAsOpened(user);
+
+      const result = { notifications };
+      return res.apiv3(result);
+    }
+    catch (err) {
+      return res.apiv3Err(err);
+    }
   });
 
   return router;

--- a/packages/app/src/server/routes/apiv3/in-app-notification.ts
+++ b/packages/app/src/server/routes/apiv3/in-app-notification.ts
@@ -103,5 +103,21 @@ module.exports = (crowi) => {
     }
   });
 
+  router.put('/open-all', accessTokenParser, loginRequiredStrictly, csrf, async(req, res) => {
+    // const user = req.user;
+    // const id = req.body.id;
+    console.log('api叩かれた');
+
+    // try {
+    //   // findする
+    //   const notifications = await inAppNotificationService.markAllNotificationsAsOpened(user);
+    //   const result = { notifications };
+    //   return res.apiv3(result);
+    // }
+    // catch (err) {
+    //   return res.apiv3Err(err);
+    // }
+  });
+
   return router;
 };

--- a/packages/app/src/server/routes/apiv3/in-app-notification.ts
+++ b/packages/app/src/server/routes/apiv3/in-app-notification.ts
@@ -107,10 +107,8 @@ module.exports = (crowi) => {
     const user = req.user;
 
     try {
-      const notifications = await inAppNotificationService.updateAllNotificationsAsOpened(user);
-
-      const result = { notifications };
-      return res.apiv3(result);
+      await inAppNotificationService.updateAllNotificationsAsOpened(user);
+      return res.apiv3();
     }
     catch (err) {
       return res.apiv3Err(err);

--- a/packages/app/src/server/routes/apiv3/in-app-notification.ts
+++ b/packages/app/src/server/routes/apiv3/in-app-notification.ts
@@ -103,7 +103,7 @@ module.exports = (crowi) => {
     }
   });
 
-  router.put('/open-all', accessTokenParser, loginRequiredStrictly, csrf, async(req, res) => {
+  router.put('/all-statuses-open', accessTokenParser, loginRequiredStrictly, csrf, async(req, res) => {
     // const user = req.user;
     // const id = req.body.id;
     console.log('api叩かれた');

--- a/packages/app/src/server/service/in-app-notification.ts
+++ b/packages/app/src/server/service/in-app-notification.ts
@@ -1,6 +1,6 @@
 import { Types } from 'mongoose';
 import { subDays } from 'date-fns';
-import { InAppNotificationStatuses, PaginateResult } from '~/interfaces/in-app-notification';
+import { InAppNotificationStatuses, PaginateResult, IInAppNotification } from '~/interfaces/in-app-notification';
 import Crowi from '../crowi';
 import {
   InAppNotification,
@@ -12,6 +12,7 @@ import InAppNotificationSettings from '~/server/models/in-app-notification-setti
 import Subscription, { STATUS_SUBSCRIBE } from '~/server/models/subscription';
 
 import { IUser } from '~/interfaces/user';
+
 import { HasObjectId } from '~/interfaces/has-object-id';
 import loggerFactory from '~/utils/logger';
 import { RoomPrefix, getRoomNameWithId } from '../util/socket-io-helpers';
@@ -139,8 +140,10 @@ export default class InAppNotificationService {
   }
 
   updateAllNotificationsAsOpened = async function(user: IUser & HasObjectId): Promise<void> {
-    const unopenedNotificatins = await InAppNotification.find({ user: user._id, status: 'UNOPENED' });
-    console.log('notifiunopenedNotificatinscatins', unopenedNotificatins);
+    const filter = { user: user._id, status: STATUS_UNOPENED };
+    const options = { status: STATUS_OPENED };
+
+    await InAppNotification.updateMany(filter, options);
     return;
   }
 

--- a/packages/app/src/server/service/in-app-notification.ts
+++ b/packages/app/src/server/service/in-app-notification.ts
@@ -138,6 +138,12 @@ export default class InAppNotificationService {
     return;
   }
 
+  updateAllNotificationsAsOpened = async function(user: IUser & HasObjectId): Promise<void> {
+    const unopenedNotificatins = await InAppNotification.find({ user: user._id, status: 'UNOPENED' });
+    console.log('notifiunopenedNotificatinscatins', unopenedNotificatins);
+    return;
+  }
+
   getUnreadCountByUser = async function(user: Types.ObjectId): Promise<number| undefined> {
     const query = { user, status: STATUS_UNREAD };
 


### PR DESCRIPTION
## Tasks
- [#81907](https://redmine.weseek.co.jp/issues/81907) 全て既読にする用のエンドポイントを追加する
- [#81951](https://redmine.weseek.co.jp/issues/81951) 「全て既読にする」ボタンを押すと、通知のステータスがOPENDになり、未読のカテゴリーに表示されなくなるようにする


## Note
- 「全て既読にする」ボタンを押すと `UNOPENED` の通知が `OPENED`に更新されるようにしました。
(現状、ドロップダウンアイコンを押すと、全ての通知のステータスは`UNREAD` -> `UNOPENED`になります。)

- TODO
    - 「全て既読にする」ボタンを押した後に、「全て」のカテゴリーに移動すると、ステータスが反映されていません。
    - (リロードすると反映されます。)
    - これは、後続タスクの[#81953「全て」「未読」カテゴリー内部のリストを共通化させる](https://redmine.weseek.co.jp/issues/81953)にて、修正予定です。

## Screen Recording

https://user-images.githubusercontent.com/59536731/143210757-a6ebabcf-9518-43f5-b707-2b0e92c12608.mov


