### PR TITLE
Imprv/83044 hover page tree

### DIFF
--- a/packages/app/src/styles/theme/_apply-colors-dark.scss
+++ b/packages/app/src/styles/theme/_apply-colors-dark.scss
@@ -251,6 +251,23 @@ ul.pagination {
   @include override-list-group-item($color-list, $bgcolor-sidebar-list-group, $color-list-hover, $bgcolor-list-hover, $color-list-active, $bgcolor-list-active);
 }
 
+// Pagetree
+.grw-pagetree {
+  .grw-pagetree-item {
+    .grw-triangle-icon {
+      svg {
+        fill: $gray-500;
+      }
+    }
+    &:hover {
+      background: $bgcolor-list-hover;
+    }
+    &:active {
+      background: lighten($bgcolor-list-hover, 5%);
+    }
+  }
+}
+
 /*
  * Popover
  */

--- a/packages/app/src/styles/theme/_apply-colors-dark.scss
+++ b/packages/app/src/styles/theme/_apply-colors-dark.scss
@@ -257,17 +257,6 @@ ul.pagination {
         fill: $gray-500;
       }
     }
-  }
-}
-
-// Pagetree
-.grw-pagetree {
-  .grw-pagetree-item {
-    .grw-triangle-icon {
-      svg {
-        fill: $gray-500;
-      }
-    }
     &:hover {
       background: $bgcolor-list-hover;
     }

--- a/packages/app/src/styles/theme/_apply-colors-light.scss
+++ b/packages/app/src/styles/theme/_apply-colors-light.scss
@@ -189,7 +189,7 @@ $border-color: $border-color-global;
       background: $bgcolor-list-hover;
     }
     &:active {
-      background: darken($bgcolor-list-hover, 5%);
+      background: $bgcolor-list-active;
     }
   }
 }

--- a/packages/app/src/styles/theme/_apply-colors-light.scss
+++ b/packages/app/src/styles/theme/_apply-colors-light.scss
@@ -168,6 +168,23 @@ $border-color: $border-color-global;
   @include override-list-group-item($color-list, $bgcolor-sidebar-list-group, $color-list-hover, $bgcolor-list-hover, $color-list-active, $bgcolor-list-active);
 }
 
+// Pagetree
+.grw-pagetree {
+  .grw-pagetree-item {
+    .grw-triangle-icon {
+      svg {
+        fill: $gray-400;
+      }
+    }
+    &:hover {
+      background: $bgcolor-list-hover;
+    }
+    &:active {
+      background: darken($bgcolor-list-hover, 5%);
+    }
+  }
+}
+
 /*
  * GROWI page list
  */

--- a/packages/app/src/styles/theme/_apply-colors-light.scss
+++ b/packages/app/src/styles/theme/_apply-colors-light.scss
@@ -174,17 +174,6 @@ $border-color: $border-color-global;
         fill: $gray-400;
       }
     }
