### PR TITLE
imprv: show toaster after page has been deleted and duplicateed

### DIFF
--- a/packages/app/src/components/PageList/PageListItemL.tsx
+++ b/packages/app/src/components/PageList/PageListItemL.tsx
@@ -23,7 +23,7 @@ import {
   IPageInfoAll, IPageInfoForEntity, IPageInfoForListing, IPageWithMeta, isIPageInfoForListing,
 } from '~/interfaces/page';
 import { IPageSearchMeta, isIPageSearchMeta } from '~/interfaces/search';
-import { OnDuplicatedFunction, OnDeletedFunction } from '~/interfaces/ui';
+import { OnDuplicatedFunction, OnRenamedFunction, OnDeletedFunction } from '~/interfaces/ui';
 import LinkedPagePath from '~/models/linked-page-path';
 
 import { ForceHideMenuItems, PageItemControl } from '../Common/Dropdown/PageItemControl';
@@ -38,6 +38,7 @@ type Props = {
   onCheckboxChanged?: (isChecked: boolean, pageId: string) => void,
   onClickItem?: (pageId: string) => void,
   onPageDuplicated?: OnDuplicatedFunction,
+  onPageRenamed?: OnRenamedFunction,
   onPageDeleted?: OnDeletedFunction,
 }
 
@@ -47,7 +48,7 @@ const PageListItemLSubstance: ForwardRefRenderFunction<ISelectable, Props> = (pr
     page: { data: pageData, meta: pageMeta }, isSelected, isEnableActions,
     forceHideMenuItems,
     showPageUpdatedTime,
-    onClickItem, onCheckboxChanged, onPageDuplicated, onPageDeleted,
+    onClickItem, onCheckboxChanged, onPageDuplicated, onPageRenamed, onPageDeleted,
   } = props;
 
   const inputRef = useRef<HTMLInputElement>(null);
@@ -115,8 +116,8 @@ const PageListItemLSubstance: ForwardRefRenderFunction<ISelectable, Props> = (pr
       revisionId: pageData.revision as string,
       path: pageData.path,
     };
