### PR TITLE
84335 sidebar button clickable area smaller

### DIFF
--- a/packages/app/src/styles/_sidebar.scss
+++ b/packages/app/src/styles/_sidebar.scss
@@ -56,7 +56,7 @@
     .hitarea {
       @extend .rounded-pill;
 
-      $size-hitarea: 80px;
+      $size-hitarea: 55px;
 
       position: absolute;
       top: ($width - $size-hitarea) / 2;


### PR DESCRIPTION
# 今回このタスクのみなので統合ブランチはありません。
dev5が統合先になってます。
動作確認してからmergeするのではmergeはお待ちください。

# Task
https://redmine.weseek.co.jp/issues/84335

# 内容
sidbarのボタンの範囲が広くてpage treeの+ボタンが押せなくなっていたのを解消。

幅変更前：
<img width="434" alt="Screen Shot 2021-12-21 at 16 14 33" src="https://user-images.githubusercontent.com/60797707/146887513-ab69973f-2e32-4c3a-aaae-61bb87a56e1d.png">


幅変更後 :
<img width="222" alt="Screen Shot 2021-12-21 at 16 03 35" src="https://user-images.githubusercontent.com/60797707/146887226-a0cfe0b9-8b26-41f8-92e7-b1a04ac6e7bd.png">

