### PR TITLE
83697 83703 fix sort design

### DIFF
--- a/packages/app/src/components/SearchPage/SortControl.tsx
+++ b/packages/app/src/components/SearchPage/SortControl.tsx
@@ -26,7 +26,7 @@ const SortControl: FC <Props> = (props: Props) => {
   };
 
   const renderSortItem = (sort, order) => {
-    return <><span className="mr-3">{t(`search_result.sort_axis.${sort}`)}</span>{renderOrderIcon(order)}</>;
+    return <div className="d-flex align-items-center"><span className="mr-3">{t(`search_result.sort_axis.${sort}`)}</span>{renderOrderIcon(order)}</div>;
   };
 
   return (
@@ -43,7 +43,7 @@ const SortControl: FC <Props> = (props: Props) => {
             className="btn border dropdown-toggle"
             data-toggle="dropdown"
           >
-            <span className="mr-4">{t(`search_result.sort_axis.${props.sort}`)}</span>
+            <span className="mr-4 text-secondary">{t(`search_result.sort_axis.${props.sort}`)}</span>
           </button>
           <div className="dropdown-menu dropdown-menu-right">
             {Object.values(SORT_AXIS).map((sortAxis) => {


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/83697

- 文字をXD通りグレーに変更
- ドロップダウン開いた中のアイコンの位置を真ん中に寄せた

before
![image](https://user-images.githubusercontent.com/35527421/145783923-bb24c28c-219b-4d01-84cd-606ba0fec87f.png)


after
![image](https://user-images.githubusercontent.com/35527421/145783834-bd14a13d-483f-4c56-9807-25d1ee787433.png)
