### PR TITLE
fix: dependabot alert trim-newlines

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -19908,9 +19908,9 @@ trim-newlines@^2.0.0:
   integrity sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=
 
 trim-newlines@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.0.tgz#79726304a6a898aa8373427298d54c2ee8b1cb30"
-  integrity sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.1.tgz#260a5d962d8b752425b32f3a7db0dcacd176c144"
+  integrity sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==
 
 trim-off-newlines@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
https://youtrack.weseek.co.jp/issue/GW-7617

Some packages are on latest version but still requires trim-newlines v1.0.0 and v2.0.0

- main package lerna is on the latest version , requires trim-newlines v1.0.0 and v3.0.0
- shipjs (also latest version) requires trim-newlines v1.0.0 and v3.0.0
- prettier-stylelint is on the latest version, requires trim-newlines v1.0.0 and v2.0.0
- stylelint v14.0.1 requires trim-newlines v3.0.0
- Rebuild trim-newlines v3.0.0, resolved by v3.0.1