### PR TITLE
fix: Domain whitelist is not respected (fix #5408)

### DIFF
--- a/packages/app/src/server/routes/apiv3/personal-setting.js
+++ b/packages/app/src/server/routes/apiv3/personal-setting.js
@@ -76,7 +76,12 @@ module.exports = (crowi) => {
   const validator = {
     personal: [
       body('name').isString().not().isEmpty(),
-      body('email').isEmail(),
+      body('email')
+        .isEmail()
+        .custom((email) => {
+          if (!User.isEmailValid(email)) throw new Error('email is not included in whitelist');
+          return true;
+        }),
       body('lang').isString().isIn(listLocaleIds()),
       body('isEmailPublished').isBoolean(),
     ],


### PR DESCRIPTION
## タスク

- https://redmine.weseek.co.jp/issues/89386

## 行ったこと

- whitelist にないメールアドレスドメインを `/me` から登録できないように修正しました
- issue: fix #5408 

## issue

https://github.com/weseek/growi/issues/5408