### PR TITLE
Imprv/83889 legacy private pages color

### DIFF
--- a/packages/app/resource/locales/en_US/translation.json
+++ b/packages/app/resource/locales/en_US/translation.json
@@ -930,5 +930,8 @@
     "success_to_send_email": "Success to send email",
     "incorrect_token_or_expired_url": "The token is incorrect or the URL has expired. Please resend a password reset request via the link below.",
     "password_and_confirm_password_does_not_match": "Password and confirm password does not match"
+  },
+  "pagetree": {
+    "private_legacy_pages": "Private Legacy Pages"
   }
 }

--- a/packages/app/resource/locales/ja_JP/translation.json
+++ b/packages/app/resource/locales/ja_JP/translation.json
@@ -923,5 +923,8 @@
     "success_to_send_email": "メールを送信しました",
     "incorrect_token_or_expired_url":"トークンが正しくないか、URLの有効期限が切れています。 以下のリンクからパスワードリセットリクエストを再送信してください。",
     "password_and_confirm_password_does_not_match": "パスワードと確認パスワードが一致しません"
+  },
+  "pagetree": {
+    "private_legacy_pages": "待避所"
   }
 }

--- a/packages/app/resource/locales/zh_CN/translation.json
+++ b/packages/app/resource/locales/zh_CN/translation.json
@@ -933,5 +933,8 @@
     "success_to_send_email": "我发了一封电子邮件",
     "incorrect_token_or_expired_url":"令牌不正确或 URL 已过期。 请通过以下链接重新发送密码重置请求",
     "password_and_confirm_password_does_not_match": "密码和确认密码不匹配"
+  },
+  "pagetree": {
+    "private_legacy_pages": "私人遗留页面"
   }
 }

