### PR TITLE
Imprv/85173 show children when overlapping to another page item

### DIFF
--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -111,9 +111,12 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
   const { data, error } = useSWRxPageChildren(isOpen ? page._id : null);
 
 
-  const [collected, drag, dragPreview] = useDrag(() => ({
+  const [{ isDragging }, drag, dragPreview] = useDrag(() => ({
     type: 'DND_GROUP',
     item: { page },
+    collect: monitor => ({
+      isDragging: !!monitor.isDragging(),
+    }),
   }));
 
   const hasChildren = useCallback((): boolean => {

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -221,7 +221,7 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
       {isEnableActions && (
         <ClosableTextInput
           isShown={isNewPageInputShown}
-          placeholder={t('Input title')}
+          placeholder={t('Input page name')}
           onClickOutside={() => { setNewPageInputShown(false) }}
           onPressEnter={onPressEnterHandler}
           inputValidator={inputValidator}

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -208,7 +208,7 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
 
   return (
     <>
-      <div ref={drag} className={`grw-pagetree-item d-flex align-items-center pr-1 ${page.isTarget ? 'grw-pagetree-is-target' : ''}`}>
+      <div ref={(c) => { drag(c); drop(c) }} className={`grw-pagetree-item d-flex align-items-center pr-1 ${page.isTarget ? 'grw-pagetree-is-target' : ''}`}>
         <button
           type="button"
           className={`grw-pagetree-button btn ${isOpen ? 'grw-pagetree-open' : ''}`}

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -134,17 +134,16 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
     }),
   }));
 
-  if (isOver) {
-    timerId.current = window.setInterval(() => {
-      setIsOpen(true);
-    }, 3000);
-  }
-
+  // variable "isOpen" will be true when a drag item is overlapped more than 1 sec
   useEffect(() => {
-    if (isOver) return;
-
-    clearTimeout(timerId.current);
-
+    if (isOver) {
+      timerId.current = window.setInterval(() => {
+        setIsOpen(true);
+      }, 1000);
+    }
+    else {
+      clearTimeout(timerId.current);
+    }
   }, [isOpen, isOver]);
 
   const hasChildren = useCallback((): boolean => {

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -1,5 +1,5 @@
 import React, {
-  useCallback, useState, FC, useEffect, memo,
+  useCallback, useState, FC, useEffect, memo, useRef,
 } from 'react';
 import nodePath from 'path';
 import { useTranslation } from 'react-i18next';
@@ -109,6 +109,7 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
   const [isNewPageInputShown, setNewPageInputShown] = useState(false);
 
   const { data, error } = useSWRxPageChildren(isOpen ? page._id : null);
+  const timerId = useRef(0);
 
 
   const [{ isDragging }, drag] = useDrag(() => ({
@@ -133,10 +134,17 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
     }),
   }));
 
-  useEffect(() => {
-    if (isOver) {
+  if (isOver) {
+    timerId.current = window.setInterval(() => {
       setIsOpen(true);
-    }
+    }, 3000);
+  }
+
+  useEffect(() => {
+    if (isOver) return;
+
+    clearTimeout(timerId.current);
+
   }, [isOpen, isOver]);
 
   const hasChildren = useCallback((): boolean => {

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -4,6 +4,7 @@ import React, {
 import nodePath from 'path';
 import { useTranslation } from 'react-i18next';
 import { pagePathUtils } from '@growi/core';
+import { useDrag } from 'react-dnd';
 import { toastWarning } from '~/client/util/apiNotification';
 
 import { ItemNode } from './ItemNode';
@@ -109,6 +110,11 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
 
   const { data, error } = useSWRxPageChildren(isOpen ? page._id : null);
 
+
+  const [collected, drag, dragPreview] = useDrag(() => ({
+    type: 'DND_GROUP',
+    item: { page },
+  }));
   const hasChildren = useCallback((): boolean => {
     return currentChildren != null && currentChildren.length > 0;
   }, [currentChildren]);
@@ -181,32 +187,38 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
 
   return (
     <>
-      <div className={`grw-pagetree-item d-flex align-items-center pr-1 ${page.isTarget ? 'grw-pagetree-is-target' : ''}`}>
-        <button
-          type="button"
-          className={`grw-pagetree-button btn ${isOpen ? 'grw-pagetree-open' : ''}`}
-          onClick={onClickLoadChildren}
-        >
-          <div className="grw-triangle-icon">
-            <TriangleIcon />
+      {collected.isDragging ? (
+        // <div ref={dragPreview}>dragging</div>
+        <></>
+      ) : (
+        <div ref={drag} {...collected} className={`grw-pagetree-item d-flex align-items-center pr-1 ${page.isTarget ? 'grw-pagetree-is-target' : ''}`}>
+          <button
+            type="button"
+            className={`grw-pagetree-button btn ${isOpen ? 'grw-pagetree-open' : ''}`}
+            onClick={onClickLoadChildren}
+          >
+            <div className="grw-triangle-icon">
+              <TriangleIcon />
+            </div>
+          </button>
+          <a href={page._id} className="grw-pagetree-title-anchor flex-grow-1">
+            <p className={`text-truncate m-auto ${page.isEmpty && 'text-muted'}`}>{nodePath.basename(page.path as string) || '/'}</p>
+          </a>
+          <div className="grw-pagetree-count-wrapper">
+            <ItemCount />
           </div>
-        </button>
-        <a href={page._id} className="grw-pagetree-title-anchor flex-grow-1">
-          <p className={`text-truncate m-auto ${page.isEmpty && 'text-muted'}`}>{nodePath.basename(page.path as string) || '/'}</p>
-        </a>
-        <div className="grw-pagetree-count-wrapper">
-          <ItemCount />
+          <div className="grw-pagetree-control d-none">
+            <ItemControl
+              page={page}
+              onClickDeleteButtonHandler={onClickDeleteButtonHandler}
+              onClickPlusButtonHandler={() => { setNewPageInputShown(true) }}
+              isEnableActions={isEnableActions}
+              isDeletable={!page.isEmpty && !isTopPage(page.path as string)}
+            />
+          </div>
         </div>
-        <div className="grw-pagetree-control d-none">
-          <ItemControl
-            page={page}
-            onClickDeleteButtonHandler={onClickDeleteButtonHandler}
-            onClickPlusButtonHandler={() => { setNewPageInputShown(true) }}
-            isEnableActions={isEnableActions}
-            isDeletable={!page.isEmpty && !isTopPage(page.path as string)}
-          />
-        </div>
-      </div>
+      )}
+
 
       {isEnableActions && (
         <ClosableTextInput

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -121,11 +121,16 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
 
   console.log('isDragging', isDragging);
 
-  const [{ isOver }, dropRef] = useDrop(() => ({
-    accept: 'PAGE_TREE',
-    // TODO: hit an api to rename the page.
+  const pageItemDropHandler = () => {
+    // TODO: hit an api to rename the page by 85175
     // eslint-disable-next-line no-console
-    drop: () => console.log('drop!!'),
+    console.log('pageItem was droped!!');
+  };
+
+  const [{ isOver }, drop] = useDrop(() => ({
+    accept: 'PAGE_TREE',
+    // eslint-disable-next-line no-console
+    drop: pageItemDropHandler,
     collect: monitor => ({
       isOver: monitor.isOver(),
     }),

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -112,7 +112,7 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
 
 
   const [{ isDragging }, drag] = useDrag(() => ({
-    type: 'DND_GROUP',
+    type: 'PAGE_TREE',
     item: { page },
     collect: monitor => ({
       isDragging: !!monitor.isDragging(),
@@ -217,7 +217,6 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
           />
         </div>
       </div>
-
 
       {isEnableActions && (
         <ClosableTextInput

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -111,7 +111,7 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
   const { data, error } = useSWRxPageChildren(isOpen ? page._id : null);
 
 
-  const [{ isDragging }, drag, dragPreview] = useDrag(() => ({
+  const [{ isDragging }, drag] = useDrag(() => ({
     type: 'DND_GROUP',
     item: { page },
     collect: monitor => ({
@@ -191,37 +191,32 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
 
   return (
     <>
-      {collected.isDragging ? (
-        // <div ref={dragPreview}>dragging</div>
-        <></>
-      ) : (
-        <div ref={drag} {...collected} className={`grw-pagetree-item d-flex align-items-center pr-1 ${page.isTarget ? 'grw-pagetree-is-target' : ''}`}>
-          <button
-            type="button"
-            className={`grw-pagetree-button btn ${isOpen ? 'grw-pagetree-open' : ''}`}
-            onClick={onClickLoadChildren}
-          >
-            <div className="grw-triangle-icon">
-              <TriangleIcon />
-            </div>
-          </button>
-          <a href={page._id} className="grw-pagetree-title-anchor flex-grow-1">
-            <p className={`text-truncate m-auto ${page.isEmpty && 'text-muted'}`}>{nodePath.basename(page.path as string) || '/'}</p>
-          </a>
-          <div className="grw-pagetree-count-wrapper">
-            <ItemCount />
+      <div ref={drag} className={`grw-pagetree-item d-flex align-items-center pr-1 ${page.isTarget ? 'grw-pagetree-is-target' : ''}`}>
+        <button
+          type="button"
+          className={`grw-pagetree-button btn ${isOpen ? 'grw-pagetree-open' : ''}`}
+          onClick={onClickLoadChildren}
+        >
+          <div className="grw-triangle-icon">
+            <TriangleIcon />
           </div>
-          <div className="grw-pagetree-control d-none">
-            <ItemControl
-              page={page}
-              onClickDeleteButtonHandler={onClickDeleteButtonHandler}
-              onClickPlusButtonHandler={() => { setNewPageInputShown(true) }}
-              isEnableActions={isEnableActions}
-              isDeletable={!page.isEmpty && !isTopPage(page.path as string)}
-            />
-          </div>
+        </button>
+        <a href={page._id} className="grw-pagetree-title-anchor flex-grow-1">
+          <p className={`text-truncate m-auto ${page.isEmpty && 'text-muted'}`}>{nodePath.basename(page.path as string) || '/'}</p>
+        </a>
+        <div className="grw-pagetree-count-wrapper">
+          <ItemCount />
         </div>
-      )}
+        <div className="grw-pagetree-control d-none">
+          <ItemControl
+            page={page}
+            onClickDeleteButtonHandler={onClickDeleteButtonHandler}
+            onClickPlusButtonHandler={() => { setNewPageInputShown(true) }}
+            isEnableActions={isEnableActions}
+            isDeletable={!page.isEmpty && !isTopPage(page.path as string)}
+          />
+        </div>
+      </div>
 
 
       {isEnableActions && (

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -115,6 +115,7 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
     type: 'DND_GROUP',
     item: { page },
   }));
+
   const hasChildren = useCallback((): boolean => {
     return currentChildren != null && currentChildren.length > 0;
   }, [currentChildren]);

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -133,6 +133,12 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
     }),
   }));
 
+  useEffect(() => {
+    if (isOver) {
+      setIsOpen(true);
+    }
+  }, [isOpen, isOver]);
+
   const hasChildren = useCallback((): boolean => {
     return currentChildren != null && currentChildren.length > 0;
   }, [currentChildren]);

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -4,7 +4,7 @@ import React, {
 import nodePath from 'path';
 import { useTranslation } from 'react-i18next';
 import { pagePathUtils } from '@growi/core';
-import { useDrag } from 'react-dnd';
+import { useDrag, useDrop } from 'react-dnd';
 import { toastWarning } from '~/client/util/apiNotification';
 
 import { ItemNode } from './ItemNode';
@@ -115,7 +115,19 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
     type: 'PAGE_TREE',
     item: { page },
     collect: monitor => ({
-      isDragging: !!monitor.isDragging(),
+      isDragging: monitor.isDragging(),
+    }),
+  }));
+
+  console.log('isDragging', isDragging);
+
+  const [{ isOver }, dropRef] = useDrop(() => ({
+    accept: 'PAGE_TREE',
+    // TODO: hit an api to rename the page.
+    // eslint-disable-next-line no-console
+    drop: () => console.log('drop!!'),
+    collect: monitor => ({
+      isOver: monitor.isOver(),
     }),
   }));
 


### PR DESCRIPTION
## Task
- [85173](https://redmine.weseek.co.jp/issues/85173) Drag中の要素が、他のページ要素に重なった時にchildrenも表示されるようにする

## ScreenRecording

