### PR TITLE
imprv: show delete compreatly modal on trash page

### DIFF
--- a/packages/app/src/components/Page/TrashPageAlert.jsx
+++ b/packages/app/src/components/Page/TrashPageAlert.jsx
@@ -7,7 +7,6 @@ import { UserPicture } from '@growi/ui';
 import { withUnstatedContainers } from '../UnstatedUtils';
 import AppContainer from '~/client/services/AppContainer';
 import PageContainer from '~/client/services/PageContainer';
-import { useSWRxPageChildren } from '~/stores/page-listing';
 import PutbackPageModal from '../PutbackPageModal';
 import EmptyTrashModal from '../EmptyTrashModal';
 
@@ -23,7 +22,6 @@ const TrashPageAlert = (props) => {
   const { data: shareLinkId } = useShareLinkId();
   const { data: pageInfo } = useSWRxPageInfo(pageId ?? null, shareLinkId);
   const { data: updatedAt } = useCurrentUpdatedAt();
-  const { mutate: mutateChildren } = useSWRxPageChildren(path);
   const [isEmptyTrashModalShown, setIsEmptyTrashModalShown] = useState(false);
   const [isPutbackPageModalShown, setIsPutbackPageModalShown] = useState(false);
   const [isAbleToDeleteCompletely, setIsAbleToDeleteCompletely] = useState(false);
@@ -56,11 +54,10 @@ const TrashPageAlert = (props) => {
     if (typeof pathOrPathsToDelete !== 'string') {
       return;
     }
-    mutateChildren();
 
     const path = pathOrPathsToDelete;
     window.location.href = path;
-  }, [mutateChildren]);
+  }, []);
 
   function openPageDeleteModalHandler() {
     const pageToDelete = {

--- a/packages/app/src/components/Page/TrashPageAlert.jsx
+++ b/packages/app/src/components/Page/TrashPageAlert.jsx
@@ -57,18 +57,10 @@ const TrashPageAlert = (props) => {
     if (typeof pathOrPathsToDelete !== 'string') {
       return;
     }
-
     mutateChildren();
 
     const path = pathOrPathsToDelete;
-
-    if (isCompletely) {
-      // redirect to NotFound Page
-      window.location.href = path;
-    }
-    else {
-      window.location.reload();
-    }
+    window.location.href = path;
   }, [mutateChildren]);
 
   function openPageDeleteModalHandler() {

--- a/packages/app/src/components/Page/TrashPageAlert.jsx
+++ b/packages/app/src/components/Page/TrashPageAlert.jsx
@@ -32,7 +32,6 @@ const TrashPageAlert = (props) => {
     if (pageInfo != null) {
       setIsAbleToDeleteCompletely(pageInfo.isAbleToDeleteCompletely);
     }
-
   }, [pageInfo]);
 
   const { open: openDeleteModal } = usePageDeleteModal();

--- a/packages/app/src/components/PageDeleteModal.tsx
+++ b/packages/app/src/components/PageDeleteModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, FC } from 'react';
+import React, { useState, useEffect, FC } from 'react';
 import {
   Modal, ModalHeader, ModalBody, ModalFooter,
 } from 'reactstrap';
@@ -36,7 +36,7 @@ const PageDeleteModal: FC = () => {
   const isDeleteCompletelyModal = deleteModalData?.isDeleteCompletelyModal ?? false;
 
   const [isDeleteRecursively, setIsDeleteRecursively] = useState(true);
-  const [isDeleteCompletely, setIsDeleteCompletely] = useState(isDeleteCompletelyModal && isAbleToDeleteCompletely);
+  const [isDeleteCompletely, setIsDeleteCompletely] = useState(false);
   const deleteMode = isDeleteCompletely ? 'completely' : 'temporary';
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -45,6 +45,10 @@ const PageDeleteModal: FC = () => {
   function changeIsDeleteRecursivelyHandler() {
     setIsDeleteRecursively(!isDeleteRecursively);
   }
+
+  useEffect(() => {
+    setIsDeleteCompletely(isDeleteCompletelyModal && isAbleToDeleteCompletely);
+  }, [isAbleToDeleteCompletely, isDeleteCompletelyModal]);
 
   function changeIsDeleteCompletelyHandler() {
     if (!isAbleToDeleteCompletely) {


### PR DESCRIPTION
## Task
- [88597](https://redmine.weseek.co.jp/issues/88597) [TrashPageAlert]  openDeleteModalの引数に`isDeleteCompletelyModal`と`isAbleToDeleteCompletely`を渡し、完全削除モーダルを表示させる

## Description
`TrashPageAlert`からは「完全削除」しかできないので、openDeleteModalの第四引数に`isDeleteCompletelyModal` を渡すことで、完全削除用のModalのみが表示されるようにしています。

## ScreenRecording
https://user-images.githubusercontent.com/59536731/154266696-403150d4-cee7-46ec-8f58-dd79412933d1.mov



