### PR TITLE
fix: Call mutate to update siblings after deletion

### DIFF
--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -31,7 +31,8 @@ interface ItemProps {
   isOpen?: boolean
   onClickDuplicateMenuItem?(pageId: string, path: string): void
   onClickRenameMenuItem?(pageId: string, revisionId: string, path: string): void
-  onClickDeleteMenuItem?(pageToDelete: IPageForPageDeleteModal | null, isAbleToDeleteCompletely: boolean): void
+  onClickDeleteMenuItem?(pageToDelete: IPageForPageDeleteModal | null, isAbleToDeleteCompletely: boolean, callback: VoidFunction): void
+  mutateSiblings?: VoidFunction
 }
 
 // Utility to mark target
@@ -73,6 +74,7 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
   const { t } = useTranslation();
   const {
     itemNode, targetPathOrId, isOpen: _isOpen = false, onClickDuplicateMenuItem, onClickRenameMenuItem, onClickDeleteMenuItem, isEnableActions,
+    mutateSiblings,
   } = props;
 
   const { page, children } = itemNode;
@@ -261,8 +263,10 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
     };
     const isAbleToDeleteCompletely = pageInfo?.isAbleToDeleteCompletely ?? false;
 
-    onClickDeleteMenuItem(pageToDelete, isAbleToDeleteCompletely);
-  }, [onClickDeleteMenuItem, page, pageInfo?.isAbleToDeleteCompletely]);
+    onClickDeleteMenuItem(pageToDelete, isAbleToDeleteCompletely, async() => {
+      if (mutateSiblings != null) await mutateSiblings();
+    });
+  }, [onClickDeleteMenuItem, page, pageInfo?.isAbleToDeleteCompletely, mutateSiblings]);
 
   const onPressEnterForCreateHandler = async(inputText: string) => {
     setNewPageInputShown(false);
@@ -423,6 +427,7 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
               onClickDuplicateMenuItem={onClickDuplicateMenuItem}
               onClickRenameMenuItem={onClickRenameMenuItem}
               onClickDeleteMenuItem={onClickDeleteMenuItem}
+              mutateSiblings={async() => { await mutateChildren() }}
             />
           </div>
         ))

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -33,7 +33,7 @@ interface ItemProps {
   onClickDuplicateMenuItem?(pageId: string, path: string): void
   onClickRenameMenuItem?(pageId: string, revisionId: string, path: string): void
   onClickDeleteMenuItem?(pageToDelete: IPageForPageDeleteModal | null, isAbleToDeleteCompletely: boolean, callback?: VoidFunction): void
-  onItemDeleted?: VoidFunction
+  onSelfDeleted?: VoidFunction
 }
 
 // Utility to mark target
@@ -75,7 +75,7 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
   const { t } = useTranslation();
   const {
     itemNode, targetPathOrId, isOpen: _isOpen = false, isEnabledAttachTitleHeader,
-    onClickDuplicateMenuItem, onClickRenameMenuItem, onClickDeleteMenuItem, isEnableActions, onItemDeleted,
+    onClickDuplicateMenuItem, onClickRenameMenuItem, onClickDeleteMenuItem, isEnableActions, onSelfDeleted,
   } = props;
 
   const { page, children } = itemNode;
@@ -264,9 +264,9 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
     const isAbleToDeleteCompletely = pageInfo?.isAbleToDeleteCompletely ?? false;
 
     onClickDeleteMenuItem(pageToDelete, isAbleToDeleteCompletely, async() => {
-      if (onItemDeleted != null) await onItemDeleted();
+      if (onSelfDeleted != null) await onSelfDeleted();
     });
-  }, [onClickDeleteMenuItem, page, pageInfo?.isAbleToDeleteCompletely, onItemDeleted]);
+  }, [onClickDeleteMenuItem, page, pageInfo?.isAbleToDeleteCompletely, onSelfDeleted]);
 
   const onPressEnterForCreateHandler = async(inputText: string) => {
     setNewPageInputShown(false);
@@ -428,7 +428,7 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
               onClickDuplicateMenuItem={onClickDuplicateMenuItem}
               onClickRenameMenuItem={onClickRenameMenuItem}
               onClickDeleteMenuItem={onClickDeleteMenuItem}
-              onItemDeleted={async() => { await mutateChildren() }}
+              onSelfDeleted={async() => { await mutateChildren() }}
             />
           </div>
         ))

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -33,7 +33,7 @@ interface ItemProps {
   onClickDuplicateMenuItem?(pageId: string, path: string): void
   onClickRenameMenuItem?(pageId: string, revisionId: string, path: string): void
   onClickDeleteMenuItem?(pageToDelete: IPageForPageDeleteModal | null, isAbleToDeleteCompletely: boolean, callback?: VoidFunction): void
-  mutateSiblings?: VoidFunction
+  onItemDeleted?: VoidFunction
 }
 
 // Utility to mark target
