### PR TITLE
imprv: do not show presentation modal on top page

### DIFF
--- a/packages/app/src/components/Navbar/GrowiContextualSubNavigation.tsx
+++ b/packages/app/src/components/Navbar/GrowiContextualSubNavigation.tsx
@@ -2,6 +2,7 @@ import React, { useState, useCallback } from 'react';
 import PropTypes from 'prop-types';
 
 import { useTranslation } from 'react-i18next';
+import { pagePathUtils } from '@growi/core';
 
 import { DropdownItem } from 'reactstrap';
 
@@ -59,6 +60,8 @@ const AdditionalMenuItems = (props: AdditionalMenuItemsProps): JSX.Element => {
     onClickTemplateMenuItem(true);
   };
 
+  const { isTopPage } = pagePathUtils;
+  const { data: currentPath } = useCurrentPagePath();
   const { data: isGuestUser } = useIsGuestUser();
   const { data: isSharedUser } = useIsSharedUser();
 
@@ -70,10 +73,13 @@ const AdditionalMenuItems = (props: AdditionalMenuItemsProps): JSX.Element => {
   return (
     <>
       {/* Presentation */}
-      <DropdownItem onClick={() => openPresentationModal(hrefForPresentationModal)}>
-        <i className="icon-fw"><PresentationIcon /></i>
-        { t('Presentation Mode') }
-      </DropdownItem>
+      {!isTopPage(currentPath ?? '')
+      && (
+        <DropdownItem onClick={() => openPresentationModal(hrefForPresentationModal)}>
+          <i className="icon-fw"><PresentationIcon /></i>
+          { t('Presentation Mode') }
+        </DropdownItem>
+      )}
 
       {/* Export markdown */}
       <DropdownItem onClick={() => exportAsMarkdown(pageId, revisionId, 'md')}>


### PR DESCRIPTION
## Task
- [87938](https://redmine.weseek.co.jp/issues/87938) Topページでは、ドロップダウンメニューにプレゼンテーションを表示させないようにする

## ScreenShots
### TopPage
<img width="1111" alt="Screen Shot 2022-02-15 at 15 52 41" src="https://user-images.githubusercontent.com/59536731/154008643-e6441583-dba6-42ed-b1fb-62918b2e27fa.png">

### TopPage以外のページ
<img width="1114" alt="Screen Shot 2022-02-15 at 15 52 54" src="https://user-images.githubusercontent.com/59536731/154008622-f2b2197b-caf5-4ed4-93bb-9625cf105809.png">


## 補足
- dev4系ではトップページのプレゼンテーションは表示されません
https://dev.growi.org/
<img width="407" alt="Screen Shot 2022-02-15 at 15 56 34" src="https://user-images.githubusercontent.com/59536731/154008877-d8fe2331-e993-49ee-9faf-49b6608393d0.png">

