### PR TITLE
fix: update markdown when resolving conflict

### DIFF
--- a/packages/app/src/components/PageEditor/ConflictDiffModal.tsx
+++ b/packages/app/src/components/PageEditor/ConflictDiffModal.tsx
@@ -14,8 +14,6 @@ import PageContainer from '../../client/services/PageContainer';
 import AppContainer from '../../client/services/AppContainer';
 import ExpandOrContractButton from '../ExpandOrContractButton';
 
-import { useEditorMode } from '~/stores/ui';
-
 import { IRevisionOnConflict } from '../../interfaces/revision';
 import { UncontrolledCodeMirror } from '../UncontrolledCodeMirror';
 
@@ -44,8 +42,6 @@ export const ConflictDiffModal: FC<ConflictDiffModalProps> = (props) => {
   const [isRevisionselected, setIsRevisionSelected] = useState<boolean>(false);
   const [isModalExpanded, setIsModalExpanded] = useState<boolean>(false);
   const [codeMirrorRef, setCodeMirrorRef] = useState<HTMLDivElement | null>(null);
-
-  const { data: editorMode } = useEditorMode();
 
   const uncontrolledRef = useRef<CodeMirror>(null);
 
@@ -102,6 +98,7 @@ export const ConflictDiffModal: FC<ConflictDiffModalProps> = (props) => {
     const codeMirrorVal = uncontrolledRef.current?.editor.doc.getValue();
 
     try {
+      const editorMode = 'editorOnResolveConflict';
       await pageContainer.resolveConflict(codeMirrorVal, editorMode);
       onClose();
       pageContainer.showSuccessToastr();


### PR DESCRIPTION
## タスク

https://redmine.weseek.co.jp/issues/86452

## 行ったこと

- コンフリクト解消後に「選んで編集したマークダウン」が変わらない `pageEditor`が持つマークダウンが瞬時に変更されない問題を修正しました 