@@ -75,7 +75,7 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
   const { t } = useTranslation();
   const {
     itemNode, targetPathOrId, isOpen: _isOpen = false, isEnabledAttachTitleHeader,
-    onClickDuplicateMenuItem, onClickRenameMenuItem, onClickDeleteMenuItem, isEnableActions, mutateSiblings,
+    onClickDuplicateMenuItem, onClickRenameMenuItem, onClickDeleteMenuItem, isEnableActions, onItemDeleted,
   } = props;
 
   const { page, children } = itemNode;
@@ -264,9 +264,9 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
     const isAbleToDeleteCompletely = pageInfo?.isAbleToDeleteCompletely ?? false;
 
     onClickDeleteMenuItem(pageToDelete, isAbleToDeleteCompletely, async() => {
-      if (mutateSiblings != null) await mutateSiblings();
+      if (onItemDeleted != null) await onItemDeleted();
     });
-  }, [onClickDeleteMenuItem, page, pageInfo?.isAbleToDeleteCompletely, mutateSiblings]);
+  }, [onClickDeleteMenuItem, page, pageInfo?.isAbleToDeleteCompletely, onItemDeleted]);
 
   const onPressEnterForCreateHandler = async(inputText: string) => {
     setNewPageInputShown(false);
@@ -428,7 +428,7 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
               onClickDuplicateMenuItem={onClickDuplicateMenuItem}
               onClickRenameMenuItem={onClickRenameMenuItem}
               onClickDeleteMenuItem={onClickDeleteMenuItem}
-              mutateSiblings={async() => { await mutateChildren() }}
+              onItemDeleted={async() => { await mutateChildren() }}
             />
           </div>
         ))

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -32,7 +32,7 @@ interface ItemProps {
   isEnabledAttachTitleHeader?: boolean
   onClickDuplicateMenuItem?(pageId: string, path: string): void
   onClickRenameMenuItem?(pageId: string, revisionId: string, path: string): void
-  onClickDeleteMenuItem?(pageToDelete: IPageForPageDeleteModal | null, isAbleToDeleteCompletely: boolean, callback: VoidFunction): void
+  onClickDeleteMenuItem?(pageToDelete: IPageForPageDeleteModal | null, isAbleToDeleteCompletely: boolean, callback?: VoidFunction): void
   mutateSiblings?: VoidFunction
 }
 

