### PR TITLE
imprv: redesign tag sidebar and modify related components

### DIFF
--- a/packages/app/src/components/Sidebar/SidebarNav.tsx
+++ b/packages/app/src/components/Sidebar/SidebarNav.tsx
@@ -79,7 +79,7 @@ const SidebarNav: FC<Props> = (props: Props) => {
       <div className="grw-sidebar-nav-primary-container">
         {!isSharedUser && <PrimaryItem contents={SidebarContentsType.CUSTOM} label="Custom Sidebar" iconName="code" onItemSelected={onItemSelected} />}
         {!isSharedUser && <PrimaryItem contents={SidebarContentsType.RECENT} label="Recent Changes" iconName="update" onItemSelected={onItemSelected} />}
-        {!isSharedUser && <PrimaryItem contents={SidebarContentsType.TAG} label="Tags" iconName="tag" onItemSelected={onItemSelected} /> }
+        {!isSharedUser && <PrimaryItem contents={SidebarContentsType.TAG} label="Tags" iconName="local_offer" onItemSelected={onItemSelected} /> }
         {/* <PrimaryItem id="favorite" label="Favorite" iconName="icon-star" /> */}
       </div>
       <div className="grw-sidebar-nav-secondary-container">

--- a/packages/app/src/components/Sidebar/Tag.tsx
+++ b/packages/app/src/components/Sidebar/Tag.tsx
@@ -48,9 +48,9 @@ const Tag: FC = () => {
       <div className="px-3 text-center">
         <TagCloudBox tags={tagData} />
       </div>
-      <div className="d-flex justify-content-center">
+      <div className="d-flex justify-content-center my-5">
         <button
-          className="btn btn-primary rounded mt-3 mb-4 px-5"
+          className="btn btn-primary rounded px-5"
           type="button"
           onClick={() => { window.location.href = '/tags' }}
         >

--- a/packages/app/src/components/Sidebar/Tag.tsx
+++ b/packages/app/src/components/Sidebar/Tag.tsx
@@ -46,11 +46,11 @@ const Tag: FC = () => {
       <h2 className="my-3">{t('popular_tags')}</h2>
 
       <div className="px-3 text-center">
-        <TagCloudBox tags={tagData} minSize={20} />
+        <TagCloudBox tags={tagData} />
       </div>
       <div className="d-flex justify-content-center">
         <button
-          className="btn btn-primary mt-3 mb-4 px-5"
+          className="btn btn-primary rounded mt-3 mb-4 px-5"
           type="button"
           onClick={() => { window.location.href = '/tags' }}
         >

--- a/packages/app/src/components/TagCloudBox.tsx
+++ b/packages/app/src/components/TagCloudBox.tsx
@@ -7,11 +7,11 @@ type Props = {
   minSize?: number,
   maxSize?: number,
   maxTagTextLength?: number,
-  isEnableRandomColor?: boolean,
+  isDisableRandomColor?: boolean,
 };
 
 const defaultProps = {
-  isEnableRandomColor: true,
+  isDisableRandomColor: true,
 };
 
 const MIN_FONT_SIZE = 10;
@@ -20,9 +20,10 @@ const MAX_TAG_TEXT_LENGTH = 8;
 
 const TagCloudBox: FC<Props> = memo((props:(Props & typeof defaultProps)) => {
   const {
-    tags, minSize, maxSize, isEnableRandomColor,
+    tags, minSize, maxSize, isDisableRandomColor,
   } = props;
   const maxTagTextLength: number = props.maxTagTextLength || MAX_TAG_TEXT_LENGTH;
+
   return (
     <>
       <TagCloud
@@ -30,17 +31,21 @@ const TagCloudBox: FC<Props> = memo((props:(Props & typeof defaultProps)) => {
         maxSize={maxSize || MAX_FONT_SIZE}
         tags={tags.map((tag:ITagCountHasId) => {
           return {
+            // text truncation
             value: (tag.name).length > maxTagTextLength ? `${(tag.name).slice(0, maxTagTextLength)}...` : tag.name,
             count: tag.count,
           };
         })}
-        disableRandomColor={!isEnableRandomColor}
+        disableRandomColor={isDisableRandomColor}
         style={{ cursor: 'pointer' }}
         className="simple-cloud text-secondary"
         onClick={(target) => { window.location.href = `/_search?q=tag:${encodeURIComponent(target.value)}` }}
       />
     </>
   );
+
 });
+
+TagCloudBox.defaultProps = defaultProps;
 
 export default TagCloudBox;

--- a/packages/app/src/components/TagCloudBox.tsx
+++ b/packages/app/src/components/TagCloudBox.tsx
@@ -22,13 +22,13 @@ const TagCloudBox: FC<Props> = memo((props:(Props & typeof defaultProps)) => {
   const {
     tags, minSize, maxSize, isDisableRandomColor,
   } = props;
-  const maxTagTextLength: number = props.maxTagTextLength || MAX_TAG_TEXT_LENGTH;
+  const maxTagTextLength: number = props.maxTagTextLength ?? MAX_TAG_TEXT_LENGTH;
 
   return (
     <>
       <TagCloud
-        minSize={minSize || MIN_FONT_SIZE}
-        maxSize={maxSize || MAX_FONT_SIZE}
+        minSize={minSize ?? MIN_FONT_SIZE}
+        maxSize={maxSize ?? MAX_FONT_SIZE}
         tags={tags.map((tag:ITagCountHasId) => {
           return {
             // text truncation

--- a/packages/app/src/components/TagCloudBox.tsx
+++ b/packages/app/src/components/TagCloudBox.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, memo } from 'react';
 import { TagCloud } from 'react-tagcloud';
 import { ITagCountHasId } from '~/interfaces/tag';
 
@@ -6,27 +6,41 @@ type Props = {
   tags:ITagCountHasId[],
   minSize?: number,
   maxSize?: number,
-}
+  maxTagTextLength?: number,
+  isEnableRandomColor?: boolean,
+};
 
-const MIN_FONT_SIZE = 12;
-const MAX_FONT_SIZE = 36;
+const defaultProps = {
+  isEnableRandomColor: true,
+};
 
-const TagCloudBox: FC<Props> = (props:Props) => {
+const MIN_FONT_SIZE = 10;
+const MAX_FONT_SIZE = 24;
+const MAX_TAG_TEXT_LENGTH = 8;
+
+const TagCloudBox: FC<Props> = memo((props:(Props & typeof defaultProps)) => {
+  const {
+    tags, minSize, maxSize, isEnableRandomColor,
+  } = props;
+  const maxTagTextLength: number = props.maxTagTextLength || MAX_TAG_TEXT_LENGTH;
   return (
     <>
       <TagCloud
-        minSize={props.minSize || MIN_FONT_SIZE}
-        maxSize={props.maxSize || MAX_FONT_SIZE}
-        tags={props.tags.map((tag) => {
-          return { value: tag.name, count: tag.count };
+        minSize={minSize || MIN_FONT_SIZE}
+        maxSize={maxSize || MAX_FONT_SIZE}
+        tags={tags.map((tag:ITagCountHasId) => {
+          return {
+            value: (tag.name).length > maxTagTextLength ? `${(tag.name).slice(0, maxTagTextLength)}...` : tag.name,
+            count: tag.count,
+          };
         })}
+        disableRandomColor={!isEnableRandomColor}
         style={{ cursor: 'pointer' }}
-        className="simple-cloud"
+        className="simple-cloud text-secondary"
         onClick={(target) => { window.location.href = `/_search?q=tag:${encodeURIComponent(target.value)}` }}
       />
     </>
   );
-
-};
+});
 
 export default TagCloudBox;

--- a/packages/app/src/components/TagList.tsx
+++ b/packages/app/src/components/TagList.tsx
@@ -26,12 +26,16 @@ const TagList: FC<TagListProps> = (props:(TagListProps & typeof defaultProps)) =
   const { t } = useTranslation('');
 
   const generateTagList = useCallback((tagData) => {
-    return tagData.map((data) => {
-      // todo: adjust design
+    return tagData.map((data:ITagCountHasId, index:number) => {
+      const tagListClasses: string = index === 0 ? 'list-group-item d-flex' : 'list-group-item d-flex border-top-0';
       return (
-        <a key={data.name} href={`/_search?q=tag:${data.name}`} className="list-group-item">
-          <i className="icon-tag mr-2"></i>{data.name}
-          <span className="ml-4 list-tag-count badge badge-secondary text-muted">{data.count}</span>
+        <a
+          key={data.name}
+          href={`/_search?q=tag:${encodeURIComponent(data.name)}`}
+          className={tagListClasses}
+        >
+          <div className="text-truncate">{data.name}</div>
+          <div className="ml-4 my-auto py-1 px-2 list-tag-count badge badge-secondary text-white">{data.count}</div>
         </a>
       );
     });

--- a/packages/app/src/components/TagList.tsx
+++ b/packages/app/src/components/TagList.tsx
@@ -26,16 +26,17 @@ const TagList: FC<TagListProps> = (props:(TagListProps & typeof defaultProps)) =
   const { t } = useTranslation('');
 
   const generateTagList = useCallback((tagData) => {
-    return tagData.map((data:ITagCountHasId, index:number) => {
+    return tagData.map((tag:ITagCountHasId, index:number) => {
       const tagListClasses: string = index === 0 ? 'list-group-item d-flex' : 'list-group-item d-flex border-top-0';
+
       return (
         <a
-          key={data.name}
-          href={`/_search?q=tag:${encodeURIComponent(data.name)}`}
+          key={tag._id}
+          href={`/_search?q=tag:${encodeURIComponent(tag.name)}`}
           className={tagListClasses}
         >
-          <div className="text-truncate">{data.name}</div>
-          <div className="ml-4 my-auto py-1 px-2 list-tag-count badge badge-secondary text-white">{data.count}</div>
+          <div className="text-truncate">{tag.name}</div>
+          <div className="ml-4 my-auto py-1 px-2 list-tag-count badge badge-secondary text-white">{tag.count}</div>
         </a>
       );
     });


### PR DESCRIPTION
## task

https://redmine.weseek.co.jp/issues/87031

## 行ったこと

- XD( https://xd.adobe.com/view/cd3cb2f8-625d-4a6b-b6e4-917f75c675c5-986f/screen/2c321a4b-f25f-4ee8-b6c2-77c9334ea48f/ ) に基づいて、サイドバーのタグゾーンのデザインを修正しました

## 画像

<img src="https://user-images.githubusercontent.com/83065937/152754282-f56f1998-5070-4832-b53d-5459300e03ad.PNG" width="400">


## この後行うこと

- デザイナーチェック依頼
- デザイナーとの相談
    - ① /tags のページが、サイドバーと分離したため、より柔軟なデザインができるようになったため、相談
    - ② swr 経由でサーバーサイドと問い合わせてる最中の loading 状態のデザイン