### PR TITLE
fix: remove one props type

### DIFF
--- a/packages/app/src/components/ExpandOrContractButton.tsx
+++ b/packages/app/src/components/ExpandOrContractButton.tsx
@@ -3,7 +3,6 @@ import React, { FC } from 'react';
 
 type Props = {
   isWindowExpanded: boolean,
-  color?: string,
   contractWindow?: () => void,
   expandWindow?: () => void,
 };


### PR DESCRIPTION
## タスク

https://redmine.weseek.co.jp/issues/84113

## 行ったこと

インターフェースに1つ不要な props を残してしまって、前のタスクが merge されてしまったので削除