### PR TITLE
fix: Swiping to previous/next page for Mac users (5.0.x)

### DIFF
--- a/packages/app/src/styles/_layout.scss
+++ b/packages/app/src/styles/_layout.scss
@@ -1,6 +1,6 @@
 body {
   overflow-y: scroll !important;
-  overscroll-behavior: none;
+  overscroll-behavior-y: none;
 }
 
 body:not(.growi-layout-fluid) .grw-container-convertible {


### PR DESCRIPTION
Redmine: https://redmine.weseek.co.jp/issues/89907

Mac ユーザーがスワイプで前後のページに移動できるように修正しました

## issue
https://github.com/weseek/growi/issues/5425