### PR TITLE
dragging one page tree item

### DIFF
--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -111,9 +111,12 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
   const { data, error } = useSWRxPageChildren(isOpen ? page._id : null);
 
 
-  const [collected, drag, dragPreview] = useDrag(() => ({
+  const [{ isDragging }, drag, dragPreview] = useDrag(() => ({
     type: 'DND_GROUP',
     item: { page },
+    collect: monitor => ({
+      isDragging: !!monitor.isDragging(),
+    }),
   }));
 
   const hasChildren = useCallback((): boolean => {

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -221,7 +221,7 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
       {isEnableActions && (
         <ClosableTextInput
           isShown={isNewPageInputShown}
-          placeholder={t('Input title')}
+          placeholder={t('Input page name')}
           onClickOutside={() => { setNewPageInputShown(false) }}
           onPressEnter={onPressEnterHandler}
           inputValidator={inputValidator}

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -4,6 +4,7 @@ import React, {
 import nodePath from 'path';
 import { useTranslation } from 'react-i18next';
 import { pagePathUtils } from '@growi/core';
+import { useDrag } from 'react-dnd';
 import { toastWarning } from '~/client/util/apiNotification';
 
 import { ItemNode } from './ItemNode';
@@ -109,6 +110,11 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
 
   const { data, error } = useSWRxPageChildren(isOpen ? page._id : null);
 
+
+  const [collected, drag, dragPreview] = useDrag(() => ({
+    type: 'DND_GROUP',
+    item: { page },
+  }));
   const hasChildren = useCallback((): boolean => {
     return currentChildren != null && currentChildren.length > 0;
   }, [currentChildren]);
@@ -181,32 +187,38 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
 
   return (
     <>
-      <div className={`grw-pagetree-item d-flex align-items-center pr-1 ${page.isTarget ? 'grw-pagetree-is-target' : ''}`}>
-        <button
-          type="button"
-          className={`grw-pagetree-button btn ${isOpen ? 'grw-pagetree-open' : ''}`}
-          onClick={onClickLoadChildren}
-        >
-          <div className="grw-triangle-icon">
-            <TriangleIcon />
+      {collected.isDragging ? (
+        // <div ref={dragPreview}>dragging</div>
+        <></>
+      ) : (
+        <div ref={drag} {...collected} className={`grw-pagetree-item d-flex align-items-center pr-1 ${page.isTarget ? 'grw-pagetree-is-target' : ''}`}>
+          <button
+            type="button"
+            className={`grw-pagetree-button btn ${isOpen ? 'grw-pagetree-open' : ''}`}
+            onClick={onClickLoadChildren}
+          >
+            <div className="grw-triangle-icon">
+              <TriangleIcon />
+            </div>
+          </button>
+          <a href={page._id} className="grw-pagetree-title-anchor flex-grow-1">
+            <p className={`text-truncate m-auto ${page.isEmpty && 'text-muted'}`}>{nodePath.basename(page.path as string) || '/'}</p>
+          </a>
+          <div className="grw-pagetree-count-wrapper">
+            <ItemCount />
           </div>
-        </button>
-        <a href={page._id} className="grw-pagetree-title-anchor flex-grow-1">
-          <p className={`text-truncate m-auto ${page.isEmpty && 'text-muted'}`}>{nodePath.basename(page.path as string) || '/'}</p>
-        </a>
-        <div className="grw-pagetree-count-wrapper">
-          <ItemCount />
+          <div className="grw-pagetree-control d-none">
+            <ItemControl
+              page={page}
+              onClickDeleteButtonHandler={onClickDeleteButtonHandler}
+              onClickPlusButtonHandler={() => { setNewPageInputShown(true) }}
+              isEnableActions={isEnableActions}
+              isDeletable={!page.isEmpty && !isTopPage(page.path as string)}
+            />
+          </div>
         </div>
-        <div className="grw-pagetree-control d-none">
-          <ItemControl
-            page={page}
-            onClickDeleteButtonHandler={onClickDeleteButtonHandler}
-            onClickPlusButtonHandler={() => { setNewPageInputShown(true) }}
-            isEnableActions={isEnableActions}
-            isDeletable={!page.isEmpty && !isTopPage(page.path as string)}
-          />
-        </div>
-      </div>
+      )}
+
 
       {isEnableActions && (
         <ClosableTextInput

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -112,7 +112,7 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
 
 
   const [{ isDragging }, drag] = useDrag(() => ({
-    type: 'DND_GROUP',
+    type: 'PAGE_TREE',
     item: { page },
     collect: monitor => ({
       isDragging: !!monitor.isDragging(),
@@ -217,7 +217,6 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
           />
         </div>
       </div>
-
 
       {isEnableActions && (
         <ClosableTextInput

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -111,7 +111,7 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
   const { data, error } = useSWRxPageChildren(isOpen ? page._id : null);
 
 
-  const [{ isDragging }, drag, dragPreview] = useDrag(() => ({
+  const [{ isDragging }, drag] = useDrag(() => ({
     type: 'DND_GROUP',
     item: { page },
     collect: monitor => ({
@@ -191,37 +191,32 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
 
   return (
     <>
-      {collected.isDragging ? (
-        // <div ref={dragPreview}>dragging</div>
-        <></>
-      ) : (
-        <div ref={drag} {...collected} className={`grw-pagetree-item d-flex align-items-center pr-1 ${page.isTarget ? 'grw-pagetree-is-target' : ''}`}>
-          <button
-            type="button"
-            className={`grw-pagetree-button btn ${isOpen ? 'grw-pagetree-open' : ''}`}
-            onClick={onClickLoadChildren}
-          >
-            <div className="grw-triangle-icon">
-              <TriangleIcon />
-            </div>
-          </button>
-          <a href={page._id} className="grw-pagetree-title-anchor flex-grow-1">
-            <p className={`text-truncate m-auto ${page.isEmpty && 'text-muted'}`}>{nodePath.basename(page.path as string) || '/'}</p>
-          </a>
-          <div className="grw-pagetree-count-wrapper">
-            <ItemCount />
+      <div ref={drag} className={`grw-pagetree-item d-flex align-items-center pr-1 ${page.isTarget ? 'grw-pagetree-is-target' : ''}`}>
+        <button
+          type="button"
+          className={`grw-pagetree-button btn ${isOpen ? 'grw-pagetree-open' : ''}`}
+          onClick={onClickLoadChildren}
+        >
+          <div className="grw-triangle-icon">
+            <TriangleIcon />
           </div>
-          <div className="grw-pagetree-control d-none">
-            <ItemControl
-              page={page}
-              onClickDeleteButtonHandler={onClickDeleteButtonHandler}
-              onClickPlusButtonHandler={() => { setNewPageInputShown(true) }}
-              isEnableActions={isEnableActions}
-              isDeletable={!page.isEmpty && !isTopPage(page.path as string)}
-            />
-          </div>
+        </button>
+        <a href={page._id} className="grw-pagetree-title-anchor flex-grow-1">
+          <p className={`text-truncate m-auto ${page.isEmpty && 'text-muted'}`}>{nodePath.basename(page.path as string) || '/'}</p>
+        </a>
+        <div className="grw-pagetree-count-wrapper">
+          <ItemCount />
         </div>
-      )}
+        <div className="grw-pagetree-control d-none">
+          <ItemControl
+            page={page}
+            onClickDeleteButtonHandler={onClickDeleteButtonHandler}
+            onClickPlusButtonHandler={() => { setNewPageInputShown(true) }}
+            isEnableActions={isEnableActions}
+            isDeletable={!page.isEmpty && !isTopPage(page.path as string)}
+          />
+        </div>
+      </div>
 
 
       {isEnableActions && (

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -115,6 +115,7 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
     type: 'DND_GROUP',
     item: { page },
   }));
+
   const hasChildren = useCallback((): boolean => {
     return currentChildren != null && currentChildren.length > 0;
   }, [currentChildren]);

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -115,7 +115,7 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
     type: 'PAGE_TREE',
     item: { page },
     collect: monitor => ({
-      isDragging: !!monitor.isDragging(),
+      isDragging: monitor.isDragging(),
     }),
   }));
 


### PR DESCRIPTION
## Task
- [85035](https://redmine.weseek.co.jp/issues/85035) useDrag hookを使用して単一の要素でドラック状態を再現することができる

## Screen Recording

https://user-images.githubusercontent.com/59536731/148185493-d2495032-6fdc-4379-acec-f3bd24239437.mov



## Note
今回のPRでは、単一の要素(pageItem)のみのDragを対象にしています。
以下の後続タスクで子供のページも同様にドラッグ対象に含むようにします。
(**※こちらのタスクは不要になる可能性があります**)
- [85045](https://redmine.weseek.co.jp/issues/85045) 親ページをドラッグした際に、子供もついてくるようにする