-    openRenameModal(page);
-  }, [openRenameModal, pageData]);
+    openRenameModal(page, { onRenamed: onPageRenamed });
+  }, [onPageRenamed, openRenameModal, pageData._id, pageData.path, pageData.revision]);
 
 
   const deleteMenuItemClickHandler = useCallback((_id: string, pageInfo: IPageInfoAll | undefined) => {

--- a/packages/app/src/components/SearchPage/SearchResultList.tsx
+++ b/packages/app/src/components/SearchPage/SearchResultList.tsx
@@ -9,7 +9,7 @@ import {
   IPageInfoForListing, IPageWithMeta, isIPageInfoForListing,
 } from '~/interfaces/page';
 import { IPageSearchMeta } from '~/interfaces/search';
-import { OnDuplicatedFunction, OnDeletedFunction } from '~/interfaces/ui';
+import { OnDuplicatedFunction, OnRenamedFunction, OnDeletedFunction } from '~/interfaces/ui';
 import { useIsGuestUser } from '~/stores/context';
 import { useSWRxPageInfoForList } from '~/stores/page';
 import { usePageTreeTermManager } from '~/stores/page-listing';
@@ -101,6 +101,12 @@ const SearchResultListSubstance: ForwardRefRenderFunction<ISelectableAll, Props>
     advanceFts();
   };
 
+  const renamedHandler: OnRenamedFunction = (path) => {
+    toastSuccess(t('renamed_pages', { path }));
+
+    advancePt();
+    advanceFts();
+  };
   const deletedHandler: OnDeletedFunction = (pathOrPathsToDelete, isRecursively, isCompletely) => {
     if (typeof pathOrPathsToDelete !== 'string') {
       return;
@@ -134,6 +140,7 @@ const SearchResultListSubstance: ForwardRefRenderFunction<ISelectableAll, Props>
             onClickItem={clickItemHandler}
             onCheckboxChanged={props.onCheckboxChanged}
             onPageDuplicated={duplicatedHandler}
+            onPageRenamed={renamedHandler}
             onPageDeleted={deletedHandler}
           />
         );

--- a/packages/app/src/components/SearchPage/SearchResultList.tsx
+++ b/packages/app/src/components/SearchPage/SearchResultList.tsx
@@ -2,11 +2,14 @@ import React, {
   forwardRef,
   ForwardRefRenderFunction, useCallback, useImperativeHandle, useRef,
 } from 'react';
+import { useTranslation } from 'react-i18next';
 import { ISelectable, ISelectableAll } from '~/client/interfaces/selectable-all';
+import { toastSuccess } from '~/client/util/apiNotification';
 import {
   IPageInfoForListing, IPageWithMeta, isIPageInfoForListing,
 } from '~/interfaces/page';
 import { IPageSearchMeta } from '~/interfaces/search';
+import { OnDuplicatedFunction, OnDeletedFunction } from '~/interfaces/ui';
 import { useIsGuestUser } from '~/stores/context';
 import { useSWRxPageInfoForList } from '~/stores/page';
 import { usePageTreeTermManager } from '~/stores/page-listing';
@@ -30,6 +33,8 @@ const SearchResultListSubstance: ForwardRefRenderFunction<ISelectableAll, Props>
     forceHideMenuItems,
     onPageSelected,
   } = props;
+
+  const { t } = useTranslation();
 
   const pageIdsWithNoSnippet = pages
     .filter(page => (page.meta?.elasticSearchResult?.snippet.length ?? 0) === 0)
@@ -88,6 +93,34 @@ const SearchResultListSubstance: ForwardRefRenderFunction<ISelectableAll, Props>
     });
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const duplicatedHandler : OnDuplicatedFunction = (fromPath, toPath) => {
+    toastSuccess(t('duplicated_pages', { fromPath }));
+
+    advancePt();
+    advanceFts();
+
+  };
+
+  const deletedHandler: OnDeletedFunction = (pathOrPathsToDelete, isRecursively, isCompletely) => {
+    if (typeof pathOrPathsToDelete !== 'string') {
+      return;
+    }
+
+    const path = pathOrPathsToDelete;
+
+    if (isCompletely) {
+      toastSuccess(t('deleted_pages_completely', { path }));
+    }
+    else {
+      toastSuccess(t('deleted_pages', { path }));
+    }
+    advancePt();
+    advanceFts();
+
+  };
+
+
   return (
     <ul data-testid="search-result-list" className="page-list-ul list-group list-group-flush">
       { (injectedPages ?? pages).map((page, i) => {
@@ -102,8 +135,8 @@ const SearchResultListSubstance: ForwardRefRenderFunction<ISelectableAll, Props>
             forceHideMenuItems={forceHideMenuItems}
             onClickItem={clickItemHandler}
             onCheckboxChanged={props.onCheckboxChanged}
-            onPageDeleted={() => { advancePt(); advanceFts() }}
-            onPageDuplicated={() => { advancePt(); advanceFts() }}
+            onPageDuplicated={duplicatedHandler}
+            onPageDeleted={deletedHandler}
           />
         );
       })}

--- a/packages/app/src/components/SearchPage/SearchResultList.tsx
+++ b/packages/app/src/components/SearchPage/SearchResultList.tsx
@@ -99,7 +99,6 @@ const SearchResultListSubstance: ForwardRefRenderFunction<ISelectableAll, Props>
 
     advancePt();
     advanceFts();
-
   };
 
   const deletedHandler: OnDeletedFunction = (pathOrPathsToDelete, isRecursively, isCompletely) => {
@@ -117,7 +116,6 @@ const SearchResultListSubstance: ForwardRefRenderFunction<ISelectableAll, Props>
     }
     advancePt();
     advanceFts();
-
   };
 
 


### PR DESCRIPTION
## Task
以下の2つです。
- [89422](https://redmine.weseek.co.jp/issues/89422) duplicate, delete時にトースターを表示させる
- [89050](https://redmine.weseek.co.jp/issues/89050) rename


## Description
以下の対応をしました
- duplicate
    - :new: トースター表示
    - (revalidateは実装済み)
- delete
    - :new: トースター表示
    - (revalidateは実装済み)
- rename
    - :new:  トースター表示
    - :new:  revalidate 

## ScreenRecording
### duplicete &delete. 

https://user-images.githubusercontent.com/59536731/156099707-a83c25d7-23d6-4bda-a0b2-2bfc1ee10fe8.mov

### rename

https://user-images.githubusercontent.com/59536731/156104829-8b2cbb59-104a-4680-be5f-2265ee440351.mov



