### PR TITLE
fix alert message

### DIFF
--- a/packages/app/src/client/services/AdminHomeContainer.js
+++ b/packages/app/src/client/services/AdminHomeContainer.js
@@ -69,7 +69,7 @@ export default class AdminHomeContainer extends Container {
     }
     catch (err) {
       logger.error(err);
-      toastError(new Error('Failed to fetch data'));
+      throw new Error('Failed to retrive AdminHome data');
     }
   }
 

--- a/packages/app/src/client/services/AdminHomeContainer.js
+++ b/packages/app/src/client/services/AdminHomeContainer.js
@@ -25,7 +25,6 @@ export default class AdminHomeContainer extends Container {
     this.timer = null;
 
     this.state = {
-      retrieveError: null,
       growiVersion: '',
       nodeVersion: '',
       npmVersion: '',

--- a/packages/app/src/components/Admin/AdminHome/AdminHome.jsx
+++ b/packages/app/src/components/Admin/AdminHome/AdminHome.jsx
@@ -10,6 +10,7 @@ import { toastError } from '~/client/util/apiNotification';
 import { withUnstatedContainers } from '../../UnstatedUtils';
 import AppContainer from '~/client/services/AppContainer';
 import AdminHomeContainer from '~/client/services/AdminHomeContainer';
+import { useSWRxV5MigrationStatus } from '~/stores/page-listing';
 import SystemInfomationTable from './SystemInfomationTable';
 import InstalledPluginTable from './InstalledPluginTable';
 import EnvVarsTable from './EnvVarsTable';
@@ -19,6 +20,7 @@ const logger = loggerFactory('growi:admin');
 const AdminHome = (props) => {
   const { adminHomeContainer } = props;
   const { t } = useTranslation();
+  const { data: migrationStatus } = useSWRxV5MigrationStatus();
 
   useEffect(() => {
     async function fetchAdminHomeData() {
@@ -34,23 +36,20 @@ const AdminHome = (props) => {
     }
   }, [adminHomeContainer]);
 
-  const { isV5Compatible } = adminHomeContainer.state;
-
-
   return (
     <>
       {
-        // Alert message will be displayed in case that V5 migration has not been compleated
-        (isV5Compatible != null && !isV5Compatible)
-          && (
-          <div className={`alert ${isV5Compatible == null ? 'alert-warning' : 'alert-info'}`}>
-              {t('admin:v5_page_migration.migration_desc')}
-              <a className="btn-link" href="/admin/app" rel="noopener noreferrer">
-                <i className="fa fa-link ml-1" aria-hidden="true"></i>
-                <strong>{t('admin:v5_page_migration.upgrade_to_v5')}</strong>
-              </a>
-            </div>
-          )
+      // Alert message will be displayed in case that V5 migration has not been compleated
+        (migrationStatus != null && !migrationStatus.isV5Compatible)
+        && (
+          <div className={`alert ${migrationStatus.isV5Compatible == null ? 'alert-warning' : 'alert-info'}`}>
+            {t('admin:v5_page_migration.migration_desc')}
+            <a className="btn-link" href="/admin/app" rel="noopener noreferrer">
+              <i className="fa fa-link ml-1" aria-hidden="true"></i>
+              <strong>{t('admin:v5_page_migration.upgrade_to_v5')}</strong>
+            </a>
+          </div>
+        )
       }
       <p>
         {t('admin:admin_top.wiki_administrator')}

--- a/packages/app/src/components/Admin/AdminHome/AdminHome.jsx
+++ b/packages/app/src/components/Admin/AdminHome/AdminHome.jsx
@@ -42,7 +42,7 @@ class AdminHome extends React.Component {
     return (
       <Fragment>
         {
-          // Alert message will be displayed in case that V5 migration has not compleated
+          // Alert message will be displayed in case that V5 migration has not been compleated
           (isV5Compatible != null && !isV5Compatible)
           && (
             <div className={`alert ${alertStyle}`}>

--- a/packages/app/src/components/Admin/AdminHome/AdminHome.jsx
+++ b/packages/app/src/components/Admin/AdminHome/AdminHome.jsx
@@ -42,8 +42,8 @@ class AdminHome extends React.Component {
     return (
       <Fragment>
         {
-          // not show if true
-          !isV5Compatible
+          // Alert message will be displayed in case that V5 migration has not compleated yet
+          (isV5Compatible != null && !isV5Compatible)
           && (
             <div className={`alert ${alertStyle}`}>
               {t('admin:v5_page_migration.migration_desc')}

--- a/packages/app/src/components/Admin/AdminHome/AdminHome.jsx
+++ b/packages/app/src/components/Admin/AdminHome/AdminHome.jsx
@@ -28,7 +28,6 @@ const AdminHome = (props) => {
     }
     catch (err) {
       toastError(err);
-      adminHomeContainer.setState({ retrieveError: err });
       logger.error(err);
     }
   }, [adminHomeContainer]);

--- a/packages/app/src/components/Admin/AdminHome/AdminHome.jsx
+++ b/packages/app/src/components/Admin/AdminHome/AdminHome.jsx
@@ -23,9 +23,10 @@ const AdminHome = (props) => {
   const { data: migrationStatus } = useSWRxV5MigrationStatus();
 
   useEffect(() => {
-    async function fetchAdminHomeData() {
+    const fetchAdminHomeData = async() => {
       await adminHomeContainer.retrieveAdminHomeData();
-    }
+    };
+
     try {
       fetchAdminHomeData();
     }

--- a/packages/app/src/components/Admin/AdminHome/AdminHome.jsx
+++ b/packages/app/src/components/Admin/AdminHome/AdminHome.jsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { withTranslation } from 'react-i18next';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
@@ -10,40 +10,39 @@ import { toastError } from '~/client/util/apiNotification';
 import { withUnstatedContainers } from '../../UnstatedUtils';
 import AppContainer from '~/client/services/AppContainer';
 import AdminHomeContainer from '~/client/services/AdminHomeContainer';
-import AdminAppContainer from '~/client/services/AdminAppContainer';
 import SystemInfomationTable from './SystemInfomationTable';
 import InstalledPluginTable from './InstalledPluginTable';
 import EnvVarsTable from './EnvVarsTable';
 
 const logger = loggerFactory('growi:admin');
 
-class AdminHome extends React.Component {
+const AdminHome = (props) => {
+  const { t, adminHomeContainer } = props;
 
-  async componentDidMount() {
-    const { adminHomeContainer } = this.props;
-
-    try {
+  useEffect(() => {
+    async function fetchAdminHomeData() {
       await adminHomeContainer.retrieveAdminHomeData();
+    }
+    try {
+      fetchAdminHomeData();
     }
     catch (err) {
       toastError(err);
       adminHomeContainer.setState({ retrieveError: err });
       logger.error(err);
     }
-  }
+  }, [adminHomeContainer]);
 
-  render() {
-    const { t, adminHomeContainer } = this.props;
-    const { isV5Compatible } = adminHomeContainer.state;
+  const { isV5Compatible } = adminHomeContainer.state;
 
-    let alertStyle = 'alert-info';
-    if (isV5Compatible == null) alertStyle = 'alert-warning';
+  let alertStyle = 'alert-info';
+  if (isV5Compatible == null) alertStyle = 'alert-warning';
 
-    return (
-      <Fragment>
-        {
-          // Alert message will be displayed in case that V5 migration has not been compleated
-          (isV5Compatible != null && !isV5Compatible)
+  return (
+    <>
+      {
+        // Alert message will be displayed in case that V5 migration has not been compleated
+        (isV5Compatible != null && !isV5Compatible)
           && (
             <div className={`alert ${alertStyle}`}>
               {t('admin:v5_page_migration.migration_desc')}
@@ -53,67 +52,66 @@ class AdminHome extends React.Component {
               </a>
             </div>
           )
-        }
-        <p>
-          {t('admin:admin_top.wiki_administrator')}
-          <br></br>
-          {t('admin:admin_top.assign_administrator')}
-        </p>
+      }
+      <p>
+        {t('admin:admin_top.wiki_administrator')}
+        <br></br>
+        {t('admin:admin_top.assign_administrator')}
+      </p>
 
-        <div className="row mb-5">
-          <div className="col-lg-12">
-            <h2 className="admin-setting-header">{t('admin:admin_top.system_information')}</h2>
-            <SystemInfomationTable />
-          </div>
+      <div className="row mb-5">
+        <div className="col-lg-12">
+          <h2 className="admin-setting-header">{t('admin:admin_top.system_information')}</h2>
+          <SystemInfomationTable />
         </div>
+      </div>
 
-        <div className="row mb-5">
-          <div className="col-lg-12">
-            <h2 className="admin-setting-header">{t('admin:admin_top.list_of_installed_plugins')}</h2>
-            <InstalledPluginTable />
-          </div>
+      <div className="row mb-5">
+        <div className="col-lg-12">
+          <h2 className="admin-setting-header">{t('admin:admin_top.list_of_installed_plugins')}</h2>
+          <InstalledPluginTable />
         </div>
+      </div>
 
-        <div className="row mb-5">
-          <div className="col-md-12">
-            <h2 className="admin-setting-header">{t('admin:admin_top.list_of_env_vars')}</h2>
-            <p>{t('admin:admin_top.env_var_priority')}</p>
+      <div className="row mb-5">
+        <div className="col-md-12">
+          <h2 className="admin-setting-header">{t('admin:admin_top.list_of_env_vars')}</h2>
+          <p>{t('admin:admin_top.env_var_priority')}</p>
+          {/* eslint-disable-next-line react/no-danger */}
+          <p dangerouslySetInnerHTML={{ __html: t('admin:admin_top.about_security') }} />
+          {adminHomeContainer.state.envVars && <EnvVarsTable envVars={adminHomeContainer.state.envVars} />}
+        </div>
+      </div>
+
+      <div className="row mb-5">
+        <div className="col-md-12">
+          <h2 className="admin-setting-header">{t('admin:admin_top.bug_report')}</h2>
+          <div className="d-flex align-items-center">
+            <CopyToClipboard
+              text={adminHomeContainer.generatePrefilledHostInformationMarkdown()}
+              onCopy={() => adminHomeContainer.onCopyPrefilledHostInformation()}
+            >
+              <button id="prefilledHostInformationButton" type="button" className="btn btn-primary">
+                {t('admin:admin_top:copy_prefilled_host_information:default')}
+              </button>
+            </CopyToClipboard>
+            <Tooltip
+              placement="bottom"
+              isOpen={adminHomeContainer.state.copyState === adminHomeContainer.copyStateValues.DONE}
+              target="prefilledHostInformationButton"
+              fade={false}
+            >
+              {t('admin:admin_top:copy_prefilled_host_information:done')}
+            </Tooltip>
             {/* eslint-disable-next-line react/no-danger */}
-            <p dangerouslySetInnerHTML={{ __html: t('admin:admin_top.about_security') }} />
-            {adminHomeContainer.state.envVars && <EnvVarsTable envVars={adminHomeContainer.state.envVars} />}
+            <span className="ml-2" dangerouslySetInnerHTML={{ __html: t('admin:admin_top:submit_bug_report') }} />
           </div>
         </div>
+      </div>
+    </>
+  );
+};
 
-        <div className="row mb-5">
-          <div className="col-md-12">
-            <h2 className="admin-setting-header">{t('admin:admin_top.bug_report')}</h2>
-            <div className="d-flex align-items-center">
-              <CopyToClipboard
-                text={adminHomeContainer.generatePrefilledHostInformationMarkdown()}
-                onCopy={() => adminHomeContainer.onCopyPrefilledHostInformation()}
-              >
-                <button id="prefilledHostInformationButton" type="button" className="btn btn-primary">
-                  {t('admin:admin_top:copy_prefilled_host_information:default')}
-                </button>
-              </CopyToClipboard>
-              <Tooltip
-                placement="bottom"
-                isOpen={adminHomeContainer.state.copyState === adminHomeContainer.copyStateValues.DONE}
-                target="prefilledHostInformationButton"
-                fade={false}
-              >
-                {t('admin:admin_top:copy_prefilled_host_information:done')}
-              </Tooltip>
-              {/* eslint-disable-next-line react/no-danger */}
-              <span className="ml-2" dangerouslySetInnerHTML={{ __html: t('admin:admin_top:submit_bug_report') }} />
-            </div>
-          </div>
-        </div>
-      </Fragment>
-    );
-  }
-
-}
 
 const AdminHomeWrapper = withUnstatedContainers(AdminHome, [AppContainer, AdminHomeContainer]);
 

--- a/packages/app/src/components/Admin/AdminHome/AdminHome.jsx
+++ b/packages/app/src/components/Admin/AdminHome/AdminHome.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { withTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
 import { Tooltip } from 'reactstrap';
 import loggerFactory from '~/utils/logger';
@@ -17,7 +17,8 @@ import EnvVarsTable from './EnvVarsTable';
 const logger = loggerFactory('growi:admin');
 
 const AdminHome = (props) => {
-  const { t, adminHomeContainer } = props;
+  const { adminHomeContainer } = props;
+  const { t } = useTranslation();
 
   useEffect(() => {
     async function fetchAdminHomeData() {
@@ -116,9 +117,8 @@ const AdminHome = (props) => {
 const AdminHomeWrapper = withUnstatedContainers(AdminHome, [AppContainer, AdminHomeContainer]);
 
 AdminHome.propTypes = {
-  t: PropTypes.func.isRequired, // i18next
   appContainer: PropTypes.instanceOf(AppContainer).isRequired,
   adminHomeContainer: PropTypes.instanceOf(AdminHomeContainer).isRequired,
 };
 
-export default withTranslation()(AdminHomeWrapper);
+export default AdminHomeWrapper;

--- a/packages/app/src/components/Admin/AdminHome/AdminHome.jsx
+++ b/packages/app/src/components/Admin/AdminHome/AdminHome.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
@@ -22,20 +22,20 @@ const AdminHome = (props) => {
   const { t } = useTranslation();
   const { data: migrationStatus } = useSWRxV5MigrationStatus();
 
-  useEffect(() => {
-    const fetchAdminHomeData = async() => {
-      await adminHomeContainer.retrieveAdminHomeData();
-    };
-
+  const fetchAdminHomeData = useCallback(async() => {
     try {
-      fetchAdminHomeData();
+      await adminHomeContainer.retrieveAdminHomeData();
     }
     catch (err) {
-      toastError(err);
       adminHomeContainer.setState({ retrieveError: err });
+      toastError(err);
       logger.error(err);
     }
   }, [adminHomeContainer]);
+
+  useEffect(() => {
+    fetchAdminHomeData();
+  }, [fetchAdminHomeData]);
 
   return (
     <>

--- a/packages/app/src/components/Admin/AdminHome/AdminHome.jsx
+++ b/packages/app/src/components/Admin/AdminHome/AdminHome.jsx
@@ -42,7 +42,7 @@ class AdminHome extends React.Component {
     return (
       <Fragment>
         {
-          // Alert message will be displayed in case that V5 migration has not compleated yet
+          // Alert message will be displayed in case that V5 migration has not compleated
           (isV5Compatible != null && !isV5Compatible)
           && (
             <div className={`alert ${alertStyle}`}>

--- a/packages/app/src/components/Admin/AdminHome/AdminHome.jsx
+++ b/packages/app/src/components/Admin/AdminHome/AdminHome.jsx
@@ -36,8 +36,6 @@ const AdminHome = (props) => {
 
   const { isV5Compatible } = adminHomeContainer.state;
 
-  let alertStyle = 'alert-info';
-  if (isV5Compatible == null) alertStyle = 'alert-warning';
 
   return (
     <>
@@ -45,7 +43,7 @@ const AdminHome = (props) => {
         // Alert message will be displayed in case that V5 migration has not been compleated
         (isV5Compatible != null && !isV5Compatible)
           && (
-            <div className={`alert ${alertStyle}`}>
+          <div className={`alert ${isV5Compatible == null ? 'alert-warning' : 'alert-info'}`}>
               {t('admin:v5_page_migration.migration_desc')}
               <a className="btn-link" href="/admin/app" rel="noopener noreferrer">
                 <i className="fa fa-link ml-1" aria-hidden="true"></i>

--- a/packages/app/src/components/Admin/AdminHome/AdminHome.jsx
+++ b/packages/app/src/components/Admin/AdminHome/AdminHome.jsx
@@ -27,8 +27,8 @@ const AdminHome = (props) => {
       await adminHomeContainer.retrieveAdminHomeData();
     }
     catch (err) {
-      adminHomeContainer.setState({ retrieveError: err });
       toastError(err);
+      adminHomeContainer.setState({ retrieveError: err });
       logger.error(err);
     }
   }, [adminHomeContainer]);


### PR DESCRIPTION
## Task
[#84328](https://redmine.weseek.co.jp/issues/84328) Wiki management home page & App Settingsで isV5Compatible が true でも一瞬だけマイグレーション促進のメッセージが表示されるのを防ぐ

## Note
`migrationStatus` の値がnull でもアラートメッセージが表示されてしまっていたのを修正しました。

やったこと
- class componentを funtional componentに書き換え
- AdminHomeContainerからではなく、`useSWRxV5MigrationStatus`で`data(migrationStatus)`を取得
- アラートを表示する条件式に、`migrationStatus != null` を追加

## Screen Recording
### Before
https://user-images.githubusercontent.com/59536731/146971741-45aac76b-3c00-4c89-ace8-3404e8a6fb8a.mov



### After
https://user-images.githubusercontent.com/59536731/146971686-a5d80828-ad4d-4b1a-8db7-8f29997fc11c.mov


