### PR TITLE
fix(Slackbot): Slash commands response when sent from disabled channels

### DIFF
--- a/packages/app/src/server/util/slack-integration.ts
+++ b/packages/app/src/server/util/slack-integration.ts
@@ -1,11 +1,10 @@
-import { getSupportedGrowiActionsRegExp, IChannelOptionalId } from '@growi/slack';
+import { getSupportedGrowiActionsRegExp, IChannelOptionalId, permissionParser } from '@growi/slack';
 
 type CommandPermission = { [key:string]: string[] | boolean }
 
 export const checkPermission = (
     commandPermission: CommandPermission, commandOrActionIdOrCallbackId: string, fromChannel: IChannelOptionalId,
-):boolean => {
-  let isPermitted = false;
+): boolean => {
 
   // help
   if (commandOrActionIdOrCallbackId === 'help') {
@@ -18,26 +17,8 @@ export const checkPermission = (
     const commandRegExp = getSupportedGrowiActionsRegExp(command);
     if (!commandRegExp.test(commandOrActionIdOrCallbackId)) return;
 
-    // permission check
-    if (permission === true) {
-      isPermitted = true;
-      return;
-    }
-
-    if (Array.isArray(permission)) {
-      if (permission.includes(fromChannel.name)) {
-        isPermitted = true;
-        return;
-      }
-
-      if (fromChannel.id == null) return;
-
-      if (permission.includes(fromChannel.id)) {
-        isPermitted = true;
-        return;
-      }
-    }
+    return permissionParser(permission, fromChannel);
   });
 
-  return isPermitted;
+  return false;
 };

--- a/packages/app/src/server/util/slack-integration.ts
+++ b/packages/app/src/server/util/slack-integration.ts
@@ -5,6 +5,7 @@ type CommandPermission = { [key:string]: string[] | boolean }
 export const checkPermission = (
     commandPermission: CommandPermission, commandOrActionIdOrCallbackId: string, fromChannel: IChannelOptionalId,
 ): boolean => {
+  let isPermitted = false;
 
   // help
   if (commandOrActionIdOrCallbackId === 'help') {
@@ -17,8 +18,8 @@ export const checkPermission = (
     const commandRegExp = getSupportedGrowiActionsRegExp(command);
     if (!commandRegExp.test(commandOrActionIdOrCallbackId)) return;
 
-    return permissionParser(permission, fromChannel);
+    isPermitted = permissionParser(permission, fromChannel);
   });
 
-  return false;
+  return isPermitted;
 };

--- a/packages/slack/src/index.ts
+++ b/packages/slack/src/index.ts
@@ -52,6 +52,7 @@ export * from './utils/response-url';
 export * from './utils/slash-command-parser';
 export * from './utils/webclient-factory';
 export * from './utils/required-scopes';
+export * from './utils/permission-parser';
 export * from './utils/interaction-payload-accessor';
 export * from './utils/payload-interaction-id-helpers';
 export * from './utils/respond-util-factory';

--- a/packages/slack/src/utils/permission-parser.ts
+++ b/packages/slack/src/utils/permission-parser.ts
@@ -1,0 +1,29 @@
+import { IChannelOptionalId } from '../interfaces/channel';
+
+
+export const permissionParser = (permissionForCommand: boolean | string[], channel: IChannelOptionalId): boolean => {
+
+  if (permissionForCommand == null) {
+    return false;
+  }
+
+  if (permissionForCommand === true) {
+    return true;
+  }
+
+  if (Array.isArray(permissionForCommand)) {
+    if (permissionForCommand.includes(channel.name)) {
+      return true;
+    }
+
+    if (channel.id == null) {
+      return false;
+    }
+
+    if (permissionForCommand.includes(channel.id)) {
+      return true;
+    }
+  }
+
+  return false;
+};

--- a/packages/slackbot-proxy/src/controllers/slack.ts
+++ b/packages/slackbot-proxy/src/controllers/slack.ts
@@ -284,7 +284,6 @@ export class SlackCtrl {
       });
     }
 
