### PR TITLE
imprv: Remove unrunnable mongo methods

### DIFF
--- a/packages/app/src/server/service/config-loader.ts
+++ b/packages/app/src/server/service/config-loader.ts
@@ -172,12 +172,6 @@ const ENV_VAR_NAME_TO_CONFIG_INFO = {
     type:    ValueType.BOOLEAN,
     default: false,
   },
-  IS_V5_INDEX_NORMALIZATION_IN_PROGRESS: {
-    ns:      'crowi',
-    key:     'app:isV5IndexNormalizationInProgress',
-    type:    ValueType.BOOLEAN,
-    default: false,
-  },
   IS_V5_COMPATIBLE: {
     ns:      'crowi',
     key:     'app:isV5Compatible',

--- a/packages/app/src/server/service/config-loader.ts
+++ b/packages/app/src/server/service/config-loader.ts
@@ -172,11 +172,11 @@ const ENV_VAR_NAME_TO_CONFIG_INFO = {
     type:    ValueType.BOOLEAN,
     default: false,
   },
-  V5_INDEX_NORMALIZATION_STATUS: {
+  IS_V5_INDEX_NORMALIZATION_IN_PROGRESS: {
     ns:      'crowi',
-    key:     'app:v5IndexNormalizationStatus',
-    type:    ValueType.STRING,
-    default: 'processable',
+    key:     'app:isV5IndexNormalizationInProgress',
+    type:    ValueType.BOOLEAN,
+    default: false,
   },
   IS_V5_COMPATIBLE: {
     ns:      'crowi',

--- a/packages/app/src/server/service/config-loader.ts
+++ b/packages/app/src/server/service/config-loader.ts
@@ -176,7 +176,7 @@ const ENV_VAR_NAME_TO_CONFIG_INFO = {
     ns:      'crowi',
     key:     'app:v5PathIndexStatus',
     type:    ValueType.STRING,
-    default: 'processable',
+    default: 'done',
   },
   IS_V5_COMPATIBLE: {
     ns:      'crowi',

--- a/packages/app/src/server/service/config-loader.ts
+++ b/packages/app/src/server/service/config-loader.ts
@@ -176,7 +176,7 @@ const ENV_VAR_NAME_TO_CONFIG_INFO = {
     ns:      'crowi',
     key:     'app:v5PathIndexStatus',
     type:    ValueType.STRING,
-    default: 'done',
+    default: 'processable',
   },
   IS_V5_COMPATIBLE: {
     ns:      'crowi',

--- a/packages/app/src/server/service/config-loader.ts
+++ b/packages/app/src/server/service/config-loader.ts
@@ -172,6 +172,12 @@ const ENV_VAR_NAME_TO_CONFIG_INFO = {
     type:    ValueType.BOOLEAN,
     default: false,
   },
+  V5_PATH_INDEX_STATUS: {
+    ns:      'crowi',
+    key:     'app:v5PathIndexStatus',
+    type:    ValueType.STRING,
+    default: 'processable',
+  },
   IS_V5_COMPATIBLE: {
     ns:      'crowi',
     key:     'app:isV5Compatible',

--- a/packages/app/src/server/service/config-loader.ts
+++ b/packages/app/src/server/service/config-loader.ts
@@ -172,9 +172,9 @@ const ENV_VAR_NAME_TO_CONFIG_INFO = {
     type:    ValueType.BOOLEAN,
     default: false,
   },
-  V5_PATH_INDEX_STATUS: {
+  V5_INDEX_NORMALIZATION_STATUS: {
     ns:      'crowi',
-    key:     'app:v5PathIndexStatus',
+    key:     'app:v5IndexNormalizationStatus',
     type:    ValueType.STRING,
     default: 'processable',
   },

--- a/packages/app/src/server/service/page.js
+++ b/packages/app/src/server/service/page.js
@@ -887,6 +887,7 @@ class PageService {
       await this._setV5PathIndexStatus('processing');
       try {
         await this._v5NormalizeIndex();
+        await this._setV5PathIndexStatus('done');
       }
       catch (err) {
         logger.error('V5 index normalization failed.', err);
@@ -895,7 +896,9 @@ class PageService {
         throw err;
       }
     }
-    await this._setV5PathIndexStatus('done');
+    else if (status === 'processing') {
+      return;
+    }
 
     // then migrate
     try {

--- a/packages/app/src/server/service/page.js
+++ b/packages/app/src/server/service/page.js
@@ -865,14 +865,14 @@ class PageService {
     }
   }
 
-  async _setV5PathIndexStatus(status) {
+  async _setV5IndexNormalizationStatus(status) {
     try {
       await this.crowi.configManager.updateConfigsInTheSameNamespace('crowi', {
-        'app:v5PathIndexStatus': status,
+        'app:v5IndexNormalizationStatus': status,
       });
     }
     catch (err) {
-      logger.error(`Failed to update app:v5PathIndexStatus to ${status} .`);
+      logger.error(`Failed to update app:v5IndexNormalizationStatus to ${status} .`);
       throw err;
     }
   }
@@ -908,7 +908,7 @@ class PageService {
 
   async v5InitialMigration(grant) {
     // const socket = this.crowi.socketIoService.getAdminSocket();
-    const status = this.crowi.configManager.getConfig('crowi', 'app:v5PathIndexStatus');
+    const status = this.crowi.configManager.getConfig('crowi', 'app:v5IndexNormalizationStatus');
 
     // avoid re-running many times
     const isProcessing = status === 'processing';
@@ -921,15 +921,15 @@ class PageService {
 
     // drop unique index first
     if (isUnique && isProcessable) {
-      await this._setV5PathIndexStatus('processing');
+      await this._setV5IndexNormalizationStatus('processing');
       try {
         await this._v5NormalizeIndex();
-        await this._setV5PathIndexStatus('processable');
+        await this._setV5IndexNormalizationStatus('processable');
       }
       catch (err) {
         logger.error('V5 index normalization failed.', err);
         // socket.emit('v5IndexNormalizationFailed', { error: err.message });
-        await this._setV5PathIndexStatus('processable');
+        await this._setV5IndexNormalizationStatus('processable');
         throw err;
       }
     }

--- a/packages/app/src/server/service/page.js
+++ b/packages/app/src/server/service/page.js
@@ -879,11 +879,10 @@ class PageService {
 
   async v5InitialMigration(grant) {
     // const socket = this.crowi.socketIoService.getAdminSocket();
-    const Page = this.crowi.model('Page');
     const status = this.crowi.configManager.getConfig('crowi', 'app:v5PathIndexStatus');
 
     // drop unique index first
-    if (status === 'processable') {
+    if (status === 'processable' || status == null) {
       await this._setV5PathIndexStatus('processing');
       try {
         await this._v5NormalizeIndex();

--- a/packages/app/src/server/service/page.js
+++ b/packages/app/src/server/service/page.js
@@ -865,18 +865,6 @@ class PageService {
     }
   }
 
-  async _setIsV5IndexNormalizationInProgress(status) {
-    try {
-      await this.crowi.configManager.updateConfigsInTheSameNamespace('crowi', {
-        'app:isV5IndexNormalizationInProgress': status,
-      });
-    }
-    catch (err) {
-      logger.error(`Failed to update app:isV5IndexNormalizationInProgress to ${status} .`);
-      throw err;
-    }
-  }
-
   async _isPagePathIndexUnique() {
     const Page = this.crowi.model('Page');
     const now = (new Date()).toString();
@@ -897,6 +885,7 @@ class PageService {
       }
       else {
         logger.error('Error occurred while checking index uniqueness.', err);
+        await Page.deleteMany({ path: { $regex: new RegExp('growi_check_is_path_index_unique', 'g') } });
         throw err;
       }
     }
@@ -906,28 +895,20 @@ class PageService {
     return isUnique;
   }
 
+  // TODO: use socket to send status to the client
   async v5InitialMigration(grant) {
     // const socket = this.crowi.socketIoService.getAdminSocket();
-    const isProcessing = this.crowi.configManager.getConfig('crowi', 'app:isV5IndexNormalizationInProgress');
-
-    // avoid re-running many times
-    if (isProcessing) {
-      return;
-    }
 
     const isUnique = await this._isPagePathIndexUnique();
 
     // drop unique index first
     if (isUnique) {
-      await this._setIsV5IndexNormalizationInProgress(true);
       try {
         await this._v5NormalizeIndex();
-        await this._setIsV5IndexNormalizationInProgress(false);
       }
       catch (err) {
         logger.error('V5 index normalization failed.', err);
         // socket.emit('v5IndexNormalizationFailed', { error: err.message });
-        await this._setIsV5IndexNormalizationInProgress(false);
         throw err;
       }
     }

--- a/packages/app/src/server/service/page.js
+++ b/packages/app/src/server/service/page.js
@@ -1099,7 +1099,7 @@ class PageService {
     }
     catch (err) {
       logger.warn('Failed to drop unique indexes from pages.path.', err);
-      // DO NOT throw err
+      throw err;
     }
 
     try {


### PR DESCRIPTION
Redmine: https://redmine.weseek.co.jp/issues/84294

Mongo で dbOwner の権限しかない場合にパブリックマイグレーションが開始できない不具合を修正しました