### PR TITLE
Bug/83040 83073 fix dot button design

### DIFF
--- a/packages/app/src/components/SearchPage/SearchResultListItem.tsx
+++ b/packages/app/src/components/SearchPage/SearchResultListItem.tsx
@@ -53,9 +53,6 @@ const PageItemControl: FC<PageItemControlProps> = (props: PageItemControlProps) 
           TODO: add function to the following buttons like using modal or others
           ref: https://estoc.weseek.co.jp/redmine/issues/79026
         */}
-        <button className="dropdown-item text-danger" type="button" onClick={deleteButtonHandler}>
-          <i className="icon-fw icon-fire"></i>{t('Delete')}
-        </button>
         <button className="dropdown-item" type="button" onClick={() => toastr.warning(t('search_result.currently_not_implemented'))}>
           <i className="icon-fw icon-star"></i>{t('Add to bookmark')}
         </button>
@@ -64,6 +61,9 @@ const PageItemControl: FC<PageItemControlProps> = (props: PageItemControlProps) 
         </button>
         <button className="dropdown-item" type="button" onClick={() => toastr.warning(t('search_result.currently_not_implemented'))}>
           <i className="icon-fw  icon-action-redo"></i>{t('Move/Rename')}
+        </button>
+        <button className="dropdown-item text-danger border-top pt-2" type="button" onClick={deleteButtonHandler}>
+          <i className="icon-fw icon-fire"></i>{t('Delete')}
         </button>
       </div>
     </>

--- a/packages/app/src/components/SearchPage/SearchResultListItem.tsx
+++ b/packages/app/src/components/SearchPage/SearchResultListItem.tsx
@@ -63,7 +63,7 @@ const PageItemControl: FC<PageItemControlProps> = (props: PageItemControlProps) 
           <i className="icon-fw  icon-action-redo"></i>{t('Move/Rename')}
         </button>
         <button className="dropdown-item text-danger border-top pt-2" type="button" onClick={deleteButtonHandler}>
-          <i className="icon-trash mr-1"></i>{t('Delete')}
+          <i className="icon-fw icon-trash"></i>{t('Delete')}
         </button>
       </div>
     </>

--- a/packages/app/src/components/SearchPage/SearchResultListItem.tsx
+++ b/packages/app/src/components/SearchPage/SearchResultListItem.tsx
@@ -62,7 +62,8 @@ const PageItemControl: FC<PageItemControlProps> = (props: PageItemControlProps) 
         <button className="dropdown-item" type="button" onClick={() => toastr.warning(t('search_result.currently_not_implemented'))}>
           <i className="icon-fw  icon-action-redo"></i>{t('Move/Rename')}
         </button>
-        <button className="dropdown-item text-danger border-top pt-2" type="button" onClick={deleteButtonHandler}>
+        <div className="dropdown-divider"></div>
+        <button className="dropdown-item text-danger pt-2" type="button" onClick={deleteButtonHandler}>
           <i className="icon-fw icon-trash"></i>{t('Delete')}
         </button>
       </div>

--- a/packages/app/src/components/SearchPage/SearchResultListItem.tsx
+++ b/packages/app/src/components/SearchPage/SearchResultListItem.tsx
@@ -63,7 +63,7 @@ const PageItemControl: FC<PageItemControlProps> = (props: PageItemControlProps) 
           <i className="icon-fw  icon-action-redo"></i>{t('Move/Rename')}
         </button>
         <button className="dropdown-item text-danger border-top pt-2" type="button" onClick={deleteButtonHandler}>
-          <i className="icon-fw icon-fire"></i>{t('Delete')}
+          <i className="icon-trash mr-1"></i>{t('Delete')}
         </button>
       </div>
     </>


### PR DESCRIPTION
# TASK 

https://redmine.weseek.co.jp/issues/83073

# やったこと
- アイコンをxd同様にする。
- 削除ボタンにborderつける。
- ボタンの順番ならべかえ

備考: 
- xdだとadd to favourites になってますが、ここはadd to bookmarkのままで良いです。
xd: https://xd.adobe.com/view/cd3cb2f8-625d-4a6b-b6e4-917f75c675c5-986f/screen/9aa528ff-a75e-4e9a-adb9-b4b942647f29/

見た目
<img width="2032" alt="Screen Shot 2021-12-07 at 14 45 08" src="https://user-images.githubusercontent.com/60797707/144973395-2a5663bd-f186-47ca-b843-78bc77dcbb02.png">
