### PR TITLE
fix: revert error in case that recursively property is null

### DIFF
--- a/packages/app/src/server/routes/page.js
+++ b/packages/app/src/server/routes/page.js
@@ -1229,7 +1229,7 @@ module.exports = function(crowi, app) {
 
   validator.revertRemove = [
     body('recursively')
-      .custom(v => v === 'true' || v === true || null)
+      .custom(v => v === 'true' || v === true || v == null)
       .withMessage('The body property "recursively" must be "true" or true. (Omit param for false)'),
   ];
 

--- a/packages/app/src/server/routes/page.js
+++ b/packages/app/src/server/routes/page.js
@@ -1229,6 +1229,7 @@ module.exports = function(crowi, app) {
 
   validator.revertRemove = [
     body('recursively')
+      .optional()
       .custom(v => v === 'true' || v === true || v == null)
       .withMessage('The body property "recursively" must be "true" or true. (Omit param for false)'),
   ];


### PR DESCRIPTION
## Task
- [89501](https://redmine.weseek.co.jp/issues/89501) 修正

- Story: [5.x][bug] 全ての子ページも元に戻す のチェックを外して、revert するとエラーが起きる


## ScreenRecording
### `/trash` での revert
https://user-images.githubusercontent.com/59536731/156112629-18794255-963c-4401-b953-5376d8cbb764.mov

### `/trash/hoge` でのrevert

https://user-images.githubusercontent.com/59536731/156112826-b4fd3640-38b4-4a44-a263-5598aacde95b.mov


