### PR TITLE
fix: Rename to under descendant

### DIFF
--- a/packages/app/src/server/routes/apiv3/pages.js
+++ b/packages/app/src/server/routes/apiv3/pages.js
@@ -492,6 +492,7 @@ module.exports = (crowi) => {
     }
 
     let page;
+    let renamedPage;
 
     try {
       page = await Page.findByIdAndViewerToEdit(pageId, req.user, true);
@@ -508,14 +509,14 @@ module.exports = (crowi) => {
       if (!page.isEmpty && !page.isUpdatable(revisionId)) {
         return res.apiv3Err(new ErrorV3('Someone could update this page, so couldn\'t delete.', 'notfound_or_forbidden'), 409);
       }
-      page = await crowi.pageService.renamePage(page, newPagePath, req.user, options);
+      renamedPage = await crowi.pageService.renamePage(page, newPagePath, req.user, options);
     }
     catch (err) {
       logger.error(err);
       return res.apiv3Err(new ErrorV3('Failed to update page.', 'unknown'), 500);
     }
 
-    const result = { page: serializePageSecurely(page) };
+    const result = { page: serializePageSecurely(renamedPage ?? page) };
 
     try {
       // global notification

--- a/packages/app/src/server/service/page-operation.ts
+++ b/packages/app/src/server/service/page-operation.ts
@@ -12,7 +12,7 @@ class PageOperationService {
     this.crowi = crowi;
 
     // TODO: Remove this code when resuming feature is implemented
-    PageOperation.deleteMany();
+    PageOperation.deleteMany({});
   }
 
   /**

--- a/packages/app/src/server/service/page.ts
+++ b/packages/app/src/server/service/page.ts
@@ -526,7 +526,6 @@ class PageService {
     return (new RegExp(`^${pathToTest}`, 'i')).test(pathToBeTested);
   }
 
-  // maximum around 10 recursive calls are expected
   private async forceCreateEmptyTreeForRename(originalPage, toPath: string) {
     const Page = mongoose.model('Page') as unknown as PageModel;
 

--- a/packages/app/src/server/service/page.ts
+++ b/packages/app/src/server/service/page.ts
@@ -455,9 +455,9 @@ class PageService {
 
     // 2. Find new parent
     let newParent;
-    // If renaming to under target, run forceCreateEmptyTreeForRename to fill new ancestors
+    // If renaming to under target, run getParentAndforceCreateEmptyTree to fill new ancestors
     if (this.isRenamingToUnderTarget(page.path, newPagePath)) {
-      newParent = await this.forceCreateEmptyTreeForRename(page, newPagePath);
+      newParent = await this.getParentAndforceCreateEmptyTree(page, newPagePath);
     }
     else {
       newParent = await Page.getParentAndFillAncestors(newPagePath);
@@ -526,7 +526,7 @@ class PageService {
     return (new RegExp(`^${pathToTest}`, 'i')).test(pathToBeTested);
   }
 
-  private async forceCreateEmptyTreeForRename(originalPage, toPath: string) {
+  private async getParentAndforceCreateEmptyTree(originalPage, toPath: string) {
     const Page = mongoose.model('Page') as unknown as PageModel;
 
     const fromPath = originalPage.path;


### PR DESCRIPTION
Redmine: https://redmine.weseek.co.jp/issues/89366

自分の配下へのリネームを修正しました

## その他の fix
- `PageCursorsForDescendantsFactory` の AsyncGenerator を生成するメソッドでたまに `Mamimum call stack error` が発生していたので、発生しないように改修しました