### PR TITLE
imprv: revalidate when page has been duplicated on search result content

### DIFF
--- a/packages/app/src/components/SearchPage/SearchResultContent.tsx
+++ b/packages/app/src/components/SearchPage/SearchResultContent.tsx
@@ -7,7 +7,10 @@ import { DropdownItem } from 'reactstrap';
 
 import { IPageWithMeta } from '~/interfaces/page';
 import { IPageSearchMeta } from '~/interfaces/search';
-import { OnDeletedFunction } from '~/interfaces/ui';
+import { OnDuplicatedFunction, OnDeletedFunction } from '~/interfaces/ui';
+import { usePageTreeTermManager } from '~/stores/page-listing';
+import { useFullTextSearchTermManager } from '~/stores/search';
+import { useDescendantsPageListForCurrentPathTermManager } from '~/stores/page';
 
 import { exportAsMarkdown } from '~/client/services/page-operation';
 import { toastSuccess } from '~/client/util/apiNotification';
@@ -76,6 +79,11 @@ const generateObserverCallback = (doScroll: ()=>void) => {
 export const SearchResultContent: FC<Props> = (props: Props) => {
   const scrollElementRef = useRef(null);
 
+  // for mutation
+  const { advance: advancePt } = usePageTreeTermManager();
+  const { advance: advanceFts } = useFullTextSearchTermManager();
+  const { advance: advanceDpl } = useDescendantsPageListForCurrentPathTermManager();
+
   // ***************************  Auto Scroll  ***************************
   useEffect(() => {
     const scrollElement = scrollElementRef.current as HTMLElement | null;
@@ -112,8 +120,15 @@ export const SearchResultContent: FC<Props> = (props: Props) => {
 
 
   const duplicateItemClickedHandler = useCallback(async(pageToDuplicate) => {
-    openDuplicateModal(pageToDuplicate);
-  }, [openDuplicateModal]);
+    const duplicatedHandler: OnDuplicatedFunction = (path) => {
+      toastSuccess(t('duplicated_pages', { path }));
+
+      advancePt();
+      advanceFts();
+      advanceDpl();
+    };
+    openDuplicateModal(pageToDuplicate, { onDuplicated: duplicatedHandler });
+  }, [advanceDpl, advanceFts, advancePt, openDuplicateModal, t]);
 
   const renameItemClickedHandler = useCallback(async(pageToRename) => {
     openRenameModal(pageToRename);


### PR DESCRIPTION
## Task
- [89043](https://redmine.weseek.co.jp/issues/89043) duplicate

[story]
- [#88858](https://redmine.weseek.co.jp/issues/88858): [PageItemControl][Search][GrowiSubNavgation] duplicate/rename/delete の処理が完了したときにrevalidateを走らせる

### Description
検索結果画面のサブナビゲーションの3点ボタンからページを**複製**した時に
- トースター表示
- revalidate
をするようにしました。

## ScreenRecording
https://user-images.githubusercontent.com/59536731/155714575-e2d2078e-91cc-49a1-84c6-9b67293cb287.mov


