### PR TITLE
imprv: change icon-plus size and the position

### DIFF
--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -417,7 +417,7 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
     >
       <li
         ref={(c) => { drag(c); drop(c) }}
-        className={`list-group-item list-group-item-action border-0 py-0 d-flex align-items-center ${page.isTarget ? 'grw-pagetree-is-target' : ''}`}
+        className={`list-group-item list-group-item-action border-0 py-0 pr-3 d-flex align-items-center ${page.isTarget ? 'grw-pagetree-is-target' : ''}`}
         id={page.isTarget ? 'grw-pagetree-is-target' : `grw-pagetree-list-${page._id}`}
       >
         <div className="grw-triangle-container d-flex justify-content-center">
@@ -464,7 +464,7 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
             onClickDeleteMenuItem={deleteMenuItemClickHandler}
           >
             {/* pass the color property to reactstrap dropdownToggle props. https://6-4-0--reactstrap.netlify.app/components/dropdowns/  */}
-            <DropdownToggle color="transparent" className="border-0 rounded btn-page-item-control p-0 grw-visible-on-hover">
+            <DropdownToggle color="transparent" className="border-0 rounded btn-page-item-control p-0 grw-visible-on-hover mr-1">
               <i className="icon-options fa fa-rotate-90 text-muted p-1"></i>
             </DropdownToggle>
           </PageItemControl>
@@ -473,7 +473,7 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
             className="border-0 rounded btn btn-page-item-control p-0 grw-visible-on-hover"
             onClick={onClickPlusButton}
           >
-            <i className="icon-plus text-muted d-block p-1" />
+            <i className="icon-plus text-muted d-block p-0" />
           </button>
         </div>
       </li>

--- a/packages/app/src/styles/_page-tree.scss
+++ b/packages/app/src/styles/_page-tree.scss
@@ -7,8 +7,7 @@ $grw-pagetree-item-padding-left: 10px;
 
   .btn-page-item-control {
     .icon-plus::before {
-      width: 18px;
-      height: 18px;
+      font-size: 18px;
     }
   }
 

--- a/packages/app/src/styles/_page-tree.scss
+++ b/packages/app/src/styles/_page-tree.scss
@@ -5,6 +5,13 @@ $grw-pagetree-item-padding-left: 10px;
 .grw-pagetree {
   min-height: calc(100vh - ($grw-navbar-height + $grw-navbar-border-width + $grw-sidebar-content-header-height + $grw-sidebar-content-footer-height));
 
+  .btn-page-item-control {
+    .icon-plus::before {
+      width: 18px;
+      height: 18px;
+    }
+  }
+
   .list-group-item {
     .grw-visible-on-hover {
       display: none;


### PR DESCRIPTION
## Task
- [89782](https://redmine.weseek.co.jp/issues/89782) [ページツリー] +ボタンのサイズを18pxに変更

## Description
やったこと
- Icon-plusのサイズを18pxに変更
- ページアイテム内部のpositionの調整

## ScreenShots
### Before
<img width="351" alt="Screen Shot 2022-03-04 at 1 13 06" src="https://user-images.githubusercontent.com/59536731/156605318-0964e3d4-3fd2-4681-b03f-6a474f8e82f1.png">


### After
<img width="368" alt="Screen Shot 2022-03-04 at 2 40 33" src="https://user-images.githubusercontent.com/59536731/156620877-9d049b61-e7ec-46a1-bb5e-e4fe3e2425a3.png">

## [XD url](https://xd.adobe.com/view/cd3cb2f8-625d-4a6b-b6e4-917f75c675c5-986f/screen/27a328ec-c82d-4fd1-b97a-1dc6cb549080/specs/)
<img width="424" alt="Screen Shot 2022-03-04 at 2 41 32" src="https://user-images.githubusercontent.com/59536731/156621029-ee30aefd-d4d5-4076-9378-e9fa6997b30b.png">



