### PR TITLE
fix: page list meta layout

### DIFF
--- a/packages/app/src/components/PageList/PageListItemL.tsx
+++ b/packages/app/src/components/PageList/PageListItemL.tsx
@@ -144,16 +144,16 @@ const PageListItemLSubstance: ForwardRefRenderFunction<ISelectable, Props> = (pr
   return (
     <li
       key={pageData._id}
-      className={`list-group-item p-0 ${styleListGroupItem} ${styleActive}`}
+      className={`list-group-item d-flex align-items-center px-3 px-md-1 ${styleListGroupItem} ${styleActive}`}
     >
       <div
-        className="text-break"
+        className="text-break w-100"
         onClick={clickHandler}
       >
         <div className="d-flex">
           {/* checkbox */}
           {onCheckboxChanged != null && (
-            <div className="d-flex align-items-center justify-content-center pl-md-2 pl-3">
+            <div className="d-flex align-items-center justify-content-center">
               <CustomInput
                 type="checkbox"
                 id={`cbSelect-${pageData._id}`}
@@ -164,7 +164,7 @@ const PageListItemLSubstance: ForwardRefRenderFunction<ISelectable, Props> = (pr
             </div>
           )}
 
-          <div className="flex-grow-1 p-md-3 pl-2 py-3 pr-3">
+          <div className="flex-grow-1 px-2 px-md-4">
             <div className="d-flex justify-content-between">
               {/* page path */}
               <PagePathHierarchicalLink

--- a/packages/app/src/components/PageList/PageListItemL.tsx
+++ b/packages/app/src/components/PageList/PageListItemL.tsx
@@ -202,7 +202,7 @@ const PageListItemLSubstance: ForwardRefRenderFunction<ISelectable, Props> = (pr
               </Clamp>
 
               {/* page meta */}
-              <div className="d-none d-md-flex py-0 px-1">
+              <div className="d-none d-md-flex py-0 px-1 ml-2 text-nowrap">
                 <PageListMeta page={pageData} bookmarkCount={pageMeta?.bookmarkCount} shouldSpaceOutIcon />
               </div>
 

--- a/packages/app/src/components/PageList/PageListItemS.jsx
+++ b/packages/app/src/components/PageList/PageListItemS.jsx
@@ -20,7 +20,9 @@ export default class PageListItemS extends React.Component {
       <>
         <UserPicture user={page.lastUpdateUser} noLink={noLink} />
         {pagePathElem}
-        <PageListMeta page={page} />
+        <span className="ml-2">
+          <PageListMeta page={page} />
+        </span>
       </>
     );
   }

--- a/packages/app/src/components/SearchTypeahead.tsx
+++ b/packages/app/src/components/SearchTypeahead.tsx
@@ -194,7 +194,7 @@ const SearchTypeahead: ForwardRefRenderFunction<IFocusable, Props> = (props: Pro
     return (
       <span>
         <UserPicture user={pageData.lastUpdateUser} size="sm" noLink />
-        <span className="ml-1 text-break text-wrap"><PagePathLabel path={pageData.path} /></span>
+        <span className="ml-1 mr-2 text-break text-wrap"><PagePathLabel path={pageData.path} /></span>
         <PageListMeta page={pageData} />
       </span>
     );

--- a/packages/plugin-lsx/src/client/js/components/LsxPageList/LsxPage.jsx
+++ b/packages/plugin-lsx/src/client/js/components/LsxPageList/LsxPage.jsx
@@ -92,7 +92,8 @@ export class LsxPage extends React.Component {
 
     return (
       <li className="page-list-li">
-        <small>{this.getIconElement()}</small> {pagePathNode} {pageListMeta}
+        <small>{this.getIconElement()}</small> {pagePathNode}
+        <span className="ml-2">{pageListMeta}</span>
         {this.getChildPageElement()}
       </li>
     );

--- a/packages/ui/src/components/PagePath/PageListMeta.jsx
+++ b/packages/ui/src/components/PagePath/PageListMeta.jsx
@@ -54,7 +54,7 @@ export class PageListMeta extends React.Component {
     }
 
     return (
-      <span className="page-list-meta ml-2">
+      <span className="page-list-meta">
         {topLabel}
         {templateLabel}
         {seenUserCount}


### PR DESCRIPTION
## Task
- [89783](https://redmine.weseek.co.jp/issues/89783) [検索結果] 文字列が右端までいくとアイコンボタンが崩れてしまうのを修正

### Description
このPRで行ったこと
- PageListMetaについていたマージンを、使用している箇所で指定するように置き換えた
- `text-nowrap`を追加することで、長いタイトルのページアイテムでもPageListMetaのアイコンたちが崩れるのを防いだ。

## VRT
- CIのエラーは関係ない部分で出ているので気にしなくてよし

## ScreenShots
### Before
<img width="749" alt="Screen Shot 2022-03-07 at 14 11 46" src="https://user-images.githubusercontent.com/59536731/156971920-d3ef1e46-8d8a-4409-9d36-a7ccdb6df957.png">

### After
<img width="788" alt="Screen Shot 2022-03-07 at 14 04 25" src="https://user-images.githubusercontent.com/59536731/156972013-ae9eca90-ef4a-418a-b03a-b6e0133a3c16.png">


### デグレがないかどうかの確認
PageListMetaについていたマージンを、使用している箇所で指定するように置き換えたので、デグレしていないかの確認をしました。
<img width="1176" alt="Screen Shot 2022-03-07 at 14 04 59" src="https://user-images.githubusercontent.com/59536731/156971976-e7f014a7-195e-4d39-91ad-6c41a4453e4a.png">
<img width="558" alt="Screen Shot 2022-03-07 at 14 04 12" src="https://user-images.githubusercontent.com/59536731/156972010-73c70d1e-11e1-40d8-b782-a1fe5dc846b9.png">




