### PR TITLE
Feat/80234 82470 adjust item pos when selected

### DIFF
--- a/packages/app/src/components/SearchPage/SearchResultListItem.tsx
+++ b/packages/app/src/components/SearchPage/SearchResultListItem.tsx
@@ -100,9 +100,9 @@ const SearchResultListItem: FC<Props> = (props:Props) => {
   );
 
   return (
-    <li key={pageData._id} className={`page-list-li search-page-item w-100 list-group-item-action ${isSelected ? 'active' : ''}`}>
+    <li key={pageData._id} className={`page-list-li search-page-item w-100 list-group-item-action pl-2 ${isSelected ? 'active' : ''}`}>
       <a
-        className="d-block pt-3"
+        className="d-block py-4 h-100"
         href={pageId}
         onClick={() => onClickSearchResultItem != null && onClickSearchResultItem(pageData._id)}
       >

--- a/packages/app/src/styles/_search.scss
+++ b/packages/app/src/styles/_search.scss
@@ -180,11 +180,10 @@
     .nav.nav-pills {
       > .page-list-li {
         &.active {
+          margin-left: -3px;
           border-left: solid 3px transparent;
         }
         > a {
-          height: 123px;
-          padding: 2px 4px;
           word-break: break-all;
 
           &:hover {

--- a/packages/app/src/styles/_search.scss
+++ b/packages/app/src/styles/_search.scss
@@ -180,7 +180,6 @@
     .nav.nav-pills {
       > .page-list-li {
         &.active {
-          padding-right: 5px;
           border-left: solid 3px transparent;
         }
         > a {

--- a/packages/app/src/styles/_search.scss
+++ b/packages/app/src/styles/_search.scss
@@ -180,6 +180,8 @@
     .nav.nav-pills {
       > .page-list-li {
         &.active {
+          // add this negative margin to avoid inner elements of .page-list-li.active
+          // moving to right side by border-left's px size.
           margin-left: -3px;
           border-left: solid 3px transparent;
         }


### PR DESCRIPTION
アイテムを選択して追加されたボーダーのpx分、中の要素が右にずれてしまうのをネガティブマージンで解消
![item list](https://user-images.githubusercontent.com/35527421/145338366-9dde5d8e-1334-4528-b88b-5a18cafbabda.gif)
