### PR TITLE
Imprv/82502 update status when move to notification list page

### DIFF
--- a/packages/app/src/components/InAppNotification/InAppNotificationDropdown.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationDropdown.tsx
@@ -5,7 +5,7 @@ import {
 import { useTranslation } from 'react-i18next';
 import loggerFactory from '~/utils/logger';
 
-import { apiv3Get, apiv3Post } from '~/client/util/apiv3-client';
+import { apiv3Post } from '~/client/util/apiv3-client';
 import { withUnstatedContainers } from '../UnstatedUtils';
 import InAppNotificationList from './InAppNotificationList';
 import SocketIoContainer from '~/client/services/SocketIoContainer';
@@ -20,17 +20,18 @@ type Props = {
 const InAppNotificationDropdown: FC<Props> = (props: Props) => {
   const { t } = useTranslation();
 
-  // const [count, setCount] = useState(0);
   const [isOpen, setIsOpen] = useState(false);
   const limit = 6;
-  const { data: inAppNotificationData, mutate } = useSWRxInAppNotifications(limit);
-  const { data: inAppNotificationStatusData } = useSWRxInAppNotificationStatus();
+  const { data: inAppNotificationData, mutate: mutateInAppNotificationData } = useSWRxInAppNotifications(limit);
+  const { data: inAppNotificationStatusData, mutate: mutateInAppNotificationStatusData } = useSWRxInAppNotificationStatus();
 
 
   const initializeSocket = (props) => {
     const socket = props.socketIoContainer.getSocket();
+    // いらなくないこれ?
     socket.on('notificationUpdated', (data: { userId: string, count: number }) => {
-      // setCount(data.count);
+      console.log('hogee');
+      mutateInAppNotificationStatusData();
     });
   };
 
@@ -44,24 +45,8 @@ const InAppNotificationDropdown: FC<Props> = (props: Props) => {
     }
   };
 
-  const fetchNotificationStatus = async() => {
-    try {
-      // const res = await apiv3Get('/in-app-notification/status');
-      // const { count } = res.data;
-      if (inAppNotificationStatusData != null) {
-        console.log('inAppNotificationStatusData', inAppNotificationStatusData);
-        const { count } = inAppNotificationStatusData;
-        // setCount(count);
-      }
-    }
-    catch (err) {
-      logger.error(err);
-    }
-  };
-
   useEffect(() => {
     initializeSocket(props);
-    fetchNotificationStatus();
   }, [props]);
 
 
@@ -72,12 +57,10 @@ const InAppNotificationDropdown: FC<Props> = (props: Props) => {
 
     const newIsOpenState = !isOpen;
     if (newIsOpenState) {
-      mutate();
+      mutateInAppNotificationData();
     }
     setIsOpen(newIsOpenState);
   };
-
-  // const { count } = inAppNotificationStatusData;
 
   let badge;
   if (inAppNotificationStatusData != null && inAppNotificationStatusData.count > 0) {

--- a/packages/app/src/components/InAppNotification/InAppNotificationDropdown.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationDropdown.tsx
@@ -27,15 +27,15 @@ const InAppNotificationDropdown: FC<Props> = (props: Props) => {
   const [isOpen, setIsOpen] = useState(false);
   const limit = 6;
   const { data: inAppNotificationData, mutate: mutateInAppNotificationData } = useSWRxInAppNotifications(limit);
-  const { data: inAppNotificationStatusData, mutate: mutateInAppNotificationStatusData } = useSWRxInAppNotificationStatus();
+  const { data: inAppNotificationUnreadStatusCount, mutate: mutateInAppNotificationUnreadStatusCount } = useSWRxInAppNotificationStatus();
 
 
   const initializeSocket = useCallback((props) => {
     const socket = props.socketIoContainer.getSocket();
     socket.on('notificationUpdated', () => {
-      mutateInAppNotificationStatusData();
+      mutateInAppNotificationUnreadStatusCount();
     });
-  }, [mutateInAppNotificationStatusData]);
+  }, [mutateInAppNotificationUnreadStatusCount]);
 
   const updateNotificationStatus = async() => {
     try {
@@ -53,9 +53,9 @@ const InAppNotificationDropdown: FC<Props> = (props: Props) => {
 
 
   const toggleDropdownHandler = async() => {
-    if (!isOpen && inAppNotificationStatusData != null && inAppNotificationStatusData > 0) {
+    if (!isOpen && inAppNotificationUnreadStatusCount != null && inAppNotificationUnreadStatusCount > 0) {
       await updateNotificationStatus();
-      mutateInAppNotificationStatusData();
+      mutateInAppNotificationUnreadStatusCount();
     }
 
     const newIsOpenState = !isOpen;
@@ -66,14 +66,12 @@ const InAppNotificationDropdown: FC<Props> = (props: Props) => {
   };
 
   let badge;
-  if (inAppNotificationStatusData != null && inAppNotificationStatusData > 0) {
-    badge = <span className="badge badge-pill badge-danger grw-notification-badge">{inAppNotificationStatusData}</span>;
+  if (inAppNotificationUnreadStatusCount != null && inAppNotificationUnreadStatusCount > 0) {
+    badge = <span className="badge badge-pill badge-danger grw-notification-badge">{inAppNotificationUnreadStatusCount}</span>;
   }
   else {
     badge = '';
   }
-
-  console.log('inAppNotificationStatusData', inAppNotificationStatusData);
 
   return (
     <Dropdown className="notification-wrapper" isOpen={isOpen} toggle={toggleDropdownHandler}>

--- a/packages/app/src/components/InAppNotification/InAppNotificationDropdown.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationDropdown.tsx
@@ -28,9 +28,7 @@ const InAppNotificationDropdown: FC<Props> = (props: Props) => {
 
   const initializeSocket = (props) => {
     const socket = props.socketIoContainer.getSocket();
-    // いらなくないこれ?
-    socket.on('notificationUpdated', (data: { userId: string, count: number }) => {
-      console.log('hogee');
+    socket.on('notificationUpdated', () => {
       mutateInAppNotificationStatusData();
     });
   };

--- a/packages/app/src/components/InAppNotification/InAppNotificationDropdown.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationDropdown.tsx
@@ -25,10 +25,6 @@ const InAppNotificationDropdown: FC<Props> = (props: Props) => {
   const limit = 6;
   const { data: inAppNotificationData, mutate } = useSWRxInAppNotifications(limit);
 
-  useEffect(() => {
-    initializeSocket(props);
-    fetchNotificationStatus();
-  }, []);
 
   const initializeSocket = (props) => {
     const socket = props.socketIoContainer.getSocket();
@@ -37,21 +33,27 @@ const InAppNotificationDropdown: FC<Props> = (props: Props) => {
     });
   };
 
-  const updateNotificationStatus = async() => {
+  const fetchNotificationStatus = async() => {
     try {
-      await apiv3Post('/in-app-notification/read');
-      setCount(0);
+      const res = await apiv3Get('/in-app-notification/status');
+      const { count } = res.data;
+      setCount(count);
     }
     catch (err) {
       logger.error(err);
     }
   };
 
-  const fetchNotificationStatus = async() => {
+  useEffect(() => {
+    initializeSocket(props);
+    fetchNotificationStatus();
+  }, [props]);
+
+
+  const updateNotificationStatus = async() => {
     try {
-      const res = await apiv3Get('/in-app-notification/status');
-      const { count } = res.data;
-      setCount(count);
+      await apiv3Post('/in-app-notification/read');
+      setCount(0);
     }
     catch (err) {
       logger.error(err);

--- a/packages/app/src/components/InAppNotification/InAppNotificationDropdown.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationDropdown.tsx
@@ -36,7 +36,6 @@ const InAppNotificationDropdown: FC<Props> = (props: Props) => {
   const updateNotificationStatus = async() => {
     try {
       await apiv3Post('/in-app-notification/read');
-      // setCount(0);
     }
     catch (err) {
       logger.error(err);
@@ -51,6 +50,7 @@ const InAppNotificationDropdown: FC<Props> = (props: Props) => {
   const toggleDropdownHandler = () => {
     if (!isOpen && inAppNotificationStatusData != null && inAppNotificationStatusData.count > 0) {
       updateNotificationStatus();
+      mutateInAppNotificationStatusData();
     }
 
     const newIsOpenState = !isOpen;

--- a/packages/app/src/components/InAppNotification/InAppNotificationDropdown.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationDropdown.tsx
@@ -13,6 +13,8 @@ import InAppNotificationList from './InAppNotificationList';
 import SocketIoContainer from '~/client/services/SocketIoContainer';
 import { useSWRxInAppNotifications, useSWRxInAppNotificationStatus } from '~/stores/in-app-notification';
 
+import { toastError } from '~/client/util/apiNotification';
+
 const logger = loggerFactory('growi:InAppNotificationDropdown');
 
 type Props = {
@@ -40,6 +42,7 @@ const InAppNotificationDropdown: FC<Props> = (props: Props) => {
       await apiv3Post('/in-app-notification/read');
     }
     catch (err) {
+      toastError(err);
       logger.error(err);
     }
   };

--- a/packages/app/src/components/InAppNotification/InAppNotificationDropdown.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationDropdown.tsx
@@ -1,4 +1,6 @@
-import React, { useState, useEffect, FC } from 'react';
+import React, {
+  useState, useEffect, FC, useCallback,
+} from 'react';
 import {
   Dropdown, DropdownToggle, DropdownMenu, DropdownItem,
 } from 'reactstrap';
@@ -26,12 +28,12 @@ const InAppNotificationDropdown: FC<Props> = (props: Props) => {
   const { data: inAppNotificationStatusData, mutate: mutateInAppNotificationStatusData } = useSWRxInAppNotificationStatus();
 
 
-  const initializeSocket = (props) => {
+  const initializeSocket = useCallback((props) => {
     const socket = props.socketIoContainer.getSocket();
     socket.on('notificationUpdated', () => {
       mutateInAppNotificationStatusData();
     });
-  };
+  }, [mutateInAppNotificationStatusData]);
 
   const updateNotificationStatus = async() => {
     try {
@@ -44,7 +46,7 @@ const InAppNotificationDropdown: FC<Props> = (props: Props) => {
 
   useEffect(() => {
     initializeSocket(props);
-  }, [props]);
+  }, [initializeSocket, props]);
 
 
   const toggleDropdownHandler = () => {

--- a/packages/app/src/components/InAppNotification/InAppNotificationDropdown.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationDropdown.tsx
@@ -9,7 +9,7 @@ import { apiv3Get, apiv3Post } from '~/client/util/apiv3-client';
 import { withUnstatedContainers } from '../UnstatedUtils';
 import InAppNotificationList from './InAppNotificationList';
 import SocketIoContainer from '~/client/services/SocketIoContainer';
-import { useSWRxInAppNotifications } from '~/stores/in-app-notification';
+import { useSWRxInAppNotifications, useSWRxInAppNotificationStatus } from '~/stores/in-app-notification';
 
 const logger = loggerFactory('growi:InAppNotificationDropdown');
 
@@ -24,6 +24,7 @@ const InAppNotificationDropdown: FC<Props> = (props: Props) => {
   const [isOpen, setIsOpen] = useState(false);
   const limit = 6;
   const { data: inAppNotificationData, mutate } = useSWRxInAppNotifications(limit);
+  const { data: inAppNotificationStatusData } = useSWRxInAppNotificationStatus();
 
 
   const initializeSocket = (props) => {
@@ -33,11 +34,25 @@ const InAppNotificationDropdown: FC<Props> = (props: Props) => {
     });
   };
 
+  const updateNotificationStatus = async() => {
+    try {
+      await apiv3Post('/in-app-notification/read');
+      setCount(0);
+    }
+    catch (err) {
+      logger.error(err);
+    }
+  };
+
   const fetchNotificationStatus = async() => {
     try {
-      const res = await apiv3Get('/in-app-notification/status');
-      const { count } = res.data;
-      setCount(count);
+      // const res = await apiv3Get('/in-app-notification/status');
+      // const { count } = res.data;
+      if (inAppNotificationStatusData != null) {
+        console.log('inAppNotificationStatusData', inAppNotificationStatusData);
+        const { count } = inAppNotificationStatusData;
+        setCount(count);
+      }
     }
     catch (err) {
       logger.error(err);
@@ -49,16 +64,6 @@ const InAppNotificationDropdown: FC<Props> = (props: Props) => {
     fetchNotificationStatus();
   }, [props]);
 
-
-  const updateNotificationStatus = async() => {
-    try {
-      await apiv3Post('/in-app-notification/read');
-      setCount(0);
-    }
-    catch (err) {
-      logger.error(err);
-    }
-  };
 
   const toggleDropdownHandler = () => {
     if (!isOpen && count > 0) {

--- a/packages/app/src/components/InAppNotification/InAppNotificationDropdown.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationDropdown.tsx
@@ -53,7 +53,7 @@ const InAppNotificationDropdown: FC<Props> = (props: Props) => {
 
 
   const toggleDropdownHandler = async() => {
-    if (!isOpen && inAppNotificationStatusData != null && inAppNotificationStatusData.count > 0) {
+    if (!isOpen && inAppNotificationStatusData != null && inAppNotificationStatusData > 0) {
       await updateNotificationStatus();
       mutateInAppNotificationStatusData();
     }
@@ -66,12 +66,14 @@ const InAppNotificationDropdown: FC<Props> = (props: Props) => {
   };
 
   let badge;
-  if (inAppNotificationStatusData != null && inAppNotificationStatusData.count > 0) {
-    badge = <span className="badge badge-pill badge-danger grw-notification-badge">{inAppNotificationStatusData.count}</span>;
+  if (inAppNotificationStatusData != null && inAppNotificationStatusData > 0) {
+    badge = <span className="badge badge-pill badge-danger grw-notification-badge">{inAppNotificationStatusData}</span>;
   }
   else {
     badge = '';
   }
+
+  console.log('inAppNotificationStatusData', inAppNotificationStatusData);
 
   return (
     <Dropdown className="notification-wrapper" isOpen={isOpen} toggle={toggleDropdownHandler}>

--- a/packages/app/src/components/InAppNotification/InAppNotificationDropdown.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationDropdown.tsx
@@ -20,7 +20,7 @@ type Props = {
 const InAppNotificationDropdown: FC<Props> = (props: Props) => {
   const { t } = useTranslation();
 
-  const [count, setCount] = useState(0);
+  // const [count, setCount] = useState(0);
   const [isOpen, setIsOpen] = useState(false);
   const limit = 6;
   const { data: inAppNotificationData, mutate } = useSWRxInAppNotifications(limit);
@@ -30,14 +30,14 @@ const InAppNotificationDropdown: FC<Props> = (props: Props) => {
   const initializeSocket = (props) => {
     const socket = props.socketIoContainer.getSocket();
     socket.on('notificationUpdated', (data: { userId: string, count: number }) => {
-      setCount(data.count);
+      // setCount(data.count);
     });
   };
 
   const updateNotificationStatus = async() => {
     try {
       await apiv3Post('/in-app-notification/read');
-      setCount(0);
+      // setCount(0);
     }
     catch (err) {
       logger.error(err);
@@ -51,7 +51,7 @@ const InAppNotificationDropdown: FC<Props> = (props: Props) => {
       if (inAppNotificationStatusData != null) {
         console.log('inAppNotificationStatusData', inAppNotificationStatusData);
         const { count } = inAppNotificationStatusData;
-        setCount(count);
+        // setCount(count);
       }
     }
     catch (err) {
@@ -66,7 +66,7 @@ const InAppNotificationDropdown: FC<Props> = (props: Props) => {
 
 
   const toggleDropdownHandler = () => {
-    if (!isOpen && count > 0) {
+    if (!isOpen && inAppNotificationStatusData != null && inAppNotificationStatusData.count > 0) {
       updateNotificationStatus();
     }
 
@@ -77,7 +77,15 @@ const InAppNotificationDropdown: FC<Props> = (props: Props) => {
     setIsOpen(newIsOpenState);
   };
 
-  const badge = count > 0 ? <span className="badge badge-pill badge-danger grw-notification-badge">{count}</span> : '';
+  // const { count } = inAppNotificationStatusData;
+
+  let badge;
+  if (inAppNotificationStatusData != null && inAppNotificationStatusData.count > 0) {
+    badge = <span className="badge badge-pill badge-danger grw-notification-badge">{inAppNotificationStatusData.count}</span>;
+  }
+  else {
+    badge = '';
+  }
 
   return (
     <Dropdown className="notification-wrapper" isOpen={isOpen} toggle={toggleDropdownHandler}>

--- a/packages/app/src/components/InAppNotification/InAppNotificationDropdown.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationDropdown.tsx
@@ -52,9 +52,9 @@ const InAppNotificationDropdown: FC<Props> = (props: Props) => {
   }, [initializeSocket, props]);
 
 
-  const toggleDropdownHandler = () => {
+  const toggleDropdownHandler = async() => {
     if (!isOpen && inAppNotificationStatusData != null && inAppNotificationStatusData.count > 0) {
-      updateNotificationStatus();
+      await updateNotificationStatus();
       mutateInAppNotificationStatusData();
     }
 

--- a/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
@@ -1,4 +1,6 @@
-import React, { FC, useState, useEffect } from 'react';
+import React, {
+  FC, useState, useEffect, useCallback,
+} from 'react';
 
 import { useTranslation } from 'react-i18next';
 import PropTypes from 'prop-types';
@@ -11,6 +13,10 @@ import CustomNavAndContents from '../CustomNavigation/CustomNavAndContents';
 import { InAppNotificationStatuses } from '~/interfaces/in-app-notification';
 import { apiv3Put, apiv3Post } from '~/client/util/apiv3-client';
 
+import loggerFactory from '~/utils/logger';
+
+const logger = loggerFactory('growi:InAppNotificationPage');
+
 
 type Props = {
   appContainer: AppContainer
@@ -22,20 +28,19 @@ const InAppNotificationPageBody: FC<Props> = (props) => {
   const { t } = useTranslation();
   const { mutate: mutateInAppNotificationStatusData } = useSWRxInAppNotificationStatus();
 
-
-  const updateNotificationStatus = async() => {
+  const updateNotificationStatus = useCallback(async() => {
     try {
       await apiv3Post('/in-app-notification/read');
       mutateInAppNotificationStatusData();
     }
     catch (err) {
-      // logger.error(err);
+      logger.error(err);
     }
-  };
+  }, [mutateInAppNotificationStatusData]);
 
   useEffect(() => {
     updateNotificationStatus();
-  }, []);
+  }, [updateNotificationStatus]);
 
   const InAppNotificationCategoryByStatus = (status?: InAppNotificationStatuses) => {
     const [activePage, setActivePage] = useState(1);

--- a/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
@@ -1,15 +1,15 @@
-import React, { FC, useState } from 'react';
+import React, { FC, useState, useEffect } from 'react';
 
 import { useTranslation } from 'react-i18next';
 import PropTypes from 'prop-types';
 import AppContainer from '~/client/services/AppContainer';
 import { withUnstatedContainers } from '../UnstatedUtils';
 import InAppNotificationList from './InAppNotificationList';
-import { useSWRxInAppNotifications } from '../../stores/in-app-notification';
+import { useSWRxInAppNotifications, useSWRxInAppNotificationStatus } from '../../stores/in-app-notification';
 import PaginationWrapper from '../PaginationWrapper';
 import CustomNavAndContents from '../CustomNavigation/CustomNavAndContents';
 import { InAppNotificationStatuses } from '~/interfaces/in-app-notification';
-import { apiv3Put } from '~/client/util/apiv3-client';
+import { apiv3Put, apiv3Post } from '~/client/util/apiv3-client';
 
 
 type Props = {
@@ -20,6 +20,22 @@ const InAppNotificationPageBody: FC<Props> = (props) => {
   const { appContainer } = props;
   const limit = appContainer.config.pageLimitationXL;
   const { t } = useTranslation();
+  const { mutate: mutateInAppNotificationStatusData } = useSWRxInAppNotificationStatus();
+
+
+  const updateNotificationStatus = async() => {
+    try {
+      await apiv3Post('/in-app-notification/read');
+      mutateInAppNotificationStatusData();
+    }
+    catch (err) {
+      // logger.error(err);
+    }
+  };
+
+  useEffect(() => {
+    updateNotificationStatus();
+  }, []);
 
   const InAppNotificationCategoryByStatus = (status?: InAppNotificationStatuses) => {
     const [activePage, setActivePage] = useState(1);

--- a/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationPage.tsx
@@ -26,17 +26,17 @@ const InAppNotificationPageBody: FC<Props> = (props) => {
   const { appContainer } = props;
   const limit = appContainer.config.pageLimitationXL;
   const { t } = useTranslation();
-  const { mutate: mutateInAppNotificationStatusData } = useSWRxInAppNotificationStatus();
+  const { mutate } = useSWRxInAppNotificationStatus();
 
   const updateNotificationStatus = useCallback(async() => {
     try {
       await apiv3Post('/in-app-notification/read');
-      mutateInAppNotificationStatusData();
+      mutate();
     }
     catch (err) {
       logger.error(err);
     }
-  }, [mutateInAppNotificationStatusData]);
+  }, [mutate]);
 
   useEffect(() => {
     updateNotificationStatus();

--- a/packages/app/src/server/routes/apiv3/in-app-notification.ts
+++ b/packages/app/src/server/routes/apiv3/in-app-notification.ts
@@ -1,4 +1,3 @@
-import { InAppNotification } from '../../models/in-app-notification';
 import { IInAppNotification } from '../../../interfaces/in-app-notification';
 
 const express = require('express');
@@ -69,8 +68,7 @@ module.exports = (crowi) => {
     const userId = req.user._id;
     try {
       const count = await inAppNotificationService.getUnreadCountByUser(userId);
-      const result = { count };
-      return res.apiv3(result);
+      return res.apiv3({ count });
     }
     catch (err) {
       return res.apiv3Err(err);

--- a/packages/app/src/server/service/in-app-notification.ts
+++ b/packages/app/src/server/service/in-app-notification.ts
@@ -42,12 +42,11 @@ export default class InAppNotificationService {
   emitSocketIo = async(targetUsers) => {
     if (this.socketIoService.isInitialized) {
       targetUsers.forEach(async(userId) => {
-        const count = await this.getUnreadCountByUser(userId);
 
         // emit to the room for each user
         await this.socketIoService.getDefaultSocket()
           .in(getRoomNameWithId(RoomPrefix.USER, userId))
-          .emit('notificationUpdated', { userId, count });
+          .emit('notificationUpdated');
       });
     }
   }

--- a/packages/app/src/stores/in-app-notification.ts
+++ b/packages/app/src/stores/in-app-notification.ts
@@ -13,3 +13,12 @@ export const useSWRxInAppNotifications = <Data, Error>(
     endpoint => apiv3Get(endpoint, { limit, offset, status }).then(response => response.data),
   );
 };
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const useSWRxInAppNotificationStatus = <Data, Error>
+  (): SWRResponse<{ count: number }, Error> => {
+  return useSWR(
+    ['/in-app-notification/status'],
+    endpoint => apiv3Get(endpoint).then(response => response.data),
+  );
+};

--- a/packages/app/src/stores/in-app-notification.ts
+++ b/packages/app/src/stores/in-app-notification.ts
@@ -16,9 +16,9 @@ export const useSWRxInAppNotifications = <Data, Error>(
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const useSWRxInAppNotificationStatus = <Data, Error>
-  (): SWRResponse<{ count: number }, Error> => {
+  (): SWRResponse<number, Error> => {
   return useSWR(
     ['/in-app-notification/status'],
-    endpoint => apiv3Get(endpoint).then(response => response.data),
+    endpoint => apiv3Get(endpoint).then(response => response.data.count),
   );
 };

--- a/packages/app/src/stores/in-app-notification.ts
+++ b/packages/app/src/stores/in-app-notification.ts
@@ -15,8 +15,8 @@ export const useSWRxInAppNotifications = <Data, Error>(
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export const useSWRxInAppNotificationStatus = <Data, Error>
-  (): SWRResponse<number, Error> => {
+export const useSWRxInAppNotificationStatus = <Data, Error>(
+): SWRResponse<number, Error> => {
   return useSWR(
     ['/in-app-notification/status'],
     endpoint => apiv3Get(endpoint).then(response => response.data.count),


### PR DESCRIPTION
## Task
- [#82502](https://redmine.weseek.co.jp/issues/82502) 通知一覧ページを表示した時に、UNREAD のステータス全てを UNOPENED に更新する


## Description 
- `/me/all-in-app-notifications` のページに移動したときに、UNREAD のステータスが `UNOPENED`に更新されるようにしました。

- swr化して、`useSWRxInAppNotificationStatus`を使用。
[ナビバーのカウント]useSWRxInAppNotificationStatus から`UNREAD`のcountのデータを取得しています。