--- a/packages/app/src/components/Sidebar/PageTree.tsx
+++ b/packages/app/src/components/Sidebar/PageTree.tsx
@@ -64,7 +64,7 @@ const PageTree: FC = memo(() => {
         />
       </div>
 
-      <div className="border-top position-absolute fixed-bottom p-3 w-100">
+      <div className="grw-pagetree-footer border-top position-absolute fixed-bottom p-3 w-100">
         {
           !isGuestUser && migrationStatus?.migratablePagesCount != null && migrationStatus.migratablePagesCount !== 0 && (
             <PrivateLegacyPages />

--- a/packages/app/src/components/Sidebar/PageTree.tsx
+++ b/packages/app/src/components/Sidebar/PageTree.tsx
@@ -64,7 +64,7 @@ const PageTree: FC = memo(() => {
         />
       </div>
 
-      <div className="grw-sidebar-content-footer">
+      <div className="border-top position-absolute fixed-bottom p-3 w-100">
         {
           !isGuestUser && migrationStatus?.migratablePagesCount != null && migrationStatus.migratablePagesCount !== 0 && (
             <PrivateLegacyPages />

--- a/packages/app/src/components/Sidebar/PageTree/PrivateLegacyPages.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/PrivateLegacyPages.tsx
@@ -5,7 +5,7 @@ const PrivateLegacyPages: FC = memo(() => {
   const { t } = useTranslation();
 
   return (
-    <a href="/private-legacy-pages?q=[nq:PrivateLegacyPages]" className="h5">
+    <a href="/private-legacy-pages?q=[nq:PrivateLegacyPages]" className="h5 grw-private-legacy-pages-anchor text-decoration-none">
       <i className="icon-drawer mr-2"></i> Private Legacy Pages
     </a>
   );

--- a/packages/app/src/components/Sidebar/PageTree/PrivateLegacyPages.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/PrivateLegacyPages.tsx
@@ -5,11 +5,9 @@ const PrivateLegacyPages: FC = memo(() => {
   const { t } = useTranslation();
 
   return (
-    <div className="grw-prvt-legacy-pages p-3">
-      <a href="/private-legacy-pages?q=[nq:PrivateLegacyPages]" className="h5">
-        <i className="icon-drawer mr-2"></i> PrivateLegacyPages
-      </a>
-    </div>
+    <a href="/private-legacy-pages?q=[nq:PrivateLegacyPages]" className="h5">
+      <i className="icon-drawer mr-2"></i> Private Legacy Pages
+    </a>
   );
 });
 

--- a/packages/app/src/components/Sidebar/PageTree/PrivateLegacyPages.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/PrivateLegacyPages.tsx
@@ -6,7 +6,7 @@ const PrivateLegacyPages: FC = memo(() => {
 
   return (
     <a href="/private-legacy-pages?q=[nq:PrivateLegacyPages]" className="h5 grw-private-legacy-pages-anchor text-decoration-none">
-      <i className="icon-drawer mr-2"></i> Private Legacy Pages
+      <i className="icon-drawer mr-2"></i> {t('pagetree.private_legacy_pages')}
     </a>
   );
 });

--- a/packages/app/src/styles/_page-tree.scss
+++ b/packages/app/src/styles/_page-tree.scss
@@ -29,7 +29,6 @@
     .grw-pagetree-title-anchor {
       width: 100%;
       overflow: hidden;
-      color: inherit;
       text-decoration: none;
 
       .grw-pagetree-title {
@@ -50,11 +49,5 @@
         padding: 0.3rem 1rem;
       }
     }
-  }
-}
-
-.grw-pagetree-footer {
-  .h5.grw-private-legacy-pages-anchor {
-    color: inherit;
   }
 }

--- a/packages/app/src/styles/_page-tree.scss
+++ b/packages/app/src/styles/_page-tree.scss
@@ -52,3 +52,9 @@
     }
   }
 }
+
+.grw-pagetree-footer {
+  .h5.grw-private-legacy-pages-anchor {
+    color: inherit;
+  }
+}

--- a/packages/app/src/styles/_sidebar.scss
+++ b/packages/app/src/styles/_sidebar.scss
@@ -235,13 +235,6 @@
       font-size: 18px;
     }
   }
-
-  .grw-sidebar-content-footer {
-    position: absolute;
-    bottom: 0;
-    width: 100%;
-    border-top: solid 1px $border-color;
-  }
 }
 
 // Dock Mode

--- a/packages/app/src/styles/theme/_apply-colors.scss
+++ b/packages/app/src/styles/theme/_apply-colors.scss
@@ -310,6 +310,19 @@ ul.pagination {
     }
   }
 
+  .grw-pagetree {
+    .grw-pagetree-item {
+      .grw-pagetree-title-anchor {
+        color: inherit;
+      }
+    }
+  }
+  .grw-pagetree-footer {
+    .h5.grw-private-legacy-pages-anchor {
+      color: inherit;
+    }
+  }
+
   .grw-recent-changes {
     .list-group {
       .list-group-item {


### PR DESCRIPTION
## Task
[#83889](https://redmine.weseek.co.jp/issues/83889) 待避所リンクの色を修正する

## Note
ついでにi18n対応もしました



## [XD](https://xd.adobe.com/view/cd3cb2f8-625d-4a6b-b6e4-917f75c675c5-986f/screen/27a328ec-c82d-4fd1-b97a-1dc6cb549080/)
<img width="591" alt="Screen Shot 2021-12-15 at 2 28 16" src="https://user-images.githubusercontent.com/59536731/146049218-d7f47ced-9247-44b8-b2b8-4d4d77670334.png">

## View
### light
<img width="314" alt="Screen Shot 2021-12-15 at 2 29 09" src="https://user-images.githubusercontent.com/59536731/146049493-3179b101-dc65-4928-80e6-3db7fd3cc0b3.png">
<img width="361" alt="Screen Shot 2021-12-15 at 2 29 53" src="https://user-images.githubusercontent.com/59536731/146049498-64b215b8-e9bb-497b-89f1-aef421863f8e.png">


### dark
<img width="340" alt="Screen Shot 2021-12-15 at 2 30 00" src="https://user-images.githubusercontent.com/59536731/146049507-6408f38d-8eae-4142-ae29-03e44a7d1e1b.png">

