### PR TITLE
imprv: Pre-calculate paths to process

### DIFF
--- a/packages/app/src/server/service/page.ts
+++ b/packages/app/src/server/service/page.ts
@@ -1960,33 +1960,6 @@ class PageService {
     await this._setIsV5CompatibleTrue();
   }
 
-  /*
-   * returns an array of js RegExp instance instead of RE2 instance for mongo filter
-   */
-  private async _generateRegExpsByPageIds(pageIds, shouldOmitDuplicateAreaPath: boolean) {
-    const Page = mongoose.model('Page') as unknown as PageModel;
-
-    let result;
-    try {
-      result = await Page.findListByPageIds(pageIds, null, false);
-    }
-    catch (err) {
-      logger.error('Failed to find pages by ids', err);
-      throw err;
-    }
-
-    const { pages } = result;
-
-    let paths = pages.map(p => p.path);
-    if (shouldOmitDuplicateAreaPath) {
-      paths = omitDuplicateAreaPathFromPaths(paths);
-    }
-
-    const regexps = paths.map(path => new RegExp(`^${escapeStringRegexp(path)}`));
-
-    return regexps;
-  }
-
   private async _setIsV5CompatibleTrue() {
     try {
       await this.crowi.configManager.updateConfigsInTheSameNamespace('crowi', {

--- a/packages/app/src/server/service/page.ts
+++ b/packages/app/src/server/service/page.ts
@@ -26,7 +26,7 @@ const debug = require('debug')('growi:services:page');
 
 const logger = loggerFactory('growi:services:page');
 const {
-  isCreatablePage, isTrashPage, isTopPage, omitDuplicatePathAreaFromPaths,
+  isCreatablePage, isTrashPage, isTopPage, omitDuplicateAreaPathFromPaths,
 } = pagePathUtils;
 
 const BULK_REINDEX_SIZE = 100;
@@ -1943,7 +1943,7 @@ class PageService {
   /*
    * returns an array of js RegExp instance instead of RE2 instance for mongo filter
    */
-  private async _generateRegExpsByPageIds(pageIds, shouldOmitDuplicatePathArea: boolean) {
+  private async _generateRegExpsByPageIds(pageIds, shouldOmitDuplicateAreaPath: boolean) {
     const Page = mongoose.model('Page') as unknown as PageModel;
 
     let result;
@@ -1958,8 +1958,8 @@ class PageService {
     const { pages } = result;
 
     let paths = pages.map(p => p.path);
-    if (shouldOmitDuplicatePathArea) {
-      paths = omitDuplicatePathAreaFromPaths(paths);
+    if (shouldOmitDuplicateAreaPath) {
+      paths = omitDuplicateAreaPathFromPaths(paths);
     }
 
     const regexps = paths.map(path => new RegExp(`^${escapeStringRegexp(path)}`));

--- a/packages/core/src/test/util/page-path-utils.test.js
+++ b/packages/core/src/test/util/page-path-utils.test.js
@@ -1,6 +1,6 @@
-import { pagePathUtils } from '~/utils/page-path-utils';
-
-const { isTopPage, convertToNewAffiliationPath, isCreatablePage } = pagePathUtils;
+import {
+  isTopPage, convertToNewAffiliationPath, isCreatablePage, omitDuplicatePathAreaFromPaths,
+} from '~/utils/page-path-utils';
 
 describe('TopPage Path test', () => {
   test('Path is only "/"', () => {
@@ -104,5 +104,35 @@ describe('isCreatablePage test', () => {
       expect(isCreatablePage(`/${pn}/`)).toBeFalsy();
       expect(isCreatablePage(`/${pn}/abc`)).toBeFalsy();
     }
+  });
+
+  describe('Test omitDuplicatePathAreaFromPaths', () => {
+    test('Should not omit when all paths are at unique area', () => {
+      const paths = ['/A', '/B/A', '/C/B/A', '/D'];
+      const expectedPaths = paths;
+
+      expect(omitDuplicatePathAreaFromPaths(paths)).toStrictEqual(paths);
+    });
+
+    test('Should omit when some paths are at duplicated area', () => {
+      const paths = ['/A', '/A/A', '/A/B/A', '/B', '/B/A', '/AA'];
+      const expectedPaths = ['/A', '/B', '/AA'];
+
+      expect(omitDuplicatePathAreaFromPaths(paths)).toStrictEqual(expectedPaths);
+    });
+
+    test('Should omit when some long paths are at duplicated area', () => {
+      const paths = ['/A/B/C', '/A/B/C/D', '/A/B/C/D/E'];
+      const expectedPaths = ['/A/B/C'];
+
+      expect(omitDuplicatePathAreaFromPaths(paths)).toStrictEqual(expectedPaths);
+    });
+
+    test('Should omit when some long paths are at duplicated area [case insensitivity]', () => {
+      const paths = ['/a/B/C', '/A/b/C/D', '/A/B/c/D/E'];
+      const expectedPaths = ['/a/B/C'];
+
+      expect(omitDuplicatePathAreaFromPaths(paths)).toStrictEqual(expectedPaths);
+    });
   });
 });

--- a/packages/core/src/test/util/page-path-utils.test.js
+++ b/packages/core/src/test/util/page-path-utils.test.js
@@ -1,5 +1,5 @@
 import {
-  isTopPage, convertToNewAffiliationPath, isCreatablePage, omitDuplicatePathAreaFromPaths,
+  isTopPage, convertToNewAffiliationPath, isCreatablePage, omitDuplicateAreaPathFromPaths,
 } from '~/utils/page-path-utils';
 
 describe('TopPage Path test', () => {
@@ -106,33 +106,33 @@ describe('isCreatablePage test', () => {
     }
   });
 
-  describe('Test omitDuplicatePathAreaFromPaths', () => {
+  describe('Test omitDuplicateAreaPathFromPaths', () => {
     test('Should not omit when all paths are at unique area', () => {
       const paths = ['/A', '/B/A', '/C/B/A', '/D'];
       const expectedPaths = paths;
 
-      expect(omitDuplicatePathAreaFromPaths(paths)).toStrictEqual(paths);
+      expect(omitDuplicateAreaPathFromPaths(paths)).toStrictEqual(paths);
     });
 
     test('Should omit when some paths are at duplicated area', () => {
       const paths = ['/A', '/A/A', '/A/B/A', '/B', '/B/A', '/AA'];
       const expectedPaths = ['/A', '/B', '/AA'];
 
-      expect(omitDuplicatePathAreaFromPaths(paths)).toStrictEqual(expectedPaths);
+      expect(omitDuplicateAreaPathFromPaths(paths)).toStrictEqual(expectedPaths);
     });
 
     test('Should omit when some long paths are at duplicated area', () => {
       const paths = ['/A/B/C', '/A/B/C/D', '/A/B/C/D/E'];
       const expectedPaths = ['/A/B/C'];
 
-      expect(omitDuplicatePathAreaFromPaths(paths)).toStrictEqual(expectedPaths);
+      expect(omitDuplicateAreaPathFromPaths(paths)).toStrictEqual(expectedPaths);
     });
 
     test('Should omit when some long paths are at duplicated area [case insensitivity]', () => {
       const paths = ['/a/B/C', '/A/b/C/D', '/A/B/c/D/E'];
       const expectedPaths = ['/a/B/C'];
 
-      expect(omitDuplicatePathAreaFromPaths(paths)).toStrictEqual(expectedPaths);
+      expect(omitDuplicateAreaPathFromPaths(paths)).toStrictEqual(expectedPaths);
     });
   });
 });

--- a/packages/core/src/utils/page-path-utils.ts
+++ b/packages/core/src/utils/page-path-utils.ts
@@ -164,11 +164,11 @@ export const collectAncestorPaths = (path: string, ancestorPaths: string[] = [])
 
 /**
  * return paths without duplicate area of regexp /^${path}\/.+/i
- * ex. expect(omitDuplicatePathAreaFromPaths(['/A', '/A/B', '/A/B/C'])).toStrictEqual(['/A'])
+ * ex. expect(omitDuplicateAreaPathFromPaths(['/A', '/A/B', '/A/B/C'])).toStrictEqual(['/A'])
  * @param paths paths to be tested
  * @returns omitted paths
  */
-export const omitDuplicatePathAreaFromPaths = (paths: string[]): string[] => {
+export const omitDuplicateAreaPathFromPaths = (paths: string[]): string[] => {
   return paths.filter((path) => {
     const isDuplicate = paths.filter(p => (new RegExp(`^${p}\\/.+`, 'i')).test(path)).length > 0;
 

--- a/packages/core/src/utils/page-path-utils.ts
+++ b/packages/core/src/utils/page-path-utils.ts
@@ -162,6 +162,12 @@ export const collectAncestorPaths = (path: string, ancestorPaths: string[] = [])
   return collectAncestorPaths(parentPath, ancestorPaths);
 };
 
+/**
+ * return paths without duplicate area of regexp /^${path}\/.+/i
+ * ex. expect(omitDuplicatePathAreaFromPaths(['/A', '/A/B', '/A/B/C'])).toStrictEqual(['/A'])
+ * @param paths paths to be tested
+ * @returns omitted paths
+ */
 export const omitDuplicatePathAreaFromPaths = (paths: string[]): string[] => {
   return paths.filter((path) => {
     const isDuplicate = paths.filter(p => (new RegExp(`^${p}\\/.+`, 'i')).test(path)).length > 0;

--- a/packages/core/src/utils/page-path-utils.ts
+++ b/packages/core/src/utils/page-path-utils.ts
@@ -161,3 +161,11 @@ export const collectAncestorPaths = (path: string, ancestorPaths: string[] = [])
   ancestorPaths.push(parentPath);
   return collectAncestorPaths(parentPath, ancestorPaths);
 };
+
+export const omitDuplicatePathAreaFromPaths = (paths: string[]): string[] => {
+  return paths.filter((path) => {
+    const isDuplicate = paths.filter(p => (new RegExp(`^${p}\\/.+`, 'i')).test(path)).length > 0;
+
+    return !isDuplicate;
+  });
+};


### PR DESCRIPTION
Redmine: https://redmine.weseek.co.jp/issues/87768

「パスの配列のうち、その子孫部分が被っている部分を計算して必要のないパスを配列から取り除くメソッド」を実装しました
複数かつ再帰的な削除・待避所からのマイグレーションをするときに、処理対象のページが被らないようにするために使われます

## 後続
- 複数指定かつ再帰的な削除の API 実装