### PR TITLE
imprv: 79291 make password min length 8 charactors

### DIFF
--- a/packages/app/resource/locales/en_US/translation.json
+++ b/packages/app/resource/locales/en_US/translation.json
@@ -194,7 +194,7 @@
     },
     "form_help": {
       "email": "You must have email address which listed below to sign up to this wiki.",
-      "password": "Your password must be at least 6 characters long.",
+      "password": "Your password must be at least 8 characters long.",
       "user_id": "The URL of pages you create will contain your User ID. Your User ID can consist of letters, numbers, and some symbols."
     }
   },

--- a/packages/app/src/server/routes/apiv3/forgot-password.js
+++ b/packages/app/src/server/routes/apiv3/forgot-password.js
@@ -23,8 +23,8 @@ module.exports = (crowi) => {
   const validator = {
     password: [
       body('newPassword').isString().not().isEmpty()
-        .isLength({ min: 6 })
-        .withMessage('password must be at least 6 characters long'),
+        .isLength({ min: 8 })
+        .withMessage('password must be at least 8 characters long'),
       // checking if password confirmation matches password
       body('newPasswordConfirm').isString().not().isEmpty()
         .custom((value, { req }) => {
@@ -81,7 +81,7 @@ module.exports = (crowi) => {
     }
   });
 
-  router.put('/', injectResetOrderByTokenMiddleware, async(req, res) => {
+  router.put('/', /* injectResetOrderByTokenMiddleware, */ async(req, res) => {
     const { passwordResetOrder } = req;
     const { email } = passwordResetOrder;
     const grobalLang = configManager.getConfig('crowi', 'app:globalLang');

--- a/packages/app/src/server/routes/apiv3/forgot-password.js
+++ b/packages/app/src/server/routes/apiv3/forgot-password.js
@@ -81,7 +81,7 @@ module.exports = (crowi) => {
     }
   });
 
-  router.put('/', injectResetOrderByTokenMiddleware, csrf, validator.password, apiV3FormValidator, async(req, res) => {
+  router.put('/', apiLimiter, injectResetOrderByTokenMiddleware, csrf, validator.password, apiV3FormValidator, async(req, res) => {
     const { passwordResetOrder } = req;
     const { email } = passwordResetOrder;
     const grobalLang = configManager.getConfig('crowi', 'app:globalLang');

--- a/packages/app/src/server/routes/apiv3/forgot-password.js
+++ b/packages/app/src/server/routes/apiv3/forgot-password.js
@@ -35,7 +35,7 @@ module.exports = (crowi) => {
 
   const apiLimiter = rateLimit({
     windowMs: 15 * 60 * 1000, // 15 minutes
-    max: 5, // limit each IP to 5 requests per windowMs
+    max: 10, // limit each IP to 10 requests per windowMs
     message:
       'Too many requests were sent from this IP. Please try a password reset request again on the password reset request form',
   });

--- a/packages/app/src/server/routes/apiv3/forgot-password.js
+++ b/packages/app/src/server/routes/apiv3/forgot-password.js
@@ -81,7 +81,7 @@ module.exports = (crowi) => {
     }
   });
 
-  router.put('/', /* injectResetOrderByTokenMiddleware, */ async(req, res) => {
+  router.put('/', injectResetOrderByTokenMiddleware, csrf, validator.password, apiV3FormValidator, async(req, res) => {
     const { passwordResetOrder } = req;
     const { email } = passwordResetOrder;
     const grobalLang = configManager.getConfig('crowi', 'app:globalLang');

--- a/packages/app/src/server/routes/apiv3/personal-setting.js
+++ b/packages/app/src/server/routes/apiv3/personal-setting.js
@@ -86,8 +86,8 @@ module.exports = (crowi) => {
     password: [
       body('oldPassword').isString(),
       body('newPassword').isString().not().isEmpty()
-        .isLength({ min: 6 })
-        .withMessage('password must be at least 6 characters long'),
+        .isLength({ min: 8 })
+        .withMessage('password must be at least 8 characters long'),
       body('newPasswordConfirm').isString().not().isEmpty()
         .custom((value, { req }) => {
           return (value === req.body.newPassword);

--- a/packages/app/src/server/routes/index.js
+++ b/packages/app/src/server/routes/index.js
@@ -13,7 +13,7 @@ const rateLimit = require('express-rate-limit');
 
 const apiLimiter = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes
-  max: 5, // limit each IP to 5 requests per windowMs
+  max: 10, // limit each IP to 5 requests per windowMs
   message:
     'Too many requests sent from this IP, please try again after 15 minutes',
 });
@@ -61,7 +61,7 @@ module.exports = function(crowi, app) {
   app.get('/login'                    , applicationInstalled, login.preLogin, login.login);
   app.get('/login/invited'            , applicationInstalled, login.invited);
   app.post('/login/activateInvited'   , applicationInstalled, form.invited                         , csrf, login.invited);
-  app.post('/login'                   , applicationInstalled, form.login                           , csrf, loginPassport.loginWithLocal, loginPassport.loginWithLdap, loginPassport.loginFailure);
+  app.post('/login'                   , apiLimiter, applicationInstalled, form.login                           , csrf, loginPassport.loginWithLocal, loginPassport.loginWithLdap, loginPassport.loginFailure);
 
   app.post('/register'                , applicationInstalled, form.register                        , csrf, login.register);
   app.get('/register'                 , applicationInstalled, login.preLogin, login.register);


### PR DESCRIPTION
## Tasks
- [79291](https://redmine.weseek.co.jp/issues/79291) [Report3][修正] 新規にパスワードを作成する時に8文字以上にする
- [86186](https://redmine.weseek.co.jp/issues/86186) [Report3][修正] ログイン時にrate limitを使用する

**※マージ先はマスターです**

### Description
- パスワード作成するケースは以下の2つなので、各ケースにてパスワードを8文字以上に設定するようにしました。
　　　- User Settings の Password Settings
　　　- Forgot Password の Reset Password
　　　

　　　
　　　
また、rate limit を5 から10 にあげました。(5は少ないと判断しました)



## ScreenShots
<img width="1259" alt="Screen Shot 2022-01-19 at 20 07 18" src="https://user-images.githubusercontent.com/59536731/150129799-4b6e4ca2-e78d-45c0-8ada-63b3f4f0914d.png">

<img width="494" alt="Screen Shot 2022-01-19 at 21 30 14" src="https://user-images.githubusercontent.com/59536731/150129808-03982957-5be3-494e-8dc0-38960097b604.png">

