### PR TITLE
feat: 82492 prevent transitions to pages that have been completely deleted

### DIFF
--- a/packages/app/src/components/InAppNotification/InAppNotificationElm.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationElm.tsx
@@ -63,7 +63,10 @@ const InAppNotificationElm = (props: Props): JSX.Element => {
     apiv3Post('/in-app-notification/open', { id: notification._id });
 
     // jump to target page
-    window.location.href = notification.target.path;
+    const targetPagePath = notification.target?.path;
+    if (targetPagePath != null) {
+      window.location.href = targetPagePath;
+    }
   }, []);
 
   const actionUsers = getActionUsers();

--- a/packages/app/src/components/InAppNotification/InAppNotificationElm.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationElm.tsx
@@ -12,7 +12,7 @@ interface Props {
 }
 
 // TODO 81946 Return to not nullable
-const InAppNotificationElm = (props: Props): JSX.Element | null => {
+const InAppNotificationElm = (props: Props): JSX.Element => {
 
   const { notification } = props;
 
@@ -68,11 +68,9 @@ const InAppNotificationElm = (props: Props): JSX.Element | null => {
 
   const actionUsers = getActionUsers();
 
-  // TODO 81946 Return to not nullable
-  const pagePath = { path: props.notification.target?.path };
-  if (pagePath.path == null) {
-    return null;
-  }
+  // TODO: 82528 Swap target.path and snapshot.path
+  // const pagePath = { path: props.notification?.target.path };
+  const pagePath = { path: 'test-page' };
 
   const actionType: string = notification.action;
   let actionMsg: string;

--- a/packages/app/src/components/InAppNotification/InAppNotificationElm.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationElm.tsx
@@ -11,7 +11,6 @@ interface Props {
   notification: IInAppNotification & HasObjectId
 }
 
-// TODO 81946 Return to not nullable
 const InAppNotificationElm = (props: Props): JSX.Element => {
 
   const { notification } = props;
@@ -72,7 +71,6 @@ const InAppNotificationElm = (props: Props): JSX.Element => {
   const actionUsers = getActionUsers();
 
   // TODO: 82528 Swap target.path and snapshot.path
-  // const pagePath = { path: props.notification?.target.path };
   const pagePath = { path: 'test-page' };
 
   const actionType: string = notification.action;


### PR DESCRIPTION
## Task
[#82492](https://redmine.weseek.co.jp/issues/82492) [client] ページを完全に削除したときに受信する通知をクリックしてもページを遷移させないようにする

## Memo
81946 ストーリー用のブランチを feat/notification から作成しました。