### PR TITLE
feat: 83427 hide page tree if migration is not done yet

### DIFF
--- a/packages/app/resource/locales/en_US/admin/admin.json
+++ b/packages/app/resource/locales/en_US/admin/admin.json
@@ -20,6 +20,8 @@
     "submit_bug_report": "<a href='https://github.com/weseek/growi/issues/new?assignees=&labels=bug&template=bug-report.md&title=Bug%3A' target='_blank' rel='noreferrer'>then submit your issue to GitHub.</a>"
   },
   "v5_page_migration": {
+    "page_tree_not_avaliable" : "Page tree feature is not available yet.",
+    "go_to_settings": "Go to settings to enable the feature",
     "migration_desc": "Some of the public pages have the old schema. To take advantage of new features such as page trees and easy renaming, please upgrade the schema of all your pages.",
     "migration_note": "Note: You will lose unique constraints from the page paths.",
     "upgrade_to_v5": "Upgrade to V5",

--- a/packages/app/resource/locales/ja_JP/admin/admin.json
+++ b/packages/app/resource/locales/ja_JP/admin/admin.json
@@ -20,6 +20,8 @@
     "submit_bug_report": "<a href='https://github.com/weseek/growi/issues/new?assignees=&labels=bug&template=bug-report.md&title=Bug%3A' target='_blank' rel='noreferrer'>次に GitHub で Issue を投稿してください。</a>"
   },
   "v5_page_migration": {
+    "page_tree_not_avaliable" : "Page Tree 機能は現在使用できません。",
+    "go_to_settings": "設定する",
     "migration_desc": "公開されているページに古いスキーマのものが存在します。ページツリーや簡単なリネームなどの新機能を利用するには、全てのページのスキーマをアップグレードしてください。",
     "migration_note": "注意: ページパスからユニーク制約が失われます。",
     "upgrade_to_v5": "V5 にアップグレード",

--- a/packages/app/resource/locales/zh_CN/admin/admin.json
+++ b/packages/app/resource/locales/zh_CN/admin/admin.json
@@ -20,6 +20,8 @@
     "submit_bug_report": "<a href='https://github.com/weseek/growi/issues/new?assignees=&labels=bug&template=bug-report.md&title=Bug%3A' target='_blank' rel='noreferrer'>然后提交你的问题到GitHub。</a>"
   },
   "v5_page_migration": {
+    "page_tree_not_avaliable": "Page Tree 功能不可用",
+    "go_to_settings": "进入设置，启用该功能",
     "migration_desc": "Some of the public pages have the old schema. To take advantage of new features such as page trees and easy renaming, please upgrade the schema of all your pages. ",
     "migration_note": "Note: You will lose unique constraints from the page paths.",
     "upgrade_to_v5": "Upgrade to V5",

--- a/packages/app/src/components/Sidebar/PageTree.tsx
+++ b/packages/app/src/components/Sidebar/PageTree.tsx
@@ -19,7 +19,7 @@ const PageTree: FC = memo(() => {
   const { data: targetId } = useCurrentPageId();
   const { data: targetAndAncestorsData } = useTargetAndAncestors();
 
-  const { data: migrationStatus } = useSWRxV5MigrationStatus(!isGuestUser);
+  const { data: migrationStatus } = useSWRxV5MigrationStatus();
 
   // for delete modal
   const [isDeleteModalOpen, setDeleteModalOpen] = useState(false);

--- a/packages/app/src/components/Sidebar/PageTree.tsx
+++ b/packages/app/src/components/Sidebar/PageTree.tsx
@@ -25,6 +25,21 @@ const PageTree: FC = memo(() => {
   const [isDeleteModalOpen, setDeleteModalOpen] = useState(false);
   const [pagesToDelete, setPagesToDelete] = useState<IPageForPageDeleteModal[]>([]);
 
+  if (!migrationStatus?.isV5Compatible) {
+    // TODO : improve design
+    // Story : https://redmine.weseek.co.jp/issues/83755
+    return (
+      <>
+        <div className="grw-sidebar-content-header p-3">
+          <h3 className="mb-0">{t('Page Tree')}</h3>
+        </div>
+        <div className="mt-5 mx-2 text-center">
+          <h3 className="text-gray">{t('admin:v5_page_migration.page_tree_not_avaliable')}</h3>
+          <a href="/admin">{t('admin:v5_page_migration.go_to_settings')}</a>
+        </div>
+      </>
+    );
+  }
   /*
    * dependencies
    */

--- a/packages/app/src/interfaces/page-listing-results.ts
+++ b/packages/app/src/interfaces/page-listing-results.ts
@@ -24,5 +24,6 @@ export interface TargetAndAncestors {
 
 
 export interface V5MigrationStatus {
+  isV5Compatible : boolean,
   migratablePagesCount: number
 }

--- a/packages/app/src/server/routes/apiv3/pages.js
+++ b/packages/app/src/server/routes/apiv3/pages.js
@@ -715,8 +715,9 @@ module.exports = (crowi) => {
 
   router.get('/v5-migration-status', accessTokenParser, loginRequired, async(req, res) => {
     try {
+      const isV5Compatible = crowi.configManager.getConfig('crowi', 'app:isV5Compatible');
       const migratablePagesCount = await crowi.pageService.v5MigratablePrivatePagesCount(req.user);
-      return res.apiv3({ migratablePagesCount });
+      return res.apiv3({ isV5Compatible, migratablePagesCount });
     }
     catch (err) {
       return res.apiv3Err(new ErrorV3('Failed to obtain migration status'));

--- a/packages/app/src/stores/page-listing.tsx
+++ b/packages/app/src/stores/page-listing.tsx
@@ -46,12 +46,12 @@ export const useSWRxPageChildren = (
 };
 
 export const useSWRxV5MigrationStatus = (
-    shouldFetch = true,
 ): SWRResponse<V5MigrationStatus, Error> => {
   return useSWR(
-    shouldFetch ? '/pages/v5-migration-status' : null,
+    '/pages/v5-migration-status',
     endpoint => apiv3Get(endpoint).then((response) => {
       return {
+        isV5Compatible: response.data.isV5Compatible,
         migratablePagesCount: response.data.migratablePagesCount,
       };
     }),


### PR DESCRIPTION
## Task: 
https://redmine.weseek.co.jp/issues/83473

## 内容
page v5のmigrationが済んでない場合にはpageTreeにメッセージを表示させる。

## スクショ：

###  migrationすんでない場合
<img width="1912" alt="Screen Shot 2021-12-14 at 13 23 10" src="https://user-images.githubusercontent.com/60797707/145933161-8c10719a-9a04-454c-b550-45e80ebcbe60.png">
<img width="1912" alt="Screen Shot 2021-12-14 at 13 27 56" src="https://user-images.githubusercontent.com/60797707/145933164-eab1c13e-fbb4-42b4-a56f-72428eaba1f2.png">
<img width="1912" alt="Screen Shot 2021-12-14 at 13 28 26" src="https://user-images.githubusercontent.com/60797707/145933166-67bf079b-783c-481f-aa93-4dd29420dcee.png">

### migrationが済んでいる場合
<img width="1912" alt="Screen Shot 2021-12-14 at 13 33 55" src="https://user-images.githubusercontent.com/60797707/145933961-f6d22c7f-73c4-483d-a1a9-00e08ddf8e0d.png">

