### PR TITLE
always show navbar

### DIFF
--- a/packages/app/src/styles/_search.scss
+++ b/packages/app/src/styles/_search.scss
@@ -184,8 +184,8 @@
     top: 0px;
 
     .search-result-list-scroll {
-      // subtract the height of SearchControl component + a gap made above #page-wrapper and below #main
-      height: calc(100vh - 117px);
+      // subtract the height of GrowiNavbar + (SearchControl component + other factors)
+      height: calc(100vh - ($grw-navbar-total-height + 110px));
       overflow-y: scroll;
     }
     .nav.nav-pills {
@@ -273,18 +273,6 @@
         border: solid 1px $gray-300;
       }
     }
-  }
-}
-
-// class to add to .grw-navbar to hide its navbar above the displaying page
-body.on-search {
-  .grw-navbar {
-    position: fixed !important;
-    width: 100vw;
-  }
-  .page-wrapper {
-    position: relative;
-    top: $grw-navbar-border-width;
   }
 }
 

--- a/packages/app/src/styles/_search.scss
+++ b/packages/app/src/styles/_search.scss
@@ -185,7 +185,7 @@
 
     .search-result-list-scroll {
       // subtract the height of GrowiNavbar + (SearchControl component + other factors)
-      height: calc(100vh - ($grw-navbar-total-height + 110px));
+      height: calc(100vh - (($grw-navbar-height + $grw-navbar-border-width) + 110px));
       overflow-y: scroll;
     }
     .nav.nav-pills {

--- a/packages/app/src/styles/_sidebar.scss
+++ b/packages/app/src/styles/_sidebar.scss
@@ -327,3 +327,19 @@
 .grw-sidebar-backdrop.modal-backdrop {
   z-index: $zindex-fixed + 1;
 }
+
+// style to apply when displaying search page
+.growi.on-search {
+  // set sidebar height shown in search page
+  $search-page-sidebar-height: calc(100vh - $grw-navbar-total-height);
+
+  .grw-sidebar {
+    height: $search-page-sidebar-height;
+    .data-layout-container {
+      height: $search-page-sidebar-height;
+    }
+    .grw-sidebar-nav {
+      height: $search-page-sidebar-height;
+    }
+  }
+}

--- a/packages/app/src/styles/_sidebar.scss
+++ b/packages/app/src/styles/_sidebar.scss
@@ -331,7 +331,7 @@
 // style to apply when displaying search page
 .growi.on-search {
   // set sidebar height shown in search page
-  $search-page-sidebar-height: calc(100vh - $grw-navbar-total-height);
+  $search-page-sidebar-height: calc(100vh - ($grw-navbar-height + $grw-navbar-border-width));
 
   .grw-sidebar {
     height: $search-page-sidebar-height;

--- a/packages/app/src/styles/_variables.scss
+++ b/packages/app/src/styles/_variables.scss
@@ -15,6 +15,7 @@ $font-family-monospace-not-strictly: Monaco, Menlo, Consolas, 'Courier New', Mei
 //== Layout
 $grw-navbar-height: 52px;
 $grw-navbar-border-width: 3.3333px;
+$grw-navbar-total-height: calc($grw-navbar-height + $grw-navbar-border-width);
 
 $grw-subnav-min-height: 95px;
 $grw-subnav-min-height-md: 115px;

--- a/packages/app/src/styles/_variables.scss
+++ b/packages/app/src/styles/_variables.scss
@@ -15,7 +15,6 @@ $font-family-monospace-not-strictly: Monaco, Menlo, Consolas, 'Courier New', Mei
 //== Layout
 $grw-navbar-height: 52px;
 $grw-navbar-border-width: 3.3333px;
-$grw-navbar-total-height: calc($grw-navbar-height + $grw-navbar-border-width);
 
 $grw-subnav-min-height: 95px;
 $grw-subnav-min-height-md: 115px;


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/84034

サイドバー内に存在する3つのクラスの高さが100vhで固定だった影響で、上部ナビバーの高さ分だけ下にスクロールできてしまう状態にあった。
検索ページのみ、ナビバーのheightを引いた値をサイドバーの高さに指定し、スクロールできないように変更

左ペインの高さも調節した

![image](https://user-images.githubusercontent.com/35527421/146365503-bd2d9109-1a67-466d-93ca-9d53f3eb7125.png)
