### PR TITLE
Imprv: 87936 switch page delete modal

### DIFF
--- a/packages/app/src/components/Common/Dropdown/PageItemControl.tsx
+++ b/packages/app/src/components/Common/Dropdown/PageItemControl.tsx
@@ -46,9 +46,6 @@ const PageItemControlDropdownMenu = React.memo((props: DropdownMenuProps): JSX.E
     additionalMenuItemRenderer: AdditionalMenuItems,
   } = props;
 
-  console.log('pageInfo_pageItemControl', pageInfo);
-
-
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const bookmarkItemClickedHandler = useCallback(async() => {
     if (!isIPageInfoForOperation(pageInfo) || onClickBookmarkMenuItem == null) {

--- a/packages/app/src/components/Common/Dropdown/PageItemControl.tsx
+++ b/packages/app/src/components/Common/Dropdown/PageItemControl.tsx
@@ -46,6 +46,8 @@ const PageItemControlDropdownMenu = React.memo((props: DropdownMenuProps): JSX.E
     additionalMenuItemRenderer: AdditionalMenuItems,
   } = props;
 
+  console.log('pageInfo_pageItemControl', pageInfo);
+
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const bookmarkItemClickedHandler = useCallback(async() => {

--- a/packages/app/src/components/Navbar/GrowiContextualSubNavigation.tsx
+++ b/packages/app/src/components/Navbar/GrowiContextualSubNavigation.tsx
@@ -188,34 +188,9 @@ const GrowiContextualSubNavigation = (props) => {
     openRenameModal(pageId, revisionId, path);
   }, [openRenameModal]);
 
-  const onDeletedHandler: OnDeletedFunction = (pathOrPathsToDelete, isRecursively, isCompletely) => {
-    if (typeof pathOrPathsToDelete !== 'string') {
-      return;
-    }
-
-    const path = pathOrPathsToDelete;
-
-    if (isRecursively) {
-      if (isCompletely) {
-        toastSuccess(t('deleted_single_page_recursively_completely', { path }));
-      }
-      else {
-        toastSuccess(t('deleted_single_page_recursively', { path }));
-      }
-    }
-    else {
-      // eslint-disable-next-line no-lonely-if
-      if (isCompletely) {
-        toastSuccess(t('deleted_single_page_completely', { path }));
-      }
-      else {
-        toastSuccess(t('deleted_single_page', { path }));
-      }
-    }
-  };
 
   const deleteItemClickedHandler = useCallback(async(pageToDelete, isAbleToDeleteCompletely) => {
-    openDeleteModal([pageToDelete], onDeletedHandler, false, isAbleToDeleteCompletely);
+    openDeleteModal([pageToDelete], isAbleToDeleteCompletely);
   }, [openDeleteModal]);
 
   const templateMenuItemClickHandler = useCallback(() => {

--- a/packages/app/src/components/Navbar/GrowiContextualSubNavigation.tsx
+++ b/packages/app/src/components/Navbar/GrowiContextualSubNavigation.tsx
@@ -148,7 +148,6 @@ const GrowiContextualSubNavigation = (props) => {
   const { open: openRenameModal } = usePageRenameModal();
   const { open: openDeleteModal } = usePageDeleteModal();
 
-  const { t } = useTranslation();
 
   const [isPageTemplateModalShown, setIsPageTempleteModalShown] = useState(false);
 

--- a/packages/app/src/components/Navbar/GrowiContextualSubNavigation.tsx
+++ b/packages/app/src/components/Navbar/GrowiContextualSubNavigation.tsx
@@ -13,7 +13,7 @@ import {
 } from '~/stores/ui';
 import {
   usePageAccessoriesModal, PageAccessoriesModalContents,
-  usePageDuplicateModal, usePageRenameModal, usePageDeleteModal, usePagePresentationModal,
+  usePageDuplicateModal, usePageRenameModal, usePageDeleteModal, OnDeletedFunction, usePagePresentationModal,
 } from '~/stores/modal';
 
 
@@ -148,6 +148,8 @@ const GrowiContextualSubNavigation = (props) => {
   const { open: openRenameModal } = usePageRenameModal();
   const { open: openDeleteModal } = usePageDeleteModal();
 
+  const { t } = useTranslation();
+
   const [isPageTemplateModalShown, setIsPageTempleteModalShown] = useState(false);
 
   const {
@@ -186,8 +188,34 @@ const GrowiContextualSubNavigation = (props) => {
     openRenameModal(pageId, revisionId, path);
   }, [openRenameModal]);
 
-  const deleteItemClickedHandler = useCallback(async(pageToDelete) => {
-    openDeleteModal([pageToDelete]);
+  const onDeletedHandler: OnDeletedFunction = (pathOrPathsToDelete, isRecursively, isCompletely) => {
+    if (typeof pathOrPathsToDelete !== 'string') {
+      return;
+    }
+
+    const path = pathOrPathsToDelete;
+
+    if (isRecursively) {
+      if (isCompletely) {
+        toastSuccess(t('deleted_single_page_recursively_completely', { path }));
+      }
+      else {
+        toastSuccess(t('deleted_single_page_recursively', { path }));
+      }
+    }
+    else {
+      // eslint-disable-next-line no-lonely-if
+      if (isCompletely) {
+        toastSuccess(t('deleted_single_page_completely', { path }));
+      }
+      else {
+        toastSuccess(t('deleted_single_page', { path }));
+      }
+    }
+  };
+
+  const deleteItemClickedHandler = useCallback(async(pageToDelete, isAbleToDeleteCompletely) => {
+    openDeleteModal([pageToDelete], onDeletedHandler, false, isAbleToDeleteCompletely);
   }, [openDeleteModal]);
 
   const templateMenuItemClickHandler = useCallback(() => {

--- a/packages/app/src/components/Navbar/GrowiContextualSubNavigation.tsx
+++ b/packages/app/src/components/Navbar/GrowiContextualSubNavigation.tsx
@@ -13,7 +13,7 @@ import {
 } from '~/stores/ui';
 import {
   usePageAccessoriesModal, PageAccessoriesModalContents,
-  usePageDuplicateModal, usePageRenameModal, usePageDeleteModal, OnDeletedFunction, usePagePresentationModal,
+  usePageDuplicateModal, usePageRenameModal, usePageDeleteModal, usePagePresentationModal,
 } from '~/stores/modal';
 
 

--- a/packages/app/src/components/Navbar/SubNavButtons.tsx
+++ b/packages/app/src/components/Navbar/SubNavButtons.tsx
@@ -23,7 +23,7 @@ type CommonProps = {
   additionalMenuItemRenderer?: React.FunctionComponent<AdditionalMenuItemsRendererProps>,
   onClickDuplicateMenuItem?: (pageId: string, path: string) => void,
   onClickRenameMenuItem?: (pageId: string, revisionId: string, path: string) => void,
-  onClickDeleteMenuItem?: (pageToDelete: IPageForPageDeleteModal | null) => void,
+  onClickDeleteMenuItem?: (pageToDelete: IPageForPageDeleteModal | null, isAbleToDeleteCompletely: boolean) => void,
 }
 
 type SubNavButtonsSubstanceProps= CommonProps & {
@@ -120,8 +120,10 @@ const SubNavButtonsSubstance = (props: SubNavButtonsSubstanceProps): JSX.Element
       path,
     };
 
-    onClickDeleteMenuItem(pageToDelete);
-  }, [onClickDeleteMenuItem, pageId, path, revisionId]);
+    const { isAbleToDeleteCompletely } = pageInfo;
+
+    onClickDeleteMenuItem(pageToDelete, isAbleToDeleteCompletely);
+  }, [onClickDeleteMenuItem, pageId, pageInfo, path, revisionId]);
 
   if (!isIPageInfoForOperation(pageInfo)) {
     return <></>;

--- a/packages/app/src/components/PageDeleteModal.tsx
+++ b/packages/app/src/components/PageDeleteModal.tsx
@@ -32,7 +32,6 @@ const PageDeleteModal: FC = () => {
   const { data: deleteModalData, close: closeDeleteModal } = usePageDeleteModal();
 
   const isOpened = deleteModalData?.isOpened != null ? deleteModalData.isOpened : false;
-  const onDeleted = deleteModalData?.onDeleted != null ? deleteModalData.onDeleted : null;
   const isDeleteCompletelyModal = deleteModalData?.isDeleteCompletelyModal != null ? deleteModalData.isDeleteCompletelyModal : false;
   const isAbleToDeleteCompletely = deleteModalData?.isAbleToDeleteCompletely != null ? deleteModalData.isAbleToDeleteCompletely : false;
 

--- a/packages/app/src/components/PageDeleteModal.tsx
+++ b/packages/app/src/components/PageDeleteModal.tsx
@@ -32,8 +32,8 @@ const PageDeleteModal: FC = () => {
   const { data: deleteModalData, close: closeDeleteModal } = usePageDeleteModal();
 
   const isOpened = deleteModalData?.isOpened != null ? deleteModalData.isOpened : false;
-  const isDeleteCompletelyModal = deleteModalData?.isDeleteCompletelyModal != null ? deleteModalData.isDeleteCompletelyModal : false;
   const isAbleToDeleteCompletely = deleteModalData?.isAbleToDeleteCompletely != null ? deleteModalData.isAbleToDeleteCompletely : false;
+  const isDeleteCompletelyModal = deleteModalData?.isDeleteCompletelyModal != null ? deleteModalData.isDeleteCompletelyModal : false;
 
   console.log('isDeleteCompletelyModal', isDeleteCompletelyModal);
 
@@ -141,13 +141,10 @@ const PageDeleteModal: FC = () => {
           name="completely"
           id="deleteCompletely"
           type="checkbox"
-          // disabled={!isAbleToDeleteCompletely}
-          // disabled // Todo: will be implemented at https://redmine.weseek.co.jp/issues/82222
+          disabled={!isAbleToDeleteCompletely}
           checked={isDeleteCompletely}
           onChange={changeIsDeleteCompletelyHandler}
         />
-        {/* ↓↓ undo this comment out at https://redmine.weseek.co.jp/issues/82222 ↓↓ */}
-        {/* <label className="custom-control-label text-danger" htmlFor="deleteCompletely"> */}
         <label className="custom-control-label" htmlFor="deleteCompletely">
           { t('modal_delete.delete_completely')}
           <p className="form-text text-muted mt-0"> { t('modal_delete.completely') }</p>

--- a/packages/app/src/components/PageDeleteModal.tsx
+++ b/packages/app/src/components/PageDeleteModal.tsx
@@ -35,6 +35,8 @@ const PageDeleteModal: FC = () => {
   const isDeleteCompletelyModal = deleteModalData?.isDeleteCompletelyModal != null ? deleteModalData.isDeleteCompletelyModal : false;
   const isAbleToDeleteCompletely = deleteModalData?.isAbleToDeleteCompletely != null ? deleteModalData.isAbleToDeleteCompletely : false;
 
+  console.log('isDeleteCompletelyModal', isDeleteCompletelyModal);
+
   const [isDeleteRecursively, setIsDeleteRecursively] = useState(true);
   const [isDeleteCompletely, setIsDeleteCompletely] = useState(isDeleteCompletelyModal && isAbleToDeleteCompletely);
   const deleteMode = isDeleteCompletely ? 'completely' : 'temporary';
@@ -69,15 +71,11 @@ const PageDeleteModal: FC = () => {
         const pageIdToRevisionIdMap = {};
         deleteModalData.pages.forEach((p) => { pageIdToRevisionIdMap[p.pageId] = p.revisionId });
 
-        const { data } = await apiv3Post<IDeleteManyPageApiv3Result>('/pages/delete', {
+        await apiv3Post<IDeleteManyPageApiv3Result>('/pages/delete', {
           pageIdToRevisionIdMap,
           isRecursively,
           isCompletely,
         });
-
-        if (onDeleted != null) {
-          onDeleted(data.paths, data.isRecursively, data.isCompletely);
-        }
       }
       catch (err) {
         setErrs([err]);
@@ -93,16 +91,12 @@ const PageDeleteModal: FC = () => {
 
         const page = deleteModalData.pages[0];
 
-        const { path, isRecursively, isCompletely } = await apiPost('/pages.remove', {
+        await apiPost('/pages.remove', {
           page_id: page.pageId,
           revision_id: page.revisionId,
           recursively,
           completely,
         }) as IDeleteSinglePageApiv1Result;
-
-        if (onDeleted != null) {
-          onDeleted(path, isRecursively, isCompletely);
-        }
       }
       catch (err) {
         setErrs([err]);

--- a/packages/app/src/components/PageDeleteModal.tsx
+++ b/packages/app/src/components/PageDeleteModal.tsx
@@ -26,22 +26,15 @@ const deleteIconAndKey = {
   },
 };
 
-type Props = {
-  isDeleteCompletelyModal: boolean,
-  isAbleToDeleteCompletely: boolean,
-  onClose?: () => void,
-}
-
-const PageDeleteModal: FC<Props> = (props: Props) => {
+const PageDeleteModal: FC = () => {
   const { t } = useTranslation('');
-  const {
-    isDeleteCompletelyModal, isAbleToDeleteCompletely,
-  } = props;
 
   const { data: deleteModalData, close: closeDeleteModal } = usePageDeleteModal();
 
   const isOpened = deleteModalData?.isOpened != null ? deleteModalData.isOpened : false;
   const onDeleted = deleteModalData?.onDeleted != null ? deleteModalData.onDeleted : null;
+  const isDeleteCompletelyModal = deleteModalData?.isDeleteCompletelyModal != null ? deleteModalData.isDeleteCompletelyModal : false;
+  const isAbleToDeleteCompletely = deleteModalData?.isAbleToDeleteCompletely != null ? deleteModalData.isAbleToDeleteCompletely : false;
 
   const [isDeleteRecursively, setIsDeleteRecursively] = useState(true);
   const [isDeleteCompletely, setIsDeleteCompletely] = useState(isDeleteCompletelyModal && isAbleToDeleteCompletely);

--- a/packages/app/src/components/SearchPage/SearchResultContent.tsx
+++ b/packages/app/src/components/SearchPage/SearchResultContent.tsx
@@ -98,11 +98,11 @@ const SearchResultContent: FC<Props> = (props: Props) => {
     showPageControlDropdown,
   } = props;
 
+  const page = focusedSearchResultData?.pageData;
+
   const { open: openDuplicateModal } = usePageDuplicateModal();
   const { open: openRenameModal } = usePageRenameModal();
   const { open: openDeleteModal } = usePageDeleteModal();
-
-  const page = focusedSearchResultData?.pageData;
 
   const growiRenderer = appContainer.getRenderer('searchresult');
 
@@ -115,8 +115,8 @@ const SearchResultContent: FC<Props> = (props: Props) => {
     openRenameModal(pageId, revisionId, path);
   }, [openRenameModal]);
 
-  const deleteItemClickedHandler = useCallback(async(pageToDelete) => {
-    openDeleteModal([pageToDelete]);
+  const deleteItemClickedHandler = useCallback(async(pageToDelete, isAbleToDeleteCompletely) => {
+    openDeleteModal([pageToDelete], isAbleToDeleteCompletely);
   }, [openDeleteModal]);
 
   const ControlComponents = useCallback(() => {
@@ -146,7 +146,7 @@ const SearchResultContent: FC<Props> = (props: Props) => {
         </div>
       </>
     );
-  }, [page, showPageControlDropdown, renameItemClickedHandler, deleteItemClickedHandler]);
+  }, [page, showPageControlDropdown, duplicateItemClickedHandler, renameItemClickedHandler, deleteItemClickedHandler]);
 
   // return if page is null
   if (page == null) return <></>;

--- a/packages/app/src/components/Sidebar/PageTree/ItemsTree.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/ItemsTree.tsx
@@ -98,6 +98,7 @@ const ItemsTree: FC<ItemsTreeProps> = (props: ItemsTreeProps) => {
   const { data: rootPageData, error: error2 } = useSWRxRootPage();
   const { open: openDuplicateModal } = usePageDuplicateModal();
   const { open: openRenameModal } = usePageRenameModal();
+  const { data: deleteModalData, open: openDeleteModal } = usePageDeleteModal();
   const { open: openDeleteModal } = usePageDeleteModal();
 
   useEffect(() => {
@@ -144,7 +145,7 @@ const ItemsTree: FC<ItemsTreeProps> = (props: ItemsTreeProps) => {
   };
 
   const onClickDeleteMenuItem = (pageToDelete: IPageForPageDeleteModal) => {
-    openDeleteModal([pageToDelete], onDeletedHandler);
+    openDeleteModal([pageToDelete], onDeletedHandler, false, true);
   };
 
   if (error1 != null || error2 != null) {

--- a/packages/app/src/components/Sidebar/PageTree/ItemsTree.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/ItemsTree.tsx
@@ -6,9 +6,9 @@ import { ItemNode } from './ItemNode';
 import Item from './Item';
 import { useSWRxPageAncestorsChildren, useSWRxRootPage } from '../../../stores/page-listing';
 import { TargetAndAncestors } from '~/interfaces/page-listing-results';
-import { toastError, toastSuccess } from '~/client/util/apiNotification';
+import { toastError } from '~/client/util/apiNotification';
 import {
-  OnDeletedFunction, IPageForPageDeleteModal, usePageDuplicateModal, usePageRenameModal, usePageDeleteModal,
+  IPageForPageDeleteModal, usePageDuplicateModal, usePageRenameModal, usePageDeleteModal,
 } from '~/stores/modal';
 import { smoothScrollIntoView } from '~/client/util/smooth-scroll';
 
@@ -64,7 +64,7 @@ const renderByInitialNode = (
     targetPathOrId?: string,
     onClickDuplicateMenuItem?: (pageId: string, path: string) => void,
     onClickRenameMenuItem?: (pageId: string, revisionId: string, path: string) => void,
-    onClickDeleteMenuItem?: (pageToDelete: IPageForPageDeleteModal | null) => void,
+    onClickDeleteMenuItem?: (pageToDelete: IPageForPageDeleteModal | null, isAbleToDeleteCompletely: boolean) => void,
 ): JSX.Element => {
 
   return (
@@ -92,14 +92,11 @@ const ItemsTree: FC<ItemsTreeProps> = (props: ItemsTreeProps) => {
     targetPath, targetPathOrId, targetAndAncestorsData, isEnableActions,
   } = props;
 
-  const { t } = useTranslation();
-
   const { data: ancestorsChildrenData, error: error1 } = useSWRxPageAncestorsChildren(targetPath);
   const { data: rootPageData, error: error2 } = useSWRxRootPage();
   const { open: openDuplicateModal } = usePageDuplicateModal();
   const { open: openRenameModal } = usePageRenameModal();
-  const { data: deleteModalData, open: openDeleteModal } = usePageDeleteModal();
-  console.log('deleteModalData_ItemsTree', deleteModalData);
+  const { open: openDeleteModal } = usePageDeleteModal();
 
   useEffect(() => {
     const startFrom = document.getElementById('grw-sidebar-contents-scroll-target');
@@ -119,8 +116,8 @@ const ItemsTree: FC<ItemsTreeProps> = (props: ItemsTreeProps) => {
   };
 
 
-  const onClickDeleteMenuItem = (pageToDelete: IPageForPageDeleteModal) => {
-    openDeleteModal([pageToDelete], true);
+  const onClickDeleteMenuItem = (pageToDelete: IPageForPageDeleteModal, isAbleToDeleteCompletely: boolean) => {
+    openDeleteModal([pageToDelete], isAbleToDeleteCompletely);
   };
 
   if (error1 != null || error2 != null) {

--- a/packages/app/src/components/Sidebar/PageTree/ItemsTree.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/ItemsTree.tsx
@@ -99,7 +99,7 @@ const ItemsTree: FC<ItemsTreeProps> = (props: ItemsTreeProps) => {
   const { open: openDuplicateModal } = usePageDuplicateModal();
   const { open: openRenameModal } = usePageRenameModal();
   const { data: deleteModalData, open: openDeleteModal } = usePageDeleteModal();
-  const { open: openDeleteModal } = usePageDeleteModal();
+  console.log('deleteModalData_ItemsTree', deleteModalData);
 
   useEffect(() => {
     const startFrom = document.getElementById('grw-sidebar-contents-scroll-target');
@@ -118,34 +118,9 @@ const ItemsTree: FC<ItemsTreeProps> = (props: ItemsTreeProps) => {
     openRenameModal(pageId, revisionId, path);
   };
 
-  const onDeletedHandler: OnDeletedFunction = (pathOrPathsToDelete, isRecursively, isCompletely) => {
-    if (typeof pathOrPathsToDelete !== 'string') {
-      return;
-    }
-
-    const path = pathOrPathsToDelete;
-
-    if (isRecursively) {
-      if (isCompletely) {
-        toastSuccess(t('deleted_single_page_recursively_completely', { path }));
-      }
-      else {
-        toastSuccess(t('deleted_single_page_recursively', { path }));
-      }
-    }
-    else {
-      // eslint-disable-next-line no-lonely-if
-      if (isCompletely) {
-        toastSuccess(t('deleted_single_page_completely', { path }));
-      }
-      else {
-        toastSuccess(t('deleted_single_page', { path }));
-      }
-    }
-  };
 
   const onClickDeleteMenuItem = (pageToDelete: IPageForPageDeleteModal) => {
-    openDeleteModal([pageToDelete], onDeletedHandler, false, true);
+    openDeleteModal([pageToDelete], true);
   };
 
   if (error1 != null || error2 != null) {

--- a/packages/app/src/stores/modal.tsx
+++ b/packages/app/src/stores/modal.tsx
@@ -36,22 +36,19 @@ export type IPageForPageDeleteModal = {
   path: string
 }
 
-export type OnDeletedFunction = (pathOrPaths: string | string[], isRecursively: Nullable<true>, isCompletely: Nullable<true>) => void;
 
 type DeleteModalStatus = {
   isOpened: boolean,
   pages?: IPageForPageDeleteModal[],
-  onDeleted?: OnDeletedFunction,
-  isDeleteCompletelyModal?: boolean,
   isAbleToDeleteCompletely?: boolean,
+  isDeleteCompletelyModal?: boolean,
 }
 
 type DeleteModalStatusUtils = {
   open(
     pages?: IPageForPageDeleteModal[],
-    onDeleted?: OnDeletedFunction,
-    isDeleteCompletelyModal?: boolean,
     isAbleToDeleteCompletely?: boolean,
+    isDeleteCompletelyModal?: boolean,
   ): Promise<DeleteModalStatus | undefined>,
   close(): Promise<DeleteModalStatus | undefined>,
 }
@@ -60,21 +57,20 @@ export const usePageDeleteModal = (status?: DeleteModalStatus): SWRResponse<Dele
   const initialData: DeleteModalStatus = {
     isOpened: false,
     pages: [],
-    onDeleted: () => {},
-    isDeleteCompletelyModal: false,
     isAbleToDeleteCompletely: false,
+    isDeleteCompletelyModal: false,
   };
   const swrResponse = useStaticSWR<DeleteModalStatus, Error>('deleteModalStatus', status, { fallbackData: initialData });
 
+  console.log('usePageDeleteModal_status', status);
   return {
     ...swrResponse,
     open: (
         pages?: IPageForPageDeleteModal[],
-        onDeleted?: OnDeletedFunction,
-        isDeleteCompletelyModal?: boolean,
         isAbleToDeleteCompletely?: boolean,
+        isDeleteCompletelyModal?: boolean,
     ) => swrResponse.mutate({
-      isOpened: true, pages, onDeleted, isDeleteCompletelyModal, isAbleToDeleteCompletely,
+      isOpened: true, pages, isDeleteCompletelyModal, isAbleToDeleteCompletely,
     }),
     close: () => swrResponse.mutate({ isOpened: false }),
   };

--- a/packages/app/src/stores/modal.tsx
+++ b/packages/app/src/stores/modal.tsx
@@ -62,7 +62,6 @@ export const usePageDeleteModal = (status?: DeleteModalStatus): SWRResponse<Dele
   };
   const swrResponse = useStaticSWR<DeleteModalStatus, Error>('deleteModalStatus', status, { fallbackData: initialData });
 
-  console.log('usePageDeleteModal_status', status);
   return {
     ...swrResponse,
     open: (

--- a/packages/app/src/stores/modal.tsx
+++ b/packages/app/src/stores/modal.tsx
@@ -42,20 +42,40 @@ type DeleteModalStatus = {
   isOpened: boolean,
   pages?: IPageForPageDeleteModal[],
   onDeleted?: OnDeletedFunction,
+  isDeleteCompletelyModal?: boolean,
+  isAbleToDeleteCompletely?: boolean,
 }
 
 type DeleteModalStatusUtils = {
-  open(pages?: IPageForPageDeleteModal[], onDeleted?: OnDeletedFunction): Promise<DeleteModalStatus | undefined>,
+  open(
+    pages?: IPageForPageDeleteModal[],
+    onDeleted?: OnDeletedFunction,
+    isDeleteCompletelyModal?: boolean,
+    isAbleToDeleteCompletely?: boolean,
+  ): Promise<DeleteModalStatus | undefined>,
   close(): Promise<DeleteModalStatus | undefined>,
 }
 
 export const usePageDeleteModal = (status?: DeleteModalStatus): SWRResponse<DeleteModalStatus, Error> & DeleteModalStatusUtils => {
-  const initialData: DeleteModalStatus = { isOpened: false, pages: [], onDeleted: () => {} };
+  const initialData: DeleteModalStatus = {
+    isOpened: false,
+    pages: [],
+    onDeleted: () => {},
+    isDeleteCompletelyModal: false,
+    isAbleToDeleteCompletely: false,
+  };
   const swrResponse = useStaticSWR<DeleteModalStatus, Error>('deleteModalStatus', status, { fallbackData: initialData });
 
   return {
     ...swrResponse,
-    open: (pages?: IPageForPageDeleteModal[], onDeleted?: OnDeletedFunction) => swrResponse.mutate({ isOpened: true, pages, onDeleted }),
+    open: (
+        pages?: IPageForPageDeleteModal[],
+        onDeleted?: OnDeletedFunction,
+        isDeleteCompletelyModal?: boolean,
+        isAbleToDeleteCompletely?: boolean,
+    ) => swrResponse.mutate({
+      isOpened: true, pages, onDeleted, isDeleteCompletelyModal, isAbleToDeleteCompletely,
+    }),
     close: () => swrResponse.mutate({ isOpened: false }),
   };
 };


### PR DESCRIPTION
**#5306 がマージされていない場合はマージしないでください。**

## Task
- [87936](https://redmine.weseek.co.jp/issues/87936) `isDeleteCompletelyModal`と`isAbleToDeleteCompletely`をSWR管理下において、完全削除かそうでないかによってモーダルの表示を切り替える

## ScreenRecording
https://user-images.githubusercontent.com/59536731/153675662-b3708007-053b-4c83-8d11-36ab17fad512.mov


## TODO
- [88260](https://redmine.weseek.co.jp/issues/88260) SearchPageでdeleteModalを開くと完全削除のボタンが押せないのを修正する。
(現状、SearchPageでmodalを開くとページツリーからもSearchResultsContentからも完全削除マークを押してもモーダルが切り替わらないのですが、そちらは後続タスクで対応します。)