### PR TITLE
imprv: 88871 revalidate after duplication on pagetree

### DIFF
--- a/packages/app/resource/locales/en_US/translation.json
+++ b/packages/app/resource/locales/en_US/translation.json
@@ -459,6 +459,7 @@
       "recursive": "Duplicate children of under this path recursively"
     }
   },
+  "duplicated_pages": "{{path}} has been duplicated",
   "modal_putback": {
     "label": {
       "Put Back Page": "Put back page",

--- a/packages/app/resource/locales/ja_JP/translation.json
+++ b/packages/app/resource/locales/ja_JP/translation.json
@@ -458,6 +458,7 @@
       "recursive": "配下のページも複製します"
     }
   },
+  "duplicated_pages": "{{path}} を複製しました",
   "modal_putback": {
     "label": {
       "Put Back Page": "ページを元に戻す",

--- a/packages/app/resource/locales/zh_CN/translation.json
+++ b/packages/app/resource/locales/zh_CN/translation.json
@@ -437,7 +437,6 @@
       "recursive": "Duplicate children of under this path recursively"
     }
   },
-
   "duplicated_pages": "{{path}} 已重复",
 	"modal_putback": {
 		"label": {

--- a/packages/app/resource/locales/zh_CN/translation.json
+++ b/packages/app/resource/locales/zh_CN/translation.json
@@ -436,7 +436,9 @@
     "help": {
       "recursive": "Duplicate children of under this path recursively"
     }
-	},
+  },
+
+  "duplicated_pages": "{{path}} 已重复",
 	"modal_putback": {
 		"label": {
 			"Put Back Page": "Put back page",

--- a/packages/app/src/components/PageDuplicateModal.jsx
+++ b/packages/app/src/components/PageDuplicateModal.jsx
@@ -113,7 +113,11 @@ const PageDuplicateModal = (props) => {
 
     try {
       await appContainer.apiv3Post('/pages/duplicate', { pageId, pageNameInput, isRecursively: isDuplicateRecursively });
-      window.location.href = encodeURI(`${pageNameInput}?duplicated=${path}`);
+      const onDuplicated = duplicateModalData.opts?.onDuplicated;
+      if (onDuplicated != null) {
+        onDuplicated(path);
+      }
+      closeDuplicateModal();
     }
     catch (err) {
       setErrs(err);

--- a/packages/app/src/components/Sidebar/PageTree/ItemsTree.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/ItemsTree.tsx
@@ -146,7 +146,6 @@ const ItemsTree: FC<ItemsTreeProps> = (props: ItemsTreeProps) => {
     const duplicatedHandler: OnDuplicatedFunction = (path) => {
       toastSuccess(t('duplicated_pages', { path }));
 
-
       advancePt();
       advanceFts();
       advanceDpl();

--- a/packages/app/src/components/Sidebar/PageTree/ItemsTree.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/ItemsTree.tsx
@@ -6,7 +6,7 @@ import { ItemNode } from './ItemNode';
 import Item from './Item';
 import { usePageTreeTermManager, useSWRxPageAncestorsChildren, useSWRxRootPage } from '~/stores/page-listing';
 import { TargetAndAncestors } from '~/interfaces/page-listing-results';
-import { OnRenamedFunction, OnDeletedFunction } from '~/interfaces/ui';
+import { OnDuplicatedFunction, OnRenamedFunction, OnDeletedFunction } from '~/interfaces/ui';
 import { toastError, toastSuccess } from '~/client/util/apiNotification';
 import {
   IPageForPageDeleteModal, IPageForPageDuplicateModal, usePageDuplicateModal, IPageForPageRenameModal, usePageRenameModal, usePageDeleteModal,
@@ -143,7 +143,16 @@ const ItemsTree: FC<ItemsTreeProps> = (props: ItemsTreeProps) => {
   }, []);
 
   const onClickDuplicateMenuItem = (pageToDuplicate: IPageForPageDuplicateModal) => {
-    openDuplicateModal(pageToDuplicate);
+    const duplicatedHandler: OnDuplicatedFunction = (path) => {
+      toastSuccess(t('duplicated_pages', { path }));
+
+
+      advancePt();
+      advanceFts();
+      advanceDpl();
+    };
+
+    openDuplicateModal(pageToDuplicate, { onDuplicated: duplicatedHandler });
   };
 
   const onClickRenameMenuItem = (pageToRename: IPageForPageRenameModal) => {

--- a/packages/app/src/interfaces/ui.ts
+++ b/packages/app/src/interfaces/ui.ts
@@ -23,3 +23,4 @@ export type ICustomNavTabMappings = { [key: string]: ICustomTabContent };
 
 export type OnDeletedFunction = (idOrPaths: string | string[], isRecursively: Nullable<true>, isCompletely: Nullable<true>) => void;
 export type OnRenamedFunction = (path: string) => void;
+export type OnDuplicatedFunction = (path: string) => void;

--- a/packages/app/src/stores/modal.tsx
+++ b/packages/app/src/stores/modal.tsx
@@ -1,6 +1,6 @@
 import { SWRResponse } from 'swr';
 import { useStaticSWR } from './use-static-swr';
-import { OnRenamedFunction, OnDeletedFunction } from '~/interfaces/ui';
+import { OnDuplicatedFunction, OnRenamedFunction, OnDeletedFunction } from '~/interfaces/ui';
 
 
 /*
@@ -83,7 +83,7 @@ export type IPageForPageDuplicateModal = {
 }
 
 export type IDuplicateModalOption = {
-  onDeleted?: OnDeletedFunction,
+  onDuplicated?: OnDuplicatedFunction,
 }
 
 type DuplicateModalStatus = {


### PR DESCRIPTION
## Task
- [88871](https://redmine.weseek.co.jp/issues/88871) duplicate

## Story
[PageItemControl][ItemsTree] duplicate/rename/delete の処理が完了したときにrevalidateを走らせる

## ScreenRecording
https://user-images.githubusercontent.com/59536731/155595178-723b3388-9216-4040-be94-82c41a5dc598.mov

## ScreenShots
<img width="510" alt="Screen Shot 2022-02-25 at 4 39 26" src="https://user-images.githubusercontent.com/59536731/155595274-785eb16c-4caa-4d9a-b6cd-2eaac2d5b099.png">



