### PR TITLE
feat: 87839 Don't let ClosableInputText do onPressEnter when validation is enabled

### DIFF
--- a/packages/app/src/components/Common/ClosableTextInput.tsx
+++ b/packages/app/src/components/Common/ClosableTextInput.tsx
@@ -29,6 +29,7 @@ const ClosableTextInput: FC<ClosableTextInputProps> = memo((props: ClosableTextI
   const inputRef = useRef<HTMLInputElement>(null);
 
   const [inputText, setInputText] = useState(props.value);
+  const [canKeyDownHandler, setCanKeyDownHandler] = useState(false);
   const [currentAlertInfo, setAlertInfo] = useState<AlertInfo | null>(null);
 
   const onChangeHandler = async(e) => {
@@ -37,6 +38,9 @@ const ClosableTextInput: FC<ClosableTextInputProps> = memo((props: ClosableTextI
     const inputText = e.target.value;
 
     const alertInfo = await props.inputValidator(inputText);
+
+    // eslint-disable-next-line no-unused-expressions
+    alertInfo == null ? setCanKeyDownHandler(true) : setCanKeyDownHandler(false);
 
     setAlertInfo(alertInfo);
     setInputText(inputText);
@@ -53,12 +57,8 @@ const ClosableTextInput: FC<ClosableTextInputProps> = memo((props: ClosableTextI
   };
 
   const onKeyDownHandler = (e) => {
-    switch (e.key) {
-      case 'Enter':
-        onPressEnter();
-        break;
-      default:
-        break;
+    if (canKeyDownHandler && e.key === 'Enter') {
+      onPressEnter();
     }
   };
 

--- a/packages/app/src/components/Common/ClosableTextInput.tsx
+++ b/packages/app/src/components/Common/ClosableTextInput.tsx
@@ -38,13 +38,13 @@ const ClosableTextInput: FC<ClosableTextInputProps> = memo((props: ClosableTextI
     }
   };
 
-  const onChangeHandler = async(e) => {
+  const onChangeHandler = async(e: React.ChangeEvent<HTMLInputElement>) => {
     const inputText = e.target.value;
     createValidation(inputText);
     setInputText(inputText);
   };
 
-  const onFocusHandler = async(e) => {
+  const onFocusHandler = async(e: React.ChangeEvent<HTMLInputElement>) => {
     const inputText = e.target.value;
     await createValidation(inputText);
   };
@@ -113,11 +113,11 @@ const ClosableTextInput: FC<ClosableTextInputProps> = memo((props: ClosableTextI
         className="form-control"
         placeholder={props.placeholder}
         name="input"
+        onFocus={onFocusHandler}
         onChange={onChangeHandler}
         onKeyDown={onKeyDownHandler}
         onBlur={onBlurHandler}
         autoFocus={false}
-        onFocus={onFocusHandler}
       />
       <AlertInfo />
     </div>

--- a/packages/app/src/components/Common/ClosableTextInput.tsx
+++ b/packages/app/src/components/Common/ClosableTextInput.tsx
@@ -52,13 +52,18 @@ const ClosableTextInput: FC<ClosableTextInputProps> = memo((props: ClosableTextI
     }
 
     const text = inputText != null ? inputText.trim() : null;
-
-    props.onPressEnter(text);
+    if (currentAlertInfo == null) {
+      props.onPressEnter(text);
+    }
   };
 
   const onKeyDownHandler = (e) => {
-    if (e.key === 'Enter' && currentAlertInfo == null) {
-      onPressEnter();
+    switch (e.key) {
+      case 'Enter':
+        onPressEnter();
+        break;
+      default:
+        break;
     }
   };
 

--- a/packages/app/src/components/Common/ClosableTextInput.tsx
+++ b/packages/app/src/components/Common/ClosableTextInput.tsx
@@ -29,7 +29,6 @@ const ClosableTextInput: FC<ClosableTextInputProps> = memo((props: ClosableTextI
   const inputRef = useRef<HTMLInputElement>(null);
 
   const [inputText, setInputText] = useState(props.value);
-  const [canKeyDownHandler, setCanKeyDownHandler] = useState(false);
   const [currentAlertInfo, setAlertInfo] = useState<AlertInfo | null>(null);
 
   const onChangeHandler = async(e) => {
@@ -39,11 +38,12 @@ const ClosableTextInput: FC<ClosableTextInputProps> = memo((props: ClosableTextI
 
     const alertInfo = await props.inputValidator(inputText);
 
-    // eslint-disable-next-line no-unused-expressions
-    alertInfo == null ? setCanKeyDownHandler(true) : setCanKeyDownHandler(false);
-
     setAlertInfo(alertInfo);
     setInputText(inputText);
+  };
+
+  const onFocusHandler = async(e) => {
+    await onChangeHandler(e);
   };
 
   const onPressEnter = () => {
@@ -57,7 +57,7 @@ const ClosableTextInput: FC<ClosableTextInputProps> = memo((props: ClosableTextI
   };
 
   const onKeyDownHandler = (e) => {
-    if (canKeyDownHandler && e.key === 'Enter') {
+    if (e.key === 'Enter' && currentAlertInfo == null) {
       onPressEnter();
     }
   };
@@ -111,6 +111,7 @@ const ClosableTextInput: FC<ClosableTextInputProps> = memo((props: ClosableTextI
         onKeyDown={onKeyDownHandler}
         onBlur={onBlurHandler}
         autoFocus={false}
+        onFocus={onFocusHandler}
       />
       <AlertInfo />
     </div>

--- a/packages/app/src/components/Common/ClosableTextInput.tsx
+++ b/packages/app/src/components/Common/ClosableTextInput.tsx
@@ -31,29 +31,30 @@ const ClosableTextInput: FC<ClosableTextInputProps> = memo((props: ClosableTextI
   const [inputText, setInputText] = useState(props.value);
   const [currentAlertInfo, setAlertInfo] = useState<AlertInfo | null>(null);
 
+  const createValidation = async(inputText: string) => {
+    if (props.inputValidator != null) {
+      const alertInfo = await props.inputValidator(inputText);
+      setAlertInfo(alertInfo);
+    }
+  };
+
   const onChangeHandler = async(e) => {
-    if (props.inputValidator == null) { return }
-
     const inputText = e.target.value;
-
-    const alertInfo = await props.inputValidator(inputText);
-
-    setAlertInfo(alertInfo);
+    createValidation(inputText);
     setInputText(inputText);
   };
 
   const onFocusHandler = async(e) => {
-    await onChangeHandler(e);
+    const inputText = e.target.value;
+    await createValidation(inputText);
   };
 
   const onPressEnter = () => {
-    if (props.onPressEnter == null) {
-      return;
-    }
-
-    const text = inputText != null ? inputText.trim() : null;
-    if (currentAlertInfo == null) {
-      props.onPressEnter(text);
+    if (props.onPressEnter != null) {
+      const text = inputText != null ? inputText.trim() : null;
+      if (currentAlertInfo == null) {
+        props.onPressEnter(text);
+      }
     }
   };
 

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -119,6 +119,11 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
     }),
   }));
 
+  const getParentPagePath = (pagePath: string) => {
+    const dirname = nodePath.dirname(page.path as string);
+    return dirname === '/' ? '' : dirname;
+  };
+
   const hasChildren = useCallback((): boolean => {
     return currentChildren != null && currentChildren.length > 0;
   }, [currentChildren]);
@@ -226,8 +231,7 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
       return;
     }
 
-    const parentPath = nodePath.dirname(page.path as string);
-
+    const parentPath = getParentPagePath(page.path as string);
     redirectToEditor(parentPath, inputText);
   };
 

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -8,7 +8,7 @@ import { useDrag, useDrop } from 'react-dnd';
 
 import nodePath from 'path';
 
-import { pagePathUtils } from '@growi/core';
+import { pathUtils } from '@growi/core';
 
 import { toastWarning, toastError } from '~/client/util/apiNotification';
 
@@ -21,8 +21,6 @@ import { bookmark, unbookmark } from '~/client/services/page-operation';
 import ClosableTextInput, { AlertInfo, AlertType } from '../../Common/ClosableTextInput';
 import { AsyncPageItemControl } from '../../Common/Dropdown/PageItemControl';
 import { ItemNode } from './ItemNode';
-
-const { generateEditorPath } = pagePathUtils;
 
 interface ItemProps {
   isEnableActions: boolean
@@ -119,11 +117,6 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
     }),
   }));
 
-  const getParentPagePath = (pagePath: string) => {
-    const dirname = nodePath.dirname(page.path as string);
-    return dirname === '/' ? '' : dirname;
-  };
-
   const hasChildren = useCallback((): boolean => {
     return currentChildren != null && currentChildren.length > 0;
   }, [currentChildren]);
@@ -210,20 +203,11 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
     onClickDeleteByPage(pageToDelete);
   }, [page, onClickDeleteByPage]);
 
-  const redirectToEditor = (...paths: string[]) => {
-    try {
-      const editorPath = generateEditorPath(...paths);
-      window.location.href = editorPath;
-    }
-    catch (err) {
-      toastError(err);
-    }
-  };
-
   const onPressEnterForCreateHandler = (inputText: string) => {
     setNewPageInputShown(false);
-    const parentPath = getParentPagePath(page.path as string);
-    redirectToEditor(parentPath, inputText);
+    const parentPath = pathUtils.addTrailingSlash(page.path as string);
+    const newPagePath = `${parentPath}${inputText}`;
+    console.log(newPagePath);
   };
 
   const inputValidator = (title: string | null): AlertInfo | null => {

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -208,6 +208,7 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
     const parentPath = pathUtils.addTrailingSlash(page.path as string);
     const newPagePath = `${parentPath}${inputText}`;
     console.log(newPagePath);
+    // TODO: https://redmine.weseek.co.jp/issues/87943
   };
 
   const inputValidator = (title: string | null): AlertInfo | null => {

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -7,6 +7,9 @@ import { useTranslation } from 'react-i18next';
 import { useDrag, useDrop } from 'react-dnd';
 
 import nodePath from 'path';
+
+import { pagePathUtils } from '@growi/core';
+
 import { toastWarning, toastError } from '~/client/util/apiNotification';
 
 import { useSWRxPageChildren } from '~/stores/page-listing';
@@ -19,6 +22,7 @@ import ClosableTextInput, { AlertInfo, AlertType } from '../../Common/ClosableTe
 import { AsyncPageItemControl } from '../../Common/Dropdown/PageItemControl';
 import { ItemNode } from './ItemNode';
 
+const { generateEditorPath } = pagePathUtils;
 
 interface ItemProps {
   isEnableActions: boolean
@@ -185,7 +189,6 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
     onClickRenameMenuItem(pageId, revisionId as string, path);
   }, [onClickRenameMenuItem, page]);
 
-
   const onClickDeleteButton = useCallback(async(_pageId: string): Promise<void> => {
     if (onClickDeleteByPage == null) {
       return;
@@ -206,11 +209,26 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
     onClickDeleteByPage(pageToDelete);
   }, [page, onClickDeleteByPage]);
 
+  const redirectToEditor = (...paths) => {
+    try {
+      const editorPath = generateEditorPath(...paths);
+      window.location.href = editorPath;
+    }
+    catch (err) {
+      toastError(err);
+    }
+  };
 
-  // TODO: go to create page page
-  const onPressEnterForCreateHandler = () => {
-    toastWarning(t('search_result.currently_not_implemented'));
+  const onPressEnterForCreateHandler = (inputText: string) => {
     setNewPageInputShown(false);
+
+    if (inputText == null || inputText === '' || inputText.trim() === '' || inputText.includes('/')) {
+      return;
+    }
+
+    const parentPath = nodePath.dirname(page.path as string);
+
+    redirectToEditor(parentPath, inputText);
   };
 
   const inputValidator = (title: string | null): AlertInfo | null => {

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -214,7 +214,7 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
     onClickDeleteByPage(pageToDelete);
   }, [page, onClickDeleteByPage]);
 
-  const redirectToEditor = (...paths) => {
+  const redirectToEditor = (...paths: string[]) => {
     try {
       const editorPath = generateEditorPath(...paths);
       window.location.href = editorPath;

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -160,11 +160,7 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
   // }, []);
 
   // const onPressEnterForRenameHandler = async(inputText: string) => {
-  //   if (inputText == null || inputText === '' || inputText.trim() === '' || inputText.includes('/')) {
-  //     return;
-  //   }
-
-  //   const parentPath = getParentPagePath(page.path)
+  //   const parentPath = getParentPagePath(page.path as string)
   //   const newPagePath = `${parentPath}/${inputText}`;
 
   //   try {
@@ -226,11 +222,6 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
 
   const onPressEnterForCreateHandler = (inputText: string) => {
     setNewPageInputShown(false);
-
-    if (inputText == null || inputText === '' || inputText.trim() === '' || inputText.includes('/')) {
-      return;
-    }
-
     const parentPath = getParentPagePath(page.path as string);
     redirectToEditor(parentPath, inputText);
   };

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -164,7 +164,7 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
   //     return;
   //   }
 
-  //   const parentPath = nodePath.dirname(page.path as string);
+  //   const parentPath = getParentPagePath(page.path)
   //   const newPagePath = `${parentPath}/${inputText}`;
 
   //   try {


### PR DESCRIPTION
## Tsak
[#87839](https://redmine.weseek.co.jp/issues/87839) [Front] ClosableInputText のバリデーション有効時に、ページの保存処理をさせない　にリネーム