-
     // select GROWI
     if (allowedRelationsForSingleUse.length > 0) {
       body.growiUrisForSingleUse = allowedRelationsForSingleUse.map(v => v.growiUri);

--- a/packages/slackbot-proxy/src/controllers/slack.ts
+++ b/packages/slackbot-proxy/src/controllers/slack.ts
@@ -284,7 +284,6 @@ export class SlackCtrl {
       });
     }
 
-    console.log('##############', allowedRelationsForBroadcastUse);
 
     // select GROWI
     if (allowedRelationsForSingleUse.length > 0) {

--- a/packages/slackbot-proxy/src/controllers/slack.ts
+++ b/packages/slackbot-proxy/src/controllers/slack.ts
@@ -284,6 +284,8 @@ export class SlackCtrl {
       });
     }
 
+    console.log('##############', allowedRelationsForBroadcastUse);
+
     // select GROWI
     if (allowedRelationsForSingleUse.length > 0) {
       body.growiUrisForSingleUse = allowedRelationsForSingleUse.map(v => v.growiUri);

--- a/packages/slackbot-proxy/src/services/RelationsService.ts
+++ b/packages/slackbot-proxy/src/services/RelationsService.ts
@@ -3,7 +3,9 @@ import { Inject, Service } from '@tsed/di';
 import axios from 'axios';
 import { addHours } from 'date-fns';
 
-import { REQUEST_TIMEOUT_FOR_PTOG, getSupportedGrowiActionsRegExp, IChannelOptionalId } from '@growi/slack';
+import {
+  REQUEST_TIMEOUT_FOR_PTOG, getSupportedGrowiActionsRegExp, IChannelOptionalId, permissionParser,
+} from '@growi/slack';
 import { Relation, PermissionSettingsInterface } from '~/entities/relation';
 import { RelationRepository } from '~/repositories/relation';
 
@@ -82,25 +84,7 @@ export class RelationsService {
 
     const permissionForCommand = permissionSettings[growiCommandType];
 
-    if (permissionForCommand == null) {
-      return false;
-    }
-
-    if (Array.isArray(permissionForCommand)) {
-      if (permissionForCommand.includes(channel.name)) {
-        return true;
-      }
-
-      if (channel.id == null) {
-        return false;
-      }
-
-      if (permissionForCommand.includes(channel.id)) {
-        return true;
-      }
-    }
-    return permissionForCommand as boolean;
-
+    return permissionParser(permissionForCommand, channel);
   }
 
   async isPermissionsForSingleUseCommands(relation: Relation, growiCommandType: string, channel: IChannelOptionalId): Promise<boolean> {


### PR DESCRIPTION
## ストーリーおよびタスク
- [**82301:【GROWI】【Slackbot】許可されていないページに向けてスラッシュコマンドを実行するとInternal Server Errorが表示される**](https://redmine.weseek.co.jp/issues/82301)
  - [**82302: 調査**](https://redmine.weseek.co.jp/issues/82302)
  - [**82327: Fix**](https://redmine.weseek.co.jp/issues/82327)
- [**81007: [Slackbot] チャンネルによるアクセス制御を行っている場合に interaction が動作しない問題を解消する**](https://redmine.weseek.co.jp/issues/81007)
  - [**82181: 権限機能のBooleanを返すfunctionをutility化**](https://redmine.weseek.co.jp/issues/82181)

## やったこと
- 権限をbooleanで返すはずのファンクションがarray<string>を返していたため、スラッシュコマンドを実行したときに正しいレスポンスを返していなかったバグを修正
- booleanを返すfunctionをutility化

## Before
![Capture0](https://user-images.githubusercontent.com/66785624/143826511-b43eeaf2-b09c-454f-93bb-35ae422e78a6.PNG)

## After
![Capture](https://user-images.githubusercontent.com/66785624/143826515-585ed227-382c-4a24-9f77-8c526f0dcd38.PNG)