-  }
-}
-
-// Pagetree
-.grw-pagetree {
-  .grw-pagetree-item {
-    .grw-triangle-icon {
-      svg {
-        fill: $gray-400;
-      }
-    }
     &:hover {
       background: $bgcolor-list-hover;
     }

--- a/packages/app/src/styles/theme/_apply-colors-light.scss
+++ b/packages/app/src/styles/theme/_apply-colors-light.scss
@@ -2,8 +2,8 @@
 $color-list: $color-global !default;
 $bgcolor-list: $bgcolor-global !default;
 $color-list-hover: $color-global !default;
-$bgcolor-list-hover: darken($bgcolor-global, 3%) !default;
-$bgcolor-list-active: $primary !default;
+$bgcolor-list-hover: lighten($primary, 72%) !default;
+$bgcolor-list-active: lighten($primary, 65%) !default;
 $color-list-active: color-yiq($bgcolor-list-active) !default;
 $bgcolor-subnav: darken($bgcolor-global, 3%) !default;
 $color-table: $color-global !default;

--- a/packages/app/src/styles/theme/_apply-colors.scss
+++ b/packages/app/src/styles/theme/_apply-colors.scss
@@ -542,6 +542,7 @@ body.pathname-sidebar {
   }
 
   .grw-pagetree-item {
+    // TODO: apply variable to　these bg-color  for each theme by 83526
     &:hover {
       background: #e0e6f7;
     }

--- a/packages/app/src/styles/theme/_apply-colors.scss
+++ b/packages/app/src/styles/theme/_apply-colors.scss
@@ -534,9 +534,17 @@ body.pathname-sidebar {
 }
 
 // Pagetree
-.grw-triangle-icon {
-  svg {
-    fill: $gray-400;
+.grw-pagetree {
+  .grw-triangle-icon {
+    svg {
+      fill: $gray-400;
+    }
+  }
+
+  .grw-pagetree-item {
+    &:hover {
+      background: #e0e6f7;
+    }
   }
 }
 

--- a/packages/app/src/styles/theme/_apply-colors.scss
+++ b/packages/app/src/styles/theme/_apply-colors.scss
@@ -545,6 +545,9 @@ body.pathname-sidebar {
     &:hover {
       background: #e0e6f7;
     }
+    &:active {
+      background: #ccd5f1;
+    }
   }
 }
 

--- a/packages/app/src/styles/theme/_apply-colors.scss
+++ b/packages/app/src/styles/theme/_apply-colors.scss
@@ -533,24 +533,6 @@ body.pathname-sidebar {
   }
 }
 
-// Pagetree
-.grw-pagetree {
-  .grw-pagetree-item {
-    .grw-triangle-icon {
-      svg {
-        fill: $gray-400;
-      }
-    }
-    // TODO: apply variable to　these bg-color  for each theme by 83526
-    &:hover {
-      background: lighten($primary, 65%);
-    }
-    &:active {
-      background: lighten($primary, 72%);
-    }
-  }
-}
-
 /*
  * GROWI Grid Edit Modal
  */


### PR DESCRIPTION
## Task
以下二つです。
- [#83044](https://redmine.weseek.co.jp/issues/83044) ホバーした時の挙動をXD に合わせる
- [#83526](https://redmine.weseek.co.jp/issues/83526) [page bg-color]ホバー、アクティブ時の色を各テーマに合わせる

## Note
- ついでにActive時のbgColor指定もしました。

## XD
<img width="288" alt="Screen Shot 2021-12-10 at 20 55 17" src="https://user-images.githubusercontent.com/59536731/145570498-5373e9de-4a57-4b61-8c7a-ab84e8377c9e.png">
https://xd.adobe.com/view/cd3cb2f8-625d-4a6b-b6e4-917f75c675c5-986f/screen/27a328ec-c82d-4fd1-b97a-1dc6cb549080/

## View
- light(一部抜粋)
(default hover)
<img width="681" alt="Screen Shot 2021-12-10 at 23 41 04" src="https://user-images.githubusercontent.com/59536731/145591655-f6ad3530-0fc8-4fa8-854a-edfd8657ba4e.png">
(default active)
<img width="567" alt="Screen Shot 2021-12-10 at 23 42 10" src="https://user-images.githubusercontent.com/59536731/145591821-1b40b1aa-2083-4946-b97c-f52fb6ddbf4b.png">

<img width="826" alt="Screen Shot 2021-12-10 at 22 58 38" src="https://user-images.githubusercontent.com/59536731/145585345-6a58bfae-5007-4de3-86e9-ed0a9a1c0cbc.png">
<img width="964" alt="Screen Shot 2021-12-10 at 22 57 07" src="https://user-images.githubusercontent.com/59536731/145585226-7bb85669-ec64-46a2-ad76-251566abb8d2.png">
<img width="962" alt="Screen Shot 2021-12-10 at 22 57 43" src="https://user-images.githubusercontent.com/59536731/145585229-20e48d0f-a034-48ae-bc8d-412d60894ab7.png">


- dark(一部抜粋)
<img width="953" alt="Screen Shot 2021-12-10 at 22 52 50" src="https://user-images.githubusercontent.com/59536731/145584749-7877b285-a0c5-4157-84d7-0bfa78626082.png">
 
<img width="832" alt="Screen Shot 2021-12-10 at 22 54 01" src="https://user-images.githubusercontent.com/59536731/145584750-653a66bd-2db5-4e56-a8d4-cef691c174ca.png">

<img width="638" alt="Screen Shot 2021-12-10 at 22 50 30" src="https://user-images.githubusercontent.com/59536731/145584744-a547f1e2-55b9-4748-ae20-94af9b83616a.png">



