### PR TITLE
improve legacy private pages position

### DIFF
--- a/packages/app/src/components/Sidebar/PageTree.tsx
+++ b/packages/app/src/components/Sidebar/PageTree.tsx
@@ -64,7 +64,7 @@ const PageTree: FC = memo(() => {
         />
       </div>
 
-      <div className="grw-pagetree-footer border-top position-absolute fixed-bottom p-3 w-100">
+      <div className="grw-pagetree-footer border-top p-3 w-100">
         {
           !isGuestUser && migrationStatus?.migratablePagesCount != null && migrationStatus.migratablePagesCount !== 0 && (
             <PrivateLegacyPages />

--- a/packages/app/src/components/Sidebar/PageTree.tsx
+++ b/packages/app/src/components/Sidebar/PageTree.tsx
@@ -64,13 +64,11 @@ const PageTree: FC = memo(() => {
         />
       </div>
 
-      <div className="grw-pagetree-footer border-top p-3 w-100">
-        {
-          !isGuestUser && migrationStatus?.migratablePagesCount != null && migrationStatus.migratablePagesCount !== 0 && (
-            <PrivateLegacyPages />
-          )
-        }
-      </div>
+      {!isGuestUser && migrationStatus?.migratablePagesCount != null && migrationStatus.migratablePagesCount !== 0 && (
+        <div className="grw-pagetree-footer border-top p-3 w-100">
+          <PrivateLegacyPages />
+        </div>
+      )}
     </>
   );
 });

--- a/packages/app/src/styles/_page-tree.scss
+++ b/packages/app/src/styles/_page-tree.scss
@@ -1,5 +1,5 @@
 .grw-pagetree {
-  min-height: 1050px;
+  min-height: calc(100vh - ($grw-navbar-height + $grw-navbar-border-width + $grw-sidebar-content-header + $grw-sidebar-content-footer));
 
   .grw-pagetree-item {
     &:hover {

--- a/packages/app/src/styles/_page-tree.scss
+++ b/packages/app/src/styles/_page-tree.scss
@@ -1,5 +1,8 @@
+$grw-sidebar-content-header-height: 58px;
+$grw-sidebar-content-footer-height: 50px;
+
 .grw-pagetree {
-  min-height: calc(100vh - ($grw-navbar-height + $grw-navbar-border-width + $grw-sidebar-content-header + $grw-sidebar-content-footer));
+  min-height: calc(100vh - ($grw-navbar-height + $grw-navbar-border-width + $grw-sidebar-content-header-height + $grw-sidebar-content-footer-height));
 
   .grw-pagetree-item {
     &:hover {

--- a/packages/app/src/styles/_page-tree.scss
+++ b/packages/app/src/styles/_page-tree.scss
@@ -1,4 +1,6 @@
 .grw-pagetree {
+  min-height: 1050px;
+
   .grw-pagetree-item {
     &:hover {
       opacity: 0.7;

--- a/packages/app/src/styles/_variables.scss
+++ b/packages/app/src/styles/_variables.scss
@@ -25,8 +25,6 @@ $grw-navbar-bottom-height: 48px;
 $grw-editor-navbar-bottom-height: 48px;
 
 $grw-sidebar-nav-width: 64px; // !!DO NOT CHANGE!! 'margin-left' for '.css-teprsg' is hardcoded
-$grw-sidebar-content-header: 58px;
-$grw-sidebar-content-footer: 50px;
 
 $grw-logo-width: $grw-sidebar-nav-width;
 $grw-logomark-width: 36px;

--- a/packages/app/src/styles/_variables.scss
+++ b/packages/app/src/styles/_variables.scss
@@ -25,6 +25,8 @@ $grw-navbar-bottom-height: 48px;
 $grw-editor-navbar-bottom-height: 48px;
 
 $grw-sidebar-nav-width: 64px; // !!DO NOT CHANGE!! 'margin-left' for '.css-teprsg' is hardcoded
+$grw-sidebar-content-header: 58px;
+$grw-sidebar-content-footer: 50px;
 
 $grw-logo-width: $grw-sidebar-nav-width;
 $grw-logomark-width: 36px;


### PR DESCRIPTION
## Task
- [#82623](https://redmine.weseek.co.jp/issues/82623)待避所リンクの位置を調整する(XD に合わせる)


## Note
Legacypages は常に表示させるのではなく、スクロール内部に入れることになりました。

## Screen Recording
- 待避所がある場合

https://user-images.githubusercontent.com/59536731/146164947-eeded9f9-46cf-478b-a10b-5a3907e57340.mov



- 待避所がない場合


https://user-images.githubusercontent.com/59536731/146164924-d8a2120f-ce4d-4d0e-9708-5f85a0b216f8.mov



