### PR TITLE
Imprv/87696 show PageDuplicateModal when clicking DuplicateMenuItem

### DIFF
--- a/packages/app/src/components/Common/Dropdown/PageItemControl.tsx
+++ b/packages/app/src/components/Common/Dropdown/PageItemControl.tsx
@@ -23,6 +23,7 @@ type CommonProps = {
   isEnableActions?: boolean,
   hideBookmarkMenuItem?: boolean,
   onClickBookmarkMenuItem?: (pageId: string, newValue?: boolean) => Promise<void>,
+  onClickDuplicateMenuItem?: (pageId: string, path: string) => void,
   onClickRenameMenuItem?: (pageId: string) => void,
   onClickDeleteMenuItem?: (pageId: string) => void,
 
@@ -32,14 +33,15 @@ type CommonProps = {
 
 type DropdownMenuProps = CommonProps & {
   pageId: string,
+  path: string,
 }
 
 const PageItemControlDropdownMenu = React.memo((props: DropdownMenuProps): JSX.Element => {
   const { t } = useTranslation('');
 
   const {
-    pageId, pageInfo, isEnableActions, hideBookmarkMenuItem,
-    onClickBookmarkMenuItem, onClickRenameMenuItem, onClickDeleteMenuItem,
+    pageId, path, pageInfo, isEnableActions, hideBookmarkMenuItem,
+    onClickBookmarkMenuItem, onClickDuplicateMenuItem, onClickRenameMenuItem, onClickDeleteMenuItem,
     additionalMenuItemRenderer: AdditionalMenuItems,
   } = props;
 
@@ -51,6 +53,14 @@ const PageItemControlDropdownMenu = React.memo((props: DropdownMenuProps): JSX.E
     }
     await onClickBookmarkMenuItem(pageId, !pageInfo.isBookmarked);
   }, [onClickBookmarkMenuItem, pageId, pageInfo]);
+
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const duplicateItemClickedHandler = useCallback(async() => {
+    if (onClickDuplicateMenuItem == null) {
+      return;
+    }
+    await onClickDuplicateMenuItem(pageId, path);
+  }, [pageId]);
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const renameItemClickedHandler = useCallback(async() => {
@@ -97,7 +107,7 @@ const PageItemControlDropdownMenu = React.memo((props: DropdownMenuProps): JSX.E
 
       {/* Duplicate */}
       { isExistPageInfo(pageInfo) && isEnableActions && (
-        <DropdownItem onClick={() => toastr.warning(t('search_result.currently_not_implemented'))}>
+        <DropdownItem onClick={duplicateItemClickedHandler}>
           <i className="icon-fw icon-docs"></i>
           {t('Duplicate')}
         </DropdownItem>
@@ -135,6 +145,7 @@ const PageItemControlDropdownMenu = React.memo((props: DropdownMenuProps): JSX.E
 
 type PageItemControlSubstanceProps = CommonProps & {
   pageId: string,
+  path: string,
   fetchOnOpen?: boolean,
 }
 
@@ -142,7 +153,7 @@ export const PageItemControlSubstance = (props: PageItemControlSubstanceProps): 
 
   const {
     pageId, pageInfo: presetPageInfo, fetchOnOpen,
-    onClickBookmarkMenuItem,
+    onClickBookmarkMenuItem, onClickDuplicateMenuItem,
   } = props;
 
   const [isOpen, setIsOpen] = useState(false);
@@ -161,6 +172,16 @@ export const PageItemControlSubstance = (props: PageItemControlSubstanceProps): 
     }
   }, [mutatePageInfo, onClickBookmarkMenuItem, shouldFetch]);
 
+  const duplicateMenuItemClickHandler = useCallback(async(_pageId: string, _path: string) => {
+    if (onClickDuplicateMenuItem != null) {
+      await onClickDuplicateMenuItem(_pageId, _path);
+    }
+
+    if (shouldFetch) {
+      mutatePageInfo();
+    }
+  }, [mutatePageInfo, onClickDuplicateMenuItem, shouldFetch]);
+
   return (
     <Dropdown isOpen={isOpen} toggle={() => setIsOpen(!isOpen)}>
       <DropdownToggle color="transparent" className="border-0 rounded grw-btn-page-management p-0">
@@ -171,6 +192,7 @@ export const PageItemControlSubstance = (props: PageItemControlSubstanceProps): 
         {...props}
         pageInfo={presetPageInfo ?? fetchedPageInfo}
         onClickBookmarkMenuItem={bookmarkMenuItemClickHandler}
+        onClickDuplicateMenuItem={duplicateMenuItemClickHandler}
       />
     </Dropdown>
   );
@@ -180,29 +202,31 @@ export const PageItemControlSubstance = (props: PageItemControlSubstanceProps): 
 
 type PageItemControlProps = CommonProps & {
   pageId?: string,
+  path?: string,
 }
 
 export const PageItemControl = (props: PageItemControlProps): JSX.Element => {
-  const { pageId } = props;
+  const { pageId, path } = props;
 
-  if (pageId == null) {
+  if (pageId == null || path == null) {
     return <></>;
   }
 
-  return <PageItemControlSubstance pageId={pageId} {...props} />;
+  return <PageItemControlSubstance pageId={pageId} path={path} {...props} />;
 };
 
 
 type AsyncPageItemControlProps = CommonProps & {
   pageId?: string,
+  path?: string,
 }
 
 export const AsyncPageItemControl = (props: AsyncPageItemControlProps): JSX.Element => {
-  const { pageId } = props;
+  const { pageId, path } = props;
 
-  if (pageId == null) {
+  if (pageId == null || path == null) {
     return <></>;
   }
 
-  return <PageItemControlSubstance pageId={pageId} fetchOnOpen {...props} />;
+  return <PageItemControlSubstance pageId={pageId} path={path} fetchOnOpen {...props} />;
 };

--- a/packages/app/src/components/Common/Dropdown/PageItemControl.tsx
+++ b/packages/app/src/components/Common/Dropdown/PageItemControl.tsx
@@ -22,10 +22,10 @@ type CommonProps = {
   pageInfo?: IPageInfoCommon | IPageInfo,
   isEnableActions?: boolean,
   hideBookmarkMenuItem?: boolean,
-  onClickBookmarkMenuItem?: (pageId: string, newValue?: boolean) => Promise<void>,
-  onClickDuplicateMenuItem?: (pageId: string) => void,
-  onClickRenameMenuItem?: (pageId: string) => void,
-  onClickDeleteMenuItem?: (pageId: string) => void,
+  onClickBookmarkMenuItem?: (pageId: string, newValue?: boolean) => Promise<void> | void,
+  onClickDuplicateMenuItem?: () => Promise<void> | void,
+  onClickRenameMenuItem?: (pageId: string) => Promise<void> | void,
+  onClickDeleteMenuItem?: (pageId: string) => Promise<void> | void,
 
   additionalMenuItemRenderer?: React.FunctionComponent<AdditionalMenuItemsRendererProps>,
 }
@@ -58,8 +58,8 @@ const PageItemControlDropdownMenu = React.memo((props: DropdownMenuProps): JSX.E
     if (onClickDuplicateMenuItem == null) {
       return;
     }
-    await onClickDuplicateMenuItem(pageId);
-  }, [onClickDuplicateMenuItem, pageId]);
+    await onClickDuplicateMenuItem();
+  }, [onClickDuplicateMenuItem]);
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const renameItemClickedHandler = useCallback(async() => {
@@ -170,15 +170,12 @@ export const PageItemControlSubstance = (props: PageItemControlSubstanceProps): 
     }
   }, [mutatePageInfo, onClickBookmarkMenuItem, shouldFetch]);
 
-  const duplicateMenuItemClickHandler = useCallback(async(_pageId: string) => {
-    if (onClickDuplicateMenuItem != null) {
-      await onClickDuplicateMenuItem(_pageId);
+  const duplicateMenuItemClickHandler = useCallback(async() => {
+    if (onClickDuplicateMenuItem == null) {
+      return;
     }
-
-    if (shouldFetch) {
-      mutatePageInfo();
-    }
-  }, [mutatePageInfo, onClickDuplicateMenuItem, shouldFetch]);
+    await onClickDuplicateMenuItem();
+  }, [onClickDuplicateMenuItem]);
 
   return (
     <Dropdown isOpen={isOpen} toggle={() => setIsOpen(!isOpen)}>

--- a/packages/app/src/components/Common/Dropdown/PageItemControl.tsx
+++ b/packages/app/src/components/Common/Dropdown/PageItemControl.tsx
@@ -23,7 +23,7 @@ type CommonProps = {
   isEnableActions?: boolean,
   hideBookmarkMenuItem?: boolean,
   onClickBookmarkMenuItem?: (pageId: string, newValue?: boolean) => Promise<void>,
-  onClickDuplicateMenuItem?: (pageId: string, path: string) => void,
+  onClickDuplicateMenuItem?: (pageId: string) => void,
   onClickRenameMenuItem?: (pageId: string) => void,
   onClickDeleteMenuItem?: (pageId: string) => void,
 
@@ -33,14 +33,13 @@ type CommonProps = {
 
 type DropdownMenuProps = CommonProps & {
   pageId: string,
-  path: string,
 }
 
 const PageItemControlDropdownMenu = React.memo((props: DropdownMenuProps): JSX.Element => {
   const { t } = useTranslation('');
 
   const {
-    pageId, path, pageInfo, isEnableActions, hideBookmarkMenuItem,
+    pageId, pageInfo, isEnableActions, hideBookmarkMenuItem,
     onClickBookmarkMenuItem, onClickDuplicateMenuItem, onClickRenameMenuItem, onClickDeleteMenuItem,
     additionalMenuItemRenderer: AdditionalMenuItems,
   } = props;
@@ -59,8 +58,8 @@ const PageItemControlDropdownMenu = React.memo((props: DropdownMenuProps): JSX.E
     if (onClickDuplicateMenuItem == null) {
       return;
     }
-    await onClickDuplicateMenuItem(pageId, path);
-  }, [pageId]);
+    await onClickDuplicateMenuItem(pageId);
+  }, [onClickDuplicateMenuItem, pageId]);
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const renameItemClickedHandler = useCallback(async() => {
@@ -145,7 +144,6 @@ const PageItemControlDropdownMenu = React.memo((props: DropdownMenuProps): JSX.E
 
 type PageItemControlSubstanceProps = CommonProps & {
   pageId: string,
-  path: string,
   fetchOnOpen?: boolean,
 }
 
@@ -172,9 +170,9 @@ export const PageItemControlSubstance = (props: PageItemControlSubstanceProps): 
     }
   }, [mutatePageInfo, onClickBookmarkMenuItem, shouldFetch]);
 
-  const duplicateMenuItemClickHandler = useCallback(async(_pageId: string, _path: string) => {
+  const duplicateMenuItemClickHandler = useCallback(async(_pageId: string) => {
     if (onClickDuplicateMenuItem != null) {
-      await onClickDuplicateMenuItem(_pageId, _path);
+      await onClickDuplicateMenuItem(_pageId);
     }
 
     if (shouldFetch) {
@@ -212,21 +210,20 @@ export const PageItemControl = (props: PageItemControlProps): JSX.Element => {
     return <></>;
   }
 
-  return <PageItemControlSubstance pageId={pageId} path={path} {...props} />;
+  return <PageItemControlSubstance pageId={pageId} {...props} />;
 };
 
 
 type AsyncPageItemControlProps = CommonProps & {
   pageId?: string,
-  path?: string,
 }
 
 export const AsyncPageItemControl = (props: AsyncPageItemControlProps): JSX.Element => {
-  const { pageId, path } = props;
+  const { pageId } = props;
 
-  if (pageId == null || path == null) {
+  if (pageId == null) {
     return <></>;
   }
 
-  return <PageItemControlSubstance pageId={pageId} path={path} fetchOnOpen {...props} />;
+  return <PageItemControlSubstance pageId={pageId} fetchOnOpen {...props} />;
 };

--- a/packages/app/src/components/PageList/PageList.tsx
+++ b/packages/app/src/components/PageList/PageList.tsx
@@ -26,7 +26,7 @@ const PageList = (props: Props): JSX.Element => {
   }
 
   const pageList = pages.items.map(page => (
-    <PageListItemL page={{ pageData: page }} />
+    <PageListItemL key={page._id} page={{ pageData: page }} />
   ));
 
   if (pageList.length === 0) {

--- a/packages/app/src/components/PageList/PageList.tsx
+++ b/packages/app/src/components/PageList/PageList.tsx
@@ -27,7 +27,7 @@ const PageList = (props: Props): JSX.Element => {
   }
 
   const pageList = pages.items.map(page => (
-    <PageListItemL page={page} isEnableActions={isEnableActions} />
+    <PageListItemL key={page.pageData._id} page={page} isEnableActions={isEnableActions} />
   ));
 
   if (pageList.length === 0) {

--- a/packages/app/src/components/PageList/PageList.tsx
+++ b/packages/app/src/components/PageList/PageList.tsx
@@ -27,7 +27,7 @@ const PageList = (props: Props): JSX.Element => {
   }
 
   const pageList = pages.items.map(page => (
-    <PageListItemL key={page._id} page={page} isEnableActions={isEnableActions} />
+    <PageListItemL page={page} isEnableActions={isEnableActions} />
   ));
 
   if (pageList.length === 0) {

--- a/packages/app/src/components/PageList/PageListItemL.tsx
+++ b/packages/app/src/components/PageList/PageListItemL.tsx
@@ -121,6 +121,7 @@ export const PageListItemL: FC<Props> = memo((props:Props) => {
                 {/* TODO: use PageItemControl with prefetched IPageInfo object */}
                 <AsyncPageItemControl
                   pageId={pageData._id}
+                  path={pageData.path}
                   onClickDeleteMenuItem={props.onClickDeleteButton}
                   isEnableActions={isEnableActions}
                 />

--- a/packages/app/src/components/PageList/PageListItemL.tsx
+++ b/packages/app/src/components/PageList/PageListItemL.tsx
@@ -121,7 +121,6 @@ export const PageListItemL: FC<Props> = memo((props:Props) => {
                 {/* TODO: use PageItemControl with prefetched IPageInfo object */}
                 <AsyncPageItemControl
                   pageId={pageData._id}
-                  path={pageData.path}
                   onClickDeleteMenuItem={props.onClickDeleteButton}
                   isEnableActions={isEnableActions}
                 />

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -23,6 +23,7 @@ interface ItemProps {
   targetPathOrId?: string
   isOpen?: boolean
   onClickDeleteByPage?(page: IPageForPageDeleteModal): void
+  onClickDuplicateMenuItem?(pageId: string, path: string): void
 }
 
 // Utility to mark target
@@ -63,7 +64,7 @@ const ItemCount: FC<ItemCountProps> = (props:ItemCountProps) => {
 const Item: FC<ItemProps> = (props: ItemProps) => {
   const { t } = useTranslation();
   const {
-    itemNode, targetPathOrId, isOpen: _isOpen = false, onClickDeleteByPage, isEnableActions,
+    itemNode, targetPathOrId, isOpen: _isOpen = false, onClickDuplicateMenuItem, onClickDeleteByPage, isEnableActions,
   } = props;
 
   const { page, children } = itemNode;
@@ -121,6 +122,13 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
   const onClickPlusButton = useCallback(() => {
     setNewPageInputShown(true);
   }, []);
+
+  const duplicateMenuItemClickHandler = async(_pageId: string, _path: string): Promise<void> => {
+    if (onClickDuplicateMenuItem == null) {
+      return;
+    }
+    await onClickDuplicateMenuItem(_pageId, _path);
+  };
 
   const onClickDeleteButton = useCallback(async(_pageId: string): Promise<void> => {
     if (onClickDeleteByPage == null) {
@@ -261,8 +269,10 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
         <div className="grw-pagetree-control d-none">
           <AsyncPageItemControl
             pageId={page._id}
+            path={page.path}
             isEnableActions={isEnableActions}
             onClickBookmarkMenuItem={bookmarkMenuItemClickHandler}
+            onClickDuplicateMenuItem={duplicateMenuItemClickHandler}
             onClickDeleteMenuItem={onClickDeleteButton}
             onClickRenameMenuItem={onClickRenameButton}
           />
@@ -293,6 +303,7 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
               itemNode={node}
               isOpen={false}
               targetPathOrId={targetPathOrId}
+              onClickDuplicateMenuItem={onClickDuplicateMenuItem}
               onClickDeleteByPage={onClickDeleteByPage}
             />
           </div>

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -123,12 +123,19 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
     setNewPageInputShown(true);
   }, []);
 
-  const duplicateMenuItemClickHandler = async(_pageId: string, _path: string): Promise<void> => {
+  const duplicateMenuItemClickHandler = useCallback((): void => {
     if (onClickDuplicateMenuItem == null) {
       return;
     }
-    await onClickDuplicateMenuItem(_pageId, _path);
-  };
+
+    const { _id: pageId, path } = page;
+
+    if (pageId == null || path == null) {
+      throw Error('Any of _id and path must not be null.');
+    }
+
+    onClickDuplicateMenuItem(pageId, path);
+  }, [onClickDuplicateMenuItem, page]);
 
   const onClickDeleteButton = useCallback(async(_pageId: string): Promise<void> => {
     if (onClickDeleteByPage == null) {
@@ -269,7 +276,6 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
         <div className="grw-pagetree-control d-none">
           <AsyncPageItemControl
             pageId={page._id}
-            path={page.path}
             isEnableActions={isEnableActions}
             onClickBookmarkMenuItem={bookmarkMenuItemClickHandler}
             onClickDuplicateMenuItem={duplicateMenuItemClickHandler}


### PR DESCRIPTION
## Task
PageItemControlの複製ボタンをクリックするとPageDuplicateModalが表示され、ページの複製を実行する


## ScreenRecording

https://user-images.githubusercontent.com/59536731/152637045-2d700125-d11f-4e32-bca5-396397e9839c.mov

## Note
※dev.5.0.xをマージした際にisRecursiveryの処理が正常に動作されなくなりましたが(単体の複製のみが成功する)、原因はこのブランチにはないと判断したためそのままPR依頼を出します(増山くんには共有済み)
モーダルで`isRecursively`にチェックした際、`routes/apiv3/pages.js` の`/duplicate` でisRecursivelyはtrueのままちゃんと渡っています。

↓原因はこの中にある
<img width="612" alt="Screen Shot 2022-02-05 at 21 23 49" src="https://user-images.githubusercontent.com/59536731/152642845-fe99e499-f5c2-4442-97f4-736400e47997.png">

