### PR TITLE
feat: Migrate private legacy pages

### DIFF
--- a/packages/app/src/server/models/obsolete-page.js
+++ b/packages/app/src/server/models/obsolete-page.js
@@ -684,13 +684,15 @@ export const getPageSchema = (crowi) => {
     return await findListFromBuilderAndViewer(builder, currentUser, showAnyoneKnowsLink, opt);
   };
 
-  pageSchema.statics.findListByPageIds = async function(ids, option) {
+  pageSchema.statics.findListByPageIds = async function(ids, option, excludeRedirect = true) {
     const User = crowi.model('User');
 
     const opt = Object.assign({}, option);
     const builder = new PageQueryBuilder(this.find({ _id: { $in: ids } }));
 
-    builder.addConditionToExcludeRedirect();
+    if (excludeRedirect) {
+      builder.addConditionToExcludeRedirect();
+    }
     builder.addConditionToPagenate(opt.offset, opt.limit);
 
     // count

--- a/packages/app/src/server/routes/apiv3/pages.js
+++ b/packages/app/src/server/routes/apiv3/pages.js
@@ -186,6 +186,7 @@ module.exports = (crowi) => {
     ],
     v5PageMigration: [
       body('action').isString().withMessage('action is required'),
+      body('pageIds').isArray().withMessage('pageIds must be an array'),
     ],
   };
 
@@ -685,17 +686,20 @@ module.exports = (crowi) => {
   });
 
   router.post('/v5-schema-migration', accessTokenParser, loginRequired, adminRequired, csrf, validator.v5PageMigration, apiV3FormValidator, async(req, res) => {
-    const { action } = req.body;
+    const { action, pageIds } = req.body;
     const isV5Compatible = crowi.configManager.getConfig('crowi', 'app:isV5Compatible');
+    const Page = crowi.model('Page');
 
     try {
       switch (action) {
         case 'initialMigration':
           if (!isV5Compatible) {
-            const Page = crowi.model('Page');
             // this method throws and emit socketIo event when error occurs
             crowi.pageService.v5InitialMigration(Page.GRANT_PUBLIC); // not await
           }
+          break;
+        case 'privateLegacyPages':
+          crowi.pageService.v5MigrationByPageIds(pageIds);
           break;
 
         default:

--- a/packages/app/src/server/service/page.js
+++ b/packages/app/src/server/service/page.js
@@ -777,7 +777,7 @@ class PageService {
   }
 
   async v5MigrationByPageIds(pageIds) {
-    const Page = this.crowi.model('Page');
+    const Page = mongoose.model('Page');
 
     if (pageIds == null || pageIds.length === 0) {
       return;
@@ -836,17 +836,21 @@ class PageService {
    */
   async _generateRegExpsByPageIds(pageIds) {
     const Page = mongoose.model('Page');
+    const { PageQueryBuilder } = Page;
 
-    let result;
+    let pages;
     try {
-      result = await Page.findListByPageIds(pageIds, null, false);
+      const builder = new PageQueryBuilder(Page.find({ _id: { $in: pageIds } }));
+      pages = await builder
+        .query
+        .lean()
+        .exec();
     }
     catch (err) {
-      logger.error('Failed to find pages by ids');
+      logger.error('Failed to find pages by ids', err);
       throw err;
     }
 
-    const { pages } = result;
     const regexps = pages.map(page => new RegExp(`^${page.path}`));
 
     return regexps;

--- a/packages/app/src/server/service/page.js
+++ b/packages/app/src/server/service/page.js
@@ -1,5 +1,4 @@
 import { pagePathUtils } from '@growi/core';
-import { callbackify } from 'util';
 import loggerFactory from '~/utils/logger';
 
 const mongoose = require('mongoose');

--- a/packages/app/src/test/integration/service/page.test.js
+++ b/packages/app/src/test/integration/service/page.test.js
@@ -706,6 +706,7 @@ describe('PageService', () => {
       deleteManyPageSpy = jest.spyOn(Page, 'deleteMany').mockImplementation();
       removeAllAttachmentsSpy = jest.spyOn(crowi.attachmentService, 'removeAllAttachments').mockImplementation();
     });
+
     test('deleteCompletelyOperation', async() => {
       await crowi.pageService.deleteCompletelyOperation([parentForDeleteCompletely._id], [parentForDeleteCompletely.path], { });
 
@@ -822,6 +823,8 @@ describe('PageService', () => {
 
   describe('v5MigrationByPageIds()', () => {
     test('should migrate all pages specified by pageIds', async() => {
+      jest.restoreAllMocks();
+
       // initialize pages for test
       const pages = await Page.insertMany([
         {
@@ -863,7 +866,7 @@ describe('PageService', () => {
 
       const expected = ['/private1', '/dummyParent', '/dummyParent/private1', '/dummyParent/private1/private2', '/dummyParent/private1/private3'];
 
-      expect(migratedPagePaths).toBe(expected);
+      expect(migratedPagePaths.sort()).toStrictEqual(expected.sort());
     });
 
   });

--- a/packages/app/src/test/integration/service/page.test.js
+++ b/packages/app/src/test/integration/service/page.test.js
@@ -820,5 +820,53 @@ describe('PageService', () => {
     });
   });
 
+  describe('_v5RecursiveMigration()', () => {
+    test('should migrate all pages specified by pageIds', async() => {
+      // initialize pages for test
+      const pages = await Page.insertMany([
+        {
+          path: '/private1',
+          grant: Page.GRANT_OWNER,
+          creator: testUser1,
+          lastUpdateUser: testUser1,
+        },
+        {
+          path: '/dummyParent/private1',
+          grant: Page.GRANT_OWNER,
+          creator: testUser1,
+          lastUpdateUser: testUser1,
+        },
+        {
+          path: '/dummyParent/private1/private2',
+          grant: Page.GRANT_OWNER,
+          creator: testUser1,
+          lastUpdateUser: testUser1,
+        },
+        {
+          path: '/dummyParent/private1/private3',
+          grant: Page.GRANT_OWNER,
+          creator: testUser1,
+          lastUpdateUser: testUser1,
+        },
+      ]);
+
+      const pageIds = pages.map(page => page._id);
+      // migrate
+      await crowi.pageService.v5MigrationByPageIds(pageIds);
+
+      const migratedPages = await Page.find({
+        path: {
+          $in: ['/private1', '/dummyParent', '/dummyParent/private1', '/dummyParent/private1/private2', '/dummyParent/private1/private3'],
+        },
+      });
+      const migratedPagePaths = migratedPages.filter(doc => doc.parent != null).map(doc => doc.path);
+
+      const expected = ['/private1', '/dummyParent', '/dummyParent/private1', '/dummyParent/private1/private2', '/dummyParent/private1/private3'];
+
+      expect(migratedPagePaths).toBe(expected);
+    });
+
+  });
+
 
 });

--- a/packages/app/src/test/integration/service/page.test.js
+++ b/packages/app/src/test/integration/service/page.test.js
@@ -820,7 +820,7 @@ describe('PageService', () => {
     });
   });
 
-  describe('_v5RecursiveMigration()', () => {
+  describe('v5MigrationByPageIds()', () => {
     test('should migrate all pages specified by pageIds', async() => {
       // initialize pages for test
       const pages = await Page.insertMany([


### PR DESCRIPTION
Redmine: https://redmine.weseek.co.jp/issues/81980

pageId の配列からページをマイグレーションする処理を実装しました

## コメント
- [filter になる部分](https://github.com/weseek/growi/compare/feat/migrate-initial-named-queries...feat/migrate-private-legacy-pages?expand=1#diff-54e9932d0d509507eff4b4551f57d5ad48472e94bbc618727db0858c3bb51bffR876-R893)をリファクタしました
- テストも書きました

## 後続
- パブリックページのマイグレーションと同じく socket でユーザーに進行状況を伝えられるようにします