### PR TITLE
inject socketIoContainer instance into admin injectableContainers

### DIFF
--- a/packages/app/src/client/admin.jsx
+++ b/packages/app/src/client/admin.jsx
@@ -69,6 +69,7 @@ const adminNotificationContainer = new AdminNotificationContainer(appContainer);
 const adminSlackIntegrationLegacyContainer = new AdminSlackIntegrationLegacyContainer(appContainer);
 const adminMarkDownContainer = new AdminMarkDownContainer(appContainer);
 const adminUserGroupDetailContainer = new AdminUserGroupDetailContainer(appContainer);
+const socketIoContainer = appContainer.getContainer('SocketIoContainer');
 const injectableContainers = [
   appContainer,
   navigationContainer,
@@ -83,6 +84,7 @@ const injectableContainers = [
   adminSlackIntegrationLegacyContainer,
   adminMarkDownContainer,
   adminUserGroupDetailContainer,
+  socketIoContainer,
 ];
 
 logger.info('unstated containers have been initialized');


### PR DESCRIPTION
## ストーリー
- Bug fix: [#81899](https://redmine.weseek.co.jp/issues/81899)【GROWI】【通知機能】Admin ページ遷移するとエラーが出る

## タスク
- [#81971](https://redmine.weseek.co.jp/issues/81971) 修正（並行）

`socketIoContainer` が、adminの`<Provider inject={injectableContainers}>`の`injectableContainers`に含まれていなかったことにより、管理画面でエラーが生じていたので、含めるようにしました。

ナビバー上のベルアイコン(InAppNotificationDropdown)にて、`socketIoContainer` が使用されています


## View(修正前)

<img width="1360" alt="Screen Shot 2021-11-29 at 21 26 32" src="https://user-images.githubusercontent.com/59536731/143868736-8352c200-ff3e-4659-a99e-c0fb981af024.png">

```
SocketIoContainer.js?4cf4:19 Uncaught TypeError: Cannot read properties of undefined (reading 'registerContainer')
    at new SocketIoContainer (SocketIoContainer.js?4cf4:19)
    at eval (unstated.es.js?75c5:128)
    at Array.map (<anonymous>)
    at Subscribe._createInstances (unstated.es.js?75c5:119)
    at eval (unstated.es.js?75c5:150)
    at Consumer.render (index.js?9c24:133)
    at finishClassComponent (VM21976 react-dom.development.js:17160)
    at updateClassComponent (VM21976 react-dom.development.js:17110)
    at beginWork (VM21976 react-dom.development.js:18620)
    at HTMLUnknownElement.callCallback (VM21976 react-dom.development.js:188)
```

## View(修正後)
<img width="1365" alt="Screen Shot 2021-11-29 at 21 43 01" src="https://user-images.githubusercontent.com/59536731/143870182-be74ebe0-a78e-4ff4-8822-3117ac8a6a95.png">
