### PR TITLE
imprv: change displayed revision name

### DIFF
--- a/packages/app/resource/locales/en_US/translation.json
+++ b/packages/app/resource/locales/en_US/translation.json
@@ -466,10 +466,10 @@
     "resolve_conflict": "Resolve Conflict",
     "resolve_and_save" : "Resolve and save",
     "select_revision" : "Select {{revision}}",
-    "requested_revision": "requested page body",
-    "origin_revision": "page body before request",
-    "latest_revision": "latest page body",
-    "selected_editable_revision": "Selected Revision(Editable)"
+    "requested_revision": "mine",
+    "origin_revision": "origin",
+    "latest_revision": "theirs",
+    "selected_editable_revision": "Selected Page Body (Editable)"
   },
   "link_edit": {
     "edit_link": "Edit Link",

--- a/packages/app/src/components/PageEditor/ConflictDiffModal.tsx
+++ b/packages/app/src/components/PageEditor/ConflictDiffModal.tsx
@@ -166,7 +166,7 @@ export const ConflictDiffModal: FC<ConflictDiffModalProps> = (props) => {
                   }}
                 >
                   <i className="icon-fw icon-arrow-down-circle"></i>
-                  {t('modal_resolve_conflict.select_revision', { revision: 'request' })}
+                  {t('modal_resolve_conflict.select_revision', { revision: 'mine' })}
                 </button>
               </div>
             </div>
@@ -196,7 +196,7 @@ export const ConflictDiffModal: FC<ConflictDiffModalProps> = (props) => {
                   }}
                 >
                   <i className="icon-fw icon-arrow-down-circle"></i>
-                  {t('modal_resolve_conflict.select_revision', { revision: 'latest' })}
+                  {t('modal_resolve_conflict.select_revision', { revision: 'theirs' })}
                 </button>
               </div>
             </div>


### PR DESCRIPTION
## タスク

https://redmine.weseek.co.jp/issues/82792

## 行ったこと

- 英語表示の revision の表示される名前を変更
- コード側の変数名は変更しないほうが開発者的に分かりやすいと思ったため、修正していません

以下のように変更しました。

- requested page body → mine
- origin page body → origin
- latest page body → theirs

## 画像

![conflict modal after revision name is changed](https://user-images.githubusercontent.com/83065937/144372223-0aec01b2-517f-4fa0-9bcf-4b9b235911f1.PNG)

