### PR TITLE
create notifications for actions on multiple pages

### DIFF
--- a/packages/app/src/server/models/activity.ts
+++ b/packages/app/src/server/models/activity.ts
@@ -75,7 +75,7 @@ activitySchema.index({
 activitySchema.methods.getNotificationTargetUsers = async function(fromPageDescendants: Array<Types.ObjectId> = []) {
   const User = getModelSafely('User') || require('~/server/models/user')();
   const {
-    user: actionUser, target,
+    user: actionUser, targetModel, target,
   } = this;
 
   const [subscribeUsers] = await Promise.all([
@@ -90,7 +90,7 @@ activitySchema.methods.getNotificationTargetUsers = async function(fromPageDesce
 
   // eslint-disable-next-line prefer-const
   let descendantPageSubscribeUsers: Array<Types.ObjectId> = [];
-  if (fromPageDescendants.length > 0) {
+  if (targetModel === 'Page' && fromPageDescendants.length > 0) {
     for (const page of fromPageDescendants) {
       // eslint-disable-next-line  no-await-in-loop
       const subscribeUsers = await Subscription.getSubscription((page as any) as Types.ObjectId);

--- a/packages/app/src/server/models/activity.ts
+++ b/packages/app/src/server/models/activity.ts
@@ -106,30 +106,6 @@ activitySchema.methods.getNotificationTargetUsers = async function(isRecursively
     }
   }
 
-  // /* eslint-disable prefer-const */
-  // let subscribeUsers: Array<Types.ObjectId> = [];
-  // let unsubscribeUsers: Array<Types.ObjectId> = [];
-  // /* eslint-disable prefer-const */
-
-  // if (targetModel === 'Page' && isRecursively) {
-  //   const Page = getModelSafely('Page') || require('~/server/models/page')();
-  //   const fromPageDescendants = await Page.findManageableListWithDescendants(target, user);
-  //   for (const page of fromPageDescendants) {
-  //     /* eslint-disable no-await-in-loop */
-  //     /* eslint-disable no-loop-func */
-  //     (await Subscription.getSubscription((page as any) as Types.ObjectId)).forEach(user => subscribeUsers.push(user));
-  //     (await Subscription.getUnsubscription((page as any) as Types.ObjectId)).forEach(user => unsubscribeUsers.push(user));
-  //     /* eslint-disable no-await-in-loop */
-  //     /* eslint-disable no-loop-func */
-  //   }
-  // }
-  // else {
-  //   [subscribeUsers, unsubscribeUsers] = await Promise.all([
-  //     Subscription.getSubscription((target as any) as Types.ObjectId),
-  //     Subscription.getUnsubscription((target as any) as Types.ObjectId),
-  //   ]);
-  // }
-
   const unique = array => Object.values(array.reduce((objects, object) => ({ ...objects, [object.toString()]: object }), {}));
   const filter = (array, pull) => {
     const ids = pull.map(object => object.toString());

--- a/packages/app/src/server/models/activity.ts
+++ b/packages/app/src/server/models/activity.ts
@@ -75,50 +75,16 @@ activitySchema.index({
 activitySchema.methods.getNotificationTargetUsers = async function(fromPageDescendants: Array<Types.ObjectId> = []) {
   const User = getModelSafely('User') || require('~/server/models/user')();
   const {
-    user: actionUser, targetModel, target, user,
+    user: actionUser, target,
   } = this;
-
-  // const [subscribeUsers, unsubscribeUsers] = await Promise.all([
-  //   Subscription.getSubscription((target as any) as Types.ObjectId),
-  //   Subscription.getUnsubscription((target as any) as Types.ObjectId),
-  // ]);
 
   const [subscribeUsers] = await Promise.all([
     Subscription.getSubscription((target as any) as Types.ObjectId),
   ]);
 
-  console.log('subscribeUsers', subscribeUsers);
-  // console.log('unsubscribeUsers', unsubscribeUsers);
-
-  // eslint-disable-next-line prefer-const
-  // let descendantsPageSubscribeUsers: Array<Types.ObjectId> = [];
-
-  // if (isRecursively && targetModel === 'Page') {
-  //   const Page = getModelSafely('Page') || require('~/server/models/page')();
-  //   const fromPageDescendants = await Page.findManageableListWithDescendants(target, user);
-  //   const targetPageId = (target as any)._id;
-
-  //   for (const page of fromPageDescendants) {
-  //     console.log(page);
-  //     // eslint-disable-next-line eqeqeq
-  //     if (page._id.toString() != targetPageId) {
-  //       // eslint-disable-next-line  no-await-in-loop
-  //       const subscribeUsers = await Subscription.getSubscription((page as any) as Types.ObjectId);
-  //       subscribeUsers.forEach((user) => {
-  //         // eslint-disable-next-line eqeqeq
-  //         if (actionUser.toString() != user.toString()) {
-  //           descendantsPageSubscribeUsers.push(user);
-  //         }
-  //       });
-  //     }
-  //   }
-  // }
-
   const unique = array => Object.values(array.reduce((objects, object) => ({ ...objects, [object.toString()]: object }), {}));
   const filter = (array, pull) => {
     const ids = pull.map(object => object.toString());
-    console.log('array', array);
-    console.log('ids', ids);
     return array.filter(object => !ids.includes(object.toString()));
   };
 
@@ -131,34 +97,7 @@ activitySchema.methods.getNotificationTargetUsers = async function(fromPageDesce
       subscribeUsers.forEach(user => descendantPageUsers.push(user));
     }
   }
-  console.log('descendantPageUsers', descendantPageUsers);
-
   const notificationUsers = filter(unique([...subscribeUsers, ...descendantPageUsers]), [actionUser]);
-
-  console.log('notificationUsers', notificationUsers);
-
-  // if (fromPageDescendants.length > 0) {
-  //   const targetPage = (target as any) as IPage;
-  //   fromPageDescendants.forEach(async(page) => {
-  //     const descendantsPage = (page as any) as IPage;
-  //     // eslint-disable-next-line eqeqeq
-  //     if (descendantsPage._id != targetPage._id) {
-  //       console.log('子');
-  //       // eslint-disable-next-line  no-await-in-loop
-  //       const subscribeUsers = await Subscription.getSubscription((page as any) as Types.ObjectId);
-  //       subscribeUsers.forEach((user) => {
-  //         // eslint-disable-next-line eqeqeq
-  //         const isAbleToPush = actionUser.toString() != user.toString() && !notificationUsers.includes(user._id);
-  //         if (isAbleToPush) {
-  //           notificationUsers.push(user);
-  //         }
-  //       });
-  //     }
-  //     else {
-  //       console.og('親');
-  //     }
-  //   });
-  // }
 
   const activeNotificationUsers = await User.find({
     _id: { $in: notificationUsers },

--- a/packages/app/src/server/models/activity.ts
+++ b/packages/app/src/server/models/activity.ts
@@ -78,9 +78,7 @@ activitySchema.methods.getNotificationTargetUsers = async function(fromPageDesce
     user: actionUser, targetModel, target,
   } = this;
 
-  const [subscribeUsers] = await Promise.all([
-    Subscription.getSubscription((target as any) as Types.ObjectId),
-  ]);
+  const subscribeUsers = await Subscription.getSubscription((target as any) as Types.ObjectId);
 
   const unique = array => Object.values(array.reduce((objects, object) => ({ ...objects, [object.toString()]: object }), {}));
   const filter = (array, pull) => {

--- a/packages/app/src/server/models/activity.ts
+++ b/packages/app/src/server/models/activity.ts
@@ -89,15 +89,15 @@ activitySchema.methods.getNotificationTargetUsers = async function(fromPageDesce
   };
 
   // eslint-disable-next-line prefer-const
-  let descendantPageUsers: Array<Types.ObjectId> = [];
+  let descendantPageSubscribeUsers: Array<Types.ObjectId> = [];
   if (fromPageDescendants.length > 0) {
     for (const page of fromPageDescendants) {
       // eslint-disable-next-line  no-await-in-loop
       const subscribeUsers = await Subscription.getSubscription((page as any) as Types.ObjectId);
-      subscribeUsers.forEach(user => descendantPageUsers.push(user));
+      subscribeUsers.forEach(user => descendantPageSubscribeUsers.push(user));
     }
   }
-  const notificationUsers = filter(unique([...subscribeUsers, ...descendantPageUsers]), [actionUser]);
+  const notificationUsers = filter(unique([...subscribeUsers, ...descendantPageSubscribeUsers]), [actionUser]);
 
   const activeNotificationUsers = await User.find({
     _id: { $in: notificationUsers },

--- a/packages/app/src/server/models/activity.ts
+++ b/packages/app/src/server/models/activity.ts
@@ -86,7 +86,7 @@ activitySchema.methods.getNotificationTargetUsers = async function(isRecursively
   // eslint-disable-next-line prefer-const
   let descendantsPageSubscribeUsers: Array<Types.ObjectId> = [];
 
-  if (isRecursively) {
+  if (isRecursively && targetModel === 'Page') {
     const Page = getModelSafely('Page') || require('~/server/models/page')();
     const fromPageDescendants = await Page.findManageableListWithDescendants(target, user);
     const targetPageId = (target as any)._id;

--- a/packages/app/src/server/service/page.js
+++ b/packages/app/src/server/service/page.js
@@ -1,4 +1,4 @@
-import { pagePathUtils, getModelSafely } from '@growi/core';
+import { pagePathUtils } from '@growi/core';
 import loggerFactory from '~/utils/logger';
 import ActivityDefine from '../util/activityDefine';
 
@@ -49,7 +49,7 @@ class PageService {
     });
 
     // rename
-    this.pageEvent.on('rename', async(page, user, fromPageDescendants) => {
+    this.pageEvent.on('rename', async(page, user, fromPageDescendants = []) => {
       try {
         await this.createAndSendNotifications(page, user, ActivityDefine.ACTION_PAGE_RENAME, fromPageDescendants);
       }
@@ -59,7 +59,7 @@ class PageService {
     });
 
     // delete
-    this.pageEvent.on('delete', async(page, user, fromPageDescendants) => {
+    this.pageEvent.on('delete', async(page, user, fromPageDescendants = []) => {
       try {
         await this.createAndSendNotifications(page, user, ActivityDefine.ACTION_PAGE_DELETE, fromPageDescendants);
       }
@@ -69,7 +69,7 @@ class PageService {
     });
 
     // delete completely
-    this.pageEvent.on('deleteCompletely', async(page, user, fromPageDescendants) => {
+    this.pageEvent.on('deleteCompletely', async(page, user, fromPageDescendants = []) => {
       try {
         await this.createAndSendNotifications(page, user, ActivityDefine.ACTION_PAGE_DELETE_COMPLETELY, fromPageDescendants);
       }
@@ -820,7 +820,7 @@ class PageService {
     }
   }
 
-  createAndSendNotifications = async function(page, user, action, fromPageDescendants) {
+  createAndSendNotifications = async function(page, user, action, fromPageDescendants = []) {
     const { activityService, inAppNotificationService } = this.crowi;
 
     const snapshot = stringifySnapshot(page);

--- a/packages/app/src/server/service/page.js
+++ b/packages/app/src/server/service/page.js
@@ -49,9 +49,9 @@ class PageService {
     });
 
     // rename
-    this.pageEvent.on('rename', async(page, user) => {
+    this.pageEvent.on('rename', async(page, user, isRecursively) => {
       try {
-        await this.createAndSendNotifications(page, user, ActivityDefine.ACTION_PAGE_RENAME);
+        await this.createAndSendNotifications(page, user, ActivityDefine.ACTION_PAGE_RENAME, isRecursively);
       }
       catch (err) {
         logger.error(err);
@@ -59,9 +59,9 @@ class PageService {
     });
 
     // delete
-    this.pageEvent.on('delete', async(page, user) => {
+    this.pageEvent.on('delete', async(page, user, isRecursively) => {
       try {
-        await this.createAndSendNotifications(page, user, ActivityDefine.ACTION_PAGE_DELETE);
+        await this.createAndSendNotifications(page, user, ActivityDefine.ACTION_PAGE_DELETE, isRecursively);
       }
       catch (err) {
         logger.error(err);
@@ -69,9 +69,9 @@ class PageService {
     });
 
     // delete completely
-    this.pageEvent.on('deleteCompletely', async(page, user) => {
+    this.pageEvent.on('deleteCompletely', async(page, user, isRecursively) => {
       try {
-        await this.createAndSendNotifications(page, user, ActivityDefine.ACTION_PAGE_DELETE_COMPLETELY);
+        await this.createAndSendNotifications(page, user, ActivityDefine.ACTION_PAGE_DELETE_COMPLETELY, isRecursively);
       }
       catch (err) {
         logger.error(err);
@@ -177,7 +177,7 @@ class PageService {
       await Page.create(path, body, user, { redirectTo: newPagePath });
     }
 
-    this.pageEvent.emit('rename', page, user);
+    this.pageEvent.emit('rename', page, user, isRecursively);
 
     return renamedPage;
   }
@@ -809,7 +809,7 @@ class PageService {
     }
   }
 
-  createAndSendNotifications = async function(page, user, action) {
+  createAndSendNotifications = async function(page, user, action, isRecursively = false) {
     const { activityService, inAppNotificationService } = this.crowi;
 
     const snapshot = stringifySnapshot(page);
@@ -824,7 +824,7 @@ class PageService {
     const activity = await activityService.createByParameters(parameters);
 
     // Get user to be notified
-    const targetUsers = await activity.getNotificationTargetUsers();
+    const targetUsers = await activity.getNotificationTargetUsers(isRecursively);
 
     // Create and send notifications
     await inAppNotificationService.upsertByActivity(targetUsers, activity, snapshot);

--- a/packages/app/src/test/integration/service/page.test.js
+++ b/packages/app/src/test/integration/service/page.test.js
@@ -352,7 +352,7 @@ describe('PageService', () => {
         expect(xssSpy).toHaveBeenCalled();
         expect(renameDescendantsWithStreamSpy).not.toHaveBeenCalled();
 
-        expect(pageEventSpy).toHaveBeenCalledWith('rename', parentForRename1, testUser2);
+        expect(pageEventSpy).toHaveBeenCalledWith('rename', parentForRename1, testUser2, false);
 
         expect(resultPage.path).toBe('/renamed1');
         expect(resultPage.updatedAt).toEqual(parentForRename1.updatedAt);
@@ -371,7 +371,7 @@ describe('PageService', () => {
         expect(xssSpy).toHaveBeenCalled();
         expect(renameDescendantsWithStreamSpy).not.toHaveBeenCalled();
 
-        expect(pageEventSpy).toHaveBeenCalledWith('rename', parentForRename2, testUser2);
+        expect(pageEventSpy).toHaveBeenCalledWith('rename', parentForRename2, testUser2, false);
 
         expect(resultPage.path).toBe('/renamed2');
         expect(resultPage.updatedAt).toEqual(dateToUse);
@@ -389,7 +389,7 @@ describe('PageService', () => {
 
         expect(xssSpy).toHaveBeenCalled();
         expect(renameDescendantsWithStreamSpy).not.toHaveBeenCalled();
-        expect(pageEventSpy).toHaveBeenCalledWith('rename', parentForRename3, testUser2);
+        expect(pageEventSpy).toHaveBeenCalledWith('rename', parentForRename3, testUser2, false);
 
         expect(resultPage.path).toBe('/renamed3');
         expect(resultPage.updatedAt).toEqual(parentForRename3.updatedAt);
@@ -412,7 +412,7 @@ describe('PageService', () => {
 
         expect(xssSpy).toHaveBeenCalled();
         expect(renameDescendantsWithStreamSpy).toHaveBeenCalled();
-        expect(pageEventSpy).toHaveBeenCalledWith('rename', parentForRename4, testUser2);
+        expect(pageEventSpy).toHaveBeenCalledWith('rename', parentForRename4, testUser2, true);
 
         expect(resultPage.path).toBe('/renamed4');
         expect(resultPage.updatedAt).toEqual(parentForRename4.updatedAt);


### PR DESCRIPTION
## Task
[#82869](https://redmine.weseek.co.jp/issues/82869) [server] 複数ページの削除・リネーム時に、親のページに対する通知のみを作成できる
