### PR TITLE
fix: 84410 error that activity is not saved

### DIFF
--- a/packages/app/src/server/models/activity.ts
+++ b/packages/app/src/server/models/activity.ts
@@ -22,7 +22,6 @@ export interface ActivityDocument extends Document {
   action: string
   event: Types.ObjectId
   eventModel: string
-  createdAt: Date
 
   getNotificationTargetUsers(): Promise<any[]>
 }
@@ -61,10 +60,8 @@ const activitySchema = new Schema<ActivityDocument, ActivityModel>({
     type: String,
     enum: ActivityDefine.getSupportEventModelNames(),
   },
-  createdAt: {
-    type: Date,
-    default: new Date(),
-  },
+}, {
+  timestamps: true,
 });
 activitySchema.index({ target: 1, action: 1 });
 activitySchema.index({


### PR DESCRIPTION
## Task
[#84410](https://redmine.weseek.co.jp/issues/84410) 修正

## やったこと
Activity を作成する action（like や rename） を行う際にエラーが発生する問題を修正しました。

## エラー内容
```
E11000 duplicate key error collection: growi.activities index: user_1_target_1_action_1_createdAt_1 dup key: { user: ObjectId('61c1b80c785f329b92d771d1'), target: ObjectId('61c1b83a785f329b92d7734a'), action: "PAGE_LIKE", createdAt: new Date(1640085622854) }
```

## 原因
Activity モデルの createdAt がスキーマが作成された時間になっており、すべての activity の createdAt が同一の時間に保存されてしまうようになっていたことがで原因でした。

