### PR TITLE
imprv: show toaster and revalidate after page has been renamed on Growi Search Result Content

### DIFF
--- a/packages/app/src/components/SearchPage/SearchResultContent.tsx
+++ b/packages/app/src/components/SearchPage/SearchResultContent.tsx
@@ -7,7 +7,7 @@ import { DropdownItem } from 'reactstrap';
 
 import { IPageToDeleteWithMeta, IPageWithMeta } from '~/interfaces/page';
 import { IPageSearchMeta } from '~/interfaces/search';
-import { OnDuplicatedFunction, OnDeletedFunction } from '~/interfaces/ui';
+import { OnDuplicatedFunction, OnRenamedFunction, OnDeletedFunction } from '~/interfaces/ui';
 import { usePageTreeTermManager } from '~/stores/page-listing';
 import { useFullTextSearchTermManager } from '~/stores/search';
 import { useDescendantsPageListForCurrentPathTermManager } from '~/stores/page';
@@ -132,8 +132,15 @@ export const SearchResultContent: FC<Props> = (props: Props) => {
   }, [advanceDpl, advanceFts, advancePt, openDuplicateModal, t]);
 
   const renameItemClickedHandler = useCallback(async(pageToRename) => {
-    openRenameModal(pageToRename);
-  }, [openRenameModal]);
+    const renamedHandler: OnRenamedFunction = (path) => {
+      toastSuccess(t('renamed_pages', { path }));
+
+      advancePt();
+      advanceFts();
+      advanceDpl();
+    };
+    openRenameModal(pageToRename, { onRenamed: renamedHandler });
+  }, [advanceDpl, advanceFts, advancePt, openRenameModal, t]);
 
   const onDeletedHandler: OnDeletedFunction = useCallback((pathOrPathsToDelete, isRecursively, isCompletely) => {
     if (typeof pathOrPathsToDelete !== 'string') {


### PR DESCRIPTION
## Task
- [89044](https://redmine.weseek.co.jp/issues/89044)  rename

- story: [PageItemControl][Search][GrowiSubNavgation] duplicate/rename/delete の処理が完了したときにrevalidateを走らせる

## Description
- SearchPageの右ペインのサブナビゲーションからページのrenameを行った時に、 **トースター表示 ** + **revalidate** を行うようにしました。
※ delete時の挙動と同様、右ペインの更新が行われないのでrename前のページが表示されたままになります。

## ScreenRecording

https://user-images.githubusercontent.com/59536731/156101656-33c233bd-7442-4a09-9ef0-0a98bf917d5e.mov



