### PR TITLE
imprv: modify conflict modal design

### DIFF
--- a/packages/app/src/components/PageEditor/ConflictDiffModal.tsx
+++ b/packages/app/src/components/PageEditor/ConflictDiffModal.tsx
@@ -137,6 +137,7 @@ export const ConflictDiffModal: FC<ConflictDiffModalProps> = (props) => {
     <Modal
       isOpen={props.isOpen || false}
       toggle={onClose}
+      backdrop="static"
       className={`${isModalExpanded ? ' grw-modal-expanded' : ''}`}
       size="xl"
     >
@@ -191,7 +192,7 @@ export const ConflictDiffModal: FC<ConflictDiffModalProps> = (props) => {
               <div className="text-center my-4">
                 <button
                   type="button"
-                  className="btn btn-primary"
+                  className="btn btn-outline-primary"
                   onClick={() => {
                     setIsRevisionSelected(true);
                     setResolvedRevision(request.revisionBody);
@@ -206,7 +207,7 @@ export const ConflictDiffModal: FC<ConflictDiffModalProps> = (props) => {
               <div className="text-center my-4">
                 <button
                   type="button"
-                  className="btn btn-primary"
+                  className="btn btn-outline-primary"
                   onClick={() => {
                     setIsRevisionSelected(true);
                     setResolvedRevision(origin.revisionBody);
@@ -221,7 +222,7 @@ export const ConflictDiffModal: FC<ConflictDiffModalProps> = (props) => {
               <div className="text-center my-4">
                 <button
                   type="button"
-                  className="btn btn-primary"
+                  className="btn btn-outline-primary"
                   onClick={() => {
                     setIsRevisionSelected(true);
                     setResolvedRevision(latest.revisionBody);
@@ -232,15 +233,17 @@ export const ConflictDiffModal: FC<ConflictDiffModalProps> = (props) => {
                 </button>
               </div>
             </div>
-            <div className="col-12 border border-dark">
-              <h3 className="font-weight-bold my-2">{t('modal_resolve_conflict.selected_editable_revision')}</h3>
-              <UncontrolledCodeMirror
-                ref={uncontrolledRef}
-                value={resolvedRevision}
-                options={{
-                  placeholder: t('modal_resolve_conflict.resolve_conflict_message'),
-                }}
-              />
+            <div className="col-12">
+              <div className="border border-dark">
+                <h3 className="font-weight-bold my-2 mx-2">{t('modal_resolve_conflict.selected_editable_revision')}</h3>
+                <UncontrolledCodeMirror
+                  ref={uncontrolledRef}
+                  value={resolvedRevision}
+                  options={{
+                    placeholder: t('modal_resolve_conflict.resolve_conflict_message'),
+                  }}
+                />
+              </div>
             </div>
           </div>
         )}


### PR DESCRIPTION
## タスク

https://redmine.weseek.co.jp/issues/78641

## 行ったこと

デザインFBに基づいて軽めのデザイン修正を行いました。

https://app.slack.com/client/T4V7GA7CM/C0111HG81GB/thread/C0111HG81GB-1639639218.378900


- モーダルの範囲外をクリックしたときにモーダルを閉じない設定にしました
- ボタンカラーを primary から outline-primary に変更しました
- 上と下の並びの横幅を揃えました（画像参照）

![adjust design](https://user-images.githubusercontent.com/83065937/146743001-1ed38b72-8863-4348-9c1a-5ca77f57d320.PNG)

## 残りタスク

- 動作確認
- 統合ブランチを master へマージ
