### PR TITLE
apply margin to Item component not using scss

### DIFF
--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -180,7 +180,7 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
   const buttonClass = isOpen ? 'rotate' : '';
 
   return (
-    <div className="grw-pagetree-item-wrapper">
+    <>
       <div style={opacityStyle} className="grw-pagetree-item d-flex align-items-center">
         <button
           type="button"
@@ -218,16 +218,18 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
       )}
       {
         isOpen && hasChildren() && currentChildren.map(node => (
-          <Item
-            key={node.page._id}
-            isEnableActions={isEnableActions}
-            itemNode={node}
-            isOpen={false}
-            onClickDeleteByPage={onClickDeleteByPage}
-          />
+          <div className="ml-3 mt-3">
+            <Item
+              key={node.page._id}
+              isEnableActions={isEnableActions}
+              itemNode={node}
+              isOpen={false}
+              onClickDeleteByPage={onClickDeleteByPage}
+            />
+          </div>
         ))
       }
-    </div>
+    </>
   );
 
 };

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -218,7 +218,7 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
       )}
       {
         isOpen && hasChildren() && currentChildren.map(node => (
-          <div className="ml-3 mt-3">
+          <div className="ml-3 mt-2">
             <Item
               key={node.page._id}
               isEnableActions={isEnableActions}

--- a/packages/app/src/styles/_page-tree.scss
+++ b/packages/app/src/styles/_page-tree.scss
@@ -1,9 +1,4 @@
 .grw-pagetree {
-  .grw-pagetree-item-wrapper {
-    margin-top: 10px;
-    margin-left: 10px;
-  }
-
   .grw-pagetree-item {
     &:hover {
       opacity: 0.7;


### PR DESCRIPTION
## Task
[#83644](https://redmine.weseek.co.jp/issues/83644) page path title の間隔を狭める

## Note
- ページツリーのコンテンツを左側に寄せて、「Page Tree」の左側と合うようにしました。
- 各ページパスの行間を詰めました

## [XD](https://xd.adobe.com/view/cd3cb2f8-625d-4a6b-b6e4-917f75c675c5-986f/screen/27a328ec-c82d-4fd1-b97a-1dc6cb549080/specs/)
<img width="351" alt="Screen Shot 2021-12-13 at 20 47 59" src="https://user-images.githubusercontent.com/59536731/145806991-7c1a6080-5db0-424c-a6e4-35cea496ccaa.png">



## View
### Before
<img width="310" alt="Screen Shot 2021-12-13 at 20 32 58" src="https://user-images.githubusercontent.com/59536731/145805215-c342e917-5a5e-440a-b223-0bb399204bcf.png">

### After
<img width="431" alt="Screen Shot 2021-12-13 at 20 44 43" src="https://user-images.githubusercontent.com/59536731/145806534-1a5538be-ad29-4fed-b326-e05843564a6c.png">


