### PR TITLE
fix: fix shown exception on browser when tag document is deleted from data…

### DIFF
--- a/packages/app/src/components/Sidebar/RecentChanges.jsx
+++ b/packages/app/src/components/Sidebar/RecentChanges.jsx
@@ -57,13 +57,16 @@ function LargePageItem({ page }) {
   }
 
   const tags = page.tags;
-  const tagElements = tags.map((tag) => {
-    return (
-      <a key={tag.name} href={`/_search?q=tag:${tag.name}`} className="grw-tag-label badge badge-secondary mr-2 small">
-        {tag.name}
-      </a>
-    );
-  });
+  // when tag document is deleted from database directly tags includes null
+  const tagElements = tags.includes(null)
+    ? <></>
+    : tags.map((tag) => {
+      return (
+        <a key={tag.name} href={`/_search?q=tag:${tag.name}`} className="grw-tag-label badge badge-secondary mr-2 small">
+          {tag.name}
+        </a>
+      );
+    });
 
   return (
     <li className="list-group-item py-3 px-0">


### PR DESCRIPTION
## タスク

https://redmine.weseek.co.jp/issues/82909
https://redmine.weseek.co.jp/issues/82956

## タスクの目的

- タグデータを DB から直接操作が行われた場合でも、エラーにならないようにする

## 行ったこと

- 1: mongodb で tag コレクションから 直接ページに関連付けられている tag ドキュメントを削除したときに RecentChanges.jsx で発生するエラーを表示させないようにしました。
- 2:  tag が mongodb 上から直接削除された場合でも、 page 更新を行うことで、 不要な(存在しない tag に関する) pagetagrelations のドキュメントを削除するようにしました。

## RecentChanges.jsx で発生していたエラーの画像(今回の PR で解消)

![recent changes error](https://user-images.githubusercontent.com/83065937/144558141-b3f918d4-8bef-4abc-9d9b-5050799e3c86.PNG)


