### PR TITLE
fix: 84315 codeql test

### DIFF
--- a/packages/app/src/server/routes/apiv3/personal-setting.js
+++ b/packages/app/src/server/routes/apiv3/personal-setting.js
@@ -577,7 +577,7 @@ module.exports = (crowi) => {
   // eslint-disable-next-line max-len
   router.put('/in-app-notification-settings', accessTokenParser, loginRequiredStrictly, csrf, validator.inAppNotificationSettings, apiV3FormValidator, async(req, res) => {
     const query = { userId: req.user.id };
-    const subscribeRules = req.body.subscribeRules;
+    const { subscribeRules } = req.body;
 
     if (subscribeRules == null) {
       return res.apiv3Err('no-rules-found');

--- a/packages/app/src/server/routes/apiv3/personal-setting.js
+++ b/packages/app/src/server/routes/apiv3/personal-setting.js
@@ -585,7 +585,7 @@ module.exports = (crowi) => {
 
     const options = { upsert: true, new: true, runValidators: true };
     try {
-      const response = await InAppNotificationSettings.findOneAndUpdate(query, { subscribeRules }, options);
+      const response = await InAppNotificationSettings.findOneAndUpdate(query, { $set: { subscribeRules } }, options);
       return res.apiv3(response);
     }
     catch (err) {

--- a/packages/app/src/server/routes/apiv3/personal-setting.js
+++ b/packages/app/src/server/routes/apiv3/personal-setting.js
@@ -577,7 +577,7 @@ module.exports = (crowi) => {
   // eslint-disable-next-line max-len
   router.put('/in-app-notification-settings', accessTokenParser, loginRequiredStrictly, csrf, validator.inAppNotificationSettings, apiV3FormValidator, async(req, res) => {
     const query = { userId: req.user.id };
-    const { subscribeRules } = req.body;
+    const subscribeRules = req.body.subscribeRules;
 
     if (subscribeRules == null) {
       return res.apiv3Err('no-rules-found');


### PR DESCRIPTION
## Task
[#84315](https://redmine.weseek.co.jp/issues/84315) CodeQL のテストで出た警告の修正

## Memo
トピックブランチ（feat/notification）の CodeQL のテストで `Building a database query from user-controlled sources is vulnerable to insertion of malicious code by the user.` という警告が出ていたので修正しました。
