### PR TITLE
fix: Improve delete modal when top page or empty page

### DIFF
--- a/packages/app/src/components/Common/Dropdown/PageItemControl.tsx
+++ b/packages/app/src/components/Common/Dropdown/PageItemControl.tsx
@@ -14,7 +14,9 @@ type PageItemControlProps = {
 
 const PageItemControl: FC<PageItemControlProps> = (props: PageItemControlProps) => {
 
-  const { page, isEnableActions, onClickDeleteButton, isDeletable } = props;
+  const {
+    page, isEnableActions, onClickDeleteButton, isDeletable,
+  } = props;
   const { t } = useTranslation('');
 
   const deleteButtonHandler = () => {

--- a/packages/app/src/components/Common/Dropdown/PageItemControl.tsx
+++ b/packages/app/src/components/Common/Dropdown/PageItemControl.tsx
@@ -8,12 +8,13 @@ import { IPageHasId } from '~/interfaces/page';
 type PageItemControlProps = {
   page: Partial<IPageHasId>
   isEnableActions: boolean
+  isDeletable: boolean
   onClickDeleteButton?: (pageId: string) => void
 }
 
 const PageItemControl: FC<PageItemControlProps> = (props: PageItemControlProps) => {
 
-  const { page, isEnableActions, onClickDeleteButton } = props;
+  const { page, isEnableActions, onClickDeleteButton, isDeletable } = props;
   const { t } = useTranslation('');
 
   const deleteButtonHandler = () => {
@@ -74,7 +75,7 @@ const PageItemControl: FC<PageItemControlProps> = (props: PageItemControlProps) 
             {t('Move/Rename')}
           </button>
         )}
-        {isEnableActions && (
+        {isDeletable && isEnableActions && (
           <>
             <div className="dropdown-divider"></div>
             <button className="dropdown-item text-danger pt-2" type="button" onClick={deleteButtonHandler}>

--- a/packages/app/src/components/SearchPage/SearchResultListItem.tsx
+++ b/packages/app/src/components/SearchPage/SearchResultListItem.tsx
@@ -3,7 +3,7 @@ import React, { FC, memo } from 'react';
 import Clamp from 'react-multiline-clamp';
 
 import { UserPicture, PageListMeta, PagePathLabel } from '@growi/ui';
-import { pagePathUtils } from 'growi-commons';
+import { pagePathUtils } from '@growi/core';
 
 import { IPageSearchResultData } from '../../interfaces/search';
 import PageItemControl from '../Common/Dropdown/PageItemControl';

--- a/packages/app/src/components/SearchPage/SearchResultListItem.tsx
+++ b/packages/app/src/components/SearchPage/SearchResultListItem.tsx
@@ -3,11 +3,12 @@ import React, { FC, memo } from 'react';
 import Clamp from 'react-multiline-clamp';
 
 import { UserPicture, PageListMeta, PagePathLabel } from '@growi/ui';
+import { pagePathUtils } from 'growi-commons';
 
 import { IPageSearchResultData } from '../../interfaces/search';
 import PageItemControl from '../Common/Dropdown/PageItemControl';
-import { isTopPage } from '^/../core/dist/cjs/utils/page-path-utils';
 
+const { isTopPage } = pagePathUtils;
 
 type Props = {
   page: IPageSearchResultData,

--- a/packages/app/src/components/SearchPage/SearchResultListItem.tsx
+++ b/packages/app/src/components/SearchPage/SearchResultListItem.tsx
@@ -6,6 +6,7 @@ import { UserPicture, PageListMeta, PagePathLabel } from '@growi/ui';
 
 import { IPageSearchResultData } from '../../interfaces/search';
 import PageItemControl from '../Common/Dropdown/PageItemControl';
+import { isTopPage } from '^/../core/dist/cjs/utils/page-path-utils';
 
 
 type Props = {
@@ -84,7 +85,12 @@ const SearchResultListItem: FC<Props> = memo((props:Props) => {
               </div>
               {/* doropdown icon includes page control buttons */}
               <div className="ml-auto">
-                <PageItemControl page={pageData} onClickDeleteButton={props.onClickDeleteButton} isEnableActions={isEnableActions} />
+                <PageItemControl
+                  page={pageData}
+                  onClickDeleteButton={props.onClickDeleteButton}
+                  isEnableActions={isEnableActions}
+                  isDeletable={!isTopPage(pageData.path)}
+                />
               </div>
             </div>
             <div className="my-2 search-result-list-snippet">

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -3,7 +3,7 @@ import React, {
 } from 'react';
 import nodePath from 'path';
 import { useTranslation } from 'react-i18next';
-import { pagePathUtils } from 'growi-commons';
+import { pagePathUtils } from '@growi/core';
 
 import { ItemNode } from './ItemNode';
 import { IPageHasId } from '~/interfaces/page';

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -3,6 +3,7 @@ import React, {
 } from 'react';
 import nodePath from 'path';
 import { useTranslation } from 'react-i18next';
+import { pagePathUtils } from 'growi-commons';
 
 import { ItemNode } from './ItemNode';
 import { IPageHasId } from '~/interfaces/page';
@@ -12,7 +13,8 @@ import PageItemControl from '../../Common/Dropdown/PageItemControl';
 import { IPageForPageDeleteModal } from '~/components/PageDeleteModal';
 
 import TriangleIcon from '~/components/Icons/TriangleIcon';
-import { isTopPage } from '^/../core/dist/cjs/utils/page-path-utils';
+
+const { isTopPage } = pagePathUtils;
 
 
 interface ItemProps {

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -12,6 +12,7 @@ import PageItemControl from '../../Common/Dropdown/PageItemControl';
 import { IPageForPageDeleteModal } from '~/components/PageDeleteModal';
 
 import TriangleIcon from '~/components/Icons/TriangleIcon';
+import { isTopPage } from '^/../core/dist/cjs/utils/page-path-utils';
 
 
 interface ItemProps {
@@ -39,6 +40,7 @@ const markTarget = (children: ItemNode[], targetId?: string): void => {
 type ItemControlProps = {
   page: Partial<IPageHasId>
   isEnableActions: boolean
+  isDeletable: boolean
   onClickDeleteButtonHandler?(): void
   onClickPlusButtonHandler?(): void
 }
@@ -66,7 +68,7 @@ const ItemControl: FC<ItemControlProps> = memo((props: ItemControlProps) => {
 
   return (
     <>
-      <PageItemControl page={props.page} onClickDeleteButton={onClickDeleteButton} isEnableActions={props.isEnableActions} />
+      <PageItemControl page={props.page} onClickDeleteButton={onClickDeleteButton} isEnableActions={props.isEnableActions} isDeletable={props.isDeletable} />
       <button
         type="button"
         className="btn-link nav-link border-0 rounded grw-btn-page-management py-0"
@@ -202,6 +204,7 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
             onClickDeleteButtonHandler={onClickDeleteButtonHandler}
             onClickPlusButtonHandler={() => { setNewPageInputShown(true) }}
             isEnableActions={isEnableActions}
+            isDeletable={!page.isEmpty && !isTopPage(page.path as string)}
           />
         </div>
       </div>


### PR DESCRIPTION
Redmine: https://redmine.weseek.co.jp/issues/83810

Empty または Top ページの時の DeleteModal の挙動を修正しました