### PR TITLE
Imprv/86369 theme colors on pagetree

### DIFF
--- a/packages/app/src/styles/theme/_apply-colors-dark.scss
+++ b/packages/app/src/styles/theme/_apply-colors-dark.scss
@@ -2,7 +2,7 @@
 $color-list: $color-global !default;
 $bgcolor-list: $bgcolor-global !default;
 $color-list-hover: $color-global !default;
-$bgcolor-list-hover: lighten($bgcolor-global, 3%) !default;
+$bgcolor-list-hover: lighten($bgcolor-global, 8%) !default;
 $color-list-active: $color-reversal !default;
 $bgcolor-list-active: $primary !default;
 $bgcolor-subnav: lighten($bgcolor-global, 3%) !default;

--- a/packages/app/src/styles/theme/future.scss
+++ b/packages/app/src/styles/theme/future.scss
@@ -109,4 +109,22 @@ html[dark] {
     color: #95abba;
     background-color: #1f1f22;
   }
+
+  /*
+ * GROWI Sidebar
+ */
+  .grw-sidebar {
+    // Pagetree
+    .grw-pagetree {
+      @include override-list-group-item-for-pagetree(
+        $color-list,
+        $bgcolor-sidebar-list-group,
+        $color-list-hover,
+        $bgcolor-list-hover,
+        $color-list-active,
+        lighten($bgcolor-list-hover, 5%),
+        $gray-600
+      );
+    }
+  }
 }

--- a/packages/app/src/styles/theme/mixins/_list-group.scss
+++ b/packages/app/src/styles/theme/mixins/_list-group.scss
@@ -36,7 +36,7 @@
     border-color: $border-color-global;
 
     &.grw-pagetree-is-target {
-      background: $bgcolor-hover;
+      background: $bgcolor-active;
     }
     .grw-pagetree-count {
       background: $bgcolor;

--- a/packages/app/src/styles/theme/mono-blue.scss
+++ b/packages/app/src/styles/theme/mono-blue.scss
@@ -32,7 +32,7 @@ html[light] {
   // $color-list: $color-global;
   $bgcolor-list: transparent;
   $color-list-hover: $color-search;
-  $bgcolor-list-hover: darken($bgcolor-global, 3%);
+  $bgcolor-list-hover: lighten($primary, 70%);
   // $color-list-active: $color-reversal;
   // $bgcolor-list-active: $primary;
 

--- a/packages/app/src/styles/theme/wood.scss
+++ b/packages/app/src/styles/theme/wood.scss
@@ -66,9 +66,9 @@ html[dark] {
   // $color-list: $color-global;
   $bgcolor-list: transparent;
   $color-list-hover: $gray-100;
-  $bgcolor-list-hover: darken($bgcolor-global, 5%);
+  $bgcolor-list-hover: lighten($primary, 40%);
   // $color-list-active: $color-reversal;
-  // $bgcolor-list-active: $primary;
+  $bgcolor-list-active: lighten($primary, 30%);
 
   // Table colors
   // $color-table: #; // optional

--- a/packages/app/src/styles/theme/wood.scss
+++ b/packages/app/src/styles/theme/wood.scss
@@ -66,7 +66,7 @@ html[dark] {
   // $color-list: $color-global;
   $bgcolor-list: transparent;
   $color-list-hover: $gray-100;
-  $bgcolor-list-hover: darken($bgcolor-global, 3%);
+  $bgcolor-list-hover: darken($bgcolor-global, 5%);
   // $color-list-active: $color-reversal;
   // $bgcolor-list-active: $primary;
 


### PR DESCRIPTION
## Tasks
- [86369](https://redmine.weseek.co.jp/issues/86369) [86184 動作確認の修正タスク] 見づらい部分の色を修正する

## description
動作確認で上がった部分のデザイン修正をしました。

## ScreenShots
### default (dark)
ホバー時真っ黒になるが、背景も濃いめの紺色なので見づらいと感じたのを修正

- before
<img width="433" alt="Screen Shot 2022-01-20 at 14 16 53" src="https://user-images.githubusercontent.com/59536731/150277983-a899901c-cfdb-4c05-8c91-d2aa9069ed9d.png">


- after
<img width="409" alt="Screen Shot 2022-01-20 at 14 15 23" src="https://user-images.githubusercontent.com/59536731/150277863-04db2b0f-22dd-4ae5-853e-f15f43b61fb1.png">

  

## mono-blue (light)
ドラッグ中に重ねた時の色が背景と同じくらい薄くて見づらいと感じたのを修正

- before
<img width="505" alt="Screen Shot 2022-01-20 at 14 17 45" src="https://user-images.githubusercontent.com/59536731/150278053-0781e8cf-1ef6-48aa-8dfe-a9ba2dbc3217.png">

- after
<img width="409" alt="Screen Shot 2022-01-20 at 13 52 21" src="https://user-images.githubusercontent.com/59536731/150277680-d7b14b69-2a1a-465f-b6b4-e1ae4f8116ef.png">


## wood
ドラッグ中に重ねた時の色が背景と同じくらい薄くて見づらいと感じたのを修正
- before
<img width="481" alt="Screen Shot 2022-01-20 at 14 18 24" src="https://user-images.githubusercontent.com/59536731/150278115-5ef0d900-0873-4a90-95ae-9904ce422fd1.png">


- after
<img width="548" alt="Screen Shot 2022-01-20 at 13 53 01" src="https://user-images.githubusercontent.com/59536731/150277648-60b965bc-6f2b-4342-b462-d9b81a61f103.png">

## future
三角ボタンのホバー時とじゃない時で違いがほとんどないと感じたのを修正
- before
<img width="361" alt="Screen Shot 2022-01-20 at 14 19 28" src="https://user-images.githubusercontent.com/59536731/150278229-63bb1887-25fd-4a03-bf32-819c2fbe0fea.png">


- after
<img width="380" alt="Screen Shot 2022-01-20 at 14 05 20" src="https://user-images.githubusercontent.com/59536731/150277695-84af215c-4e35-4518-9102-3b9bc8edab57.png">

