### PR TITLE
imprv: add filter method about tag to recent changes

### DIFF
--- a/packages/app/src/components/Sidebar/RecentChanges.tsx
+++ b/packages/app/src/components/Sidebar/RecentChanges.tsx
@@ -57,15 +57,13 @@ function LargePageItem({ page }) {
 
   const tags = page.tags;
   // when tag document is deleted from database directly tags includes null
-  const tagElements = tags.includes(null)
-    ? <></>
-    : tags.map((tag) => {
-      return (
-        <a key={tag.name} href={`/_search?q=tag:${tag.name}`} className="grw-tag-label badge badge-secondary mr-2 small">
-          {tag.name}
-        </a>
-      );
-    });
+  const tagElements = tags.filter(tag => tag != null).map((tag) => {
+    return (
+      <a key={tag.name} href={`/_search?q=tag:${tag.name}`} className="grw-tag-label badge badge-secondary mr-2 small">
+        {tag.name}
+      </a>
+    );
+  });
 
   return (
     <li className="list-group-item py-3 px-0">


### PR DESCRIPTION
## タスク

https://redmine.weseek.co.jp/issues/85053

## 行ったこと

- tag が null の場合(DB から直接削除された場合)に、null の tag のみを除外して表示するように変更
- ↑(同じ page でも 直接 DB から削除されたもの以外は表示される)

## 後続

 - 動作確認