### PR TITLE
fix: 84451 do not fire the delete completely event when page revert

### DIFF
--- a/packages/app/src/server/service/page.js
+++ b/packages/app/src/server/service/page.js
@@ -649,7 +649,7 @@ class PageService {
     return;
   }
 
-  async deleteCompletely(page, user, options = {}, isRecursively = false) {
+  async deleteCompletely(page, user, options = {}, isRecursively = false, isRevertPage = false) {
     const ids = [page._id];
     const paths = [page.path];
 
@@ -661,11 +661,7 @@ class PageService {
       this.deleteCompletelyDescendantsWithStream(page, user, options);
     }
 
-    // when revertDeletedPage is executed, the revert event is raised
-    if (page.redirectTo != null && isTrashPage(page.redirectTo)) {
-      this.pageEvent.emit('revert', page, user);
-    }
-    else {
+    if (!isRevertPage) {
       this.pageEvent.emit('deleteCompletely', page, user);
     }
 
@@ -770,7 +766,9 @@ class PageService {
       if (originPage.redirectTo !== page.path) {
         throw new Error('The new page of to revert is exists and the redirect path of the page is not the deleted page.');
       }
-      await this.deleteCompletely(originPage, options);
+
+      await this.deleteCompletely(originPage, user, options, false, true);
+      this.pageEvent.emit('revert', page, user);
     }
 
     if (isRecursively) {

--- a/packages/app/src/server/service/page.js
+++ b/packages/app/src/server/service/page.js
@@ -661,7 +661,12 @@ class PageService {
       this.deleteCompletelyDescendantsWithStream(page, user, options);
     }
 
-    this.pageEvent.emit('deleteCompletely', page, user); // update as renamed page
+    if (page.redirectTo != null && isTrashPage(page.redirectTo)) {
+      this.pageEvent.emit('revert', page, user);
+    }
+    else {
+      this.pageEvent.emit('deleteCompletely', page, user);
+    }
 
     return;
   }

--- a/packages/app/src/server/service/page.js
+++ b/packages/app/src/server/service/page.js
@@ -649,7 +649,7 @@ class PageService {
     return;
   }
 
-  async deleteCompletely(page, user, options = {}, isRecursively = false, isRevertPage = false) {
+  async deleteCompletely(page, user, options = {}, isRecursively = false, isRevertDeletedPage = false) {
     const ids = [page._id];
     const paths = [page.path];
 
@@ -661,7 +661,7 @@ class PageService {
       this.deleteCompletelyDescendantsWithStream(page, user, options);
     }
 
-    if (!isRevertPage) {
+    if (!isRevertDeletedPage) {
       this.pageEvent.emit('deleteCompletely', page, user);
     }
 

--- a/packages/app/src/server/service/page.js
+++ b/packages/app/src/server/service/page.js
@@ -649,7 +649,7 @@ class PageService {
     return;
   }
 
-  async deleteCompletely(page, user, options = {}, isRecursively = false, isRevertDeletedPage = false) {
+  async deleteCompletely(page, user, options = {}, isRecursively = false, preventEmitting = false) {
     const ids = [page._id];
     const paths = [page.path];
 
@@ -661,7 +661,7 @@ class PageService {
       this.deleteCompletelyDescendantsWithStream(page, user, options);
     }
 
-    if (!isRevertDeletedPage) {
+    if (!preventEmitting) {
       this.pageEvent.emit('deleteCompletely', page, user);
     }
 

--- a/packages/app/src/server/service/page.js
+++ b/packages/app/src/server/service/page.js
@@ -661,6 +661,7 @@ class PageService {
       this.deleteCompletelyDescendantsWithStream(page, user, options);
     }
 
+    // when revertDeletedPage is executed, the revert event is raised
     if (page.redirectTo != null && isTrashPage(page.redirectTo)) {
       this.pageEvent.emit('revert', page, user);
     }

--- a/packages/app/src/server/service/search.ts
+++ b/packages/app/src/server/service/search.ts
@@ -115,6 +115,7 @@ class SearchService implements SearchQueryParser, SearchResolver {
     pageEvent.on('create', this.fullTextSearchDelegator.syncPageUpdated.bind(this.fullTextSearchDelegator));
     pageEvent.on('update', this.fullTextSearchDelegator.syncPageUpdated.bind(this.fullTextSearchDelegator));
     pageEvent.on('delete', this.fullTextSearchDelegator.syncPageDeleted.bind(this.fullTextSearchDelegator));
+    pageEvent.on('revert', this.fullTextSearchDelegator.syncPageDeleted.bind(this.fullTextSearchDelegator));
     pageEvent.on('deleteCompletely', this.fullTextSearchDelegator.syncPageDeleted.bind(this.fullTextSearchDelegator));
     pageEvent.on('syncDescendantsDelete', this.fullTextSearchDelegator.syncDescendantsPagesDeleted.bind(this.fullTextSearchDelegator));
     pageEvent.on('updateMany', this.fullTextSearchDelegator.syncPagesUpdated.bind(this.fullTextSearchDelegator));


### PR DESCRIPTION
## Task
[#84451](https://redmine.weseek.co.jp/issues/84451) ページを revert したときにエラーが発生する