### PR TITLE
fix: Highlight all keywords in search content

### DIFF
--- a/packages/app/src/components/Page/RevisionRenderer.jsx
+++ b/packages/app/src/components/Page/RevisionRenderer.jsx
@@ -74,7 +74,7 @@ class LegacyRevisionRenderer extends React.PureComponent {
     });
 
     const normalizedKeywords = `(${normalizedKeywordsArray.join('|')})`;
-    const keywordExp = new RegExp(`(?<!<)${normalizedKeywords}(?!(.*?("|>)))`, 'ig'); // https://regex101.com/r/dznxyh/1
+    const keywordExp = new RegExp(`(?<!<)${normalizedKeywords}(?!(.*?("|>)))`, 'ig'); // exclude html tag as well https://regex101.com/r/dznxyh/1
 
     return returnBody.replace(keywordExp, '<em class="highlighted-keyword">$&</em>');
   }

--- a/packages/app/src/components/Page/RevisionRenderer.jsx
+++ b/packages/app/src/components/Page/RevisionRenderer.jsx
@@ -74,7 +74,7 @@ class LegacyRevisionRenderer extends React.PureComponent {
     });
 
     const normalizedKeywords = `(${normalizedKeywordsArray.join('|')})`;
-    const keywordExp = new RegExp(`${normalizedKeywords}(?!(.*?"))`, 'ig'); // https://regex101.com/r/jw3T0F/1
+    const keywordExp = new RegExp(`(?<!<)${normalizedKeywords}(?!(.*?"))`, 'ig'); // https://regex101.com/r/XRWtXA/1
 
     return returnBody.replace(keywordExp, '<em class="highlighted-keyword">$&</em>');
   }

--- a/packages/app/src/components/Page/RevisionRenderer.jsx
+++ b/packages/app/src/components/Page/RevisionRenderer.jsx
@@ -74,9 +74,9 @@ class LegacyRevisionRenderer extends React.PureComponent {
     });
 
     const normalizedKeywords = `(${normalizedKeywordsArray.join('|')})`;
-    const keywordExp = new RegExp(`${normalizedKeywords}(?!(.*?"))`, 'ig');
+    const keywordExp = new RegExp(`${normalizedKeywords}(?!(.*?"))`, 'ig'); // https://regex101.com/r/jw3T0F/1
 
-    return returnBody.replace(keywordExp, '<em class="highlighted-keyword">$&</em>');;
+    return returnBody.replace(keywordExp, '<em class="highlighted-keyword">$&</em>');
   }
 
   async renderHtml() {

--- a/packages/app/src/components/Page/RevisionRenderer.jsx
+++ b/packages/app/src/components/Page/RevisionRenderer.jsx
@@ -74,7 +74,7 @@ class LegacyRevisionRenderer extends React.PureComponent {
     });
 
     const normalizedKeywords = `(${normalizedKeywordsArray.join('|')})`;
-    const keywordExp = new RegExp(`(?<!<)${normalizedKeywords}(?!(.*?"))`, 'ig'); // https://regex101.com/r/XRWtXA/1
+    const keywordExp = new RegExp(`(?<!<)${normalizedKeywords}(?!(.*?("|>)))`, 'ig'); // https://regex101.com/r/dznxyh/1
 
     return returnBody.replace(keywordExp, '<em class="highlighted-keyword">$&</em>');
   }

--- a/packages/app/src/components/Page/RevisionRenderer.jsx
+++ b/packages/app/src/components/Page/RevisionRenderer.jsx
@@ -60,20 +60,23 @@ class LegacyRevisionRenderer extends React.PureComponent {
    * @param {string} keywords
    */
   getHighlightedBody(body, keywords) {
-    let returnBody = body;
+    const returnBody = body;
 
-    keywords.replace(/"/g, '').split(' ').forEach((keyword) => {
+    const normalizedKeywordsArray = [];
+    keywords.replace(/"/g, '').split(/[\u{20}\u{3000}]/u).forEach((keyword, i) => { // split by both full-with and half-width space
       if (keyword === '') {
         return;
       }
       const k = keyword
-        .replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+        .replace(/[.*+?^${}()|[\]\\]/g, '\\$&') // escape regex operators
         .replace(/(^"|"$)/g, ''); // for phrase (quoted) keyword
-      const keywordExp = new RegExp(`(${k}(?!(.*?")))`, 'ig');
-      returnBody = returnBody.replace(keywordExp, '<em class="highlighted-keyword">$&</em>');
+      normalizedKeywordsArray.push(k);
     });
 
-    return returnBody;
+    const normalizedKeywords = `(${normalizedKeywordsArray.join('|')})`;
+    const keywordExp = new RegExp(`${normalizedKeywords}(?!(.*?"))`, 'ig');
+
+    return returnBody.replace(keywordExp, '<em class="highlighted-keyword">$&</em>');;
   }
 
   async renderHtml() {


### PR DESCRIPTION
Redmine(２つ): https://redmine.weseek.co.jp/issues/84436, https://redmine.weseek.co.jp/issues/84274

検索の右ペインでハイライトが正常にかかるように修正しました
ついでに a で検索すると右ペインの結果がリンクになってしまう問題も修正しました

動作確認は https://redmine.weseek.co.jp/issues/84488 でまとめてやります