### PR TITLE
fix: Not show NotFoundAlert when not creatable or forbidden

### DIFF
--- a/packages/app/src/server/views/widget/page_alerts.html
+++ b/packages/app/src/server/views/widget/page_alerts.html
@@ -76,7 +76,7 @@
     {% if isTrashPage() %}
       <div id="trash-page-alert"></div>
     {% endif %}
-    {% if !page %}
+    {% if page == null and !isAlertHidden %}
       <div id="not-found-alert"></div>
     {% endif %}
   </div>


### PR DESCRIPTION
Redmine: https://redmine.weseek.co.jp/issues/84536

NotFoundAlert が forbidden と not_creatable で表示されないようにしました