### PR TITLE
imprv: 89795 add cursor pointer to sort elm on search page

### DIFF
--- a/packages/app/src/components/SearchPage/SearchControl.tsx
+++ b/packages/app/src/components/SearchPage/SearchControl.tsx
@@ -105,7 +105,7 @@ const SearchControl: FC <Props> = React.memo((props: Props) => {
           </button>
         </div>
         <div className="d-none d-lg-flex align-items-center ml-auto search-control-include-options">
-          <div className="border rounded px-3 py-2 mr-3">
+          <div className="border rounded px-2 py-1 mr-3">
             <div className="custom-control custom-checkbox custom-checkbox-primary">
               <input
                 className="custom-control-input mr-2"
@@ -119,7 +119,7 @@ const SearchControl: FC <Props> = React.memo((props: Props) => {
               </label>
             </div>
           </div>
-          <div className="border rounded px-3 py-2">
+          <div className="border rounded px-2 py-1">
             <div className="custom-control custom-checkbox custom-checkbox-primary">
               <input
                 className="custom-control-input mr-2"

--- a/packages/app/src/components/SearchPage/SearchControl.tsx
+++ b/packages/app/src/components/SearchPage/SearchControl.tsx
@@ -119,16 +119,20 @@ const SearchControl: FC <Props> = React.memo((props: Props) => {
               </label>
             </div>
           </div>
-          <div className="card mb-0">
-            <div className="card-body">
-              <label className="search-include-label mb-0 d-flex align-items-center text-secondary with-no-font-weight" htmlFor="flexCheckChecked">
-                <input
-                  className="mr-2"
-                  type="checkbox"
-                  id="flexCheckChecked"
-                  defaultChecked={includeTrashPages}
-                  onChange={e => setIncludeTrashPages(e.target.checked)}
-                />
+          <div className="border rounded py-1 px-2">
+            <div className="custom-control custom-checkbox custom-checkbox-primary">
+              <input
+                className="custom-control-input mr-2"
+                type="checkbox"
+                id="flexCheckChecked"
+                checked={includeTrashPages}
+                onChange={e => setIncludeTrashPages(e.target.checked)}
+              />
+              <label
+                className="custom-control-label search-include-label
+              d-flex align-items-center text-secondary with-no-font-weight"
+                htmlFor="flexCheckChecked"
+              >
                 {t('Include Subordinated Target Page', { target: '/trash' })}
               </label>
             </div>

--- a/packages/app/src/components/SearchPage/SearchControl.tsx
+++ b/packages/app/src/components/SearchPage/SearchControl.tsx
@@ -105,21 +105,21 @@ const SearchControl: FC <Props> = React.memo((props: Props) => {
           </button>
         </div>
         <div className="d-none d-lg-flex align-items-center ml-auto search-control-include-options">
-          <div className="card mr-3 mb-0">
-            <div className="card-body">
-              <label className="search-include-label mb-0 d-flex align-items-center text-secondary with-no-font-weight" htmlFor="flexCheckDefault">
-                <input
-                  className="mr-2"
-                  type="checkbox"
-                  id="flexCheckDefault"
-                  defaultChecked={includeUserPages}
-                  onChange={e => setIncludeUserPages(e.target.checked)}
-                />
+          <div className="border rounded px-3 py-2 mr-3">
+            <div className="custom-control custom-checkbox custom-checkbox-primary">
+              <input
+                className="custom-control-input mr-2"
+                type="checkbox"
+                id="flexCheckDefault"
+                defaultChecked={includeUserPages}
+                onChange={e => setIncludeUserPages(e.target.checked)}
+              />
+              <label className="custom-control-label mb-0 d-flex align-items-center text-secondary with-no-font-weight" htmlFor="flexCheckDefault">
                 {t('Include Subordinated Target Page', { target: '/user' })}
               </label>
             </div>
           </div>
-          <div className="border rounded py-1 px-2">
+          <div className="border rounded px-3 py-2">
             <div className="custom-control custom-checkbox custom-checkbox-primary">
               <input
                 className="custom-control-input mr-2"
@@ -129,7 +129,7 @@ const SearchControl: FC <Props> = React.memo((props: Props) => {
                 onChange={e => setIncludeTrashPages(e.target.checked)}
               />
               <label
-                className="custom-control-label search-include-label
+                className="custom-control-label
               d-flex align-items-center text-secondary with-no-font-weight"
                 htmlFor="flexCheckChecked"
               >


### PR DESCRIPTION
## Task
- [89795](https://redmine.weseek.co.jp/issues/89795) [検索結果] [/user 下も含む, /trash 下も含む, 表示件数] hover時にcursor pointerにする

### Description
- `custom-control` を使用
- class から`card` をなくし、`border`を代わりに使用しました。

VRT見るとわかるんですけど、「user下を含む」「trash下を含む」の要素がちょっと大きくなっています。
custom-controlを使用したことによって、inputの枠線も大きくなってます。

## ScreenShots
### Before
<img width="787" alt="Screen Shot 2022-03-04 at 4 50 19" src="https://user-images.githubusercontent.com/59536731/156641938-7fb104dd-6d7b-4f66-a7ee-1b3d706ab37b.png">

### After
<img width="953" alt="Screen Shot 2022-03-04 at 4 49 16" src="https://user-images.githubusercontent.com/59536731/156641929-e9f96d7c-f0d3-4e22-9ba2-f2db0658ec62.png">

## [XD url](https://xd.adobe.com/view/cd3cb2f8-625d-4a6b-b6e4-917f75c675c5-986f/screen/9aa528ff-a75e-4e9a-adb9-b4b942647f29/)
<img width="747" alt="Screen Shot 2022-03-04 at 5 00 39" src="https://user-images.githubusercontent.com/59536731/156643496-f3d46865-2ad1-49f1-8c22-181a312dbd44.png">


## ScreenRecording

https://user-images.githubusercontent.com/59536731/156643112-603b1d56-a0ce-47a5-afb9-03961c3f9fcb.mov


