### PR TITLE
fix: 89241 Custom Sidebar

### DIFF
--- a/packages/app/src/components/Page/RevisionRenderer.jsx
+++ b/packages/app/src/components/Page/RevisionRenderer.jsx
@@ -192,6 +192,7 @@ const RevisionRenderer = (props) => {
 RevisionRenderer.propTypes = {
   growiRenderer: PropTypes.instanceOf(GrowiRenderer).isRequired,
   markdown: PropTypes.string.isRequired,
+  isRenderable: PropTypes.bool,
   highlightKeywords: PropTypes.arrayOf(PropTypes.string),
   additionalClassName: PropTypes.string,
 };

--- a/packages/app/src/components/Page/RevisionRenderer.jsx
+++ b/packages/app/src/components/Page/RevisionRenderer.jsx
@@ -192,7 +192,6 @@ const RevisionRenderer = (props) => {
 RevisionRenderer.propTypes = {
   growiRenderer: PropTypes.instanceOf(GrowiRenderer).isRequired,
   markdown: PropTypes.string.isRequired,
-  isRenderable: PropTypes.bool,
   highlightKeywords: PropTypes.arrayOf(PropTypes.string),
   additionalClassName: PropTypes.string,
 };

--- a/packages/app/src/components/Sidebar/CustomSidebar.tsx
+++ b/packages/app/src/components/Sidebar/CustomSidebar.tsx
@@ -51,6 +51,7 @@ const CustomSidebar: FC<Props> = (props: Props) => {
       { markdown != null && (
         <div className="p-3">
           <RevisionRenderer
+            isRenderable
             growiRenderer={renderer}
             markdown={markdown}
             additionalClassName="grw-custom-sidebar-content"

--- a/packages/app/src/components/Sidebar/CustomSidebar.tsx
+++ b/packages/app/src/components/Sidebar/CustomSidebar.tsx
@@ -33,7 +33,6 @@ const CustomSidebar: FC<Props> = (props: Props) => {
 
   const { data: page, mutate } = useSWRxPageByPath('/Sidebar');
 
-  const isLoading = page === undefined;
   const markdown = (page?.revision as IRevision | undefined)?.body;
 
   return (
@@ -47,7 +46,7 @@ const CustomSidebar: FC<Props> = (props: Props) => {
           <i className="icon icon-reload"></i>
         </button>
       </div>
-      { !isLoading && markdown == null && <SidebarNotFound /> }
+      { markdown == null && <SidebarNotFound /> }
       {/* eslint-disable-next-line react/no-danger */}
       { markdown != null && (
         <div className="p-3">

--- a/packages/app/src/components/Sidebar/CustomSidebar.tsx
+++ b/packages/app/src/components/Sidebar/CustomSidebar.tsx
@@ -31,8 +31,9 @@ const CustomSidebar: FC<Props> = (props: Props) => {
 
   const renderer = appContainer.getRenderer('sidebar');
 
-  const { data: page, mutate } = useSWRxPageByPath('/Sidebar');
+  const { data: page, error, mutate } = useSWRxPageByPath('/Sidebar');
 
+  const isLoading = page === undefined && error == null;
   const markdown = (page?.revision as IRevision | undefined)?.body;
 
   return (
@@ -46,14 +47,23 @@ const CustomSidebar: FC<Props> = (props: Props) => {
           <i className="icon icon-reload"></i>
         </button>
       </div>
+
       {
-        markdown != null ? (
+        isLoading && (
+          <div className="text-muted text-center">
+            <i className="fa fa-2x fa-spinner fa-pulse mr-1"></i>
+          </div>
+        )
+      }
+
+      {
+        !isLoading && markdown != null ? (
           <div className="p-3">
             <RevisionRenderer
-              isRenderable
               growiRenderer={renderer}
               markdown={markdown}
               additionalClassName="grw-custom-sidebar-content"
+              isRenderable
             />
           </div>
         ) : (

--- a/packages/app/src/components/Sidebar/CustomSidebar.tsx
+++ b/packages/app/src/components/Sidebar/CustomSidebar.tsx
@@ -46,21 +46,22 @@ const CustomSidebar: FC<Props> = (props: Props) => {
           <i className="icon icon-reload"></i>
         </button>
       </div>
-      { markdown == null && <SidebarNotFound /> }
-      {/* eslint-disable-next-line react/no-danger */}
-      { markdown != null && (
-        <div className="p-3">
-          <RevisionRenderer
-            isRenderable
-            growiRenderer={renderer}
-            markdown={markdown}
-            additionalClassName="grw-custom-sidebar-content"
-          />
-        </div>
-      ) }
+      {
+        markdown != null ? (
+          <div className="p-3">
+            <RevisionRenderer
+              isRenderable
+              growiRenderer={renderer}
+              markdown={markdown}
+              additionalClassName="grw-custom-sidebar-content"
+            />
+          </div>
+        ) : (
+          <SidebarNotFound />
+        )
+      }
     </>
   );
-
 };
 
 /**


### PR DESCRIPTION
## Task
[#89241](https://redmine.weseek.co.jp/issues/89241) /Sidebar が存在しない時に <SidebarNotFound> が表示されない

## Appearance
- before 
<img width="1440" alt="ScreenShot 2022-03-01 14 10 58" src="https://user-images.githubusercontent.com/34241526/156109091-61cd8cc1-5485-40ec-b582-b16dbfad29c2.png">

- after 
<img width="1440" alt="ScreenShot 2022-03-01 14 12 13" src="https://user-images.githubusercontent.com/34241526/156109107-5a5a32ee-c573-4662-89ab-72adabc2092f.png">

- 