### PR TITLE
show children

### DIFF
--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -141,7 +141,6 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
     },
   }));
 
-
   const hasChildren = useCallback((): boolean => {
     return currentChildren != null && currentChildren.length > 0;
   }, [currentChildren]);

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -126,25 +126,20 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
     console.log('pageItem was droped!!');
   };
 
-  const [{ isOver }, drop] = useDrop(() => ({
+  const [, drop] = useDrop(() => ({
     accept: 'PAGE_TREE',
     drop: pageItemDropHandler,
-    collect: monitor => ({
-      isOver: monitor.isOver(),
-    }),
+    hover: (item, monitor) => {
+      if (monitor.isOver()) {
+        setTimeout(() => {
+          if (monitor.isOver()) {
+            setIsOpen(true);
+          }
+        }, 1000);
+      }
+    },
   }));
 
-  // variable "isOpen" will be true when a drag item is overlapped more than 1 sec
-  useEffect(() => {
-    if (isOver) {
-      timerId.current = window.setInterval(() => {
-        setIsOpen(true);
-      }, 1000);
-    }
-    else {
-      clearTimeout(timerId.current);
-    }
-  }, [isOpen, isOver]);
 
   const hasChildren = useCallback((): boolean => {
     return currentChildren != null && currentChildren.length > 0;

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -109,7 +109,6 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
   const [isNewPageInputShown, setNewPageInputShown] = useState(false);
 
   const { data, error } = useSWRxPageChildren(isOpen ? page._id : null);
-  const timerId = useRef(0);
 
 
   const [{ isDragging }, drag] = useDrag(() => ({

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -1,5 +1,5 @@
 import React, {
-  useCallback, useState, FC, useEffect, memo,
+  useCallback, useState, FC, useEffect, memo, useRef,
 } from 'react';
 import nodePath from 'path';
 import { useTranslation } from 'react-i18next';
@@ -109,6 +109,7 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
   const [isNewPageInputShown, setNewPageInputShown] = useState(false);
 
   const { data, error } = useSWRxPageChildren(isOpen ? page._id : null);
+  const timerId = useRef(0);
 
 
   const [{ isDragging }, drag] = useDrag(() => ({
@@ -132,6 +133,18 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
       isOver: monitor.isOver(),
     }),
   }));
+
+  // variable "isOpen" will be true when a drag item is overlapped more than 1 sec
+  useEffect(() => {
+    if (isOver) {
+      timerId.current = window.setInterval(() => {
+        setIsOpen(true);
+      }, 1000);
+    }
+    else {
+      clearTimeout(timerId.current);
+    }
+  }, [isOpen, isOver]);
 
   const hasChildren = useCallback((): boolean => {
     return currentChildren != null && currentChildren.length > 0;

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -130,6 +130,7 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
     accept: 'PAGE_TREE',
     drop: pageItemDropHandler,
     hover: (item, monitor) => {
+      // when a drag item is overlapped more than 1 sec, the drop target item will be opened.
       if (monitor.isOver()) {
         setTimeout(() => {
           if (monitor.isOver()) {


### PR DESCRIPTION
## Task
- [85173](https://redmine.weseek.co.jp/issues/85173) Drag中の要素が、他のページ要素に重なった時にchildrenも表示されるようにする

## Note
- Drag中のページとDropターゲットのページが1s以上重なった場合にのみ、Dropターゲットページの子供が表示されるようにしました。
(現状、子供がいなくても三角ボタンは表示される)


## ScreenRecording

https://user-images.githubusercontent.com/59536731/148947952-b05a56bf-e3dc-4536-b78d-99b20fe84a7e.mov


