### PR TITLE
fix: fix tag search

### DIFF
--- a/packages/app/src/client/services/PageContainer.js
+++ b/packages/app/src/client/services/PageContainer.js
@@ -389,7 +389,7 @@ export default class PageContainer extends Container {
       revisionId: revision._id,
       revisionCreatedAt: new Date(revision.createdAt).getTime() / 1000,
       remoteRevisionId: revision._id,
-      revisionAuthor: page.revision.author,
+      revisionAuthor: revision.author,
       revisionIdHackmdSynced: page.revisionHackmdSynced,
       hasDraftOnHackmd: page.hasDraftOnHackmd,
       markdown: revision.body,

--- a/packages/app/src/client/services/PageContainer.js
+++ b/packages/app/src/client/services/PageContainer.js
@@ -425,7 +425,7 @@ export default class PageContainer extends Container {
    * update page meta data
    * @param {object} page Page instance
    * @param {object} revision Revision instance
-   * @param {Array[Tag]} tags Array of Tag
+   * @param {String[]} tags Array of Tag
    */
   updatePageMetaData(page, revision, tags) {
 

--- a/packages/app/src/client/services/PageContainer.js
+++ b/packages/app/src/client/services/PageContainer.js
@@ -406,6 +406,7 @@ export default class PageContainer extends Container {
     if (pageEditor != null) {
       if (editorMode !== 'edit') {
         pageEditor.updateEditorValue(newState.markdown);
+        // mark
       }
     }
     // PageEditorByHackmd component

--- a/packages/app/src/client/services/PageContainer.js
+++ b/packages/app/src/client/services/PageContainer.js
@@ -441,11 +441,11 @@ export default class PageContainer extends Container {
     if (tags != null) {
       newState.tags = tags;
     }
+
     this.setState(newState);
 
     $('input[name="revision_id"]').val(newState.revisionId);
   }
-
 
   /**
    * Save page

--- a/packages/app/src/client/services/PageContainer.js
+++ b/packages/app/src/client/services/PageContainer.js
@@ -406,7 +406,6 @@ export default class PageContainer extends Container {
     if (pageEditor != null) {
       if (editorMode !== 'edit') {
         pageEditor.updateEditorValue(newState.markdown);
-        // mark
       }
     }
     // PageEditorByHackmd component
@@ -421,6 +420,32 @@ export default class PageContainer extends Container {
     // hidden input
     $('input[name="revision_id"]').val(newState.revisionId);
   }
+
+  /**
+   * update page meta data
+   * @param {object} page Page instance
+   * @param {object} revision Revision instance
+   * @param {Array[Tag]} tags Array of Tag
+   */
+  updatePageMetaData(page, revision, tags) {
+
+    const newState = {
+      revisionId: revision._id,
+      revisionCreatedAt: new Date(revision.createdAt).getTime() / 1000,
+      remoteRevisionId: revision._id,
+      revisionAuthor: revision.author,
+      revisionIdHackmdSynced: page.revisionHackmdSynced,
+      hasDraftOnHackmd: page.hasDraftOnHackmd,
+      updatedAt: page.updatedAt,
+    };
+    if (tags != null) {
+      newState.tags = tags;
+    }
+    this.setState(newState);
+
+    $('input[name="revision_id"]').val(newState.revisionId);
+  }
+
 
   /**
    * Save page

--- a/packages/app/src/client/services/PageContainer.js
+++ b/packages/app/src/client/services/PageContainer.js
@@ -374,15 +374,6 @@ export default class PageContainer extends Container {
     }
   }
 
-  // TODO : temporaly use only
-  updateStateAfterTagAdded(page) {
-    const newState = {
-      updatedAt: page.updatedAt,
-      revisionAuthor: page.revision.author,
-    };
-    this.setState(newState);
-  }
-
   /**
    * save success handler
    * @param {object} page Page instance
@@ -398,6 +389,7 @@ export default class PageContainer extends Container {
       revisionId: revision._id,
       revisionCreatedAt: new Date(revision.createdAt).getTime() / 1000,
       remoteRevisionId: revision._id,
+      revisionAuthor: page.revision.author,
       revisionIdHackmdSynced: page.revisionHackmdSynced,
       hasDraftOnHackmd: page.hasDraftOnHackmd,
       markdown: revision.body,

--- a/packages/app/src/client/services/PageContainer.js
+++ b/packages/app/src/client/services/PageContainer.js
@@ -417,8 +417,6 @@ export default class PageContainer extends Container {
       }
     }
 
-    // hidden input
-    $('input[name="revision_id"]').val(newState.revisionId);
   }
 
   /**
@@ -444,7 +442,6 @@ export default class PageContainer extends Container {
 
     this.setState(newState);
 
-    $('input[name="revision_id"]').val(newState.revisionId);
   }
 
   /**

--- a/packages/app/src/components/Page/TagLabels.jsx
+++ b/packages/app/src/components/Page/TagLabels.jsx
@@ -60,6 +60,11 @@ class TagLabels extends React.Component {
       });
       editorContainer.setState({ tags });
       pageContainer.updateStateAfterSave(savedPage, tags, savedPage.revision);
+      // if drafted
+      const pageEditor = appContainer.getComponentInstance('PageEditor');
+      const markDown = pageEditor.getMarkdown();
+      pageContainer.setState({ markDown });
+
       toastSuccess('updated tags successfully');
     }
     catch (err) {

--- a/packages/app/src/components/Page/TagLabels.jsx
+++ b/packages/app/src/components/Page/TagLabels.jsx
@@ -59,8 +59,8 @@ class TagLabels extends React.Component {
         pageId, tags: newTags, revisionId,
       });
       editorContainer.setState({ tags });
-      pageContainer.updateStateAfterSave(savedPage, tags, savedPage.revision);
-      // if drafted
+      pageContainer.updatePageMetaData(savedPage, savedPage.revision, tags);
+
       const pageEditor = appContainer.getComponentInstance('PageEditor');
       const markDown = pageEditor.getMarkdown();
       pageContainer.setState({ markDown });

--- a/packages/app/src/components/Page/TagLabels.jsx
+++ b/packages/app/src/components/Page/TagLabels.jsx
@@ -60,11 +60,6 @@ class TagLabels extends React.Component {
       });
       editorContainer.setState({ tags });
       pageContainer.updatePageMetaData(savedPage, savedPage.revision, tags);
-
-      const pageEditor = appContainer.getComponentInstance('PageEditor');
-      const markDown = pageEditor.getMarkdown();
-      pageContainer.setState({ markDown });
-
       toastSuccess('updated tags successfully');
     }
     catch (err) {

--- a/packages/app/src/components/Page/TagLabels.jsx
+++ b/packages/app/src/components/Page/TagLabels.jsx
@@ -54,23 +54,17 @@ class TagLabels extends React.Component {
     if (editorMode === 'edit') {
       return editorContainer.setState({ tags: newTags });
     }
-    let page;
     try {
       const { tags, savedPage } = await appContainer.apiPost('/tags.update', {
         pageId, tags: newTags, revisionId,
       });
-      page = savedPage;
-      // update pageContainer.state
-      pageContainer.setState({ tags });
-      // update editorContainer.state
       editorContainer.setState({ tags });
-
+      pageContainer.updateStateAfterSave(savedPage, tags, savedPage.revision);
       toastSuccess('updated tags successfully');
     }
     catch (err) {
       toastError(err, 'fail to update tags');
     }
-    pageContainer.updateStateAfterTagAdded(page);
   }
 
 

--- a/packages/app/src/server/service/page.js
+++ b/packages/app/src/server/service/page.js
@@ -20,6 +20,7 @@ class PageService {
   constructor(crowi) {
     this.crowi = crowi;
     this.pageEvent = crowi.event('page');
+    this.tagEvent = crowi.event('tag');
 
     // init
     this.pageEvent.on('create', this.pageEvent.onCreate);
@@ -271,6 +272,7 @@ class PageService {
     if (originTags != null) {
       await PageTagRelation.updatePageTags(createdPage.id, originTags);
       savedTags = await PageTagRelation.listTagNamesByPage(createdPage.id);
+      this.tagEvent.emit('update', createdPage, savedTags);
     }
 
     const result = serializePageSecurely(createdPage);


### PR DESCRIPTION
## タスク

https://redmine.weseek.co.jp/issues/83278

https://redmine.weseek.co.jp/issues/82980

## 行ったこと

- page に tag を付けた際に、 revision が outdated となり、ページ更新が行えなくなる挙動を修正
- duplicate した際に、 elasticsearch 側に tag が保存されず、検索にひっかからないバグを修正

## 後続

- 動作確認
- master へマージ