### PR TITLE
imprv: Disable rubber band scroll for Mac & iOS users

### DIFF
--- a/packages/app/src/styles/_layout.scss
+++ b/packages/app/src/styles/_layout.scss
@@ -1,5 +1,6 @@
 body {
   overflow-y: scroll !important;
+  overscroll-behavior: none;
 }
 
 body:not(.growi-layout-fluid) .grw-container-convertible {


### PR DESCRIPTION
Redmine: https://redmine.weseek.co.jp/issues/83285

Mac, iOS でラバーバンドスクロールを無効化しました