### PR TITLE
fix: 84367 error that occurs when a page is completely deleted 

### DIFF
--- a/packages/app/src/server/crowi/index.js
+++ b/packages/app/src/server/crowi/index.js
@@ -146,6 +146,9 @@ Crowi.prototype.initForTest = async function() {
   await this.setupModels();
   await this.setupConfigManager();
 
+  // setup messaging services
+  await this.setupSocketIoService();
+
   // // customizeService depends on AppService and XssService
   // // passportService depends on appService
   await Promise.all([
@@ -170,8 +173,8 @@ Crowi.prototype.initForTest = async function() {
     // this.setupExport(),
     // this.setupImport(),
     this.setupPageService(),
-    // this.setupInAppNotificationService(),
-    // this.setupActivityService(),
+    this.setupInAppNotificationService(),
+    this.setupActivityService(),
   ]);
 
   // globalNotification depends on slack and mailer

--- a/packages/app/src/server/service/page.js
+++ b/packages/app/src/server/service/page.js
@@ -69,9 +69,9 @@ class PageService {
     });
 
     // delete completely
-    this.pageEvent.on('deleteCompletely', async(page, user) => {
+    this.pageEvent.on('deleteCompletely', async(pages, user) => {
       try {
-        await this.createAndSendNotifications(page, user, ActivityDefine.ACTION_PAGE_DELETE_COMPLETELY);
+        await this.createAndSendNotifications(pages[0], user, ActivityDefine.ACTION_PAGE_DELETE_COMPLETELY);
       }
       catch (err) {
         logger.error(err);
@@ -658,7 +658,7 @@ class PageService {
       this.deleteCompletelyDescendantsWithStream(page, user, options);
     }
 
-    this.pageEvent.emit('deleteCompletely', page, user); // update as renamed page
+    this.pageEvent.emit('deleteCompletely', [page], user); // update as renamed page
 
     return;
   }

--- a/packages/app/src/server/service/page.js
+++ b/packages/app/src/server/service/page.js
@@ -69,11 +69,9 @@ class PageService {
     });
 
     // delete completely
-    this.pageEvent.on('deleteCompletely', async(pages, user, isRecursively = false) => {
+    this.pageEvent.on('deleteCompletely', async(page, user) => {
       try {
-        if (!isRecursively) {
-          await this.createAndSendNotifications(pages[0], user, ActivityDefine.ACTION_PAGE_DELETE_COMPLETELY);
-        }
+        await this.createAndSendNotifications(page, user, ActivityDefine.ACTION_PAGE_DELETE_COMPLETELY);
       }
       catch (err) {
         logger.error(err);
@@ -643,7 +641,7 @@ class PageService {
 
     await this.deleteCompletelyOperation(ids, paths);
 
-    this.pageEvent.emit('deleteCompletely', pages, user); // update as renamed page
+    this.pageEvent.emit('deleteMultipleCompletely', pages, user); // update as renamed page
 
     return;
   }
@@ -660,7 +658,7 @@ class PageService {
       this.deleteCompletelyDescendantsWithStream(page, user, options);
     }
 
-    this.pageEvent.emit('deleteCompletely', [page], user, isRecursively); // update as renamed page
+    this.pageEvent.emit('deleteCompletely', page, user); // update as renamed page
 
     return;
   }

--- a/packages/app/src/server/service/page.js
+++ b/packages/app/src/server/service/page.js
@@ -595,6 +595,9 @@ class PageService {
         throw new Error('Failed to revert pages: ', err);
       }
     }
+    finally {
+      this.pageEvent.emit('syncDescendantsDeleted', pages, user);
+    }
   }
 
   /**
@@ -641,7 +644,7 @@ class PageService {
 
     await this.deleteCompletelyOperation(ids, paths);
 
-    this.pageEvent.emit('deleteMultipleCompletely', pages, user); // update as renamed page
+    this.pageEvent.emit('syncDescendantsDeleted', pages, user); // update as renamed page
 
     return;
   }

--- a/packages/app/src/server/service/page.js
+++ b/packages/app/src/server/service/page.js
@@ -69,9 +69,11 @@ class PageService {
     });
 
     // delete completely
-    this.pageEvent.on('deleteCompletely', async(pages, user) => {
+    this.pageEvent.on('deleteCompletely', async(pages, user, isRecursively = false) => {
       try {
-        await this.createAndSendNotifications(pages[0], user, ActivityDefine.ACTION_PAGE_DELETE_COMPLETELY);
+        if (!isRecursively) {
+          await this.createAndSendNotifications(pages[0], user, ActivityDefine.ACTION_PAGE_DELETE_COMPLETELY);
+        }
       }
       catch (err) {
         logger.error(err);
@@ -658,7 +660,7 @@ class PageService {
       this.deleteCompletelyDescendantsWithStream(page, user, options);
     }
 
-    this.pageEvent.emit('deleteCompletely', [page], user); // update as renamed page
+    this.pageEvent.emit('deleteCompletely', [page], user, isRecursively); // update as renamed page
 
     return;
   }

--- a/packages/app/src/server/service/page.js
+++ b/packages/app/src/server/service/page.js
@@ -303,7 +303,7 @@ class PageService {
         logger.debug(`Reverting pages has completed: (totalCount=${count})`);
         // update  path
         targetPage.path = newPagePath;
-        pageEvent.emit('syncDescendants', targetPage, user);
+        pageEvent.emit('syncDescendantsUpdate', targetPage, user);
         callback();
       },
     });
@@ -499,7 +499,7 @@ class PageService {
         logger.debug(`Adding pages has completed: (totalCount=${count})`);
         // update  path
         page.path = newPagePath;
-        pageEvent.emit('syncDescendants', page, user);
+        pageEvent.emit('syncDescendantsUpdate', page, user);
         callback();
       },
     });
@@ -596,7 +596,7 @@ class PageService {
       }
     }
     finally {
-      this.pageEvent.emit('syncDescendantsDeleted', pages, user);
+      this.pageEvent.emit('syncDescendantsDelete', pages, user);
     }
   }
 
@@ -644,7 +644,7 @@ class PageService {
 
     await this.deleteCompletelyOperation(ids, paths);
 
-    this.pageEvent.emit('syncDescendantsDeleted', pages, user); // update as renamed page
+    this.pageEvent.emit('syncDescendantsDelete', pages, user); // update as renamed page
 
     return;
   }

--- a/packages/app/src/server/service/search-delegator/elasticsearch.ts
+++ b/packages/app/src/server/service/search-delegator/elasticsearch.ts
@@ -957,9 +957,9 @@ class ElasticsearchDelegator implements SearchDelegator<Data> {
     return this.updateOrInsertDescendantsPagesById(parentPage, user);
   }
 
-  async syncPageDeleteMultipleCompletely(pages, user) {
+  async syncDescendantsPagesDeleted(pages, user) {
     for (let i = 0; i < pages.length; i++) {
-      logger.debug('SearchClient.syncPageDeleteMultipleCompletely', pages[i].path);
+      logger.debug('SearchClient.syncDescendantsPagesDeleted', pages[i].path);
     }
 
     try {

--- a/packages/app/src/server/service/search-delegator/elasticsearch.ts
+++ b/packages/app/src/server/service/search-delegator/elasticsearch.ts
@@ -957,9 +957,9 @@ class ElasticsearchDelegator implements SearchDelegator<Data> {
     return this.updateOrInsertDescendantsPagesById(parentPage, user);
   }
 
-  async syncPagesDeletedCompletely(pages, user) {
+  async syncPageDeleteMultipleCompletely(pages, user) {
     for (let i = 0; i < pages.length; i++) {
-      logger.debug('SearchClient.syncPageDeleted', pages[i].path);
+      logger.debug('SearchClient.syncPageDeleteMultipleCompletely', pages[i].path);
     }
 
     try {

--- a/packages/app/src/server/service/search.ts
+++ b/packages/app/src/server/service/search.ts
@@ -116,9 +116,9 @@ class SearchService implements SearchQueryParser, SearchResolver {
     pageEvent.on('update', this.fullTextSearchDelegator.syncPageUpdated.bind(this.fullTextSearchDelegator));
     pageEvent.on('delete', this.fullTextSearchDelegator.syncPageDeleted.bind(this.fullTextSearchDelegator));
     pageEvent.on('deleteCompletely', this.fullTextSearchDelegator.syncPageDeleted.bind(this.fullTextSearchDelegator));
-    pageEvent.on('syncDescendantsDeleted', this.fullTextSearchDelegator.syncDescendantsPagesDeleted.bind(this.fullTextSearchDelegator));
+    pageEvent.on('syncDescendantsDelete', this.fullTextSearchDelegator.syncDescendantsPagesDeleted.bind(this.fullTextSearchDelegator));
     pageEvent.on('updateMany', this.fullTextSearchDelegator.syncPagesUpdated.bind(this.fullTextSearchDelegator));
-    pageEvent.on('syncDescendants', this.fullTextSearchDelegator.syncDescendantsPagesUpdated.bind(this.fullTextSearchDelegator));
+    pageEvent.on('syncDescendantsUpdate', this.fullTextSearchDelegator.syncDescendantsPagesUpdated.bind(this.fullTextSearchDelegator));
     pageEvent.on('addSeenUsers', this.fullTextSearchDelegator.syncPageUpdated.bind(this.fullTextSearchDelegator));
     pageEvent.on('rename', () => {
       this.fullTextSearchDelegator.syncPageDeleted.bind(this.fullTextSearchDelegator);

--- a/packages/app/src/server/service/search.ts
+++ b/packages/app/src/server/service/search.ts
@@ -114,8 +114,9 @@ class SearchService implements SearchQueryParser, SearchResolver {
     const pageEvent = this.crowi.event('page');
     pageEvent.on('create', this.fullTextSearchDelegator.syncPageUpdated.bind(this.fullTextSearchDelegator));
     pageEvent.on('update', this.fullTextSearchDelegator.syncPageUpdated.bind(this.fullTextSearchDelegator));
-    pageEvent.on('syncDescendantsDeleted', this.fullTextSearchDelegator.syncDescendantsPagesDeleted.bind(this.fullTextSearchDelegator));
+    pageEvent.on('delete', this.fullTextSearchDelegator.syncPageDeleted.bind(this.fullTextSearchDelegator));
     pageEvent.on('deleteCompletely', this.fullTextSearchDelegator.syncPageDeleted.bind(this.fullTextSearchDelegator));
+    pageEvent.on('syncDescendantsDeleted', this.fullTextSearchDelegator.syncDescendantsPagesDeleted.bind(this.fullTextSearchDelegator));
     pageEvent.on('delete', this.fullTextSearchDelegator.syncPageDeleted.bind(this.fullTextSearchDelegator));
     pageEvent.on('updateMany', this.fullTextSearchDelegator.syncPagesUpdated.bind(this.fullTextSearchDelegator));
     pageEvent.on('syncDescendants', this.fullTextSearchDelegator.syncDescendantsPagesUpdated.bind(this.fullTextSearchDelegator));

--- a/packages/app/src/server/service/search.ts
+++ b/packages/app/src/server/service/search.ts
@@ -114,7 +114,8 @@ class SearchService implements SearchQueryParser, SearchResolver {
     const pageEvent = this.crowi.event('page');
     pageEvent.on('create', this.fullTextSearchDelegator.syncPageUpdated.bind(this.fullTextSearchDelegator));
     pageEvent.on('update', this.fullTextSearchDelegator.syncPageUpdated.bind(this.fullTextSearchDelegator));
-    pageEvent.on('deleteCompletely', this.fullTextSearchDelegator.syncPagesDeletedCompletely.bind(this.fullTextSearchDelegator));
+    pageEvent.on('deleteMultipleCompletely', this.fullTextSearchDelegator.syncPageDeleteMultipleCompletely.bind(this.fullTextSearchDelegator));
+    pageEvent.on('deleteCompletely', this.fullTextSearchDelegator.syncPageDeleted.bind(this.fullTextSearchDelegator));
     pageEvent.on('delete', this.fullTextSearchDelegator.syncPageDeleted.bind(this.fullTextSearchDelegator));
     pageEvent.on('updateMany', this.fullTextSearchDelegator.syncPagesUpdated.bind(this.fullTextSearchDelegator));
     pageEvent.on('syncDescendants', this.fullTextSearchDelegator.syncDescendantsPagesUpdated.bind(this.fullTextSearchDelegator));

--- a/packages/app/src/server/service/search.ts
+++ b/packages/app/src/server/service/search.ts
@@ -117,7 +117,6 @@ class SearchService implements SearchQueryParser, SearchResolver {
     pageEvent.on('delete', this.fullTextSearchDelegator.syncPageDeleted.bind(this.fullTextSearchDelegator));
     pageEvent.on('deleteCompletely', this.fullTextSearchDelegator.syncPageDeleted.bind(this.fullTextSearchDelegator));
     pageEvent.on('syncDescendantsDeleted', this.fullTextSearchDelegator.syncDescendantsPagesDeleted.bind(this.fullTextSearchDelegator));
-    pageEvent.on('delete', this.fullTextSearchDelegator.syncPageDeleted.bind(this.fullTextSearchDelegator));
     pageEvent.on('updateMany', this.fullTextSearchDelegator.syncPagesUpdated.bind(this.fullTextSearchDelegator));
     pageEvent.on('syncDescendants', this.fullTextSearchDelegator.syncDescendantsPagesUpdated.bind(this.fullTextSearchDelegator));
     pageEvent.on('addSeenUsers', this.fullTextSearchDelegator.syncPageUpdated.bind(this.fullTextSearchDelegator));

--- a/packages/app/src/server/service/search.ts
+++ b/packages/app/src/server/service/search.ts
@@ -114,7 +114,7 @@ class SearchService implements SearchQueryParser, SearchResolver {
     const pageEvent = this.crowi.event('page');
     pageEvent.on('create', this.fullTextSearchDelegator.syncPageUpdated.bind(this.fullTextSearchDelegator));
     pageEvent.on('update', this.fullTextSearchDelegator.syncPageUpdated.bind(this.fullTextSearchDelegator));
-    pageEvent.on('deleteMultipleCompletely', this.fullTextSearchDelegator.syncPageDeleteMultipleCompletely.bind(this.fullTextSearchDelegator));
+    pageEvent.on('syncDescendantsDeleted', this.fullTextSearchDelegator.syncDescendantsPagesDeleted.bind(this.fullTextSearchDelegator));
     pageEvent.on('deleteCompletely', this.fullTextSearchDelegator.syncPageDeleted.bind(this.fullTextSearchDelegator));
     pageEvent.on('delete', this.fullTextSearchDelegator.syncPageDeleted.bind(this.fullTextSearchDelegator));
     pageEvent.on('updateMany', this.fullTextSearchDelegator.syncPagesUpdated.bind(this.fullTextSearchDelegator));

--- a/packages/app/src/test/integration/service/page.test.js
+++ b/packages/app/src/test/integration/service/page.test.js
@@ -723,7 +723,7 @@ describe('PageService', () => {
       expect(deleteCompletelyOperationSpy).toHaveBeenCalled();
       expect(deleteCompletelyDescendantsWithStreamSpy).not.toHaveBeenCalled();
 
-      expect(pageEventSpy).toHaveBeenCalledWith('deleteCompletely', parentForDeleteCompletely, testUser2);
+      expect(pageEventSpy).toHaveBeenCalledWith('deleteCompletely', [parentForDeleteCompletely], testUser2, false);
     });
 
 
@@ -733,7 +733,7 @@ describe('PageService', () => {
       expect(deleteCompletelyOperationSpy).toHaveBeenCalled();
       expect(deleteCompletelyDescendantsWithStreamSpy).toHaveBeenCalled();
 
-      expect(pageEventSpy).toHaveBeenCalledWith('deleteCompletely', parentForDeleteCompletely, testUser2);
+      expect(pageEventSpy).toHaveBeenCalledWith('deleteCompletely', [parentForDeleteCompletely], testUser2, true);
     });
   });
 

--- a/packages/app/src/test/integration/service/page.test.js
+++ b/packages/app/src/test/integration/service/page.test.js
@@ -723,7 +723,7 @@ describe('PageService', () => {
       expect(deleteCompletelyOperationSpy).toHaveBeenCalled();
       expect(deleteCompletelyDescendantsWithStreamSpy).not.toHaveBeenCalled();
 
-      expect(pageEventSpy).toHaveBeenCalledWith('deleteCompletely', [parentForDeleteCompletely], testUser2);
+      expect(pageEventSpy).toHaveBeenCalledWith('deleteCompletely', parentForDeleteCompletely, testUser2);
     });
 
 
@@ -733,7 +733,7 @@ describe('PageService', () => {
       expect(deleteCompletelyOperationSpy).toHaveBeenCalled();
       expect(deleteCompletelyDescendantsWithStreamSpy).toHaveBeenCalled();
 
-      expect(pageEventSpy).toHaveBeenCalledWith('deleteCompletely', [parentForDeleteCompletely], testUser2);
+      expect(pageEventSpy).toHaveBeenCalledWith('deleteCompletely', parentForDeleteCompletely, testUser2);
     });
   });
 

--- a/packages/app/src/test/integration/service/page.test.js
+++ b/packages/app/src/test/integration/service/page.test.js
@@ -723,7 +723,7 @@ describe('PageService', () => {
       expect(deleteCompletelyOperationSpy).toHaveBeenCalled();
       expect(deleteCompletelyDescendantsWithStreamSpy).not.toHaveBeenCalled();
 
-      expect(pageEventSpy).toHaveBeenCalledWith('deleteCompletely', [parentForDeleteCompletely], testUser2, false);
+      expect(pageEventSpy).toHaveBeenCalledWith('deleteCompletely', [parentForDeleteCompletely], testUser2);
     });
 
 
@@ -733,7 +733,7 @@ describe('PageService', () => {
       expect(deleteCompletelyOperationSpy).toHaveBeenCalled();
       expect(deleteCompletelyDescendantsWithStreamSpy).toHaveBeenCalled();
 
-      expect(pageEventSpy).toHaveBeenCalledWith('deleteCompletely', [parentForDeleteCompletely], testUser2, true);
+      expect(pageEventSpy).toHaveBeenCalledWith('deleteCompletely', [parentForDeleteCompletely], testUser2);
     });
   });
 


### PR DESCRIPTION
## Task
[#84367](https://redmine.weseek.co.jp/issues/84367) 修正

## Memo
ページを完全に削除したときに以下のようなエラーがでる問題、完全に削除したページの path を検索したときに検索結果画面に `Cannot  read proety '_doc' of undifined` というエラーが表示される問題を修正しました。

```
 deletePages:ES Error TypeError: pages.forEach is not a function
      at ElasticsearchDelegator.deletePages (/workspace/growi/packages/app/src/server/service/search-delegator/elasticsearch.ts:575:11)
      at ElasticsearchDelegator.syncPagesDeletedCompletely (/workspace/growi/packages/app/src/server/service/search-delegator/elasticsearch.ts:967:25)
      at PageEvent.emit (events.js:412:35)
      at PageService.deleteCompletely (/workspace/growi/packages/app/src/server/service/page.js:661:20)
      at processTicksAndRejections (internal/process/task_queues.js:95:5)
      at api.remove (/workspace/growi/packages/app/src/server/routes/page.js:1091:9)
```


