### PR TITLE
fix bookmarks counter button style

### DIFF
--- a/packages/app/src/styles/_subnav.scss
+++ b/packages/app/src/styles/_subnav.scss
@@ -92,14 +92,12 @@
     .btn-bookmark {
       @extend .btn-sm;
 
-      height: 30px;
-      font-size: 15px !important;
       border-radius: $border-radius-xl;
     }
 
     .total-likes,
     .total-bookmarks {
-      height: 12px;
+      height: auto;
       font-size: 12px;
     }
   }


### PR DESCRIPTION
Before:
![Screen Shot 2021-12-09 at 16 12 46](https://user-images.githubusercontent.com/88186212/145360622-6ca52e98-f380-49d8-a820-0d762e4673d7.png)
- The hover area of likes counter number is not in full height
- Font size and vertical alignment of bookmarks counter number is wrong

After:
![Screen Shot 2021-12-09 at 16 03 42](https://user-images.githubusercontent.com/88186212/145360640-9cf63262-97d2-40a2-ab8e-69532203ea9c.png)


- Fix likes and bookmarks counter number when scrolled down (sticky top bar)
- Fix bookmarks counter number size and position and make likes counter number button full