### PR TITLE
fix: display create button when any user group unexists 

### DIFF
--- a/packages/app/src/components/Admin/UserGroup/UserGroupForm.tsx
+++ b/packages/app/src/components/Admin/UserGroup/UserGroupForm.tsx
@@ -1,4 +1,6 @@
-import React, { FC, useCallback, useState } from 'react';
+import React, {
+  FC, useCallback, useState, memo,
+} from 'react';
 import { useTranslation } from 'react-i18next';
 import dateFnsFormat from 'date-fns/format';
 import { TFunctionResult } from 'i18next';
@@ -18,7 +20,7 @@ type Props = {
   onSubmit?: (userGroupData: Partial<IUserGroup>) => Promise<IUserGroupHasId | void>
 };
 
-const UserGroupForm: FC<Props> = (props: Props) => {
+const UserGroupForm: FC<Props> = memo((props: Props) => {
   const xss: Xss = (window as CustomWindow).xss;
 
   const { t } = useTranslation();
@@ -109,7 +111,7 @@ const UserGroupForm: FC<Props> = (props: Props) => {
       </fieldset>
     </form>
   );
-};
+});
 
 /**
  * Wrapper component for using unstated

--- a/packages/app/src/components/Admin/UserGroup/UserGroupPage.tsx
+++ b/packages/app/src/components/Admin/UserGroup/UserGroupPage.tsx
@@ -1,5 +1,5 @@
 import React, {
-  FC, Fragment, useState, useCallback, useMemo,
+  FC, Fragment, useState, useCallback,
 } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -104,11 +104,6 @@ const UserGroupPage: FC<Props> = (props: Props) => {
     }
   }, [mutateUserGroups, mutateUserGroupRelations]);
 
-  const isAnyGroupNull: boolean = useMemo(() => {
-    return (
-      userGroups == null || userGroupRelations == null || childUserGroups == null
-    );
-  }, [userGroups, userGroupRelations, childUserGroups]);
 
   return (
     <Fragment>
@@ -131,29 +126,25 @@ const UserGroupPage: FC<Props> = (props: Props) => {
           t('admin:user_group_management.deny_create_group')
         )
       }
-      {!isAnyGroupNull
-        && (
-          <>
-            <UserGroupTable
-              appContainer={props.appContainer}
-              userGroups={userGroups ?? []}
-              childUserGroups={childUserGroups ?? []}
-              isAclEnabled={isAclEnabled}
-              onDelete={showDeleteModal}
-              userGroupRelations={userGroupRelations ?? []}
-            />
-            <UserGroupDeleteModal
-              appContainer={props.appContainer}
-              userGroups={userGroups ?? []}
-              deleteUserGroup={selectedUserGroup}
-              onDelete={deleteUserGroupById}
-              isShow={isDeleteModalShown}
-              onShow={showDeleteModal}
-              onHide={hideDeleteModal}
-            />
-          </>
-        )
-      }
+      <>
+        <UserGroupTable
+          appContainer={props.appContainer}
+          userGroups={userGroups ?? []}
+          childUserGroups={childUserGroups ?? []}
+          isAclEnabled={isAclEnabled}
+          onDelete={showDeleteModal}
+          userGroupRelations={userGroupRelations ?? []}
+        />
+        <UserGroupDeleteModal
+          appContainer={props.appContainer}
+          userGroups={userGroups ?? []}
+          deleteUserGroup={selectedUserGroup}
+          onDelete={deleteUserGroupById}
+          isShow={isDeleteModalShown}
+          onShow={showDeleteModal}
+          onHide={hideDeleteModal}
+        />
+      </>
     </Fragment>
   );
 };

--- a/packages/app/src/components/Admin/UserGroup/UserGroupPage.tsx
+++ b/packages/app/src/components/Admin/UserGroup/UserGroupPage.tsx
@@ -1,5 +1,5 @@
 import React, {
-  FC, Fragment, useState, useCallback,
+  FC, Fragment, useState, useCallback, useMemo,
 } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -104,9 +104,11 @@ const UserGroupPage: FC<Props> = (props: Props) => {
     }
   }, [mutateUserGroups, mutateUserGroupRelations]);
 
-  if (userGroups == null || userGroupRelations == null || childUserGroups == null) {
-    return <></>;
-  }
+  const isAnyGroupNull: boolean = useMemo(() => {
+    return (
+      userGroups == null || userGroupRelations == null || childUserGroups == null
+    );
+  }, [userGroups, userGroupRelations, childUserGroups]);
 
   return (
     <Fragment>
@@ -129,23 +131,29 @@ const UserGroupPage: FC<Props> = (props: Props) => {
           t('admin:user_group_management.deny_create_group')
         )
       }
-      <UserGroupTable
-        appContainer={props.appContainer}
-        userGroups={userGroups}
-        childUserGroups={childUserGroups}
-        isAclEnabled={isAclEnabled}
-        onDelete={showDeleteModal}
-        userGroupRelations={userGroupRelations}
-      />
-      <UserGroupDeleteModal
-        appContainer={props.appContainer}
-        userGroups={userGroups}
-        deleteUserGroup={selectedUserGroup}
-        onDelete={deleteUserGroupById}
-        isShow={isDeleteModalShown}
-        onShow={showDeleteModal}
-        onHide={hideDeleteModal}
-      />
+      {!isAnyGroupNull
+        && (
+          <>
+            <UserGroupTable
+              appContainer={props.appContainer}
+              userGroups={userGroups ?? []}
+              childUserGroups={childUserGroups ?? []}
+              isAclEnabled={isAclEnabled}
+              onDelete={showDeleteModal}
+              userGroupRelations={userGroupRelations ?? []}
+            />
+            <UserGroupDeleteModal
+              appContainer={props.appContainer}
+              userGroups={userGroups ?? []}
+              deleteUserGroup={selectedUserGroup}
+              onDelete={deleteUserGroupById}
+              isShow={isDeleteModalShown}
+              onShow={showDeleteModal}
+              onHide={hideDeleteModal}
+            />
+          </>
+        )
+      }
     </Fragment>
   );
 };


### PR DESCRIPTION
## タスク

https://redmine.weseek.co.jp/issues/88951

## 行ったこと

- usergroup が 1つも存在しないときに、ユーザーグループ作成ボタンと表が消えていたので修正しました

### 修正前画像

![修正前](https://user-images.githubusercontent.com/83065937/154951313-063917ed-ee7a-4323-86aa-7466ec2cb153.PNG)


### 修正後画像


![ユーザーグループが存在しないとき-修正後](https://user-images.githubusercontent.com/83065937/154951104-9d1cb2e1-4973-4b3e-8bbe-25bd029a64ba.PNG)

