### PR TITLE
Imprv/83432 closable text input alert

### DIFF
--- a/packages/app/src/components/Common/ClosableTextInput.tsx
+++ b/packages/app/src/components/Common/ClosableTextInput.tsx
@@ -83,7 +83,7 @@ const ClosableTextInput: FC<ClosableTextInputProps> = memo((props: ClosableTextI
     const alertMessage = currentAlertInfo.message != null ? currentAlertInfo.message : 'Invalid value';
 
     return (
-      <p className="alert alert-danger">{alertType}: {alertMessage}</p>
+      <p className="text-danger text-center mt-1">{alertType}: {alertMessage}</p>
     );
   };
 
@@ -93,7 +93,7 @@ const ClosableTextInput: FC<ClosableTextInputProps> = memo((props: ClosableTextI
       <input
         ref={inputRef}
         type="text"
-        className="form-control"
+        className="form-control mt-1"
         placeholder={props.placeholder}
         name="input"
         onChange={onChangeHandler}

--- a/packages/app/src/components/Common/ClosableTextInput.tsx
+++ b/packages/app/src/components/Common/ClosableTextInput.tsx
@@ -74,7 +74,20 @@ const ClosableTextInput: FC<ClosableTextInputProps> = memo((props: ClosableTextI
   });
 
 
-  // TODO: improve style
+  const AlertInfo = () => {
+    if (currentAlertInfo == null) {
+      return <></>;
+    }
+
+    const alertType = currentAlertInfo.type != null ? currentAlertInfo.type : AlertType.ERROR;
+    const alertMessage = currentAlertInfo.message != null ? currentAlertInfo.message : 'Invalid value';
+
+    return (
+      <p className="alert alert-danger">{alertType}: {alertMessage}</p>
+    );
+  };
+
+
   return (
     <div className={props.isShown ? 'd-block' : 'd-none'}>
       <input
@@ -89,12 +102,9 @@ const ClosableTextInput: FC<ClosableTextInputProps> = memo((props: ClosableTextI
         autoFocus={false}
       />
       <div>
-        {currentAlertInfo != null && (
-          <p>
-            {/* eslint-disable-next-line max-len */}
-            {currentAlertInfo.type != null ? currentAlertInfo.type : AlertType.ERROR}: {currentAlertInfo.message != null ? currentAlertInfo.message : 'Invalid value' }
-          </p>
-        )}
+        {/* {currentAlertInfo != null && ( */}
+        <AlertInfo />
+        {/* // )} */}
       </div>
     </div>
   );

--- a/packages/app/src/components/Common/ClosableTextInput.tsx
+++ b/packages/app/src/components/Common/ClosableTextInput.tsx
@@ -81,7 +81,6 @@ const ClosableTextInput: FC<ClosableTextInputProps> = memo((props: ClosableTextI
 
     const alertType = currentAlertInfo.type != null ? currentAlertInfo.type : AlertType.ERROR;
     const alertMessage = currentAlertInfo.message != null ? currentAlertInfo.message : 'Invalid value';
-
     return (
       <p className="text-danger text-center mt-1">{alertType}: {alertMessage}</p>
     );
@@ -101,11 +100,7 @@ const ClosableTextInput: FC<ClosableTextInputProps> = memo((props: ClosableTextI
         onBlur={onBlurHandler}
         autoFocus={false}
       />
-      <div>
-        {/* {currentAlertInfo != null && ( */}
-        <AlertInfo />
-        {/* // )} */}
-      </div>
+      <AlertInfo />
     </div>
   );
 });

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -4,6 +4,7 @@ import React, {
 import nodePath from 'path';
 import { useTranslation } from 'react-i18next';
 import { pagePathUtils } from '@growi/core';
+import { toastWarning } from '~/client/util/apiNotification';
 
 import { ItemNode } from './ItemNode';
 import { IPageHasId } from '~/interfaces/page';
@@ -149,7 +150,7 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
 
   // TODO: go to create page page
   const onPressEnterHandler = () => {
-    console.log('Enter key was pressed!');
+    toastWarning(t('search_result.currently_not_implemented'));
   };
 
   // didMount

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -142,7 +142,6 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
         type: AlertType.ERROR,
         message: t('Page title is required'),
       };
-      return;
     }
 
     return null;

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -141,6 +141,7 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
         type: AlertType.ERROR,
         message: t('Page title is required'),
       };
+      return;
     }
 
     return null;


### PR DESCRIPTION
## Task
[#83432](https://redmine.weseek.co.jp/issues/83432) Alert の表示を見るに堪えるものにする

## Note
- ページタイトルが空の時に表示されるエラーのstyle修正
- Enterキーを押したときに「実装されていません」のWarningを出す

## View
### Before
<img width="234" alt="Screen Shot 2021-12-16 at 20 33 20" src="https://user-images.githubusercontent.com/59536731/146364335-819d5e8a-15b6-4afb-b1c1-c75248f54978.png">

### After
<img width="222" alt="Screen Shot 2021-12-16 at 20 32 08" src="https://user-images.githubusercontent.com/59536731/146364196-069ecce9-b7e9-464d-a37e-aec547b656a4.png">

### Screen Recording
https://user-images.githubusercontent.com/59536731/146364531-853ac968-f5f7-4161-b070-433873fd5d64.mov