### PR TITLE
fix: modify docker-compose indent

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -35,11 +35,11 @@ services:
       - /data/db
 
   ogp:
-  image: ghcr.io/weseek/growi-unique-ogp:latest
-  ports:
-    - 8088:8088
-  restart: unless-stopped
-  tty: true
+    image: ghcr.io/weseek/growi-unique-ogp:latest
+    ports:
+      - 8088:8088
+    restart: unless-stopped
+    tty: true
 
   # This container requires '../../growi-docker-compose' repository
   #   cloned from https://github.com/weseek/growi-docker-compose.git


### PR DESCRIPTION
## タスク

https://redmine.weseek.co.jp/issues/88371

## 行ったこと

-  docker-compose の indent を忘れて devcontainer が立ち上がらなかったため修正
- ci は失敗してますが、`dev/4.5.x` から切ったブランチのため