### PR TITLE
fix: Regex support for non-chrome browsers

### DIFF
--- a/packages/app/src/client/app.jsx
+++ b/packages/app/src/client/app.jsx
@@ -96,10 +96,6 @@ Object.assign(componentMappings, {
   'trash-page-list': <TrashPageList />,
 
   'not-found-page': <NotFoundPage />,
-  'not-found-alert': <NotFoundAlert
-    isGuestUserMode={appContainer.isGuestUser}
-    isHidden={pageContainer.state.pageId != null ? (pageContainer.state.isNotCreatable ?? pageContainer.state.isTrashPage) : false} // !!DO NOT MOVE THIS!! https://github.com/weseek/growi/pull/4899
-  />,
 
   'forbidden-page': <ForbiddenPage />,
 

--- a/packages/app/src/components/Page/RevisionRenderer.jsx
+++ b/packages/app/src/components/Page/RevisionRenderer.jsx
@@ -8,6 +8,9 @@ import { addSmoothScrollEvent } from '~/client/util/smooth-scroll';
 import { blinkElem } from '~/client/util/blink-section-header';
 
 import RevisionBody from './RevisionBody';
+import { loggerFactory } from '^/../codemirror-textlint/src/utils/logger';
+
+const logger = loggerFactory('components:Page:RevisionRenderer');
 
 class LegacyRevisionRenderer extends React.PureComponent {
 
@@ -75,7 +78,15 @@ class LegacyRevisionRenderer extends React.PureComponent {
 
     const normalizedKeywords = `(${normalizedKeywordsArray.join('|')})`;
     const keywordRegxp = new RegExp(`${normalizedKeywords}(?!(.*?"))`, 'ig'); // prior https://regex101.com/r/oX7dq5/1
-    const keywordRegexp2 = new RegExp(`(?<!<)${normalizedKeywords}(?!(.*?("|>)))`, 'ig'); // inferior (this doesn't work well when html tags exist a lot) https://regex101.com/r/Dfi61F/1
+    let keywordRegexp2 = keywordRegxp;
+
+    // for non-chrome browsers compatibility
+    try {
+      keywordRegexp2 = new RegExp(`(?<!<)${normalizedKeywords}(?!(.*?("|>)))`, 'ig'); // inferior (this doesn't work well when html tags exist a lot) https://regex101.com/r/Dfi61F/1
+    }
+    catch (err) {
+      logger.debug('Failed to initialize regex:', err);
+    }
 
     const highlighter = (str) => { return str.replace(keywordRegxp, '<em class="highlighted-keyword">$&</em>') }; // prior
     const highlighter2 = (str) => { return str.replace(keywordRegexp2, '<em class="highlighted-keyword">$&</em>') }; // inferior

--- a/packages/app/src/components/Page/TrashPageAlert.jsx
+++ b/packages/app/src/components/Page/TrashPageAlert.jsx
@@ -16,7 +16,7 @@ import PageDeleteModal from '../PageDeleteModal';
 const TrashPageAlert = (props) => {
   const { t, pageContainer } = props;
   const {
-    pageId, path, isDeleted, lastUpdateUsername, deletedUserName, deletedAt, isAbleToDeleteCompletely,
+    pageId, revisionId, path, isDeleted, lastUpdateUsername, deletedUserName, deletedAt, isAbleToDeleteCompletely,
   } = pageContainer.state;
   const { data: updatedAt } = useCurrentUpdatedAt();
   const [isEmptyTrashModalShown, setIsEmptyTrashModalShown] = useState(false);

--- a/packages/core/src/models/devided-page-path.js
+++ b/packages/core/src/models/devided-page-path.js
@@ -32,7 +32,7 @@ export class DevidedPagePath {
       }
     }
 
-    let PATTERN_DEFAULT = /^((.*)\/)?(.+)$/; // https://regex101.com/r/jpZwIe/1
+    let PATTERN_DEFAULT = /^((.*)\/)?(.+)$/; // this will not ignore html end tags https://regex101.com/r/jpZwIe/1
     try { // for non-chrome browsers
       PATTERN_DEFAULT = new RegExp('^((.*)(?<!<)\\/)?(.+)$'); // https://regex101.com/r/HJNvMW/1
     }

--- a/packages/core/src/models/devided-page-path.js
+++ b/packages/core/src/models/devided-page-path.js
@@ -3,9 +3,6 @@ import * as pathUtils from '../utils/path-utils';
 // https://regex101.com/r/BahpKX/2
 const PATTERN_INCLUDE_DATE = /^(.+\/[^/]+)\/(\d{4}|\d{4}\/\d{2}|\d{4}\/\d{2}\/\d{2})$/;
 
-// (?<!filename)\.js$
-// ^(?:(?!filename\.js$).)*\.js$
-
 export class DevidedPagePath {
 
   constructor(path, skipNormalize = false, evalDatePath = false) {
@@ -35,7 +32,7 @@ export class DevidedPagePath {
       }
     }
 
-    let PATTERN_DEFAULT = /^((.*)\/)?(.+)$/;
+    let PATTERN_DEFAULT = /^((.*)\/)?(.+)$/; // https://regex101.com/r/jpZwIe/1
     try { // for non-chrome browsers
       PATTERN_DEFAULT = /^((.*)(?<!<)\/)?(.+)$/; // https://regex101.com/r/HJNvMW/1
     }

--- a/packages/core/src/models/devided-page-path.js
+++ b/packages/core/src/models/devided-page-path.js
@@ -2,8 +2,9 @@ import * as pathUtils from '../utils/path-utils';
 
 // https://regex101.com/r/BahpKX/2
 const PATTERN_INCLUDE_DATE = /^(.+\/[^/]+)\/(\d{4}|\d{4}\/\d{2}|\d{4}\/\d{2}\/\d{2})$/;
-// https://regex101.com/r/HJNvMW/1
-const PATTERN_DEFAULT = /^((.*)(?<!<)\/)?(.+)$/;
+
+// (?<!filename)\.js$
+// ^(?:(?!filename\.js$).)*\.js$
 
 export class DevidedPagePath {
 
@@ -32,6 +33,14 @@ export class DevidedPagePath {
         this.latter = matchDate[2];
         return;
       }
+    }
+
+    let PATTERN_DEFAULT = /^((.*)\/)?(.+)$/;
+    try { // for non-chrome browsers
+      PATTERN_DEFAULT = /^((.*)(?<!<)\/)?(.+)$/; // https://regex101.com/r/HJNvMW/1
+    }
+    catch (err) {
+      // lookbehind regex is not supported on non-chrome browsers
     }
 
     const matchDefault = pagePath.match(PATTERN_DEFAULT);

--- a/packages/core/src/models/devided-page-path.js
+++ b/packages/core/src/models/devided-page-path.js
@@ -34,7 +34,7 @@ export class DevidedPagePath {
 
     let PATTERN_DEFAULT = /^((.*)\/)?(.+)$/; // https://regex101.com/r/jpZwIe/1
     try { // for non-chrome browsers
-      PATTERN_DEFAULT = /^((.*)(?<!<)\/)?(.+)$/; // https://regex101.com/r/HJNvMW/1
+      PATTERN_DEFAULT = new RegExp('^((.*)(?<!<)\\/)?(.+)$'); // https://regex101.com/r/HJNvMW/1
     }
     catch (err) {
       // lookbehind regex is not supported on non-chrome browsers


### PR DESCRIPTION
Redmine(２つ): https://redmine.weseek.co.jp/issues/84600, https://redmine.weseek.co.jp/issues/84204

正規表現の後読みがサポートがされていないブラウザで GROWI が正常に動作しなくなる不具合を修正しました