### PR TITLE
imprv: Utilize canMoveByPath

### DIFF
--- a/packages/app/src/server/routes/apiv3/pages.js
+++ b/packages/app/src/server/routes/apiv3/pages.js
@@ -175,6 +175,7 @@ module.exports = (crowi) => {
       body('newPagePath').isLength({ min: 1 }).withMessage('newPagePath is required'),
       body('isRenameRedirect').if(value => value != null).isBoolean().withMessage('isRenameRedirect must be boolean'),
       body('isRemainMetadata').if(value => value != null).isBoolean().withMessage('isRemainMetadata must be boolean'),
+      body('isMoveMode').if(value => value != null).isBoolean().withMessage('isMoveMode must be boolean'),
     ],
     duplicatePage: [
       body('pageId').isMongoId().withMessage('pageId is required'),
@@ -473,6 +474,7 @@ module.exports = (crowi) => {
     const options = {
       createRedirectPage: req.body.isRenameRedirect,
       updateMetadata: !req.body.isRemainMetadata,
+      isMoveMode: req.body.isMoveMode,
     };
 
     if (!isCreatablePage(newPagePath)) {

--- a/packages/app/src/server/service/page-operation.ts
+++ b/packages/app/src/server/service/page-operation.ts
@@ -1,10 +1,8 @@
-import { pagePathUtils, pathUtils } from '@growi/core';
-import escapeStringRegexp from 'escape-string-regexp';
+import { pagePathUtils } from '@growi/core';
 
 import PageOperation from '~/server/models/page-operation';
 
-const { addTrailingSlash } = pathUtils;
-const { isTrashPage } = pagePathUtils;
+const { isOperatable } = pagePathUtils;
 
 class PageOperationService {
 
@@ -33,67 +31,7 @@ class PageOperationService {
 
     const toPaths = mainOps.map(op => op.toPath).filter((p): p is string => p != null);
 
-    if (isRecursively) {
-
-      if (fromPathToOp != null && !isTrashPage(fromPathToOp)) {
-        const flag = toPaths.some(p => this.isEitherOfPathAreaOverlap(p, fromPathToOp));
-        if (flag) return false;
-      }
-
-      if (toPathToOp != null && !isTrashPage(toPathToOp)) {
-        const flag = toPaths.some(p => this.isPathAreaOverlap(p, toPathToOp));
-        if (flag) return false;
-      }
-
-    }
-    else {
-
-      if (fromPathToOp != null && !isTrashPage(fromPathToOp)) {
-        const flag = toPaths.some(p => this.isPathAreaOverlap(p, fromPathToOp));
-        if (flag) return false;
-      }
-
-      if (toPathToOp != null && !isTrashPage(toPathToOp)) {
-        const flag = toPaths.some(p => this.isPathAreaOverlap(p, toPathToOp));
-        if (flag) return false;
-      }
-
-    }
-
-    return true;
-  }
-
-  private isEitherOfPathAreaOverlap(path1: string, path2: string): boolean {
-    if (path1 === path2) {
-      return true;
-    }
-
-    const path1WithSlash = addTrailingSlash(path1);
-    const path2WithSlash = addTrailingSlash(path2);
-
-    const path1Area = new RegExp(`^${escapeStringRegexp(path1WithSlash)}`);
-    const path2Area = new RegExp(`^${escapeStringRegexp(path2WithSlash)}`);
-
-    if (path1Area.test(path2) || path2Area.test(path1)) {
-      return true;
-    }
-
-    return false;
-  }
-
-  private isPathAreaOverlap(pathToTest: string, pathToBeTested: string): boolean {
-    if (pathToTest === pathToBeTested) {
-      return true;
-    }
-
-    const pathWithSlash = addTrailingSlash(pathToTest);
-
-    const pathAreaToTest = new RegExp(`^${escapeStringRegexp(pathWithSlash)}`);
-    if (pathAreaToTest.test(pathToBeTested)) {
-      return true;
-    }
-
-    return false;
+    return isOperatable(isRecursively, fromPathToOp, toPathToOp, toPaths);
   }
 
 }

--- a/packages/core/src/utils/page-path-utils.ts
+++ b/packages/core/src/utils/page-path-utils.ts
@@ -250,9 +250,5 @@ export const isPathAreaOverlap = (pathToTest: string, pathToBeTested: string): b
  * @returns boolean
  */
 export const canMoveByPath = (fromPath: string, toPath: string): boolean => {
-  if (fromPath === toPath) {
-    return false;
-  }
-
   return !isPathAreaOverlap(fromPath, toPath);
 };

--- a/packages/core/src/utils/page-path-utils.ts
+++ b/packages/core/src/utils/page-path-utils.ts
@@ -1,6 +1,7 @@
 import nodePath from 'path';
 
 import escapeStringRegexp from 'escape-string-regexp';
+import { addTrailingSlash } from './path-utils';
 
 /**
  * Whether path is the top page
@@ -193,4 +194,68 @@ export const omitDuplicateAreaPageFromPages = (pages: any[]): any[] => {
 
     return !isDuplicate;
   });
+};
+
+
+const isEitherOfPathAreaOverlap = (path1: string, path2: string): boolean => {
+  if (path1 === path2) {
+    return true;
+  }
+
+  const path1WithSlash = addTrailingSlash(path1);
+  const path2WithSlash = addTrailingSlash(path2);
+
+  const path1Area = new RegExp(`^${escapeStringRegexp(path1WithSlash)}`);
+  const path2Area = new RegExp(`^${escapeStringRegexp(path2WithSlash)}`);
+
+  if (path1Area.test(path2) || path2Area.test(path1)) {
+    return true;
+  }
+
+  return false;
+};
+const isPathAreaOverlap = (pathToTest: string, pathToBeTested: string): boolean => {
+  if (pathToTest === pathToBeTested) {
+    return true;
+  }
+
+  const pathWithSlash = addTrailingSlash(pathToTest);
+
+  const pathAreaToTest = new RegExp(`^${escapeStringRegexp(pathWithSlash)}`);
+  if (pathAreaToTest.test(pathToBeTested)) {
+    return true;
+  }
+
+  return false;
+};
+
+export const isOperatable = (isRecursively: boolean, fromPathToOp: string | null, toPathToOp: string | null, toPathsToTest: string[]): boolean => {
+  if (isRecursively) {
+
+    if (fromPathToOp != null && !isTrashPage(fromPathToOp)) {
+      const flag = toPathsToTest.some(p => isEitherOfPathAreaOverlap(p, fromPathToOp));
+      if (flag) return false;
+    }
+
+    if (toPathToOp != null && !isTrashPage(toPathToOp)) {
+      const flag = toPathsToTest.some(p => isPathAreaOverlap(p, toPathToOp));
+      if (flag) return false;
+    }
+
+  }
+  else {
+
+    if (fromPathToOp != null && !isTrashPage(fromPathToOp)) {
+      const flag = toPathsToTest.some(p => isPathAreaOverlap(p, fromPathToOp));
+      if (flag) return false;
+    }
+
+    if (toPathToOp != null && !isTrashPage(toPathToOp)) {
+      const flag = toPathsToTest.some(p => isPathAreaOverlap(p, toPathToOp));
+      if (flag) return false;
+    }
+
+  }
+
+  return true;
 };

--- a/packages/core/src/utils/page-path-utils.ts
+++ b/packages/core/src/utils/page-path-utils.ts
@@ -196,8 +196,14 @@ export const omitDuplicateAreaPageFromPages = (pages: any[]): any[] => {
   });
 };
 
-
-const isEitherOfPathAreaOverlap = (path1: string, path2: string): boolean => {
+/**
+ * Check if the area of either path1 or path2 includes the area of the other path
+ * The area of path is the same as /^\/hoge\//i
+ * @param pathToTest string
+ * @param pathToBeTested string
+ * @returns boolean
+ */
+export const isEitherOfPathAreaOverlap = (path1: string, path2: string): boolean => {
   if (path1 === path2) {
     return true;
   }
@@ -205,8 +211,8 @@ const isEitherOfPathAreaOverlap = (path1: string, path2: string): boolean => {
   const path1WithSlash = addTrailingSlash(path1);
   const path2WithSlash = addTrailingSlash(path2);
 
-  const path1Area = new RegExp(`^${escapeStringRegexp(path1WithSlash)}`);
-  const path2Area = new RegExp(`^${escapeStringRegexp(path2WithSlash)}`);
+  const path1Area = new RegExp(`^${escapeStringRegexp(path1WithSlash)}`, 'i');
+  const path2Area = new RegExp(`^${escapeStringRegexp(path2WithSlash)}`, 'i');
 
   if (path1Area.test(path2) || path2Area.test(path1)) {
     return true;
@@ -214,14 +220,22 @@ const isEitherOfPathAreaOverlap = (path1: string, path2: string): boolean => {
 
   return false;
 };
-const isPathAreaOverlap = (pathToTest: string, pathToBeTested: string): boolean => {
+
+/**
+ * Check if the area of pathToTest includes the area of pathToBeTested
+ * The area of path is the same as /^\/hoge\//i
+ * @param pathToTest string
+ * @param pathToBeTested string
+ * @returns boolean
+ */
+export const isPathAreaOverlap = (pathToTest: string, pathToBeTested: string): boolean => {
   if (pathToTest === pathToBeTested) {
     return true;
   }
 
   const pathWithSlash = addTrailingSlash(pathToTest);
 
-  const pathAreaToTest = new RegExp(`^${escapeStringRegexp(pathWithSlash)}`);
+  const pathAreaToTest = new RegExp(`^${escapeStringRegexp(pathWithSlash)}`, 'i');
   if (pathAreaToTest.test(pathToBeTested)) {
     return true;
   }
@@ -229,33 +243,16 @@ const isPathAreaOverlap = (pathToTest: string, pathToBeTested: string): boolean 
   return false;
 };
 
-export const isOperatable = (isRecursively: boolean, fromPathToOp: string | null, toPathToOp: string | null, toPathsToTest: string[]): boolean => {
-  if (isRecursively) {
-
-    if (fromPathToOp != null && !isTrashPage(fromPathToOp)) {
-      const flag = toPathsToTest.some(p => isEitherOfPathAreaOverlap(p, fromPathToOp));
-      if (flag) return false;
-    }
-
-    if (toPathToOp != null && !isTrashPage(toPathToOp)) {
-      const flag = toPathsToTest.some(p => isPathAreaOverlap(p, toPathToOp));
-      if (flag) return false;
-    }
-
-  }
-  else {
-
-    if (fromPathToOp != null && !isTrashPage(fromPathToOp)) {
-      const flag = toPathsToTest.some(p => isPathAreaOverlap(p, fromPathToOp));
-      if (flag) return false;
-    }
-
-    if (toPathToOp != null && !isTrashPage(toPathToOp)) {
-      const flag = toPathsToTest.some(p => isPathAreaOverlap(p, toPathToOp));
-      if (flag) return false;
-    }
-
+/**
+ * Determine whether can move by fromPath and toPath
+ * @param fromPath string
+ * @param toPath string
+ * @returns boolean
+ */
+export const canMoveByPath = (fromPath: string, toPath: string): boolean => {
+  if (fromPath === toPath) {
+    return false;
   }
 
-  return true;
+  return !isPathAreaOverlap(fromPath, toPath);
 };


### PR DESCRIPTION
Redmine(２つ): https://redmine.weseek.co.jp/issues/89220, https://redmine.weseek.co.jp/issues/89173

canMovePath を @growi/core に実装して、renamePage のバリデーションで使用しました

## その他の変更
PageOperationService の private メソッドを @growi/core に移動しました