### PR TITLE
83704 three dot icon and rename icon

### DIFF
--- a/packages/app/resource/locales/en_US/translation.json
+++ b/packages/app/resource/locales/en_US/translation.json
@@ -11,6 +11,7 @@
   "phone":"Smartphone",
   "tablet":"Tablet",
   "Click to copy": "Click to copy",
+  "Rename" : "Rename",
   "Move/Rename": "Move/Rename",
   "Moved": "Moved",
   "Redirected": "Redirected",

--- a/packages/app/resource/locales/ja_JP/translation.json
+++ b/packages/app/resource/locales/ja_JP/translation.json
@@ -11,6 +11,7 @@
   "phone":"スマホ",
   "tablet":"タブレット",
   "Click to copy": "クリックでコピー",
+  "Rename": "名前変更",
   "Move/Rename": "移動/名前変更",
   "Moved": "移動しました",
   "Redirected": "リダイレクトされました",

--- a/packages/app/resource/locales/zh_CN/translation.json
+++ b/packages/app/resource/locales/zh_CN/translation.json
@@ -12,6 +12,7 @@
   "tablet":"平板",
 	"Login": "登录",
 	"Click to copy": "点击复制",
+  "Rename": "重命名",
 	"Move/Rename": "移动/重命名",
 	"Moved": "移动",
 	"Redirected": "重定向",

--- a/packages/app/src/components/Common/Dropdown/PageItemControl.tsx
+++ b/packages/app/src/components/Common/Dropdown/PageItemControl.tsx
@@ -28,7 +28,7 @@ const PageItemControl: FC<PageItemControlProps> = (props: PageItemControlProps) 
         className="btn-link nav-link dropdown-toggle dropdown-toggle-no-caret border-0 rounded grw-btn-page-management py-0"
         data-toggle="dropdown"
       >
-        <i className="fa fa-ellipsis-v text-muted"></i>
+        <i className="icon-options fa fa-rotate-90 text-muted"></i>
       </button>
       <div className="dropdown-menu dropdown-menu-right">
 
@@ -70,8 +70,8 @@ const PageItemControl: FC<PageItemControlProps> = (props: PageItemControlProps) 
         )}
         {isEnableActions && (
           <button className="dropdown-item" type="button" onClick={() => toastr.warning(t('search_result.currently_not_implemented'))}>
-            <i className="icon-fw  icon-action-redo"></i>
-            {t('Move/Rename')}
+            <i className="icon-fw icon-note"></i>
+            {t('Rename')}
           </button>
         )}
         {isEnableActions && (

--- a/packages/app/src/components/Common/Dropdown/PageItemControl.tsx
+++ b/packages/app/src/components/Common/Dropdown/PageItemControl.tsx
@@ -25,7 +25,7 @@ const PageItemControl: FC<PageItemControlProps> = (props: PageItemControlProps) 
     <>
       <button
         type="button"
-        className="btn-link nav-link dropdown-toggle dropdown-toggle-no-caret border-0 rounded grw-btn-page-management py-0"
+        className="btn-link dropdown-toggle dropdown-toggle-no-caret border-0 rounded grw-btn-page-management py-0"
         data-toggle="dropdown"
       >
         <i className="icon-options fa fa-rotate-90 text-muted"></i>

--- a/packages/app/src/components/SearchPage/SearchResultListItem.tsx
+++ b/packages/app/src/components/SearchPage/SearchResultListItem.tsx
@@ -71,7 +71,7 @@ const SearchResultListItem: FC<Props> = (props:Props) => {
               <i className="icon-fw icon-home"></i>
               {pagePathElem}
             </small>
-            <div className="d-flex my-1 align-items-center">
+            <div className="d-flex my-1 align-items-center mr-2">
               {/* page title */}
               <h3 className="mb-0">
                 <UserPicture user={pageData.lastUpdateUser} />


### PR DESCRIPTION
# Task 
https://redmine.weseek.co.jp/issues/83704

# やったこと

<img width="1101" alt="Screen Shot 2021-12-16 at 15 53 55" src="https://user-images.githubusercontent.com/60797707/146322675-e6a908bb-411c-4ece-918b-4e9aa3149baf.png">

story内に記載してあること。

- 3点ボタン自体クリック時のフォーカスの色が違う <- yoheiさんの対応で改善済み
     - 検索pageのxd上だと灰色になってるが、mos さんに確認したところここは濃い青でいいとのことです。
- 3点ボタンのアイコンの種類が違う
- 移動・名前変更のアイコンが違う

# メモ
mosさんにデザインチェックしてもらっていくつか出た内容は後継タスクにしました。
[後継タスク](https://redmine.weseek.co.jp/issues/84033)
