### PR TITLE
using mixin for light theme

### DIFF
--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -217,7 +217,7 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
     <div className={`grw-pagetree-item-container ${isOver ? 'grw-pagetree-is-over' : ''}`}>
       <li
         ref={(c) => { drag(c); drop(c) }}
-        className={`list-group-item border-0 py-1 d-flex align-items-center  ${page.isTarget ? 'grw-pagetree-is-target' : ''}`}
+        className={`list-group-item list-group-item-action border-0 py-1 d-flex align-items-center  ${page.isTarget ? 'grw-pagetree-is-target' : ''}`}
       >
         <button
           type="button"

--- a/packages/app/src/styles/theme/_apply-colors-dark.scss
+++ b/packages/app/src/styles/theme/_apply-colors-dark.scss
@@ -257,32 +257,15 @@ ul.pagination {
 
   // Pagetree
   .grw-pagetree {
-    .grw-pagetree-is-over {
-      background: $bgcolor-list-hover;
-    }
-    .list-group-item {
-      &.grw-pagetree-is-target {
-        background: $bgcolor-list-hover;
-      }
-
-      .grw-pagetree-count {
-        background: $bgcolor-sidebar-list-group;
-      }
-
-      .grw-pagetree-button {
-        &:not(:hover) {
-          svg {
-            fill: $gray-500;
-          }
-        }
-      }
-      &:hover {
-        background: $bgcolor-list-hover;
-      }
-      &:active {
-        background: lighten($bgcolor-list-hover, 5%);
-      }
-    }
+    @include override-list-group-item-for-pagetree(
+      $color-list,
+      $bgcolor-sidebar-list-group,
+      $color-list-hover,
+      $bgcolor-list-hover,
+      $color-list-active,
+      lighten($bgcolor-list-hover, 5%),
+      $gray-500
+    );
   }
 }
 

--- a/packages/app/src/styles/theme/_apply-colors-light.scss
+++ b/packages/app/src/styles/theme/_apply-colors-light.scss
@@ -170,32 +170,7 @@ $border-color: $border-color-global;
 
   // Pagetree
   .grw-pagetree {
-    .grw-pagetree-is-over {
-      background: $bgcolor-list-hover;
-    }
-    .list-group-item {
-      &.grw-pagetree-is-target {
-        background: $bgcolor-list-hover;
-      }
-
-      .grw-pagetree-count {
-        background: $bgcolor-sidebar-list-group;
-      }
-
-      .grw-pagetree-button {
-        &:not(:hover) {
-          svg {
-            fill: $gray-400;
-          }
-        }
-      }
-      &:hover {
-        background: $bgcolor-list-hover;
-      }
-      &:active {
-        background: $bgcolor-list-active;
-      }
-    }
+    @include override-list-group-item-for-pagetree($color-list, $bgcolor-sidebar-list-group, $color-list-hover, $bgcolor-list-hover, $color-list-active, red);
   }
 }
 

--- a/packages/app/src/styles/theme/_apply-colors-light.scss
+++ b/packages/app/src/styles/theme/_apply-colors-light.scss
@@ -170,7 +170,15 @@ $border-color: $border-color-global;
 
   // Pagetree
   .grw-pagetree {
-    @include override-list-group-item-for-pagetree($color-list, $bgcolor-sidebar-list-group, $color-list-hover, $bgcolor-list-hover, $color-list-active, red);
+    @include override-list-group-item-for-pagetree(
+      $color-list,
+      $bgcolor-sidebar-list-group,
+      $color-list-hover,
+      $bgcolor-list-hover,
+      $color-list-active,
+      $bgcolor-list-active,
+      $gray-400
+    );
   }
 }
 

--- a/packages/app/src/styles/theme/mixins/_list-group.scss
+++ b/packages/app/src/styles/theme/mixins/_list-group.scss
@@ -24,7 +24,8 @@
   $color-hover: $color,
   $bgcolor-hover: $bgcolor,
   $color-active: $color,
-  $bgcolor-active: $bgcolor
+  $bgcolor-active: $bgcolor,
+  $button-color
 ) {
   .grw-pagetree-is-over {
     background: $bgcolor-hover;
@@ -43,7 +44,7 @@
     .grw-pagetree-button {
       &:not(:hover) {
         svg {
-          fill: $gray-400;
+          fill: $button-color;
         }
       }
     }

--- a/packages/app/src/styles/theme/mixins/_list-group.scss
+++ b/packages/app/src/styles/theme/mixins/_list-group.scss
@@ -53,7 +53,7 @@
       &:hover {
         background-color: $bgcolor-hover;
       }
-      &.active {
+      &:active {
         background-color: $bgcolor-active;
       }
     }

--- a/packages/app/src/styles/theme/mixins/_list-group.scss
+++ b/packages/app/src/styles/theme/mixins/_list-group.scss
@@ -17,3 +17,44 @@
     }
   }
 }
+
+@mixin override-list-group-item-for-pagetree(
+  $color,
+  $bgcolor,
+  $color-hover: $color,
+  $bgcolor-hover: $bgcolor,
+  $color-active: $color,
+  $bgcolor-active: $bgcolor
+) {
+  .grw-pagetree-is-over {
+    background: $bgcolor-hover;
+  }
+  .list-group-item {
+    color: $color;
+    background-color: transparent;
+    border-color: $border-color-global;
+
+    &.grw-pagetree-is-target {
+      background: $bgcolor-hover;
+    }
+    .grw-pagetree-count {
+      background: $bgcolor;
+    }
+    .grw-pagetree-button {
+      &:not(:hover) {
+        svg {
+          fill: $gray-400;
+        }
+      }
+    }
+
+    &.list-group-item-action {
+      &:hover {
+        background-color: $bgcolor-hover;
+      }
+      &.active {
+        background-color: $bgcolor-active;
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Task
- [85800](https://redmine.weseek.co.jp/issues/85800) サイドバー専用のmixinを作成し、defaultテーマに適用させる

## Note
default以外のテーマは以下の後続タスクにて着手します
[86183](https://redmine.weseek.co.jp/issues/86183) default 以外のテーマで、見づらい部分があれば調整する

## ScreenShots
### Before
- light
<img width="435" alt="Screen Shot 2022-01-18 at 15 31 02" src="https://user-images.githubusercontent.com/59536731/149884092-12dbcfa6-8cac-438c-bff2-00dc9a768358.png">
- dark
<img width="408" alt="Screen Shot 2022-01-18 at 15 30 52" src="https://user-images.githubusercontent.com/59536731/149884098-243d29a2-c1f0-42ae-9de8-1e4444e2121d.png">

### After
- light
<img width="470" alt="Screen Shot 2022-01-18 at 15 40 46" src="https://user-images.githubusercontent.com/59536731/149884155-c5f72e0a-c233-4469-8d1f-f2fdfc6ba7ee.png">

- dark
<img width="411" alt="Screen Shot 2022-01-18 at 15 40 40" src="https://user-images.githubusercontent.com/59536731/149884159-5ce3d9c6-a884-40f6-b7a9-39fd6427c786.png">


## ScreenRecording

https://user-images.githubusercontent.com/59536731/149884357-9cfb8aa2-3e74-40bc-801a-77f57b5c0689.mov


