### PR TITLE
fix: dependabot alert socket.io-parser

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -18115,10 +18115,11 @@ socket.io-client@^4.2.0:
     socket.io-parser "~4.0.4"
 
 socket.io-parser@~3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-3.3.0.tgz#2b52a96a509fdf31440ba40fed6094c7d4f1262f"
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-3.3.2.tgz#ef872009d0adcf704f2fbe830191a14752ad50b6"
+  integrity sha512-FJvDBuOALxdCI9qwRrO/Rfp9yfndRtc1jSgVgV8FDraihmSP/MLGD5PEuJrNfjALvcQ+vMDM/33AWOYP/JSjDg==
   dependencies:
-    component-emitter "1.2.1"
+    component-emitter "~1.3.0"
     debug "~3.1.0"
     isarray "2.0.1"
 


### PR DESCRIPTION
https://youtrack.weseek.co.jp/issue/GW-7618
- Rebuild socket.io-parser v3.3.0, resolved by v3.3.2