### PR TITLE
84092 hide search page

### DIFF
--- a/packages/app/src/client/services/ContextExtractor.tsx
+++ b/packages/app/src/client/services/ContextExtractor.tsx
@@ -65,7 +65,7 @@ const ContextExtractorOnce: FC = () => {
   const targetAndAncestors = JSON.parse(document.getElementById('growi-pagetree-target-and-ancestors')?.textContent || jsonNull);
   const notFoundTargetPathOrId = JSON.parse(notFoundContent?.getAttribute('data-not-found-target-path-or-id') || jsonNull);
   const slackChannels = mainContent?.getAttribute('data-slack-channels') || '';
-  const isSearchPage = document.getElementById('search-page') || null;
+  const isSearchPage = document.getElementById('search-page') != null;
 
   /*
    * use static swr

--- a/packages/app/src/client/services/ContextExtractor.tsx
+++ b/packages/app/src/client/services/ContextExtractor.tsx
@@ -6,7 +6,7 @@ import {
   useIsDeletable, useIsDeleted, useIsNotCreatable, useIsPageExist, useIsTrashPage, useIsUserPage, useLastUpdateUsername,
   useCurrentPageId, usePageIdOnHackmd, usePageUser, useCurrentPagePath, useRevisionCreatedAt, useRevisionId, useRevisionIdHackmdSynced,
   useShareLinkId, useShareLinksNumber, useTemplateTagData, useUpdatedAt, useCreator, useRevisionAuthor, useCurrentUser, useTargetAndAncestors,
-  useSlackChannels, useNotFoundTargetPathOrId,
+  useSlackChannels, useNotFoundTargetPathOrId, useIsSearchPage,
 } from '../../stores/context';
 import {
   useIsDeviceSmallerThanMd,
@@ -65,6 +65,7 @@ const ContextExtractorOnce: FC = () => {
   const targetAndAncestors = JSON.parse(document.getElementById('growi-pagetree-target-and-ancestors')?.textContent || jsonNull);
   const notFoundTargetPathOrId = JSON.parse(notFoundContent?.getAttribute('data-not-found-target-path-or-id') || jsonNull);
   const slackChannels = mainContent?.getAttribute('data-slack-channels') || '';
+  const isSearchPage = document.getElementById('search-page') || null;
 
   /*
    * use static swr
@@ -108,6 +109,7 @@ const ContextExtractorOnce: FC = () => {
   useRevisionAuthor(revisionAuthor);
   useTargetAndAncestors(targetAndAncestors);
   useNotFoundTargetPathOrId(notFoundTargetPathOrId);
+  useIsSearchPage(isSearchPage);
 
   // Navigation
   usePreferDrawerModeByUser();

--- a/packages/app/src/components/Navbar/GrowiNavbar.tsx
+++ b/packages/app/src/components/Navbar/GrowiNavbar.tsx
@@ -8,13 +8,13 @@ import { UncontrolledTooltip } from 'reactstrap';
 import AppContainer from '~/client/services/AppContainer';
 import { IUser } from '~/interfaces/user';
 import { useIsDeviceSmallerThanMd, useCreateModalStatus } from '~/stores/ui';
+import { useIsSearchPage } from '~/stores/context';
 
 import { withUnstatedContainers } from '../UnstatedUtils';
 import GrowiLogo from '../Icons/GrowiLogo';
 
 import PersonalDropdown from './PersonalDropdown';
 import GlobalSearch from './GlobalSearch';
-import { useIsSearchPage } from '~/stores/context';
 
 type NavbarRightProps = {
   currentUser: IUser,
@@ -80,11 +80,12 @@ const Confidential: FC<ConfidentialProps> = memo((props: ConfidentialProps) => {
 
 const GrowiNavbar = (props) => {
 
-  const { appContainer, hideSearchInput } = props;
+  const { appContainer } = props;
   const { currentUser } = appContainer;
   const { crowi, isSearchServiceConfigured } = appContainer.config;
 
   const { data: isDeviceSmallerThanMd } = useIsDeviceSmallerThanMd();
+  const { data: isSearchPage } = useIsSearchPage();
 
   return (
     <>
@@ -106,7 +107,7 @@ const GrowiNavbar = (props) => {
         <Confidential confidential={crowi.confidential}></Confidential>
       </ul>
 
-      { isSearchServiceConfigured && !isDeviceSmallerThanMd && !hideSearchInput && (
+      { isSearchServiceConfigured && !isDeviceSmallerThanMd && !isSearchPage && (
         <div className="grw-global-search grw-global-search-top position-absolute">
           <GlobalSearch />
         </div>
@@ -119,19 +120,10 @@ const GrowiNavbar = (props) => {
 /**
  * Wrapper component for using unstated
  */
-const GrowiNavbarUnstatedWrapper = withUnstatedContainers(GrowiNavbar, [AppContainer]);
+const GrowiNavbarWrapper = withUnstatedContainers(GrowiNavbar, [AppContainer]);
 
 GrowiNavbar.propTypes = {
   appContainer: PropTypes.instanceOf(AppContainer).isRequired,
-  hideSearchInput: PropTypes.bool.isRequired,
 };
 
-const UnstatedWrapperWithProps = (props) => {
-  return <GrowiNavbarUnstatedWrapper {...props}></GrowiNavbarUnstatedWrapper>;
-};
-
-const GrowiNavbarWrapper = () => {
-  const { data: isSearchPage } = useIsSearchPage();
-  return <UnstatedWrapperWithProps hideSearchInput={isSearchPage}></UnstatedWrapperWithProps>;
-};
 export default GrowiNavbarWrapper;

--- a/packages/app/src/components/Navbar/GrowiNavbar.tsx
+++ b/packages/app/src/components/Navbar/GrowiNavbar.tsx
@@ -14,6 +14,7 @@ import GrowiLogo from '../Icons/GrowiLogo';
 
 import PersonalDropdown from './PersonalDropdown';
 import GlobalSearch from './GlobalSearch';
+import { useIsSearchPage } from '~/stores/context';
 
 type NavbarRightProps = {
   currentUser: IUser,
@@ -79,13 +80,11 @@ const Confidential: FC<ConfidentialProps> = memo((props: ConfidentialProps) => {
 
 const GrowiNavbar = (props) => {
 
-  const { appContainer } = props;
+  const { appContainer, hideSearchInput } = props;
   const { currentUser } = appContainer;
   const { crowi, isSearchServiceConfigured } = appContainer.config;
 
   const { data: isDeviceSmallerThanMd } = useIsDeviceSmallerThanMd();
-
-  const isNotSearchPage = document.getElementById('search-page') == null;
 
   return (
     <>
@@ -107,7 +106,7 @@ const GrowiNavbar = (props) => {
         <Confidential confidential={crowi.confidential}></Confidential>
       </ul>
 
-      { isSearchServiceConfigured && !isDeviceSmallerThanMd && isNotSearchPage && (
+      { isSearchServiceConfigured && !isDeviceSmallerThanMd && !hideSearchInput && (
         <div className="grw-global-search grw-global-search-top position-absolute">
           <GlobalSearch />
         </div>
@@ -120,11 +119,19 @@ const GrowiNavbar = (props) => {
 /**
  * Wrapper component for using unstated
  */
-const GrowiNavbarWrapper = withUnstatedContainers(GrowiNavbar, [AppContainer]);
-
+const GrowiNavbarUnstatedWrapper = withUnstatedContainers(GrowiNavbar, [AppContainer]);
 
 GrowiNavbar.propTypes = {
   appContainer: PropTypes.instanceOf(AppContainer).isRequired,
+  hideSearchInput: PropTypes.bool.isRequired,
 };
 
+const UnstatedWrapperWithProps = (props) => {
+  return <GrowiNavbarUnstatedWrapper {...props}></GrowiNavbarUnstatedWrapper>;
+};
+
+const GrowiNavbarWrapper = () => {
+  const { data: isSearchPage } = useIsSearchPage();
+  return <UnstatedWrapperWithProps hideSearchInput={isSearchPage}></UnstatedWrapperWithProps>;
+};
 export default GrowiNavbarWrapper;

--- a/packages/app/src/components/Navbar/GrowiNavbar.tsx
+++ b/packages/app/src/components/Navbar/GrowiNavbar.tsx
@@ -85,6 +85,8 @@ const GrowiNavbar = (props) => {
 
   const { data: isDeviceSmallerThanMd } = useIsDeviceSmallerThanMd();
 
+  const isNotSearchPage = document.getElementById('search-page') == null;
+
   return (
     <>
       {/* Brand Logo  */}
@@ -105,7 +107,7 @@ const GrowiNavbar = (props) => {
         <Confidential confidential={crowi.confidential}></Confidential>
       </ul>
 
-      { isSearchServiceConfigured && !isDeviceSmallerThanMd && (
+      { isSearchServiceConfigured && !isDeviceSmallerThanMd && isNotSearchPage && (
         <div className="grw-global-search grw-global-search-top position-absolute">
           <GlobalSearch />
         </div>

--- a/packages/app/src/components/Navbar/GrowiNavbar.tsx
+++ b/packages/app/src/components/Navbar/GrowiNavbar.tsx
@@ -122,6 +122,7 @@ const GrowiNavbar = (props) => {
  */
 const GrowiNavbarWrapper = withUnstatedContainers(GrowiNavbar, [AppContainer]);
 
+
 GrowiNavbar.propTypes = {
   appContainer: PropTypes.instanceOf(AppContainer).isRequired,
 };

--- a/packages/app/src/components/Navbar/GrowiNavbarBottom.jsx
+++ b/packages/app/src/components/Navbar/GrowiNavbarBottom.jsx
@@ -8,11 +8,11 @@ import { useCurrentPagePath, useIsSearchPage } from '~/stores/context';
 import GlobalSearch from './GlobalSearch';
 
 const GrowiNavbarBottom = (props) => {
-  const { hideSearchInput } = props;
   const { data: isDrawerOpened, mutate: mutateDrawerOpened } = useDrawerOpened();
   const { data: isDeviceSmallerThanMd } = useIsDeviceSmallerThanMd();
   const { open: openCreateModal } = useCreateModalStatus();
   const { data: currentPagePath } = useCurrentPagePath();
+  const { data: isSearchPage } = useIsSearchPage();
 
   const additionalClasses = ['grw-navbar-bottom'];
   if (isDrawerOpened) {
@@ -22,7 +22,7 @@ const GrowiNavbarBottom = (props) => {
   return (
     <div className="d-md-none d-edit-none fixed-bottom">
 
-      { isDeviceSmallerThanMd && (
+      { isDeviceSmallerThanMd && !isSearchPage && (
         <div id="grw-global-search-collapse" className="grw-global-search collapse bg-dark">
           <div className="p-3">
             <GlobalSearch dropup />
@@ -33,7 +33,7 @@ const GrowiNavbarBottom = (props) => {
       <div className={`navbar navbar-expand navbar-dark bg-primary px-0 ${additionalClasses.join(' ')}`}>
 
         <ul className="navbar-nav w-100">
-          <li className="nav-item">
+          <li className="nav-item mr-auto">
             <a
               role="button"
               className="nav-link btn-lg"
@@ -42,9 +42,9 @@ const GrowiNavbarBottom = (props) => {
               <i className="icon-menu"></i>
             </a>
           </li>
-          <li className="nav-item mx-auto">
-            {
-              !hideSearchInput && (
+          {
+            !isSearchPage && (
+              <li className="nav-item">
                 <a
                   role="button"
                   className="nav-link btn-lg"
@@ -53,11 +53,10 @@ const GrowiNavbarBottom = (props) => {
                 >
                   <i className="icon-magnifier"></i>
                 </a>
-
-              )
-            }
-          </li>
-          <li className="nav-item">
+              </li>
+            )
+          }
+          <li className="nav-item ml-auto">
             <a
               role="button"
               className="nav-link btn-lg"
@@ -72,13 +71,5 @@ const GrowiNavbarBottom = (props) => {
     </div>
   );
 };
-GrowiNavbarBottom.propTypes = {
-  hideSearchInput: PropTypes.bool.isRequired,
-};
 
-const GrowiNavbarBottomWrapper = () => {
-  const { data: isSeachPage } = useIsSearchPage();
-  return <GrowiNavbarBottom hideSearchInput={isSeachPage}></GrowiNavbarBottom>;
-};
-
-export default GrowiNavbarBottomWrapper;
+export default GrowiNavbarBottom;

--- a/packages/app/src/components/Navbar/GrowiNavbarBottom.jsx
+++ b/packages/app/src/components/Navbar/GrowiNavbarBottom.jsx
@@ -1,12 +1,14 @@
 import React from 'react';
+import PropTypes from 'prop-types';
+
 
 import { useCreateModalStatus, useIsDeviceSmallerThanMd, useDrawerOpened } from '~/stores/ui';
-import { useCurrentPagePath } from '~/stores/context';
+import { useCurrentPagePath, useIsSearchPage } from '~/stores/context';
 
 import GlobalSearch from './GlobalSearch';
 
 const GrowiNavbarBottom = (props) => {
-
+  const { hideSearchInput } = props;
   const { data: isDrawerOpened, mutate: mutateDrawerOpened } = useDrawerOpened();
   const { data: isDeviceSmallerThanMd } = useIsDeviceSmallerThanMd();
   const { open: openCreateModal } = useCreateModalStatus();
@@ -16,8 +18,6 @@ const GrowiNavbarBottom = (props) => {
   if (isDrawerOpened) {
     additionalClasses.push('grw-navbar-bottom-drawer-opened');
   }
-
-  const isNotSearchPage = document.getElementById('search-page') == null;
 
   return (
     <div className="d-md-none d-edit-none fixed-bottom">
@@ -43,17 +43,19 @@ const GrowiNavbarBottom = (props) => {
             </a>
           </li>
           <li className="nav-item mx-auto">
-            {isNotSearchPage
-            && (
-              <a
-                role="button"
-                className="nav-link btn-lg"
-                data-target="#grw-global-search-collapse"
-                data-toggle="collapse"
-              >
-                <i className="icon-magnifier"></i>
-              </a>
-            )}
+            {
+              !hideSearchInput && (
+                <a
+                  role="button"
+                  className="nav-link btn-lg"
+                  data-target="#grw-global-search-collapse"
+                  data-toggle="collapse"
+                >
+                  <i className="icon-magnifier"></i>
+                </a>
+
+              )
+            }
           </li>
           <li className="nav-item">
             <a
@@ -70,6 +72,13 @@ const GrowiNavbarBottom = (props) => {
     </div>
   );
 };
+GrowiNavbarBottom.propTypes = {
+  hideSearchInput: PropTypes.bool.isRequired,
+};
 
+const GrowiNavbarBottomWrapper = () => {
+  const { data: isSeachPage } = useIsSearchPage();
+  return <GrowiNavbarBottom hideSearchInput={isSeachPage}></GrowiNavbarBottom>;
+};
 
-export default GrowiNavbarBottom;
+export default GrowiNavbarBottomWrapper;

--- a/packages/app/src/components/Navbar/GrowiNavbarBottom.jsx
+++ b/packages/app/src/components/Navbar/GrowiNavbarBottom.jsx
@@ -8,6 +8,7 @@ import { useCurrentPagePath, useIsSearchPage } from '~/stores/context';
 import GlobalSearch from './GlobalSearch';
 
 const GrowiNavbarBottom = (props) => {
+
   const { data: isDrawerOpened, mutate: mutateDrawerOpened } = useDrawerOpened();
   const { data: isDeviceSmallerThanMd } = useIsDeviceSmallerThanMd();
   const { open: openCreateModal } = useCreateModalStatus();
@@ -71,5 +72,6 @@ const GrowiNavbarBottom = (props) => {
     </div>
   );
 };
+
 
 export default GrowiNavbarBottom;

--- a/packages/app/src/components/Navbar/GrowiNavbarBottom.jsx
+++ b/packages/app/src/components/Navbar/GrowiNavbarBottom.jsx
@@ -17,6 +17,8 @@ const GrowiNavbarBottom = (props) => {
     additionalClasses.push('grw-navbar-bottom-drawer-opened');
   }
 
+  const isNotSearchPage = document.getElementById('search-page') == null;
+
   return (
     <div className="d-md-none d-edit-none fixed-bottom">
 
@@ -41,14 +43,17 @@ const GrowiNavbarBottom = (props) => {
             </a>
           </li>
           <li className="nav-item mx-auto">
-            <a
-              role="button"
-              className="nav-link btn-lg"
-              data-target="#grw-global-search-collapse"
-              data-toggle="collapse"
-            >
-              <i className="icon-magnifier"></i>
-            </a>
+            {isNotSearchPage
+            && (
+              <a
+                role="button"
+                className="nav-link btn-lg"
+                data-target="#grw-global-search-collapse"
+                data-toggle="collapse"
+              >
+                <i className="icon-magnifier"></i>
+              </a>
+            )}
           </li>
           <li className="nav-item">
             <a

--- a/packages/app/src/stores/context.tsx
+++ b/packages/app/src/stores/context.tsx
@@ -124,6 +124,9 @@ export const useSlackChannels = (initialData?: Nullable<any>): SWRResponse<Nulla
   return useStaticSWR<Nullable<any>, Error>('slackChannels', initialData ?? null);
 };
 
+export const useIsSearchPage = (initialData?: Nullable<any>) : SWRResponse<Nullable<any>, Error> => {
+  return useStaticSWR<Nullable<any>, Error>('isSearchPage', initialData ?? null);
+};
 /** **********************************************************
  *                     Computed contexts
  *********************************************************** */


### PR DESCRIPTION
# Task 
https://redmine.weseek.co.jp/issues/84092

# やったこと
SearchPageかではGlobalSearchを表示しないようにする。
Navバーにあるのと、spサイズ時画面下にも出てきてた。

# 写真

<img width="1920" alt="Screen Shot 2021-12-20 at 13 46 49" src="https://user-images.githubusercontent.com/60797707/146713289-a5e03962-9978-45b3-b0be-f2131e5ad147.png">


<img width="251" alt="Screen Shot 2021-12-20 at 13 47 33" src="https://user-images.githubusercontent.com/60797707/146713306-00118204-1559-4874-afd6-688cfcfd9973.png">

