### PR TITLE
remove margin

### DIFF
--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -218,7 +218,7 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
       )}
       {
         isOpen && hasChildren() && currentChildren.map(node => (
-          <div key={node.page._id} className="grw-pagetree-item-container mt-2">
+          <div key={node.page._id} className="grw-pagetree-item-container">
             <Item
               isEnableActions={isEnableActions}
               itemNode={node}

--- a/packages/app/src/styles/_page-tree.scss
+++ b/packages/app/src/styles/_page-tree.scss
@@ -37,7 +37,6 @@ $grw-pagetree-item-padding-left: 10px;
 
       .grw-pagetree-title {
         overflow: hidden;
-        font-size: medium;
         text-overflow: ellipsis;
       }
     }

--- a/packages/app/src/styles/theme/_apply-colors-dark.scss
+++ b/packages/app/src/styles/theme/_apply-colors-dark.scss
@@ -259,7 +259,7 @@ ul.pagination {
         background: $bgcolor-list-hover;
       }
 
-      .grw-triangle-icon {
+      .grw-pagetree-button {
         &:not(:hover) {
           svg {
             fill: $gray-500;

--- a/packages/app/src/styles/theme/_apply-colors-light.scss
+++ b/packages/app/src/styles/theme/_apply-colors-light.scss
@@ -176,7 +176,7 @@ $border-color: $border-color-global;
         background: $bgcolor-list-hover;
       }
 
-      .grw-triangle-icon {
+      .grw-pagetree-button {
         &:not(:hover) {
           svg {
             fill: $gray-400;


### PR DESCRIPTION
## Task
- [#84326](https://redmine.weseek.co.jp/issues/84326) アイテムとアイテムの間の余白を失くす
- [#84327](https://redmine.weseek.co.jp/issues/84327) タイトルのfont-sizeを変更する
- [#84329](https://redmine.weseek.co.jp/issues/84329) 子ページ開閉ボタンのホバー範囲を広げる

## Before
<img width="405" alt="Screen Shot 2021-12-21 at 14 30 41" src="https://user-images.githubusercontent.com/59536731/146877278-f542f3f6-41d3-4e17-9373-cdd16cf9eed5.png">

## After
<img width="350" alt="Screen Shot 2021-12-21 at 16 13 24" src="https://user-images.githubusercontent.com/59536731/146887391-ec6bceb0-35a7-4be9-9d6e-37a8b7b22327.png">



