### PR TITLE
imprv: 89790  page item control style on pagelist

### DIFF
--- a/packages/app/src/components/Common/Dropdown/PageItemControl.tsx
+++ b/packages/app/src/components/Common/Dropdown/PageItemControl.tsx
@@ -252,7 +252,7 @@ export const PageItemControlSubstance = (props: PageItemControlSubstanceProps): 
   return (
     <Dropdown isOpen={isOpen} toggle={() => setIsOpen(!isOpen)} data-testid="open-page-item-control-btn">
       { children ?? (
-        <DropdownToggle color="transparent" className="border-0 rounded btn-page-item-control">
+        <DropdownToggle color="transparent" className="border-0 rounded btn-page-item-control d-flex align-items-center justify-content-center">
           <i className="icon-options text-muted"></i>
         </DropdownToggle>
       ) }

--- a/packages/app/src/components/PageList/PageListItemL.tsx
+++ b/packages/app/src/components/PageList/PageListItemL.tsx
@@ -207,7 +207,7 @@ const PageListItemLSubstance: ForwardRefRenderFunction<ISelectable, Props> = (pr
               </div>
 
               {/* doropdown icon includes page control buttons */}
-              <div className="item-control ml-auto">
+              <div className="ml-auto">
                 <PageItemControl
                   pageId={pageData._id}
                   pageInfo={isIPageInfoForListing(pageMeta) ? pageMeta : undefined}

--- a/packages/app/src/styles/_page_list.scss
+++ b/packages/app/src/styles/_page_list.scss
@@ -5,9 +5,6 @@ body .page-list {
   }
 
   .btn-page-item-control {
-    display: flex;
-    align-items: center;
-    justify-content: center;
     width: 20px;
     height: 20px;
     padding: 0px;

--- a/packages/app/src/styles/_page_list.scss
+++ b/packages/app/src/styles/_page_list.scss
@@ -4,6 +4,15 @@ body .page-list {
     line-height: 1.6em;
   }
 
+  .btn-page-item-control {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    height: 20px;
+    padding: 0px;
+  }
+
   .page-list-ul {
     padding-left: 0;
     margin: 0;

--- a/packages/app/src/styles/_subnav.scss
+++ b/packages/app/src/styles/_subnav.scss
@@ -131,7 +131,6 @@
     .btn-page-item-control {
       width: 32px;
       height: 32px;
-      padding: 4px;
       font-size: 12px;
     }
   }


### PR DESCRIPTION
## Task
- [89790](https://redmine.weseek.co.jp/issues/89790) 3点ボタンを正方形にする

## ScreenShots
### [XD url](https://xd.adobe.com/view/cd3cb2f8-625d-4a6b-b6e4-917f75c675c5-986f/screen/9aa528ff-a75e-4e9a-adb9-b4b942647f29/specs/)
<img width="1064" alt="Screen Shot 2022-03-04 at 20 18 04" src="https://user-images.githubusercontent.com/59536731/156754101-4e8152c1-3cea-49db-9e84-56fafbf91883.png">


### Before
<img width="386" alt="Screen Shot 2022-03-04 at 20 17 38" src="https://user-images.githubusercontent.com/59536731/156754042-1fcf35a8-e104-4cc5-9a21-9430eec8222f.png">



### After
<img width="245" alt="Screen Shot 2022-03-04 at 20 16 04" src="https://user-images.githubusercontent.com/59536731/156753939-7d1590ee-57be-4928-b458-2f7495663121.png">


### デグレしていないことの確認

<img width="370" alt="Screen Shot 2022-03-04 at 20 16 10" src="https://user-images.githubusercontent.com/59536731/156753944-4bd3e813-1186-40fd-9455-240660be3626.png">
<img width="752" alt="Screen Shot 2022-03-04 at 20 16 30" src="https://user-images.githubusercontent.com/59536731/156753945-d004e354-5158-428c-95a1-967d95ea6eb2.png">

