### PR TITLE
imprv: 89046 reload after page has been duplicated on growi contextual subnavgation

### DIFF
--- a/packages/app/resource/locales/en_US/translation.json
+++ b/packages/app/resource/locales/en_US/translation.json
@@ -459,7 +459,7 @@
       "recursive": "Duplicate children of under this path recursively"
     }
   },
-  "duplicated_pages": "{{path}} has been duplicated",
+  "duplicated_pages": "{{fromPath}} has been duplicated",
   "modal_putback": {
     "label": {
       "Put Back Page": "Put back page",

--- a/packages/app/resource/locales/ja_JP/translation.json
+++ b/packages/app/resource/locales/ja_JP/translation.json
@@ -458,7 +458,7 @@
       "recursive": "配下のページも複製します"
     }
   },
-  "duplicated_pages": "{{path}} を複製しました",
+  "duplicated_pages": "{{fromPath}} を複製しました",
   "modal_putback": {
     "label": {
       "Put Back Page": "ページを元に戻す",

--- a/packages/app/resource/locales/zh_CN/translation.json
+++ b/packages/app/resource/locales/zh_CN/translation.json
@@ -437,7 +437,7 @@
       "recursive": "Duplicate children of under this path recursively"
     }
   },
-  "duplicated_pages": "{{path}} 已重复",
+  "duplicated_pages": "{{fromPath}} 已重复",
 	"modal_putback": {
 		"label": {
 			"Put Back Page": "Put back page",

--- a/packages/app/src/components/Navbar/GrowiContextualSubNavigation.tsx
+++ b/packages/app/src/components/Navbar/GrowiContextualSubNavigation.tsx
@@ -184,8 +184,8 @@ const GrowiContextualSubNavigation = (props) => {
   }, [pageId]);
 
   const duplicateItemClickedHandler = useCallback(async(page: IPageForPageDuplicateModal) => {
-    const duplicatedHandler: OnDuplicatedFunction = (path, pageId) => {
-      window.location.href = pageId;
+    const duplicatedHandler: OnDuplicatedFunction = (fromPath, toPath) => {
+      window.location.href = toPath;
     };
     openDuplicateModal(page, { onDuplicated: duplicatedHandler });
   }, [openDuplicateModal]);

--- a/packages/app/src/components/Navbar/GrowiContextualSubNavigation.tsx
+++ b/packages/app/src/components/Navbar/GrowiContextualSubNavigation.tsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 
 import { DropdownItem } from 'reactstrap';
 
-import { OnRenamedFunction, OnDeletedFunction } from '~/interfaces/ui';
+import { OnDuplicatedFunction, OnRenamedFunction, OnDeletedFunction } from '~/interfaces/ui';
 import { IPageHasId } from '~/interfaces/page';
 
 import { withUnstatedContainers } from '../UnstatedUtils';
@@ -184,7 +184,10 @@ const GrowiContextualSubNavigation = (props) => {
   }, [pageId]);
 
   const duplicateItemClickedHandler = useCallback(async(page: IPageForPageDuplicateModal) => {
-    openDuplicateModal(page);
+    const duplicatedHandler: OnDuplicatedFunction = (path, pageId) => {
+      window.location.href = pageId;
+    };
+    openDuplicateModal(page, { onDuplicated: duplicatedHandler });
   }, [openDuplicateModal]);
 
   const renameItemClickedHandler = useCallback(async(page: IPageForPageRenameModal) => {

--- a/packages/app/src/components/PageDuplicateModal.jsx
+++ b/packages/app/src/components/PageDuplicateModal.jsx
@@ -112,10 +112,10 @@ const PageDuplicateModal = (props) => {
     setErrs(null);
 
     try {
-      await appContainer.apiv3Post('/pages/duplicate', { pageId, pageNameInput, isRecursively: isDuplicateRecursively });
+      const { data } = await appContainer.apiv3Post('/pages/duplicate', { pageId, pageNameInput, isRecursively: isDuplicateRecursively });
       const onDuplicated = duplicateModalData.opts?.onDuplicated;
       if (onDuplicated != null) {
-        onDuplicated(path);
+        onDuplicated(path, data.page._id);
       }
       closeDuplicateModal();
     }

--- a/packages/app/src/components/PageDuplicateModal.jsx
+++ b/packages/app/src/components/PageDuplicateModal.jsx
@@ -114,8 +114,11 @@ const PageDuplicateModal = (props) => {
     try {
       const { data } = await appContainer.apiv3Post('/pages/duplicate', { pageId, pageNameInput, isRecursively: isDuplicateRecursively });
       const onDuplicated = duplicateModalData.opts?.onDuplicated;
+      const fromPath = path;
+      const toPath = data.page.path;
+
       if (onDuplicated != null) {
-        onDuplicated(path, data.page._id);
+        onDuplicated(fromPath, toPath);
       }
       closeDuplicateModal();
     }

--- a/packages/app/src/components/SearchPage/SearchResultContent.tsx
+++ b/packages/app/src/components/SearchPage/SearchResultContent.tsx
@@ -120,7 +120,8 @@ export const SearchResultContent: FC<Props> = (props: Props) => {
 
 
   const duplicateItemClickedHandler = useCallback(async(pageToDuplicate) => {
-    const duplicatedHandler: OnDuplicatedFunction = (path) => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const duplicatedHandler: OnDuplicatedFunction = (path, pageId) => {
       toastSuccess(t('duplicated_pages', { path }));
 
       advancePt();

--- a/packages/app/src/components/SearchPage/SearchResultContent.tsx
+++ b/packages/app/src/components/SearchPage/SearchResultContent.tsx
@@ -121,8 +121,8 @@ export const SearchResultContent: FC<Props> = (props: Props) => {
 
   const duplicateItemClickedHandler = useCallback(async(pageToDuplicate) => {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const duplicatedHandler: OnDuplicatedFunction = (path, pageId) => {
-      toastSuccess(t('duplicated_pages', { path }));
+    const duplicatedHandler: OnDuplicatedFunction = (fromPath, toPath) => {
+      toastSuccess(t('duplicated_pages', { fromPath }));
 
       advancePt();
       advanceFts();

--- a/packages/app/src/components/Sidebar/PageTree/ItemsTree.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/ItemsTree.tsx
@@ -144,8 +144,8 @@ const ItemsTree: FC<ItemsTreeProps> = (props: ItemsTreeProps) => {
 
   const onClickDuplicateMenuItem = (pageToDuplicate: IPageForPageDuplicateModal) => {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const duplicatedHandler: OnDuplicatedFunction = (path, pageId) => {
-      toastSuccess(t('duplicated_pages', { path }));
+    const duplicatedHandler: OnDuplicatedFunction = (fromPath, toPath) => {
+      toastSuccess(t('duplicated_pages', { fromPath }));
 
       advancePt();
       advanceFts();

--- a/packages/app/src/components/Sidebar/PageTree/ItemsTree.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/ItemsTree.tsx
@@ -143,7 +143,8 @@ const ItemsTree: FC<ItemsTreeProps> = (props: ItemsTreeProps) => {
   }, []);
 
   const onClickDuplicateMenuItem = (pageToDuplicate: IPageForPageDuplicateModal) => {
-    const duplicatedHandler: OnDuplicatedFunction = (path) => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const duplicatedHandler: OnDuplicatedFunction = (path, pageId) => {
       toastSuccess(t('duplicated_pages', { path }));
 
       advancePt();

--- a/packages/app/src/interfaces/ui.ts
+++ b/packages/app/src/interfaces/ui.ts
@@ -23,4 +23,4 @@ export type ICustomNavTabMappings = { [key: string]: ICustomTabContent };
 
 export type OnDeletedFunction = (idOrPaths: string | string[], isRecursively: Nullable<true>, isCompletely: Nullable<true>) => void;
 export type OnRenamedFunction = (path: string) => void;
-export type OnDuplicatedFunction = (path: string, pageId: string) => void;
+export type OnDuplicatedFunction = (fromPath: string, toPath: string) => void;

--- a/packages/app/src/interfaces/ui.ts
+++ b/packages/app/src/interfaces/ui.ts
@@ -23,4 +23,4 @@ export type ICustomNavTabMappings = { [key: string]: ICustomTabContent };
 
 export type OnDeletedFunction = (idOrPaths: string | string[], isRecursively: Nullable<true>, isCompletely: Nullable<true>) => void;
 export type OnRenamedFunction = (path: string) => void;
-export type OnDuplicatedFunction = (path: string) => void;
+export type OnDuplicatedFunction = (path: string, pageId: string) => void;


### PR DESCRIPTION
## Task
- [89046](https://redmine.weseek.co.jp/issues/89046) duplicate

- story: [PageItemControl][GrowiContextualSubNavgation]duplicate/rename/delete の処理が完了したときに対象ページに遷移させる

## Description
やったこと
- onDuplicated の第二引数に複製先のpagePathを渡すようにし、delete処理が完了した後にそのページに遷移するようにしました。
┗ onDuplicated は　第一引数に 元のパス、第二引数に 新しいパス を渡しています。

## TODO
後続タスク([89403](https://redmine.weseek.co.jp/issues/89403))で
- DuplicatedAlert
- RenamedAlert
関連の不要なコードを削除します。


## ScreenRecording
https://user-images.githubusercontent.com/59536731/155738153-4ea99ded-5129-4eb2-8cf8-a61698806042.mov


