### PR TITLE
84265 adjast to changes from dev5

### DIFF
--- a/packages/app/src/components/Common/Dropdown/PageItemControl.tsx
+++ b/packages/app/src/components/Common/Dropdown/PageItemControl.tsx
@@ -28,10 +28,10 @@ const PageItemControl: FC<PageItemControlProps> = (props: PageItemControlProps) 
     <>
       <button
         type="button"
-        className="btn-link dropdown-toggle dropdown-toggle-no-caret border-0 rounded grw-btn-page-management p-0"
+        className="dropdown-toggle dropdown-toggle-no-caret border-0 rounded grw-btn-page-management p-0"
         data-toggle="dropdown"
       >
-        <i className="icon-options fa fa-rotate-90  text-muted p-1"></i>
+        <i className="icon-options fa fa-rotate-90 text-muted p-1"></i>
       </button>
       <div className="dropdown-menu dropdown-menu-right">
         {/* TODO: if there is the following button in XD add it here

--- a/packages/app/src/components/Common/Dropdown/PageItemControl.tsx
+++ b/packages/app/src/components/Common/Dropdown/PageItemControl.tsx
@@ -28,7 +28,7 @@ const PageItemControl: FC<PageItemControlProps> = (props: PageItemControlProps) 
     <>
       <button
         type="button"
-        className="btn-link dropdown-toggle dropdown-toggle-no-caret border-0 rounded grw-btn-page-management py-0 px-2"
+        className="btn-link dropdown-toggle dropdown-toggle-no-caret border-0 rounded grw-btn-page-management p-0"
         data-toggle="dropdown"
       >
         <i className="icon-options fa fa-rotate-90  text-muted p-1"></i>


### PR DESCRIPTION
# Task
https://redmine.weseek.co.jp/issues/84265

#　内容
dev5を統合にマージしたら、buttonのクリックした時の幅が調整されていたが、84265storyで button内のfont-awesomeからsimple-iconに変えたのでdev5での変更が意図した通りに動いていなかった為の対応タスク。
paddingいじっただけ。

<img width="241" alt="Screen Shot 2021-12-20 at 15 23 33" src="https://user-images.githubusercontent.com/60797707/146721342-360b2288-212a-4f7f-8c88-a9d48e6047d7.png">

<img width="1166" alt="Screen Shot 2021-12-20 at 15 23 17" src="https://user-images.githubusercontent.com/60797707/146721326-9b7d322a-b511-4eeb-811d-c24fdbee1404.png">

