### PR TITLE
fix: 88258 Prevent items hidden when dropped outside the PageTree

### DIFF
--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -24,7 +24,7 @@ import ClosableTextInput, { AlertInfo, AlertType } from '../../Common/ClosableTe
 import { PageItemControl } from '../../Common/Dropdown/PageItemControl';
 import { ItemNode } from './ItemNode';
 
-const DROP_TARGET = 'PAGE_TREE';
+const ITEM_TYPE = 'PAGE_TREE';
 
 type DropResult = {
   dropEffect: string
@@ -113,12 +113,12 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
   }, []);
 
   const [{ isDragging }, drag] = useDrag(() => ({
-    type: DROP_TARGET,
+    type: ITEM_TYPE,
     item: { page },
     end: (item, monitor) => {
       // in order to set d-none to dropped Item
       const dropResult = monitor.getDropResult() as DropResult;
-      if (dropResult != null && dropResult.dropTarget === DROP_TARGET) {
+      if (dropResult != null && dropResult.dropTarget === ITEM_TYPE) {
         setShouldHide(true);
       }
     },
@@ -168,10 +168,10 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
   };
 
   const [{ isOver }, drop] = useDrop(() => ({
-    accept: DROP_TARGET,
+    accept: ITEM_TYPE,
     drop: (item) => {
       pageItemDropHandler(item);
-      return { dropTarget: DROP_TARGET };
+      return { dropTarget: ITEM_TYPE };
     },
     hover: (item, monitor) => {
       // when a drag item is overlapped more than 1 sec, the drop target item will be opened.

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -24,6 +24,13 @@ import ClosableTextInput, { AlertInfo, AlertType } from '../../Common/ClosableTe
 import { PageItemControl } from '../../Common/Dropdown/PageItemControl';
 import { ItemNode } from './ItemNode';
 
+const DROP_TARGET = 'PAGE_TREE';
+
+type DropResult = {
+  dropEffect: string
+  dropTarget: string
+}
+
 interface ItemProps {
   isEnableActions: boolean
   itemNode: ItemNode
@@ -106,11 +113,12 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
   }, []);
 
   const [{ isDragging }, drag] = useDrag(() => ({
-    type: 'PAGE_TREE',
+    type: DROP_TARGET,
     item: { page },
     end: (item, monitor) => {
       // in order to set d-none to dropped Item
-      if (monitor.getDropResult() != null) {
+      const dropResult = monitor.getDropResult() as DropResult;
+      if (dropResult != null && dropResult.dropTarget === 'PAGE_TREE') {
         setShouldHide(true);
       }
     },
@@ -119,7 +127,7 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
     }),
   }));
 
-  const pageItemDropHandler = async(item, monitor) => {
+  const pageItemDropHandler = async(item) => {
     if (page == null || page.path == null) {
       return;
     }
@@ -160,8 +168,11 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
   };
 
   const [{ isOver }, drop] = useDrop(() => ({
-    accept: 'PAGE_TREE',
-    drop: pageItemDropHandler,
+    accept: DROP_TARGET,
+    drop: (item) => {
+      pageItemDropHandler(item);
+      return { dropTarget: DROP_TARGET };
+    },
     hover: (item, monitor) => {
       // when a drag item is overlapped more than 1 sec, the drop target item will be opened.
       if (monitor.isOver()) {

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -120,7 +120,7 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
     }),
   }));
 
-  const pageItemDropHandler = async(item) => {
+  const pageItemDropHandler = async(item, monitor) => {
     if (page == null || page.path == null) {
       return;
     }

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -118,7 +118,7 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
     end: (item, monitor) => {
       // in order to set d-none to dropped Item
       const dropResult = monitor.getDropResult() as DropResult;
-      if (dropResult != null && dropResult.dropTarget === 'PAGE_TREE') {
+      if (dropResult != null && dropResult.dropTarget === DROP_TARGET) {
         setShouldHide(true);
       }
     },

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -108,9 +108,11 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
   const [{ isDragging }, drag] = useDrag(() => ({
     type: 'PAGE_TREE',
     item: { page },
-    end: () => {
+    end: (item, monitor) => {
       // in order to set d-none to dropped Item
-      setShouldHide(true);
+      if (monitor.getDropResult() != null) {
+        setShouldHide(true);
+      }
     },
     collect: monitor => ({
       isDragging: monitor.isDragging(),

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -24,13 +24,6 @@ import ClosableTextInput, { AlertInfo, AlertType } from '../../Common/ClosableTe
 import { PageItemControl } from '../../Common/Dropdown/PageItemControl';
 import { ItemNode } from './ItemNode';
 
-const ITEM_TYPE = 'PAGE_TREE';
-
-type DropResult = {
-  dropEffect: string
-  dropTarget: string
-}
-
 interface ItemProps {
   isEnableActions: boolean
   itemNode: ItemNode
@@ -113,12 +106,12 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
   }, []);
 
   const [{ isDragging }, drag] = useDrag(() => ({
-    type: ITEM_TYPE,
+    type: 'PAGE_TREE',
     item: { page },
     end: (item, monitor) => {
       // in order to set d-none to dropped Item
-      const dropResult = monitor.getDropResult() as DropResult;
-      if (dropResult != null && dropResult.dropTarget === ITEM_TYPE) {
+      const dropResult = monitor.getDropResult();
+      if (dropResult != null) {
         setShouldHide(true);
       }
     },
@@ -168,11 +161,8 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
   };
 
   const [{ isOver }, drop] = useDrop(() => ({
-    accept: ITEM_TYPE,
-    drop: (item) => {
-      pageItemDropHandler(item);
-      return { dropTarget: ITEM_TYPE };
-    },
+    accept: 'PAGE_TREE',
+    drop: pageItemDropHandler,
     hover: (item, monitor) => {
       // when a drag item is overlapped more than 1 sec, the drop target item will be opened.
       if (monitor.isOver()) {


### PR DESCRIPTION
## Task
[#88258](https://redmine.weseek.co.jp/issues/88320)  [5.x][Bug][PageTree][RreactDnD] ドラッグ中のアイテムを他のページアイテム以外の範囲にドロップした時にドラッグ中のアイテムがページツリーから消えてしまう