### PR TITLE
fix: 88961 Insert page title header

### DIFF
--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -281,7 +281,8 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
 
     let initBody = '';
     if (isEnabledAttachTitleHeader) {
-      initBody = pathUtils.attachTitleHeader(newPagePath);
+      const pageTitle = pathUtils.addHeadingSlash(nodePath.basename(newPagePath));
+      initBody = pathUtils.attachTitleHeader(pageTitle);
     }
 
     try {


### PR DESCRIPTION
## Task
[#88961](https://redmine.weseek.co.jp/issues/88961) isEnabledAttachTitleHeader が true だった場合、ページパスではなくページタイトルを挿入できる
