### PR TITLE
imprv: chnage fontsize of page item count

### DIFF
--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -100,7 +100,7 @@ type ItemCountProps = {
 const ItemCount: FC<ItemCountProps> = (props:ItemCountProps) => {
   return (
     <>
-      <span className="grw-pagetree-count badge badge-pill badge-light text-muted">
+      <span className="grw-pagetree-count px-0 badge badge-pill badge-light text-muted">
         {props.descendantCount}
       </span>
     </>

--- a/packages/app/src/styles/_page-tree.scss
+++ b/packages/app/src/styles/_page-tree.scss
@@ -51,6 +51,7 @@ $grw-pagetree-item-padding-left: 10px;
 
       .grw-pagetree-count {
         width: 23px;
+        height: 14px;
         padding: 0.1rem 0.3rem;
         font-size: 12px;
       }

--- a/packages/app/src/styles/_page-tree.scss
+++ b/packages/app/src/styles/_page-tree.scss
@@ -51,8 +51,7 @@ $grw-pagetree-item-padding-left: 10px;
 
       .grw-pagetree-count {
         width: 23px;
-        height: 14px;
-        padding: 0.1rem 0.3rem;
+        padding: 0.1rem 0;
         font-size: 12px;
       }
     }

--- a/packages/app/src/styles/_page-tree.scss
+++ b/packages/app/src/styles/_page-tree.scss
@@ -51,6 +51,7 @@ $grw-pagetree-item-padding-left: 10px;
 
       .grw-pagetree-count {
         padding: 0.1rem 0.3rem;
+        font-size: 12px;
       }
     }
   }

--- a/packages/app/src/styles/_page-tree.scss
+++ b/packages/app/src/styles/_page-tree.scss
@@ -50,6 +50,7 @@ $grw-pagetree-item-padding-left: 10px;
       }
 
       .grw-pagetree-count {
+        width: 23px;
         padding: 0.1rem 0.3rem;
         font-size: 12px;
       }

--- a/packages/app/src/styles/_page-tree.scss
+++ b/packages/app/src/styles/_page-tree.scss
@@ -50,7 +50,7 @@ $grw-pagetree-item-padding-left: 10px;
       }
 
       .grw-pagetree-count {
-        width: 23px;
+        width: 26px;
         padding: 0.1rem 0;
         font-size: 12px;
       }


### PR DESCRIPTION
## Task
以下の2つ
- [89773](https://redmine.weseek.co.jp/issues/89773) [ページツリー][子孫数] 文字のフォントサイズを12pxに変更
- [89777](https://redmine.weseek.co.jp/issues/89777) [ページツリー][子孫数] 1桁と2桁の場合の横幅を固定させる

## Screenshots
### Before
<img width="420" alt="Screen Shot 2022-03-04 at 7 02 47" src="https://user-images.githubusercontent.com/59536731/156660355-49105c0a-1e40-4b3c-8fbc-26fe7b9512ad.png">


### After
XDだとwidth 23px だが、3桁の場合に子孫数がギリギリになってしまうのでwidth 26pxに変更しました。
(XDだと3桁の場合の表示がない)
<img width="889" alt="Screen Shot 2022-03-04 at 7 06 26" src="https://user-images.githubusercontent.com/59536731/156660818-ce11b675-e6ee-403c-be21-0d3b7d4f0861.png">

