### PR TITLE
exclude null tag on server side in routes/apiv3/pages

### DIFF
--- a/packages/app/src/components/Sidebar/RecentChanges.tsx
+++ b/packages/app/src/components/Sidebar/RecentChanges.tsx
@@ -56,8 +56,7 @@ function LargePageItem({ page }) {
   }
 
   const tags = page.tags;
-  // when tag document is deleted from database directly tags includes null
-  const tagElements = tags.filter(tag => tag != null).map((tag) => {
+  const tagElements = tags.map((tag) => {
     return (
       <a key={tag.name} href={`/_search?q=tag:${tag.name}`} className="grw-tag-label badge badge-secondary mr-2 small">
         {tag.name}

--- a/packages/app/src/server/routes/apiv3/pages.js
+++ b/packages/app/src/server/routes/apiv3/pages.js
@@ -381,7 +381,9 @@ module.exports = (crowi) => {
         if (!relationsMap.has(pageId)) {
           relationsMap.set(pageId, []);
         }
-        relationsMap.get(pageId).push(relation.relatedTag);
+        if (relation.relatedTag != null) {
+          relationsMap.get(pageId).push(relation.relatedTag);
+        }
       });
       // add tags to each page
       result.pages.forEach((page) => {


### PR DESCRIPTION
## タスク

https://redmine.weseek.co.jp/issues/86650

## 行ったこと

- tag を MongoDB から直接削除した場合のためのコード
- `routes/apiv3/pages/recent` 側で page についている null な tag を除外し、フロントで null なタグを除外する処理をなくしました