### PR TITLE
fix page tree path color

### DIFF
--- a/packages/app/src/styles/_page-tree.scss
+++ b/packages/app/src/styles/_page-tree.scss
@@ -28,6 +28,8 @@
     .grw-pagetree-title-anchor {
       width: 100%;
       overflow: hidden;
+      color: inherit;
+      text-decoration: none;
 
       .grw-pagetree-title {
         overflow: hidden;


### PR DESCRIPTION
## Task
- [#83431](https://redmine.weseek.co.jp/issues/83431) ページの文字色をXDのように修正

## [XD](https://xd.adobe.com/view/cd3cb2f8-625d-4a6b-b6e4-917f75c675c5-986f/screen/27a328ec-c82d-4fd1-b97a-1dc6cb549080/)
<img width="332" alt="Screen Shot 2021-12-12 at 22 47 51" src="https://user-images.githubusercontent.com/59536731/145714958-6aec23ed-7ae8-41f6-a4a2-5860b9efe91e.png">


## View
### Before
<img width="602" alt="Screen Shot 2021-12-12 at 22 45 15" src="https://user-images.githubusercontent.com/59536731/145714892-19c9ed6e-f46a-4cbf-97d7-db78085e65f2.png">
<img width="607" alt="Screen Shot 2021-12-12 at 22 45 31" src="https://user-images.githubusercontent.com/59536731/145714894-6535c600-814c-4f76-a569-7cf132d607e6.png">

### After
<img width="621" alt="Screen Shot 2021-12-12 at 22 44 35" src="https://user-images.githubusercontent.com/59536731/145714888-cddf4831-c775-4b02-ba5e-b8580455e054.png">
<img width="496" alt="Screen Shot 2021-12-12 at 22 44 43" src="https://user-images.githubusercontent.com/59536731/145714891-0764884f-39b4-4c82-95c4-dab5d59db9c6.png">