### PR TITLE
fix: grantedGroup issue when adding tag

### DIFF
--- a/packages/app/src/server/models/page.ts
+++ b/packages/app/src/server/models/page.ts
@@ -738,7 +738,7 @@ export default (crowi: Crowi): any => {
 
     const Revision = mongoose.model('Revision') as any; // TODO: Typescriptize model
     const grant = options.grant || pageData.grant; // use the previous data if absence
-    const grantUserGroupId = options.grantUserGroupId || pageData.grantUserGroupId; // use the previous data if absence
+    const grantUserGroupId: undefined | ObjectIdLike = options.grantUserGroupId ?? pageData.grantedGroup?._id.toString();
     const isSyncRevisionToHackmd = options.isSyncRevisionToHackmd;
     const grantedUserIds = pageData.grantedUserIds || [user._id];
 


### PR DESCRIPTION
## タスク

https://redmine.weseek.co.jp/issues/88254

## 行ったこと

- https://github.com/weseek/growi/issues/5189 の issue の問題を修正

## 概要
- PR 箇所の `grantUserGroupId`  がタグを TagEditModal からつけた時に undefined になってしまっていたため、
- https://github.com/weseek/growi/blob/fix/87052-88254-fix-tag-issue-about-adding-tag-in-view-mode/packages/app/src/server/service/page-grant.ts#L54 ←の 箇所に引っかかっていたみたいです