### PR TITLE
fix: Header for PrivateLegacyPage overlaps search help dropdown

### DIFF
--- a/packages/app/src/components/PrivateLegacyPages.tsx
+++ b/packages/app/src/components/PrivateLegacyPages.tsx
@@ -218,7 +218,7 @@ export const PrivateLegacyPages = (props: Props): JSX.Element => {
 
   const searchControl = useMemo(() => {
     return (
-      <div className="position-sticky fixed-top shadow-sm">
+      <div className="shadow-sm">
         <div className="search-control d-flex align-items-center py-md-2 py-3 px-md-4 px-3 border-bottom border-gray">
           <div className="d-flex pl-md-2">
             <OperateAllControl


### PR DESCRIPTION
## Task
https://redmine.weseek.co.jp/issues/88696

## やったこと
PrivateLegacyPageのヘッダー部分が検索のHelpドロップダウンの上にかぶるのを修正しました。

### Before
<img width="996" alt="Screen Shot 2022-02-17 at 5 10 36 PM" src="https://user-images.githubusercontent.com/66785624/154433450-cb541dcd-c72a-4cca-a10c-2df2f566b399.png">

### After
<img width="982" alt="Screen Shot 2022-02-17 at 5 10 03 PM" src="https://user-images.githubusercontent.com/66785624/154433447-bdcd5937-bbc5-479c-9ab4-c2b555a494c3.png">

