### PR TITLE
Imprv/81953 commonalize notification category

### DIFF
--- a/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
@@ -18,12 +18,9 @@ type Props = {
 
 const InAppNotificationPageBody: FC<Props> = (props) => {
   const { appContainer } = props;
+  const limit = appContainer.config.pageLimitationXL;
   const { t } = useTranslation();
 
-  const limit = appContainer.config.pageLimitationXL;
-
-
-  // commonize notification lists by 81953
   const InAppNotificationCategoryByStatus = (status?: string) => {
     const [activePage, setActivePage] = useState(1);
     const offset = (activePage - 1) * limit;

--- a/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
@@ -59,7 +59,7 @@ const InAppNotificationPageBody: FC<Props> = (props) => {
 
     return (
       <>
-        {status === 'UNOPENED'
+        {status === InAppNotificationStatuses.STATUS_UNOPENED
       && (
         <div className="mb-2 d-flex justify-content-end">
           <button

--- a/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
@@ -24,10 +24,10 @@ const InAppNotificationPageBody: FC<Props> = (props) => {
 
 
   // commonize notification lists by 81953
-  const InAppNotificationCategory = () => {
+  const InAppNotificationCategoryByStatus = (status?) => {
     const [activePage, setActivePage] = useState(1);
     const offset = (activePage - 1) * limit;
-    const { data: notificationData } = useSWRxInAppNotifications(limit, offset);
+    const { data: notificationData, mutate } = useSWRxInAppNotifications(limit, offset);
 
     const setAllNotificationPageNumber = (selectedPageNumber): void => {
       setActivePage(selectedPageNumber);
@@ -44,9 +44,28 @@ const InAppNotificationPageBody: FC<Props> = (props) => {
       );
     }
 
+    const updateUnopendNotificationStatusesToOpened = async() => {
+      await apiv3Put('/in-app-notification/all-statuses-open');
+      mutate();
+    };
+
 
     return (
       <>
+        {status === 'UNOPENED'
+      && (
+        <div className="mb-2 d-flex justify-content-end">
+          <button
+            type="button"
+            className="btn btn-outline-primary"
+            onClick={updateUnopendNotificationStatusesToOpened}
+          >
+            {t('in_app_notification.mark_all_as_read')}
+          </button>
+        </div>
+      )
+        }
+
         <InAppNotificationList inAppNotificationData={notificationData} />
         <PaginationWrapper
           activePage={activePage}
@@ -115,13 +134,13 @@ const InAppNotificationPageBody: FC<Props> = (props) => {
   const navTabMapping = {
     user_infomation: {
       Icon: () => <></>,
-      Content: () => InAppNotificationCategory,
+      Content: () => InAppNotificationCategoryByStatus(),
       i18n: t('in_app_notification.all'),
       index: 0,
     },
     external_accounts: {
       Icon: () => <></>,
-      Content: UnopenedInAppNotificationList,
+      Content: () => InAppNotificationCategoryByStatus('UNOPENED'),
       i18n: t('in_app_notification.unopend'),
       index: 1,
     },

--- a/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
@@ -24,10 +24,17 @@ const InAppNotificationPageBody: FC<Props> = (props) => {
 
 
   // commonize notification lists by 81953
-  const InAppNotificationCategoryByStatus = (status?) => {
+  const InAppNotificationCategoryByStatus = (status?: string) => {
     const [activePage, setActivePage] = useState(1);
     const offset = (activePage - 1) * limit;
-    const { data: notificationData, mutate } = useSWRxInAppNotifications(limit, offset);
+
+    let categoryStatus;
+
+    if (status === 'UNOPENED') {
+      categoryStatus = InAppNotificationStatuses.STATUS_UNOPENED;
+    }
+
+    const { data: notificationData, mutate } = useSWRxInAppNotifications(limit, offset, categoryStatus);
 
     const setAllNotificationPageNumber = (selectedPageNumber): void => {
       setActivePage(selectedPageNumber);

--- a/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
@@ -21,22 +21,18 @@ const InAppNotificationPageBody: FC<Props> = (props) => {
   const { t } = useTranslation();
 
   const limit = appContainer.config.pageLimitationXL;
-  const [activePageOfAllNotificationCat, setActivePage] = useState(1);
-  const [activePageOfUnopenedNotificationCat, setActiveUnopenedNotificationPage] = useState(1);
 
-
-  const setAllNotificationPageNumber = (selectedPageNumber): void => {
-    setActivePage(selectedPageNumber);
-  };
-
-  const setUnopenedPageNumber = (selectedPageNumber): void => {
-    setActiveUnopenedNotificationPage(selectedPageNumber);
-  };
 
   // commonize notification lists by 81953
   const AllInAppNotificationList = () => {
+    const [activePageOfAllNotificationCat, setActivePage] = useState(1);
     const offsetOfAllNotificationCat = (activePageOfAllNotificationCat - 1) * limit;
     const { data: allNotificationData } = useSWRxInAppNotifications(limit, offsetOfAllNotificationCat);
+
+    const setAllNotificationPageNumber = (selectedPageNumber): void => {
+      setActivePage(selectedPageNumber);
+    };
+
 
     if (allNotificationData == null) {
       return (
@@ -67,10 +63,15 @@ const InAppNotificationPageBody: FC<Props> = (props) => {
 
   // commonize notification lists by 81953
   const UnopenedInAppNotificationList = () => {
+    const [activePageOfUnopenedNotificationCat, setActiveUnopenedNotificationPage] = useState(1);
     const offsetOfUnopenedNotificationCat = (activePageOfUnopenedNotificationCat - 1) * limit;
     const {
       data: unopendNotificationData, mutate,
     } = useSWRxInAppNotifications(limit, offsetOfUnopenedNotificationCat, InAppNotificationStatuses.STATUS_UNOPENED);
+
+    const setUnopenedPageNumber = (selectedPageNumber): void => {
+      setActiveUnopenedNotificationPage(selectedPageNumber);
+    };
 
     const updateUnopendNotificationStatusesToOpened = async() => {
       await apiv3Put('/in-app-notification/all-statuses-open');

--- a/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
@@ -25,16 +25,16 @@ const InAppNotificationPageBody: FC<Props> = (props) => {
 
   // commonize notification lists by 81953
   const AllInAppNotificationList = () => {
-    const [activePageOfAllNotificationCat, setActivePage] = useState(1);
-    const offsetOfAllNotificationCat = (activePageOfAllNotificationCat - 1) * limit;
-    const { data: allNotificationData } = useSWRxInAppNotifications(limit, offsetOfAllNotificationCat);
+    const [activePage, setActivePage] = useState(1);
+    const offset = (activePage - 1) * limit;
+    const { data: notificationData } = useSWRxInAppNotifications(limit, offset);
 
     const setAllNotificationPageNumber = (selectedPageNumber): void => {
       setActivePage(selectedPageNumber);
     };
 
 
-    if (allNotificationData == null) {
+    if (notificationData == null) {
       return (
         <div className="wiki">
           <div className="text-muted text-center">
@@ -47,12 +47,12 @@ const InAppNotificationPageBody: FC<Props> = (props) => {
 
     return (
       <>
-        <InAppNotificationList inAppNotificationData={allNotificationData} />
+        <InAppNotificationList inAppNotificationData={notificationData} />
         <PaginationWrapper
-          activePage={activePageOfAllNotificationCat}
+          activePage={activePage}
           changePage={setAllNotificationPageNumber}
-          totalItemsCount={allNotificationData.totalDocs}
-          pagingLimit={allNotificationData.limit}
+          totalItemsCount={notificationData.totalDocs}
+          pagingLimit={notificationData.limit}
           align="center"
           size="sm"
         />

--- a/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
@@ -24,7 +24,7 @@ const InAppNotificationPageBody: FC<Props> = (props) => {
 
 
   // commonize notification lists by 81953
-  const AllInAppNotificationList = () => {
+  const InAppNotificationCategory = () => {
     const [activePage, setActivePage] = useState(1);
     const offset = (activePage - 1) * limit;
     const { data: notificationData } = useSWRxInAppNotifications(limit, offset);
@@ -115,7 +115,7 @@ const InAppNotificationPageBody: FC<Props> = (props) => {
   const navTabMapping = {
     user_infomation: {
       Icon: () => <></>,
-      Content: AllInAppNotificationList,
+      Content: () => InAppNotificationCategory,
       i18n: t('in_app_notification.all'),
       index: 0,
     },

--- a/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
@@ -21,13 +21,13 @@ const InAppNotificationPageBody: FC<Props> = (props) => {
   const limit = appContainer.config.pageLimitationXL;
   const { t } = useTranslation();
 
-  const InAppNotificationCategoryByStatus = (status?: string) => {
+  const InAppNotificationCategoryByStatus = (status?: InAppNotificationStatuses) => {
     const [activePage, setActivePage] = useState(1);
     const offset = (activePage - 1) * limit;
 
     let categoryStatus;
 
-    if (status === 'UNOPENED') {
+    if (status === InAppNotificationStatuses.STATUS_UNOPENED) {
       categoryStatus = InAppNotificationStatuses.STATUS_UNOPENED;
     }
 
@@ -92,7 +92,7 @@ const InAppNotificationPageBody: FC<Props> = (props) => {
     },
     external_accounts: {
       Icon: () => <></>,
-      Content: () => InAppNotificationCategoryByStatus('UNOPENED'),
+      Content: () => InAppNotificationCategoryByStatus(InAppNotificationStatuses.STATUS_UNOPENED),
       i18n: t('in_app_notification.unopend'),
       index: 1,
     },

--- a/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
@@ -27,8 +27,11 @@ const InAppNotificationPageBody: FC<Props> = (props) => {
 
     let categoryStatus;
 
-    if (status === InAppNotificationStatuses.STATUS_UNOPENED) {
-      categoryStatus = InAppNotificationStatuses.STATUS_UNOPENED;
+    switch (status) {
+      case InAppNotificationStatuses.STATUS_UNOPENED:
+        categoryStatus = InAppNotificationStatuses.STATUS_UNOPENED;
+        break;
+      default:
     }
 
     const { data: notificationData, mutate } = useSWRxInAppNotifications(limit, offset, categoryStatus);

--- a/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
@@ -86,58 +86,6 @@ const InAppNotificationPageBody: FC<Props> = (props) => {
     );
   };
 
-
-  // commonize notification lists by 81953
-  const UnopenedInAppNotificationList = () => {
-    const [activePageOfUnopenedNotificationCat, setActiveUnopenedNotificationPage] = useState(1);
-    const offsetOfUnopenedNotificationCat = (activePageOfUnopenedNotificationCat - 1) * limit;
-    const {
-      data: unopendNotificationData, mutate,
-    } = useSWRxInAppNotifications(limit, offsetOfUnopenedNotificationCat, InAppNotificationStatuses.STATUS_UNOPENED);
-
-    const setUnopenedPageNumber = (selectedPageNumber): void => {
-      setActiveUnopenedNotificationPage(selectedPageNumber);
-    };
-
-    const updateUnopendNotificationStatusesToOpened = async() => {
-      await apiv3Put('/in-app-notification/all-statuses-open');
-      mutate();
-    };
-
-    if (unopendNotificationData == null) {
-      return (
-        <div className="wiki">
-          <div className="text-muted text-center">
-            <i className="fa fa-2x fa-spinner fa-pulse mr-1"></i>
-          </div>
-        </div>
-      );
-    }
-
-    return (
-      <>
-        <div className="mb-2 d-flex justify-content-end">
-          <button
-            type="button"
-            className="btn btn-outline-primary"
-            onClick={updateUnopendNotificationStatusesToOpened}
-          >
-            {t('in_app_notification.mark_all_as_read')}
-          </button>
-        </div>
-        <InAppNotificationList inAppNotificationData={unopendNotificationData} />
-        <PaginationWrapper
-          activePage={activePageOfUnopenedNotificationCat}
-          changePage={setUnopenedPageNumber}
-          totalItemsCount={unopendNotificationData.totalDocs}
-          pagingLimit={unopendNotificationData.limit}
-          align="center"
-          size="sm"
-        />
-      </>
-    );
-  };
-
   const navTabMapping = {
     user_infomation: {
       Icon: () => <></>,

--- a/packages/app/src/server/service/in-app-notification.ts
+++ b/packages/app/src/server/service/in-app-notification.ts
@@ -140,8 +140,8 @@ export default class InAppNotificationService {
   }
 
   updateAllNotificationsAsOpened = async function(user: IUser & HasObjectId): Promise<void> {
-    const filter = { user: user._id, status: STATUS_UNOPENED };
-    const options = { status: STATUS_OPENED };
+    const filter = { user: user._id, status: STATUS_OPENED };
+    const options = { status: STATUS_UNOPENED };
 
     await InAppNotification.updateMany(filter, options);
     return;

--- a/packages/app/src/server/service/in-app-notification.ts
+++ b/packages/app/src/server/service/in-app-notification.ts
@@ -140,8 +140,8 @@ export default class InAppNotificationService {
   }
 
   updateAllNotificationsAsOpened = async function(user: IUser & HasObjectId): Promise<void> {
-    const filter = { user: user._id, status: STATUS_OPENED };
-    const options = { status: STATUS_UNOPENED };
+    const filter = { user: user._id, status: STATUS_UNOPENED };
+    const options = { status: STATUS_OPENED };
 
     await InAppNotification.updateMany(filter, options);
     return;


### PR DESCRIPTION
## Task
- [#81953](https://redmine.weseek.co.jp/issues/81953) 「全て」「未読」カテゴリー内部のリストを共通化させる

## Description
- AllInAppNotificationList
- UnopenedNotificationList
の二つのコンポーネントの共通化をし、
`InAppNotificationCategoryByStatus`に統一しました。

引数にstatusを渡すか渡さないかでカテゴリー分けを行っています。