### PR TITLE
Imprv/gw7581 fix bookmark number style

### DIFF
--- a/packages/app/src/styles/_subnav.scss
+++ b/packages/app/src/styles/_subnav.scss
@@ -93,14 +93,13 @@
       @extend .btn-sm;
 
       height: 30px;
-      font-size: 15px !important;
       border-radius: $border-radius-xl;
     }
 
     .total-likes,
     .total-bookmarks {
-      height: 12px;
-      font-size: 12px;
+      height: auto;
+      font-size: 15px;
     }
   }
 }


### PR DESCRIPTION
The buttons are in sticky top nav when scrolled down.

Before:
- When hover to likes counter number, the effect is not in full height.
![Screen Shot 2021-12-09 at 14 23 50](https://user-images.githubusercontent.com/88186212/145351805-c0199fe3-5cea-4390-ac7f-385d79500792.png)
- The bookmarks counter number has wrong position and font size.
![Screen Shot 2021-12-09 at 14 23 59](https://user-images.githubusercontent.com/88186212/145351815-a21ab18b-bd13-4501-b1e1-a7e319ad3bd6.png)

After:
![Screen Shot 2021-12-09 at 15 15 11](https://user-images.githubusercontent.com/88186212/145352275-5d8728ca-13d8-4dac-ae28-add2e1e4b889.png)

