### PR TITLE
feat: 82869 allow children's pages to be notified when actions are taken on multiple pages

### DIFF
--- a/packages/app/src/server/service/page.js
+++ b/packages/app/src/server/service/page.js
@@ -545,6 +545,8 @@ class PageService {
         redirectTo: newPath,
         revision: revisionId,
       });
+
+      this.pageEvent.emit('delete', page, user);
     });
 
     try {

--- a/packages/app/src/server/service/page.js
+++ b/packages/app/src/server/service/page.js
@@ -606,7 +606,7 @@ class PageService {
 
     await this.deleteCompletelyOperation(ids, paths);
 
-    this.pageEvent.emit('deleteCompletely', pages, user); // update as renamed page
+    pages.map(page => this.pageEvent.emit('deleteCompletely', page, user));
 
     return;
   }

--- a/packages/app/src/server/service/page.js
+++ b/packages/app/src/server/service/page.js
@@ -215,6 +215,8 @@ class PageService {
         });
       }
       revisionUnorderedBulkOp.find({ path: page.path }).update({ $set: { path: newPagePath } }, { multi: true });
+
+      this.pageEvent.emit('rename', page, user);
     });
 
     try {

--- a/packages/app/src/server/service/search-delegator/elasticsearch.js
+++ b/packages/app/src/server/service/search-delegator/elasticsearch.js
@@ -993,13 +993,11 @@ class ElasticsearchDelegator {
     return this.updateOrInsertDescendantsPagesById(parentPage, user);
   }
 
-  async syncPagesDeletedCompletely(pages, user) {
-    for (let i = 0; i < pages.length; i++) {
-      logger.debug('SearchClient.syncPageDeleted', pages[i].path);
-    }
+  async syncPageDeletedCompletely(page, user) {
+    logger.debug('SearchClient.syncPageDeleted', page.path);
 
     try {
-      return await this.deletePages(pages);
+      return await this.deletePages([page]);
     }
     catch (err) {
       logger.error('deletePages:ES Error', err);

--- a/packages/app/src/server/service/search-delegator/elasticsearch.js
+++ b/packages/app/src/server/service/search-delegator/elasticsearch.js
@@ -993,17 +993,6 @@ class ElasticsearchDelegator {
     return this.updateOrInsertDescendantsPagesById(parentPage, user);
   }
 
-  async syncPageDeletedCompletely(page, user) {
-    logger.debug('SearchClient.syncPageDeleted', page.path);
-
-    try {
-      return await this.deletePages([page]);
-    }
-    catch (err) {
-      logger.error('deletePages:ES Error', err);
-    }
-  }
-
   async syncPageDeleted(page, user) {
     logger.debug('SearchClient.syncPageDeleted', page.path);
 

--- a/packages/app/src/server/service/search.js
+++ b/packages/app/src/server/service/search.js
@@ -64,7 +64,7 @@ class SearchService {
     const pageEvent = this.crowi.event('page');
     pageEvent.on('create', this.delegator.syncPageUpdated.bind(this.delegator));
     pageEvent.on('update', this.delegator.syncPageUpdated.bind(this.delegator));
-    pageEvent.on('deleteCompletely', this.delegator.syncPagesDeletedCompletely.bind(this.delegator));
+    pageEvent.on('deleteCompletely', this.delegator.syncPageDeletedCompletely.bind(this.delegator));
     pageEvent.on('delete', this.delegator.syncPageDeleted.bind(this.delegator));
     pageEvent.on('updateMany', this.delegator.syncPagesUpdated.bind(this.delegator));
     pageEvent.on('syncDescendants', this.delegator.syncDescendantsPagesUpdated.bind(this.delegator));

--- a/packages/app/src/server/service/search.js
+++ b/packages/app/src/server/service/search.js
@@ -64,7 +64,7 @@ class SearchService {
     const pageEvent = this.crowi.event('page');
     pageEvent.on('create', this.delegator.syncPageUpdated.bind(this.delegator));
     pageEvent.on('update', this.delegator.syncPageUpdated.bind(this.delegator));
-    pageEvent.on('deleteCompletely', this.delegator.syncPageDeletedCompletely.bind(this.delegator));
+    pageEvent.on('deleteCompletely', this.delegator.syncPageDeleted.bind(this.delegator));
     pageEvent.on('delete', this.delegator.syncPageDeleted.bind(this.delegator));
     pageEvent.on('updateMany', this.delegator.syncPagesUpdated.bind(this.delegator));
     pageEvent.on('syncDescendants', this.delegator.syncDescendantsPagesUpdated.bind(this.delegator));


### PR DESCRIPTION
## Task
[#82869](https://redmine.weseek.co.jp/issues/82869) 複数削除、複数完全削除、複数リネーム時に子供のページをサブスクライブしているユーザーに通知を送れるようにする
