### PR TITLE
Imprv/86183 each theme color

### DIFF
--- a/packages/app/src/styles/theme/christmas.scss
+++ b/packages/app/src/styles/theme/christmas.scss
@@ -17,6 +17,7 @@ $themecolor: #b3000c;
 $themelight: white;
 $subthemecolor: #30882c;
 $bgcolor-global: $themelight;
+
 $linktext: $subthemecolor;
 $linktext-hover: lighten($subthemecolor, 15%);
 $sidebar-text: white;
@@ -62,8 +63,8 @@ html[dark] {
   // $color-list: $color-global;
   $bgcolor-list: transparent;
   // $color-list-hover: $color-reversal;
-  $color-list-active: white;
-  $bgcolor-list-active: $themecolor;
+  $color-list-active: $themelight;
+  // $bgcolor-list-active:;
 
   // Navbar
   $bgcolor-navbar: $themecolor;
@@ -179,6 +180,24 @@ html[dark] {
   .grw-page-editor-mode-manager {
     .btn.btn-outline-primary {
       @include btn-page-editor-mode-manager(darken($subthemecolor, 15%), lighten($subthemecolor, 35%), lighten($subthemecolor, 45%));
+    }
+  }
+
+  /*
+ * GROWI Sidebar
+ */
+  .grw-sidebar {
+    // Pagetree
+    .grw-pagetree {
+      @include override-list-group-item-for-pagetree(
+        $color-list,
+        $bgcolor-sidebar-list-group,
+        $color-list-hover,
+        $bgcolor-list-hover,
+        $color-list-active,
+        $bgcolor-list-active,
+        $gray-400
+      );
     }
   }
 }

--- a/packages/app/src/styles/theme/christmas.scss
+++ b/packages/app/src/styles/theme/christmas.scss
@@ -17,7 +17,6 @@ $themecolor: #b3000c;
 $themelight: white;
 $subthemecolor: #30882c;
 $bgcolor-global: $themelight;
-
 $linktext: $subthemecolor;
 $linktext-hover: lighten($subthemecolor, 15%);
 $sidebar-text: white;

--- a/packages/app/src/styles/theme/christmas.scss
+++ b/packages/app/src/styles/theme/christmas.scss
@@ -64,7 +64,7 @@ html[dark] {
   $bgcolor-list: transparent;
   // $color-list-hover: $color-reversal;
   $color-list-active: $themelight;
-  // $bgcolor-list-active:;
+  $bgcolor-list-active: $themecolor;
 
   // Navbar
   $bgcolor-navbar: $themecolor;
@@ -195,7 +195,7 @@ html[dark] {
         $color-list-hover,
         $bgcolor-list-hover,
         $color-list-active,
-        $bgcolor-list-active,
+        $bgcolor-list-hover,
         $gray-400
       );
     }

--- a/packages/app/src/styles/theme/island.scss
+++ b/packages/app/src/styles/theme/island.scss
@@ -31,7 +31,7 @@ html[dark] {
   // $color-list-hover: ;
   $bgcolor-list-hover: $color-themelight;
   $color-list-active: $color-global;
-  $bgcolor-list-active: lighten($bgcolor-list-hover, 5%);
+  $bgcolor-list-active: $primary;
 
   // Table colors
   // $color-table: #; // optional
@@ -131,7 +131,7 @@ html[dark] {
         $color-list-hover,
         $bgcolor-list-hover,
         $color-list-active,
-        $bgcolor-list-active,
+        lighten($bgcolor-list-hover, 5%),
         $gray-400
       );
     }

--- a/packages/app/src/styles/theme/island.scss
+++ b/packages/app/src/styles/theme/island.scss
@@ -29,9 +29,9 @@ html[dark] {
   // $color-list: $color-global;
   // $bgcolor-list: lighten($color-themelight, 10%);
   // $color-list-hover: ;
-  // $bgcolor-list-hover: ;
+  $bgcolor-list-hover: $color-themelight;
   $color-list-active: $color-global;
-  // $bgcolor-list-active: $primary;
+  $bgcolor-list-active: lighten($bgcolor-list-hover, 5%);
 
   // Table colors
   // $color-table: #; // optional
@@ -118,4 +118,24 @@ html[dark] {
       color: $color-reversal;
     }
   }
+
+  /*
+   * GROWI Sidebar
+  */
+  .grw-sidebar {
+    // Pagetree
+    .grw-pagetree {
+      @include override-list-group-item-for-pagetree(
+        $color-list,
+        $bgcolor-sidebar-list-group,
+        $color-list-hover,
+        $bgcolor-list-hover,
+        $color-list-active,
+        $bgcolor-list-active,
+        $gray-400
+      );
+    }
+  }
 }
