### PR TITLE
imprv: Show site url in unfurl footer

### DIFF
--- a/packages/app/src/server/service/slack-event-handler/link-shared.ts
+++ b/packages/app/src/server/service/slack-event-handler/link-shared.ts
@@ -86,8 +86,10 @@ export class LinkSharedEventHandler implements SlackEventHandler<UnfurlRequestEv
   generateLinkUnfurls(body: PublicData, growiTargetUrl: string, toUrl: string): LinkUnfurls {
     const { pageBody: text, updatedAt, commentCount } = body;
 
+    const siteUrl = this.crowi.appService.getSiteUrl();
+
     const updatedAtFormatted = format(updatedAt, 'yyyy-MM-dd HH:mm');
-    const footer = `updated at: ${updatedAtFormatted}  comments: ${commentCount}`;
+    const footer = `URL: ${siteUrl}  Updated at: ${updatedAtFormatted}`;
 
     const attachment: MessageAttachment = {
       title: body.path,


### PR DESCRIPTION
Redmine: https://redmine.weseek.co.jp/issues/82345

unfurl したときに GROWI の siteUrl を表示するように改善しました

<img width="533" alt="Screen Shot 2021-11-29 at 13 42 53" src="https://user-images.githubusercontent.com/58432773/143810147-8eca53b6-5b34-4a86-b53b-45fc52a86956.png">

