### PR TITLE
imprv: commonize codemirror

### DIFF
--- a/packages/app/src/components/PageEditor/AbstractEditor.tsx
+++ b/packages/app/src/components/PageEditor/AbstractEditor.tsx
@@ -12,6 +12,10 @@ export interface AbstractEditorProps extends ICodeMirror {
   onCtrlEnter?: (event: Event) => void;
 }
 
+interface defaultProps {
+  isGfmMode: true,
+}
+
 export default class AbstractEditor<T extends AbstractEditorProps> extends React.Component<T, Record<string, unknown>> {
 
   constructor(props: Readonly<T>) {
@@ -28,6 +32,10 @@ export default class AbstractEditor<T extends AbstractEditorProps> extends React
 
     this.dispatchSave = this.dispatchSave.bind(this);
   }
+
+  public static defaultProps: defaultProps = {
+    isGfmMode: true,
+  };
 
   forceToFocus(): void {}
 

--- a/packages/app/src/components/PageEditor/CodeMirrorEditor.jsx
+++ b/packages/app/src/components/PageEditor/CodeMirrorEditor.jsx
@@ -31,7 +31,6 @@ import LinkEditModal from './LinkEditModal';
 import HandsontableModal from './HandsontableModal';
 import EditorIcon from './EditorIcon';
 import DrawioModal from './DrawioModal';
-// import { UncontrolledCodeMirror } from '../UncontrolledCodeMirror';
 
 // Textlint
 window.JSHINT = JSHINT;

--- a/packages/app/src/components/PageEditor/CodeMirrorEditor.jsx
+++ b/packages/app/src/components/PageEditor/CodeMirrorEditor.jsx
@@ -3,8 +3,6 @@ import PropTypes from 'prop-types';
 
 import urljoin from 'url-join';
 import * as codemirror from 'codemirror';
-import { UnControlled as UncontrolledCodeMirror } from 'react-codemirror2';
-
 import { Button } from 'reactstrap';
 
 import { JSHINT } from 'jshint';
@@ -13,6 +11,7 @@ import * as loadScript from 'simple-load-script';
 import * as loadCssSync from 'load-css-file';
 
 import { createValidator } from '@growi/codemirror-textlint';
+import { UncontrolledCodeMirror } from '../UncontrolledCodeMirror';
 import InterceptorManager from '~/services/interceptor-manager';
 import loggerFactory from '~/utils/logger';
 
@@ -110,7 +109,7 @@ export default class CodeMirrorEditor extends AbstractEditor {
 
     this.state = {
       value: this.props.value,
-      isGfmMode: this.props.isGfmMode ?? true,
+      isGfmMode: this.props.isGfmMode,
       isEnabledEmojiAutoComplete: false,
       isLoadingKeymap: false,
       isSimpleCheatsheetShown: this.props.isGfmMode && this.props.value.length === 0,
@@ -909,7 +908,6 @@ export default class CodeMirrorEditor extends AbstractEditor {
   }
 
   render() {
-    const mode = this.state.isGfmMode ? 'gfm-growi' : undefined;
     const lint = this.props.isTextlintEnabled ? this.codemirrorLintConfig : false;
     const additionalClasses = Array.from(this.state.additionalClassSet).join(' ');
     const placeholder = this.state.isGfmMode ? 'Input with Markdown..' : 'Input with Plain Text..';
@@ -936,12 +934,6 @@ export default class CodeMirrorEditor extends AbstractEditor {
           }}
           value={this.state.value}
           options={{
-            mode,
-            theme: this.props.editorOptions.theme,
-            styleActiveLine: this.props.editorOptions.styleActiveLine,
-            lineNumbers: this.props.lineNumbers,
-            tabSize: 4,
-            indentUnit: this.props.indentSize,
             lineWrapping: true,
             scrollPastEnd: true,
             autoRefresh: { force: true }, // force option is enabled by autorefresh.ext.js -- Yuki Takei

--- a/packages/app/src/components/PageEditor/CodeMirrorEditor.jsx
+++ b/packages/app/src/components/PageEditor/CodeMirrorEditor.jsx
@@ -933,6 +933,7 @@ export default class CodeMirrorEditor extends AbstractEditor {
           }}
           value={this.state.value}
           options={{
+            // indentUnit: this.props.indentSize,
             lineWrapping: true,
             scrollPastEnd: true,
             autoRefresh: { force: true }, // force option is enabled by autorefresh.ext.js -- Yuki Takei

--- a/packages/app/src/components/PageEditor/CodeMirrorEditor.jsx
+++ b/packages/app/src/components/PageEditor/CodeMirrorEditor.jsx
@@ -933,7 +933,7 @@ export default class CodeMirrorEditor extends AbstractEditor {
           }}
           value={this.state.value}
           options={{
-            // indentUnit: this.props.indentSize,
+            indentUnit: this.props.indentSize,
             lineWrapping: true,
             scrollPastEnd: true,
             autoRefresh: { force: true }, // force option is enabled by autorefresh.ext.js -- Yuki Takei

--- a/packages/app/src/components/UncontrolledCodeMirror.tsx
+++ b/packages/app/src/components/UncontrolledCodeMirror.tsx
@@ -12,7 +12,6 @@ export interface UncontrolledCodeMirrorProps extends AbstractEditorProps {
   value: string;
   options?: ICodeMirror['options'];
   isGfmMode?: boolean;
-  indentSize?: number;
   lineNumbers?: boolean;
 }
 
@@ -26,7 +25,7 @@ class UncontrolledCodeMirrorCore extends AbstractEditor<UncontrolledCodeMirrorCo
   render(): ReactNode {
 
     const {
-      value, isGfmMode, indentSize, lineNumbers, editorContainer, options, forwardedRef, ...rest
+      value, isGfmMode, lineNumbers, editorContainer, options, forwardedRef, ...rest
     } = this.props;
 
     const { editorOptions } = editorContainer.state;
@@ -41,7 +40,6 @@ class UncontrolledCodeMirrorCore extends AbstractEditor<UncontrolledCodeMirrorCo
           theme: editorOptions.theme,
           styleActiveLine: editorOptions.styleActiveLine,
           tabSize: 4,
-          indentUnit: indentSize,
           ...options,
         }}
         {...rest}


### PR DESCRIPTION
## タスク

https://redmine.weseek.co.jp/issues/86391

## issue

- https://github.com/weseek/growi/issues/5060

## 行ったこと

- https://github.com/weseek/growi/pull/5061/files ← 応急処置で追加されたコードを revert
- https://github.com/weseek/growi/pull/4764/files ← で忘れ去られた isGfmMode を復活
- その他、変数を1つ修正

## バグった原因

- AbstractEditor.tsx の isGfmMode の default 値が消えていた
- そのため CodeMirrorEditor.jsx の `handleEnterKey` メソッドなどをはじめとした `isGfmMode` が true な場合の処理が実行されていなかった

## 修正後画像

### ビルトインエディタ

![ビルトインエディタ](https://user-images.githubusercontent.com/83065937/150330708-450c3636-072e-4971-8cad-1b377975614d.PNG)

### コンフリクト解消モーダル

![コンフリクト解消のモーダル](https://user-images.githubusercontent.com/83065937/150330700-491d6c24-181f-4923-a1a4-5c1fd8ea6bc7.PNG)

## 挙動の確認

- マークダウンハイライト → 出る
- オートインデント → される
- テーブルが自動で作れる
