### PR TITLE
feat: 86741 Rename when press enter

### DIFF
--- a/packages/app/resource/locales/en_US/translation.json
+++ b/packages/app/resource/locales/en_US/translation.json
@@ -973,6 +973,7 @@
   },
   "pagetree": {
     "private_legacy_pages": "Private Legacy Pages",
+    "this_title_cannot_be_renamed": "This title cannot be renamed",
     "cannot_rename_a_title_that_contains_slash": "Cannot rename a title that contains '/'"
   },
   "duplicated_page_alert" : {

--- a/packages/app/resource/locales/en_US/translation.json
+++ b/packages/app/resource/locales/en_US/translation.json
@@ -972,7 +972,8 @@
     "password_and_confirm_password_does_not_match": "Password and confirm password does not match"
   },
   "pagetree": {
-    "private_legacy_pages": "Private Legacy Pages"
+    "private_legacy_pages": "Private Legacy Pages",
+    "cannot_rename_a_title_that_contains_slash": "Cannot rename a title that contains '/'"
   },
   "duplicated_page_alert" : {
     "same_page_name_exists": "Same page name exits as「{{pageName}}」",

--- a/packages/app/resource/locales/en_US/translation.json
+++ b/packages/app/resource/locales/en_US/translation.json
@@ -178,7 +178,9 @@
     "error_message": "Some values ​​are incorrect",
     "required": "%s is required",
     "invalid_syntax": "The syntax of %s is invalid.",
-    "title_required": "Title is required."
+    "title_required": "Title is required.",
+    "slashed_are_not_yet_supported": "Titles containing slashes are not yet supported"
+
   },
   "not_found_page": {
     "Create Page": "Create Page",

--- a/packages/app/resource/locales/en_US/translation.json
+++ b/packages/app/resource/locales/en_US/translation.json
@@ -973,7 +973,6 @@
   },
   "pagetree": {
     "private_legacy_pages": "Private Legacy Pages",
-    "this_title_cannot_be_renamed": "This title cannot be renamed",
     "cannot_rename_a_title_that_contains_slash": "Cannot rename a title that contains '/'"
   },
   "duplicated_page_alert" : {

--- a/packages/app/resource/locales/ja_JP/translation.json
+++ b/packages/app/resource/locales/ja_JP/translation.json
@@ -966,7 +966,6 @@
   },
   "pagetree": {
     "private_legacy_pages": "待避所",
-    "this_title_cannot_be_renamed": "このタイトルにはリネームできません",
     "cannot_rename_a_title_that_contains_slash": "`/` が含まれているタイトルにリネームできません"
   },
   "duplicated_page_alert" : {

--- a/packages/app/resource/locales/ja_JP/translation.json
+++ b/packages/app/resource/locales/ja_JP/translation.json
@@ -180,7 +180,8 @@
     "error_message": "いくつかの値が設定されていません",
     "required": "%sに値を入力してください",
     "invalid_syntax": "%sの構文が不正です",
-    "title_required": "タイトルを入力してください"
+    "title_required": "タイトルを入力してください",
+    "slashed_are_not_yet_supported": "スラッシュを含むタイトルにはまだ対応していません"
   },
   "not_found_page": {
     "Create Page": "ページを作成する",

--- a/packages/app/resource/locales/ja_JP/translation.json
+++ b/packages/app/resource/locales/ja_JP/translation.json
@@ -966,6 +966,7 @@
   },
   "pagetree": {
     "private_legacy_pages": "待避所",
+    "this_title_cannot_be_renamed": "このタイトルにはリネームできません",
     "cannot_rename_a_title_that_contains_slash": "`/` が含まれているタイトルにリネームできません"
   },
   "duplicated_page_alert" : {

--- a/packages/app/resource/locales/ja_JP/translation.json
+++ b/packages/app/resource/locales/ja_JP/translation.json
@@ -965,7 +965,8 @@
     "password_and_confirm_password_does_not_match": "パスワードと確認パスワードが一致しません"
   },
   "pagetree": {
-    "private_legacy_pages": "待避所"
+    "private_legacy_pages": "待避所",
+    "cannot_rename_a_title_that_contains_slash": "`/` が含まれているタイトルにリネームできません"
   },
   "duplicated_page_alert" : {
     "same_page_name_exists": "ページ名 「{{pageName}}」が重複しています",

--- a/packages/app/resource/locales/zh_CN/translation.json
+++ b/packages/app/resource/locales/zh_CN/translation.json
@@ -976,6 +976,7 @@
   },
   "pagetree": {
     "private_legacy_pages": "私人遗留页面",
+    "this_title_cannot_be_renamed": "This title cannot be renamed",
     "cannot_rename_a_title_that_contains_slash": "不能重命名包含 ’/' 的标题"
   },
   "duplicated_page_alert" : {

--- a/packages/app/resource/locales/zh_CN/translation.json
+++ b/packages/app/resource/locales/zh_CN/translation.json
@@ -178,7 +178,8 @@
 		"error_message": "有些值不正确",
 		"required": "%s 是必需的",
 		"invalid_syntax": "%s的语法无效。",
-    "title_required": "标题是必需的。"
+    "title_required": "标题是必需的。",
+    "slashed_are_not_yet_supported": "スラッシュを含むタイトルにはまだ対応していません"
   },
   "not_found_page": {
     "Create Page": "创建页面",

--- a/packages/app/resource/locales/zh_CN/translation.json
+++ b/packages/app/resource/locales/zh_CN/translation.json
@@ -975,7 +975,8 @@
     "password_and_confirm_password_does_not_match": "密码和确认密码不匹配"
   },
   "pagetree": {
-    "private_legacy_pages": "私人遗留页面"
+    "private_legacy_pages": "私人遗留页面",
+    "cannot_rename_a_title_that_contains_slash": "不能重命名包含 ’/' 的标题"
   },
   "duplicated_page_alert" : {
     "same_page_name_exists": "页面名称「{{pageName}}」是重复的",

--- a/packages/app/resource/locales/zh_CN/translation.json
+++ b/packages/app/resource/locales/zh_CN/translation.json
@@ -976,7 +976,6 @@
   },
   "pagetree": {
     "private_legacy_pages": "私人遗留页面",
-    "this_title_cannot_be_renamed": "This title cannot be renamed",
     "cannot_rename_a_title_that_contains_slash": "不能重命名包含 ’/' 的标题"
   },
   "duplicated_page_alert" : {

--- a/packages/app/src/components/Common/ClosableTextInput.tsx
+++ b/packages/app/src/components/Common/ClosableTextInput.tsx
@@ -1,3 +1,4 @@
+import { text } from 'body-parser';
 import React, {
   FC, memo, useEffect, useRef, useState,
 } from 'react';
@@ -19,7 +20,7 @@ type ClosableTextInputProps = {
   isShown: boolean
   placeholder?: string
   inputValidator?(text: string): AlertInfo | Promise<AlertInfo> | null
-  onPressEnter?(): void
+  onPressEnter?(inputText: string): void
   onClickOutside?(): void
 }
 
@@ -27,14 +28,18 @@ const ClosableTextInput: FC<ClosableTextInputProps> = memo((props: ClosableTextI
   const { t } = useTranslation();
   const inputRef = useRef<HTMLInputElement>(null);
 
+  const [inputText, setInputText] = useState('');
   const [currentAlertInfo, setAlertInfo] = useState<AlertInfo | null>(null);
 
   const onChangeHandler = async(e) => {
     if (props.inputValidator == null) { return }
 
-    const alertInfo = await props.inputValidator(e.target.value);
+    const inputText = e.target.value;
+
+    const alertInfo = await props.inputValidator(inputText);
 
     setAlertInfo(alertInfo);
+    setInputText(inputText);
   };
 
   const onPressEnter = () => {
@@ -42,7 +47,7 @@ const ClosableTextInput: FC<ClosableTextInputProps> = memo((props: ClosableTextI
       return;
     }
 
-    props.onPressEnter();
+    props.onPressEnter(inputText);
   };
 
   const onKeyDownHandler = (e) => {

--- a/packages/app/src/components/Common/ClosableTextInput.tsx
+++ b/packages/app/src/components/Common/ClosableTextInput.tsx
@@ -47,7 +47,7 @@ const ClosableTextInput: FC<ClosableTextInputProps> = memo((props: ClosableTextI
       return;
     }
 
-    props.onPressEnter(inputText);
+    props.onPressEnter(inputText.trim());
   };
 
   const onKeyDownHandler = (e) => {

--- a/packages/app/src/components/Common/ClosableTextInput.tsx
+++ b/packages/app/src/components/Common/ClosableTextInput.tsx
@@ -1,4 +1,3 @@
-import { text } from 'body-parser';
 import React, {
   FC, memo, useEffect, useRef, useState,
 } from 'react';
@@ -18,9 +17,10 @@ export type AlertInfo = {
 
 type ClosableTextInputProps = {
   isShown: boolean
+  value?: string
   placeholder?: string
   inputValidator?(text: string): AlertInfo | Promise<AlertInfo> | null
-  onPressEnter?(inputText: string): void
+  onPressEnter?(inputText: string | null): void
   onClickOutside?(): void
 }
 
@@ -28,7 +28,7 @@ const ClosableTextInput: FC<ClosableTextInputProps> = memo((props: ClosableTextI
   const { t } = useTranslation();
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const [inputText, setInputText] = useState('');
+  const [inputText, setInputText] = useState(props.value);
   const [currentAlertInfo, setAlertInfo] = useState<AlertInfo | null>(null);
 
   const onChangeHandler = async(e) => {
@@ -47,7 +47,9 @@ const ClosableTextInput: FC<ClosableTextInputProps> = memo((props: ClosableTextI
       return;
     }
 
-    props.onPressEnter(inputText.trim());
+    const text = inputText != null ? inputText.trim() : null;
+
+    props.onPressEnter(text);
   };
 
   const onKeyDownHandler = (e) => {
@@ -99,6 +101,7 @@ const ClosableTextInput: FC<ClosableTextInputProps> = memo((props: ClosableTextI
   return (
     <div className={props.isShown ? 'd-block' : 'd-none'}>
       <input
+        value={inputText}
         ref={inputRef}
         type="text"
         className="form-control"

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -196,7 +196,6 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
     setRenameInputShown(true);
   }, []);
 
-  // TODO: make a put request to pages/title
   const onPressEnterForRenameHandler = async(inputText: string) => {
 
     if (inputText.includes('/')) {
@@ -204,15 +203,12 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
       return;
     }
 
-    const parentPath = nodePath.dirname(page.path as string || '/');
-    const childPath = nodePath.basename(inputText);
-    const newPagePath = `${parentPath}/${childPath}`;
+    const parentPath = nodePath.dirname(page.path as string);
+    const newPagePath = `${parentPath}/${inputText}`;
 
     try {
-      const res = await apiv3Put('pages/rename', { newPagePath, pageId: page._id, revisionId: page.revision });
-
-      const title = nodePath.basename(res.data.page.path);
-      setPageTitle(title);
+      await apiv3Put('pages/rename', { newPagePath, pageId: page._id, revisionId: page.revision });
+      setPageTitle(inputText);
     }
     catch (err) {
       toastError(err);

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -283,6 +283,7 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
         { isRenameInputShown && (
           <ClosableTextInput
             isShown
+            value={nodePath.basename(pageTitle as string)}
             placeholder={t('Input page name')}
             onClickOutside={() => { setRenameInputShown(false) }}
             onPressEnter={onPressEnterForRenameHandler}

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -197,11 +197,6 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
   }, []);
 
   const onPressEnterForRenameHandler = async(inputText: string) => {
-    if (inputText === '') {
-      toastWarning(t('pagetree.this_title_cannot_be_renamed'));
-      return;
-    }
-
     if (inputText.includes('/')) {
       toastWarning(t('pagetree.cannot_rename_a_title_that_contains_slash'));
       return;
@@ -229,7 +224,7 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
   };
 
   const inputValidator = (title: string | null): AlertInfo | null => {
-    if (title == null || title === '') {
+    if (title == null || title === '' || title.trim() === '') {
       return {
         type: AlertType.WARNING,
         message: t('form_validation.title_required'),

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -197,6 +197,11 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
   }, []);
 
   const onPressEnterForRenameHandler = async(inputText: string) => {
+    if (inputText === '') {
+      toastWarning(t('pagetree.this_title_cannot_be_renamed'));
+      return;
+    }
+
     if (inputText.includes('/')) {
       toastWarning(t('pagetree.cannot_rename_a_title_that_contains_slash'));
       return;

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -197,11 +197,6 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
   }, []);
 
   const onPressEnterForRenameHandler = async(inputText: string) => {
-    if (inputText.includes('/')) {
-      toastWarning(t('pagetree.cannot_rename_a_title_that_contains_slash'));
-      return;
-    }
-
     const parentPath = nodePath.dirname(page.path as string);
     const newPagePath = `${parentPath}/${inputText}`;
 
@@ -228,6 +223,13 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
       return {
         type: AlertType.WARNING,
         message: t('form_validation.title_required'),
+      };
+    }
+
+    if (title.includes('/')) {
+      return {
+        type: AlertType.WARNING,
+        message: t('form_validation.slashed_are_not_yet_supported'),
       };
     }
 

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -197,20 +197,26 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
   }, []);
 
   const onPressEnterForRenameHandler = async(inputText: string) => {
+    if (inputText == null || inputText === '' || inputText.trim() === '' || inputText.includes('/')) {
+      return;
+    }
+
     const parentPath = nodePath.dirname(page.path as string);
     const newPagePath = `${parentPath}/${inputText}`;
 
     try {
-      await apiv3Put('pages/rename', { newPagePath, pageId: page._id, revisionId: page.revision });
       setPageTitle(inputText);
+      setRenameInputShown(false);
+      await apiv3Put('/pages/rename', { newPagePath, pageId: page._id, revisionId: page.revision });
     }
     catch (err) {
+      // open ClosableInput and set pageTitle back to the previous title
+      setPageTitle(nodePath.basename(pageTitle as string));
+      setRenameInputShown(true);
       toastError(err);
     }
-    finally {
-      setRenameInputShown(false);
-    }
   };
+
 
   // TODO: go to create page page
   const onPressEnterForCreateHandler = () => {

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -197,9 +197,8 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
   }, []);
 
   const onPressEnterForRenameHandler = async(inputText: string) => {
-
     if (inputText.includes('/')) {
-      toastWarning('Cannot rename a title that contains "/"');
+      toastWarning(t('pagetree.cannot_rename_a_title_that_contains_slash'));
       return;
     }
 

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -199,6 +199,11 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
   // TODO: make a put request to pages/title
   const onPressEnterForRenameHandler = async(inputText: string) => {
 
+    if (inputText.includes('/')) {
+      toastWarning('Cannot rename a title that contains "/"');
+      return;
+    }
+
     const parentPath = nodePath.dirname(page.path as string || '/');
     const childPath = nodePath.basename(inputText);
     const newPagePath = `${parentPath}/${childPath}`;


### PR DESCRIPTION
## Task
[#86741](https://redmine.weseek.co.jp/issues/86741) エンターキーを押した時に rename できる

## Appearance
https://user-images.githubusercontent.com/34241526/151123372-c2040c9f-de62-4219-8090-42def1080b93.mov

↑ やっていること
- 既存のパスにリネーム
- スラッシュを含むタイトルにリネーム
- 空文字のタイトルにリネーム
- 正しいタイトルにリネーム



