### PR TITLE
82533 add isHtmlInPath to esResult

### DIFF
--- a/packages/app/src/components/SearchPage/SearchResultListItem.tsx
+++ b/packages/app/src/components/SearchPage/SearchResultListItem.tsx
@@ -3,7 +3,6 @@ import React, { FC } from 'react';
 import Clamp from 'react-multiline-clamp';
 
 import { UserPicture, PageListMeta, PagePathLabel } from '@growi/ui';
-import { DevidedPagePath } from '@growi/core';
 
 import { IPageSearchResultData } from '../../interfaces/search';
 import PageItemControl from '../Common/Dropdown/PageItemControl';
@@ -27,13 +26,19 @@ const SearchResultListItem: FC<Props> = (props:Props) => {
   // Add prefix 'id_' in pageId, because scrollspy of bootstrap doesn't work when the first letter of id attr of target component is numeral.
   const pageId = `#${pageData._id}`;
 
-  const isPathIncludedHtml = pageMeta.elasticSearchResult?.highlightedPath != null || pageData.path != null;
-  const dPagePath = new DevidedPagePath(pageData.path, false, true);
+  const pageTitle = (
+    <PagePathLabel
+      path={pageMeta.elasticSearchResult?.highlightedPath || pageData.path}
+      isLatterOnly
+      isPathIncludedHtml={pageMeta.elasticSearchResult?.isHtmlInPath}
+    >
+    </PagePathLabel>
+  );
   const pagePathElem = (
     <PagePathLabel
       path={pageMeta.elasticSearchResult?.highlightedPath || pageData.path}
       isFormerOnly
-      isPathIncludedHtml={isPathIncludedHtml}
+      isPathIncludedHtml={pageMeta.elasticSearchResult?.isHtmlInPath}
     />
   );
 
@@ -69,7 +74,7 @@ const SearchResultListItem: FC<Props> = (props:Props) => {
               {/* page title */}
               <h3 className="mb-0">
                 <UserPicture user={pageData.lastUpdateUser} />
-                <span className="mx-2">{dPagePath.latter}</span>
+                <span className="mx-2">{pageTitle}</span>
               </h3>
               {/* page meta */}
               <div className="d-flex mx-2">

--- a/packages/app/src/interfaces/search.ts
+++ b/packages/app/src/interfaces/search.ts
@@ -7,12 +7,13 @@ export enum CheckboxType {
 }
 
 export type IPageSearchResultData = {
-  pageData: IPageHasId,
+  pageData: IPageHasId;
   pageMeta: {
-    bookmarkCount?: number,
+    bookmarkCount?: number;
     elasticSearchResult?: {
-      snippet: string,
-      highlightedPath: string,
-    },
-  },
-}
+      snippet: string;
+      highlightedPath: string;
+      isHtmlInPath: boolean;
+    };
+  };
+};

--- a/packages/app/src/server/service/search.ts
+++ b/packages/app/src/server/service/search.ts
@@ -416,10 +416,12 @@ class SearchService implements SearchQueryParser, SearchResolver {
         if (highlightData != null) {
           const snippet = highlightData['body.en'] || highlightData['body.ja'] || '';
           const pathMatch = highlightData['path.en'] || highlightData['path.ja'] || '';
+          const isHtmlInPath = highlightData['path.en'] != null || highlightData['path.ja'] != null;
 
           elasticSearchResult = {
             snippet: filterXss.process(snippet),
             highlightedPath: filterXss.process(pathMatch),
+            isHtmlInPath,
           };
         }
 


### PR DESCRIPTION
旧PR: https://github.com/weseek/growi/pull/4779
task : https://redmine.weseek.co.jp/issues/82533 
dev5.0 mergeしたら少し形変わってたので、しんブランチ切って対応した方がスムーズだと思い新しくブランチ切りました。
対応内容としては
- isHtmlInPathをsearchの結果に追加
- タイトルでもハイライトが表示されるようにする。
<img width="1988" alt="Screen Shot 2021-12-09 at 13 46 19" src="https://user-images.githubusercontent.com/60797707/145336371-f8c19f45-05a1-495f-879e-dcf69b7d601e.png">

このPRがまーじされたら旧PRを閉じます。