--- a/packages/app/src/components/Sidebar/PageTree/ItemsTree.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/ItemsTree.tsx
@@ -64,7 +64,7 @@ const renderByInitialNode = (
     targetPathOrId?: string,
     onClickDuplicateMenuItem?: (pageId: string, path: string) => void,
     onClickRenameMenuItem?: (pageId: string, revisionId: string, path: string) => void,
-    onClickDeleteMenuItem?: (pageToDelete: IPageForPageDeleteModal | null, isAbleToDeleteCompletely: boolean) => void,
+    onClickDeleteMenuItem?: (pageToDelete: IPageForPageDeleteModal | null, isAbleToDeleteCompletely: boolean, mutateSiblingsOfItem: VoidFunction) => void,
 ): JSX.Element => {
 
   return (
@@ -95,7 +95,6 @@ const ItemsTree: FC<ItemsTreeProps> = (props: ItemsTreeProps) => {
   const { t } = useTranslation();
 
   const { data: ancestorsChildrenData, error: error1 } = useSWRxPageAncestorsChildren(targetPath);
-  const { mutate: mutateChildren } = useSWRxPageChildren(targetPathOrId);
   const { data: rootPageData, error: error2 } = useSWRxRootPage();
   const { open: openDuplicateModal } = usePageDuplicateModal();
   const { open: openRenameModal } = usePageRenameModal();
@@ -118,24 +117,24 @@ const ItemsTree: FC<ItemsTreeProps> = (props: ItemsTreeProps) => {
     openRenameModal(pageId, revisionId, path);
   };
 
-  const onDeletedHandler: OnDeletedFunction = (pathOrPathsToDelete, isRecursively, isCompletely) => {
-    if (typeof pathOrPathsToDelete !== 'string') {
-      return;
-    }
+  const onClickDeleteMenuItem = (pageToDelete: IPageForPageDeleteModal, isAbleToDeleteCompletely, mutateSiblingsOfItem: VoidFunction) => {
+    const onDeletedHandler: OnDeletedFunction = (pathOrPathsToDelete, isRecursively, isCompletely) => {
+      if (typeof pathOrPathsToDelete !== 'string') {
+        return;
+      }
 
-    mutateChildren();
+      mutateSiblingsOfItem();
 
-    const path = pathOrPathsToDelete;
+      const path = pathOrPathsToDelete;
 
-    if (isCompletely) {
-      toastSuccess(t('deleted_pages_completely', { path }));
-    }
-    else {
-      toastSuccess(t('deleted_pages', { path }));
-    }
-  };
+      if (isCompletely) {
+        toastSuccess(t('deleted_pages_completely', { path }));
+      }
+      else {
+        toastSuccess(t('deleted_pages', { path }));
+      }
+    };
 
-  const onClickDeleteMenuItem = (pageToDelete: IPageForPageDeleteModal, isAbleToDeleteCompletely) => {
     openDeleteModal([pageToDelete], onDeletedHandler, isAbleToDeleteCompletely);
   };
 

--- a/packages/app/src/components/Sidebar/PageTree/ItemsTree.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/ItemsTree.tsx
@@ -67,7 +67,7 @@ const renderByInitialNode = (
     isEnabledAttachTitleHeader?: boolean,
     onClickDuplicateMenuItem?: (pageId: string, path: string) => void,
     onClickRenameMenuItem?: (pageId: string, revisionId: string, path: string) => void,
-    onClickDeleteMenuItem?: (pageToDelete: IPageForPageDeleteModal | null, isAbleToDeleteCompletely: boolean, mutateSiblingsOfItem: VoidFunction) => void,
+    onClickDeleteMenuItem?: (pageToDelete: IPageForPageDeleteModal | null, isAbleToDeleteCompletely: boolean, onItemDeleted: VoidFunction) => void,
 ): JSX.Element => {
 
   return (
@@ -122,13 +122,13 @@ const ItemsTree: FC<ItemsTreeProps> = (props: ItemsTreeProps) => {
     openRenameModal(pageId, revisionId, path);
   };
 
-  const onClickDeleteMenuItem = (pageToDelete: IPageForPageDeleteModal, isAbleToDeleteCompletely, mutateSiblingsOfItem: VoidFunction) => {
+  const onClickDeleteMenuItem = (pageToDelete: IPageForPageDeleteModal, isAbleToDeleteCompletely, onItemDeleted: VoidFunction) => {
     const onDeletedHandler: OnDeletedFunction = (pathOrPathsToDelete, isRecursively, isCompletely) => {
       if (typeof pathOrPathsToDelete !== 'string') {
         return;
       }
 
-      mutateSiblingsOfItem();
+      onItemDeleted();
 
       const path = pathOrPathsToDelete;
 

--- a/packages/app/src/stores/modal.tsx
+++ b/packages/app/src/stores/modal.tsx
@@ -39,7 +39,7 @@ export type IPageForPageDeleteModal = {
   isDeleteCompletelyModal?: boolean,
 }
 
-export type OnDeletedFunction = (pathOrPaths: string | string[], isRecursively: Nullable<true>, isCompletely: Nullable<true>) => void;
+export type OnDeletedFunction = (pathOrPaths: string | string[], isRecursively: Nullable<true>, isCompletely: Nullable<true>, callback: VoidFunction) => void;
 
 type DeleteModalStatus = {
   isOpened: boolean,

--- a/packages/app/src/stores/modal.tsx
+++ b/packages/app/src/stores/modal.tsx
@@ -39,7 +39,7 @@ export type IPageForPageDeleteModal = {
   isDeleteCompletelyModal?: boolean,
 }
 
-export type OnDeletedFunction = (pathOrPaths: string | string[], isRecursively: Nullable<true>, isCompletely: Nullable<true>, callback: VoidFunction) => void;
+export type OnDeletedFunction = (pathOrPaths: string | string[], isRecursively: Nullable<true>, isCompletely: Nullable<true>) => void;
 
 type DeleteModalStatus = {
   isOpened: boolean,


### PR DESCRIPTION
Redmine: https://redmine.weseek.co.jp/issues/88725

ページツリーから削除したあとに削除したアイテムの兄弟を更新することで変更を UI に反映できるようにしました