### PR TITLE
imprv: Compress response bodies

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -78,6 +78,7 @@
     "browser-bunyan": "^1.6.3",
     "bunyan": "^1.8.15",
     "check-node-version": "^4.1.0",
+    "compression": "^1.7.4",
     "connect-flash": "~0.1.1",
     "connect-mongo": "^4.6.0",
     "connect-redis": "^4.0.4",

--- a/packages/app/src/server/crowi/express-init.js
+++ b/packages/app/src/server/crowi/express-init.js
@@ -4,6 +4,7 @@ module.exports = function(crowi, app) {
   const debug = require('debug')('growi:crowi:express-init');
   const path = require('path');
   const express = require('express');
+  const compression = require('compression');
   const helmet = require('helmet');
   const bodyParser = require('body-parser');
   const cookieParser = require('cookie-parser');
@@ -52,6 +53,8 @@ module.exports = function(crowi, app) {
       // change nsSeparator from ':' to '::' because ':' is used in config keys and these are used in i18n keys
       nsSeparator: '::',
     });
+
+  app.use(compression());
 
   app.use(helmet({
     contentSecurityPolicy: false,


### PR DESCRIPTION
This PR is a partial fix for the issue https://github.com/weseek/growi/issues/5022. I added [the compression middleware](https://expressjs.com/en/resources/middleware/compression.html) to compress response bodies.

The HTTP response now has `Content-Encoding: gzip` and the transferred size is reduced to 1.88MB.

![image](https://user-images.githubusercontent.com/54441600/148043669-3953c36f-b204-41ca-9935-cb7ca37f4065.png)

before:
![image](https://user-images.githubusercontent.com/54441600/148044202-5705f76c-b02b-4709-8980-e1a9b912d9b9.png)
