### PR TITLE
fix dropdown background

### DIFF
--- a/packages/app/src/styles/_page-tree.scss
+++ b/packages/app/src/styles/_page-tree.scss
@@ -7,8 +7,6 @@ $grw-pagetree-item-padding-left: 10px;
 
   .grw-pagetree-item {
     &:hover {
-      opacity: 0.7;
-
       .grw-pagetree-control {
         display: flex !important;
       }


### PR DESCRIPTION
## Task
- [#84226](https://redmine.weseek.co.jp/issues/84226) ３点リーダーのドロップダウンが透けるのを修正する

## XD
https://xd.adobe.com/view/cd3cb2f8-625d-4a6b-b6e4-917f75c675c5-986f/screen/27a328ec-c82d-4fd1-b97a-1dc6cb549080/specs/

## Before
<img width="256" alt="Screen Shot 2021-12-20 at 12 57 12" src="https://user-images.githubusercontent.com/59536731/146709742-9c114b4f-0dff-4c24-b6b1-01a469f5a528.png">
<img width="269" alt="Screen Shot 2021-12-20 at 13 07 34" src="https://user-images.githubusercontent.com/59536731/146710490-1c7495af-fb2c-4fc6-bfba-cea20b1a4535.png">


## After
<img width="279" alt="Screen Shot 2021-12-20 at 12 56 21" src="https://user-images.githubusercontent.com/59536731/146709712-099ad2fc-58e1-4199-8701-7a480f87e68c.png">
<img width="295" alt="Screen Shot 2021-12-20 at 13 06 51" src="https://user-images.githubusercontent.com/59536731/146710441-95cac5ef-1f32-4630-8cae-91002dac0666.png">

