### PR TITLE
imprv: revalidate when page has been deleted

### DIFF
--- a/packages/app/src/components/SearchPage/SearchResultContent.tsx
+++ b/packages/app/src/components/SearchPage/SearchResultContent.tsx
@@ -147,8 +147,10 @@ export const SearchResultContent: FC<Props> = (props: Props) => {
     else {
       toastSuccess(t('deleted_pages', { path }));
     }
-
-  }, []);
+    advancePt();
+    advanceFts();
+    advanceDpl();
+  }, [advanceDpl, advanceFts, advancePt, t]);
 
   const deleteItemClickedHandler = useCallback((pageToDelete) => {
     openDeleteModal([pageToDelete], { onDeleted: onDeletedHandler });


### PR DESCRIPTION
 **※  #5431 がまだマージされていない場合は、このPRをマージしないでください。**


## Task
- [89259](https://redmine.weseek.co.jp/issues/89259) delete 

[story]
- [#88858](https://redmine.weseek.co.jp/issues/88858): [PageItemControl][Search][GrowiSubNavgation] duplicate/rename/delete の処理が完了したときにrevalidateを走らせる

### Description
検索結果画面のサブナビゲーションの3点ボタンからページを**削除**した時に
- revalidate
をするようにしました。
(トースターは別タスクで追加していただいたようなのでこのPRはrevalidateのみです。)

## ScreenRecording

https://user-images.githubusercontent.com/59536731/155716722-16a0e96b-7819-47f4-a79a-430429583359.mov


