### PR TITLE
imprv: Public migration fill with empty pages over private pages

### DIFF
--- a/packages/app/src/server/models/page.ts
+++ b/packages/app/src/server/models/page.ts
@@ -39,7 +39,7 @@ type TargetAndAncestorsResult = {
 }
 export interface PageModel extends Model<PageDocument> {
   [x: string]: any; // for obsolete methods
-  createEmptyPagesByPaths(paths: string[], publicOnly: boolean): Promise<void>
+  createEmptyPagesByPaths(paths: string[], publicOnly?: boolean): Promise<void>
   getParentIdAndFillAncestors(path: string): Promise<string | null>
   findByPathAndViewer(path: string | null, user, userGroups?, useFindOne?: boolean): Promise<PageDocument[]>
   findTargetAndAncestorsByPathOrId(pathOrId: string): Promise<TargetAndAncestorsResult>

--- a/packages/app/src/server/models/page.ts
+++ b/packages/app/src/server/models/page.ts
@@ -39,7 +39,7 @@ type TargetAndAncestorsResult = {
 }
 export interface PageModel extends Model<PageDocument> {
   [x: string]: any; // for obsolete methods
-  createEmptyPagesByPaths(paths: string[]): Promise<void>
+  createEmptyPagesByPaths(paths: string[], publicOnly: boolean): Promise<void>
   getParentIdAndFillAncestors(path: string): Promise<string | null>
   findByPathAndViewer(path: string | null, user, userGroups?, useFindOne?: boolean): Promise<PageDocument[]>
   findTargetAndAncestorsByPathOrId(pathOrId: string): Promise<TargetAndAncestorsResult>
@@ -141,9 +141,9 @@ const generateChildrenRegExp = (path: string): RegExp => {
 /*
  * Create empty pages if the page in paths didn't exist
  */
-schema.statics.createEmptyPagesByPaths = async function(paths: string[]): Promise<void> {
+schema.statics.createEmptyPagesByPaths = async function(paths: string[], publicOnly = false): Promise<void> {
   // find existing parents
-  const builder = new PageQueryBuilder(this.find({}, { _id: 0, path: 1 }));
+  const builder = new PageQueryBuilder(this.find(publicOnly ? { grant: GRANT_PUBLIC } : {}, { _id: 0, path: 1 }));
   const existingPages = await builder
     .addConditionToListByPathsArray(paths)
     .query

--- a/packages/app/src/server/service/page.js
+++ b/packages/app/src/server/service/page.js
@@ -996,7 +996,7 @@ class PageService {
         const parentPaths = Array.from(parentPathsSet);
 
         // fill parents with empty pages
-        await Page.createEmptyPagesByPaths(parentPaths);
+        await Page.createEmptyPagesByPaths(parentPaths, true);
 
         // find parents again
         const builder = new PageQueryBuilder(Page.find({}, { _id: 1, path: 1 }));

--- a/packages/app/src/test/integration/service/page.test.js
+++ b/packages/app/src/test/integration/service/page.test.js
@@ -901,6 +901,12 @@ describe('PageService', () => {
           creator: testUser1,
           lastUpdateUser: testUser1,
         },
+        {
+          path: '/parenthesis/(a)[b]{c}d/public',
+          grant: Page.GRANT_PUBLIC,
+          creator: testUser1,
+          lastUpdateUser: testUser1,
+        },
       ]);
 
       // migrate
@@ -908,7 +914,7 @@ describe('PageService', () => {
 
       const migratedPages = await Page.find({
         path: {
-          $in: ['/publicA', '/publicA/privateB/publicC', '/parenthesis/(a)[b]{c}d'],
+          $in: ['/publicA', '/publicA/privateB/publicC', '/parenthesis/(a)[b]{c}d', '/parenthesis/(a)[b]{c}d/public'],
         },
         isEmpty: false,
         grant: Page.GRANT_PUBLIC,
@@ -921,7 +927,7 @@ describe('PageService', () => {
         grant: Page.GRANT_PUBLIC,
       });
 
-      expect(migratedPages.length).toBe(3);
+      expect(migratedPages.length).toBe(4);
       expect(migratedEmptyPages.length).toBe(2);
     });
   });


### PR DESCRIPTION
Redmine: https://redmine.weseek.co.jp/issues/83846

パブリックマイグレーションで全てのパブリックページがページツリーに表示できるように修正しました

## コメント
- private ページが親になる場合はその部分に Empty ページを生成するようにしました
- テストコードも書きました
    - ついでに `(){}[]` を含むパスでのマイグレーションが正常動作するかもテストに含めました
- 一旦 socket に関する記述はコメントアウトしました
    - テスト時に socketIoService を初期化する必要がでるため
