### PR TITLE
fix: Downgrade node image for build

### DIFF
--- a/packages/app/docker/Dockerfile
+++ b/packages/app/docker/Dockerfile
@@ -7,7 +7,7 @@ ARG flavor=default
 ##
 ## deps-resolver
 ##
-FROM node:16-slim AS deps-resolver
+FROM node:14-slim AS deps-resolver
 LABEL maintainer Yuki Takei <yuki@weseek.co.jp>
 
 ENV appDir /opt/growi
@@ -51,7 +51,7 @@ RUN tar cf node_modules.tar \
 ##
 ## prebuilder-default
 ##
-FROM node:16-slim AS prebuilder-default
+FROM node:14-slim AS prebuilder-default
 
 ENV appDir /opt/growi
 
@@ -124,7 +124,7 @@ RUN tar cf packages.tar \
 ##
 ## release
 ##
-FROM node:16-slim
+FROM node:14-slim
 LABEL maintainer Yuki Takei <yuki@weseek.co.jp>
 
 ENV NODE_ENV production

--- a/packages/slackbot-proxy/docker/Dockerfile
+++ b/packages/slackbot-proxy/docker/Dockerfile
@@ -3,7 +3,7 @@
 ##
 ## deps-resolver-base
 ##
-FROM node:16-slim AS deps-resolver-base
+FROM node:14-slim AS deps-resolver-base
 
 ENV appDir /opt
 
@@ -46,7 +46,7 @@ RUN tar cf dependencies.tar \
 ##
 ## builder
 ##
-FROM node:16-slim AS builder
+FROM node:14-slim AS builder
 
 ENV appDir /opt
 
@@ -83,7 +83,7 @@ RUN tar cf packages.tar \
 ##
 ## release
 ##
-FROM node:16-slim
+FROM node:14-slim
 LABEL maintainer Yuki Takei <yuki@weseek.co.jp>
 
 ENV NODE_ENV production


### PR DESCRIPTION
/app/docker/Dockerfile, /slackbot-proxy/docker/Dockerfile のベースイメージを node:14-slim に下げました

ci エラー: https://github.com/weseek/growi/runs/4578512955?check_suite_focus=true

References:
- https://github.com/nodejs/node-gyp/issues/1599
- https://github.com/nodejs/docker-node/blob/6f740b0ca772e978b44c11d194f369e554c54a14/16/buster-slim/Dockerfile
- https://github.com/weseek/growi/commit/5d2b86a59d5916aac1750cf7665b4376b94709b3