### PR TITLE
feat: 82935 nested anchor tag warnings

### DIFF
--- a/packages/ui/src/components/User/UserPicture.jsx
+++ b/packages/ui/src/components/User/UserPicture.jsx
@@ -38,8 +38,10 @@ export class UserPicture extends React.Component {
   RootElmWithLink = (props) => {
     const { user } = this.props;
     const href = userPageRoot(user);
-
-    return <a href={href} {...props}>{props.children}</a>;
+    // Using <span> tag here instead of <a> tag because UserPicture is used in SearchResultList which is essentially a anchor tag.
+    // Nested anchor tags causes a warning.
+    // https://stackoverflow.com/questions/13052598/creating-anchor-tag-inside-anchor-taga
+    return <span onClick={() => { window.location.href = href }} {...props}>{props.children}</span>;
   }
 
   withTooltip = (RootElm) => {


### PR DESCRIPTION
## やったこと
[task](https://redmine.weseek.co.jp/issues/82935)

```
:Warning: validateDOMNesting(...): <a> cannot appear as a descendant of <a>.
in a
in Unknown
in Unknown (created by UserPicture)
in UserPicture (created by SearchResultListItem)
in h3 (created by SearchResultListItem)
in div (created by SearchResultListItem)
in div (created by SearchResultListItem)
in div (created by SearchResultListItem)
in a (created by SearchResultListItem)
in li (created by SearchResultListItem)
in SearchResultListItem (created by SearchResultList)
in SearchResultList
in Unknown (created by SearchPageLayout)
in ul (created by SearchPageLayout)....
```

が検索pageで出ないようにしました。
原因はa tag のnestでした。