### PR TITLE
Imprv/81999 unshown pagination and mark as read button

### DIFF
--- a/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
@@ -59,7 +59,7 @@ const InAppNotificationPageBody: FC<Props> = (props) => {
 
     return (
       <>
-        {status === InAppNotificationStatuses.STATUS_UNOPENED
+        {(status === InAppNotificationStatuses.STATUS_UNOPENED && notificationData.totalDocs > 0)
       && (
         <div className="mb-2 d-flex justify-content-end">
           <button
@@ -70,18 +70,22 @@ const InAppNotificationPageBody: FC<Props> = (props) => {
             {t('in_app_notification.mark_all_as_read')}
           </button>
         </div>
-      )
-        }
-
+      )}
         <InAppNotificationList inAppNotificationData={notificationData} />
-        <PaginationWrapper
-          activePage={activePage}
-          changePage={setAllNotificationPageNumber}
-          totalItemsCount={notificationData.totalDocs}
-          pagingLimit={notificationData.limit}
-          align="center"
-          size="sm"
-        />
+
+        {notificationData.totalDocs > 0
+          && (
+
+            <PaginationWrapper
+              activePage={activePage}
+              changePage={setAllNotificationPageNumber}
+              totalItemsCount={notificationData.totalDocs}
+              pagingLimit={notificationData.limit}
+              align="center"
+              size="sm"
+            />
+          )
+        }
       </>
     );
   };

--- a/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
@@ -75,7 +75,6 @@ const InAppNotificationPageBody: FC<Props> = (props) => {
 
         {notificationData.totalDocs > 0
           && (
-
             <PaginationWrapper
               activePage={activePage}
               changePage={setAllNotificationPageNumber}


### PR DESCRIPTION
## Task
- [#81999](https://redmine.weseek.co.jp/issues/81999) 通知がひとつもない場合、ページネーションと「全て既読にする」ボタンが表示されないようにする

## View
- 「通知がある場合」
<img width="1017" alt="Screen Shot 2021-11-26 at 16 08 51" src="https://user-images.githubusercontent.com/59536731/143541007-95fa278d-c1eb-48e2-ba7a-6cdfa8211e1d.png">

- 「通知がない場合」
<img width="1026" alt="Screen Shot 2021-11-26 at 16 09 11" src="https://user-images.githubusercontent.com/59536731/143541009-51bb3eb8-4325-4f9e-9839-62ce5881522a.png">


