### PR TITLE
fix: Highlight all keywords in search content (second)

### DIFF
--- a/packages/app/src/components/Page/RevisionRenderer.jsx
+++ b/packages/app/src/components/Page/RevisionRenderer.jsx
@@ -74,7 +74,15 @@ class LegacyRevisionRenderer extends React.PureComponent {
     });
 
     const normalizedKeywords = `(${normalizedKeywordsArray.join('|')})`;
-    const keywordExp = new RegExp(`(?<!<)${normalizedKeywords}(?!(.*?("|>)))`, 'ig'); // exclude html tag as well https://regex101.com/r/dznxyh/1
+    const keywordExp = new RegExp(`${normalizedKeywords}(?!(.*?"))`, 'ig');
+
+    // body to dom
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(body, 'text/html');
+
+    // replace innerText
+
+    // dom to body
 
     return returnBody.replace(keywordExp, '<em class="highlighted-keyword">$&</em>');
   }

--- a/packages/app/src/components/Page/RevisionRenderer.jsx
+++ b/packages/app/src/components/Page/RevisionRenderer.jsx
@@ -60,9 +60,9 @@ class LegacyRevisionRenderer extends React.PureComponent {
    * @param {string} keywords
    */
   getHighlightedBody(body, keywords) {
-    const returnBody = body;
-
     const normalizedKeywordsArray = [];
+    // !!TODO!!: care double quote
+    // !!TODO!!: add test code
     keywords.replace(/"/g, '').split(/[\u{20}\u{3000}]/u).forEach((keyword, i) => { // split by both full-with and half-width space
       if (keyword === '') {
         return;
@@ -74,17 +74,37 @@ class LegacyRevisionRenderer extends React.PureComponent {
     });
 
     const normalizedKeywords = `(${normalizedKeywordsArray.join('|')})`;
-    const keywordExp = new RegExp(`${normalizedKeywords}(?!(.*?"))`, 'ig');
+    const keywordRegxp = new RegExp(`${normalizedKeywords}(?!(.*?"))`, 'ig'); // prior https://regex101.com/r/oX7dq5/1
+    const keywordRegexp2 = new RegExp(`(?<!<)${normalizedKeywords}(?!(.*?("|>)))`, 'ig'); // inferior (this doesn't work well when html tags exist a lot) https://regex101.com/r/Dfi61F/1
 
-    // body to dom
-    const parser = new DOMParser();
-    const doc = parser.parseFromString(body, 'text/html');
+    const highlighter = (str) => { return str.replace(keywordRegxp, '<em class="highlighted-keyword">$&</em>') }; // prior
+    const highlighter2 = (str) => { return str.replace(keywordRegexp2, '<em class="highlighted-keyword">$&</em>') }; // inferior
 
-    // replace innerText
+    const insideTagRegex = /<[^<>]*>/g;
+    const betweenTagRegex = />([^<>]*)</g; // use (group) to ignore >< around
 
-    // dom to body
+    const insideTagStrs = body.match(insideTagRegex);
+    const betweenTagMatches = Array.from(body.matchAll(betweenTagRegex));
 
-    return returnBody.replace(keywordExp, '<em class="highlighted-keyword">$&</em>');
+    let returnBody = body;
+    const isSafeHtml = insideTagStrs.length === betweenTagMatches.length + 1; // to check whether is safe to join
+    if (isSafeHtml) {
+      // highlight
+      const betweenTagStrs = betweenTagMatches.map(match => highlighter(match[1])); // get only grouped part (exclude >< around)
+
+      const arr = [];
+      insideTagStrs.forEach((str, i) => {
+        arr.push(str);
+        arr.push(betweenTagStrs[i]);
+      });
+      returnBody = arr.join('');
+    }
+    else {
+      // inferior highlighter
+      returnBody = highlighter2(body);
+    }
+
+    return returnBody;
   }
 
   async renderHtml() {


### PR DESCRIPTION
Redmine(２つ): https://redmine.weseek.co.jp/issues/84436, https://redmine.weseek.co.jp/issues/84274

RevisionRenderer のハイライトを修正しました

## 修正
- html タグ内はハイライトの対象から外しました

## 後続タスク
- テストコード追加
- keyword に "" が含まれている場合をケア
- renderHtml メソッド周り改修 (既存のバグ)
  - コードブロック内が正しくレンダリングされていない
  - view と render のされ方が違うので view に揃える
  - ハイライターによるものではない