### PR TITLE
fix: Highlight-addons and drawio-viewer for view missing

### DIFF
--- a/packages/app/src/server/views/layout-growi/page.html
+++ b/packages/app/src/server/views/layout-growi/page.html
@@ -1,6 +1,8 @@
 {% extends 'base/layout.html' %}
 
 {% block html_additional_headers %}
+  {% parent %}
+
   <!-- OGP -->
   <meta property="og:site_name" content="{{ appService.getAppTitle() | preventXss }}" />
   <meta property="og:title" content="{{ page.path | preventXss }}" />


### PR DESCRIPTION
fix #5367 