### PR TITLE
improve long pagetree title

### DIFF
--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -191,7 +191,7 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
           </div>
         </button>
         <a href={page._id} className="grw-pagetree-title-anchor flex-grow-1">
-          <p className={`grw-pagetree-title m-auto ${page.isEmpty && 'text-muted'}`}>{nodePath.basename(page.path as string) || '/'}</p>
+          <p className={`text-truncate m-auto ${page.isEmpty && 'text-muted'}`}>{nodePath.basename(page.path as string) || '/'}</p>
         </a>
         <div className="grw-pagetree-count-wrapper">
           <ItemCount />

--- a/packages/app/src/styles/_page-tree.scss
+++ b/packages/app/src/styles/_page-tree.scss
@@ -34,11 +34,6 @@ $grw-pagetree-item-padding-left: 10px;
       width: 100%;
       overflow: hidden;
       text-decoration: none;
-
-      .grw-pagetree-title {
-        overflow: hidden;
-        text-overflow: ellipsis;
-      }
     }
 
     .grw-pagetree-count-wrapper {


### PR DESCRIPTION
## Task
[#84325](https://redmine.weseek.co.jp/issues/84325) 長いタイトルは省略する


## View
### Before
<img width="465" alt="Screen Shot 2021-12-22 at 2 37 13" src="https://user-images.githubusercontent.com/59536731/146974243-8419dcd4-982a-45ea-aff6-43ddc4e296a4.png">

### After
<img width="354" alt="Screen Shot 2021-12-22 at 2 36 38" src="https://user-images.githubusercontent.com/59536731/146974233-7b523a6c-7c09-474e-b3f3-451e6378d18f.png">