+// $color-list-hover,
+// $bgcolor-list-hover,

--- a/packages/app/src/styles/theme/kibela.scss
+++ b/packages/app/src/styles/theme/kibela.scss
@@ -109,4 +109,22 @@ html[dark] {
       @include btn-page-editor-mode-manager(darken($primary, 15%), lighten($primary, 45%), lighten($primary, 50%));
     }
   }
+
+  /*
+ * GROWI Sidebar
+ */
+  .grw-sidebar {
+    // Pagetree
+    .grw-pagetree {
+      @include override-list-group-item-for-pagetree(
+        $color-list,
+        $bgcolor-sidebar-list-group,
+        $color-list-hover,
+        $bgcolor-list-hover,
+        $color-list-active,
+        lighten($bgcolor-list-active, 55%),
+        $gray-400
+      );
+    }
+  }
 }

--- a/packages/app/src/styles/theme/wood.scss
+++ b/packages/app/src/styles/theme/wood.scss
@@ -88,7 +88,7 @@ html[dark] {
   $color-editor-icons: $color-global;
 
   // Sidebar
-  $bgcolor-sidebar: transparent;
+  $bgcolor-sidebar: $themecolor;
   // Sidebar contents
   $color-sidebar-context: #9d7406;
   $bgcolor-sidebar-context: transparent;


### PR DESCRIPTION
## Task
- [86183](https://redmine.weseek.co.jp/issues/86183) default 以外のテーマで、見づらい部分があれば色調整する

## ScreenShots
### Christmas
- before
<img width="504" alt="Screen Shot 2022-01-19 at 0 20 11" src="https://user-images.githubusercontent.com/59536731/149965502-31a75a70-2cbf-4d94-9c96-c5dce1ccf3b1.png">


- after
<img width="437" alt="Screen Shot 2022-01-19 at 0 03 21" src="https://user-images.githubusercontent.com/59536731/149963588-55799b6c-2028-43ce-acfa-8ddb55f2e404.png">

### Island
- before
<img width="534" alt="Screen Shot 2022-01-19 at 0 21 03" src="https://user-images.githubusercontent.com/59536731/149965683-a385d4f7-8a38-4c26-bdec-8106fa757088.png">


- after
<img width="459" alt="Screen Shot 2022-01-19 at 0 08 49" src="https://user-images.githubusercontent.com/59536731/149963645-9a98553c-05a0-4561-9115-a653c09ef397.png">


### Kibera
- before
<img width="357" alt="Screen Shot 2022-01-19 at 0 21 50" src="https://user-images.githubusercontent.com/59536731/149965829-300b1b22-f430-4516-a961-90e8b82c7b06.png">

- after
<img width="473" alt="Screen Shot 2022-01-19 at 0 11 21" src="https://user-images.githubusercontent.com/59536731/149963965-7fc718c4-7086-42a8-87ae-5ea25a5abb1e.png">


### Wood
- before
<img width="407" alt="Screen Shot 2022-01-19 at 0 13 57" src="https://user-images.githubusercontent.com/59536731/149964418-7b1eaeca-6668-4900-9a7c-9a47a1381bc2.png">

- after
<img width="492" alt="Screen Shot 2022-01-19 at 0 12 30" src="https://user-images.githubusercontent.com/59536731/149964150-3ccbc0ef-6eaf-4853-aaad-de4fb4fd962a.png">

