### PR TITLE
imprv: reload page when page has been renamed on growi contextual subnavigation

### DIFF
--- a/packages/app/src/components/Navbar/GrowiContextualSubNavigation.tsx
+++ b/packages/app/src/components/Navbar/GrowiContextualSubNavigation.tsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 
 import { DropdownItem } from 'reactstrap';
 
-import { OnDeletedFunction } from '~/interfaces/ui';
+import { OnRenamedFunction, OnDeletedFunction } from '~/interfaces/ui';
 import { IPageHasId } from '~/interfaces/page';
 
 import { withUnstatedContainers } from '../UnstatedUtils';
@@ -188,7 +188,10 @@ const GrowiContextualSubNavigation = (props) => {
   }, [openDuplicateModal]);
 
   const renameItemClickedHandler = useCallback(async(page: IPageForPageRenameModal) => {
-    openRenameModal(page);
+    const renamedHandler: OnRenamedFunction = () => {
+      window.location.reload();
+    };
+    openRenameModal(page, { onRenamed: renamedHandler });
   }, [openRenameModal]);
 
   const onDeletedHandler: OnDeletedFunction = useCallback((pathOrPathsToDelete, isRecursively, isCompletely) => {


### PR DESCRIPTION
## Task
- [89047](https://redmine.weseek.co.jp/issues/89047) rename


story: [PageItemControl][GrowiContextualSubNavgation]duplicate/rename/delete の処理が完了したときに対象ページに遷移させる

## Description
- GrowiContextualSubNavgation上の3点ボタンからリネーム操作した時に、ページがリロードされるようにしました。

## ScreenRecording

https://user-images.githubusercontent.com/59536731/155723885-776d2a75-65d5-44ce-9bee-cdf85696a1ca.mov



## 相談
dev-4 系までは、以下の画像のように、`RenamedAlert`が表示されていました。
<img width="1302" alt="Screen Shot 2022-02-25 at 22 02 47" src="https://user-images.githubusercontent.com/59536731/155719685-8e663493-2166-4bb0-be6e-c7c382f39005.png">

- 4系は、クエリストリングに`renamedFrom`がある場合、`RenamedAlert` が表示されるようになっています。
- 5系は、urlがpageIdになっています。
こういう場合ってPageIdの後ろにくっつけちゃっていいのでしょうか...?
その場合以下のようなURLなってしまうんですかね... :eyes: 
```
http://localhost:3000/6218cd71655a6e063280e81f?renamedFrom=6218cd71655a6e063280e81f
```
↓4系
```
https://demo.growi.org/download-test-2?renamedFrom=%2Fdownload-test
```

### 参考
https://github.com/weseek/growi/blob/9f3e8d180a4bd2f6fe1790fd17d6e4671b148a72/packages/app/src/components/PageRenameModal.jsx#L130-L135

https://github.com/weseek/growi/blob/2f235893bc828784dff301aafce242df97e99a65/packages/app/src/server/views/widget/page_alerts.html#L38-L40



