### PR TITLE
fix: checkbox position on search page

### DIFF
--- a/packages/app/src/components/PageList/PageListItemL.tsx
+++ b/packages/app/src/components/PageList/PageListItemL.tsx
@@ -144,16 +144,16 @@ const PageListItemLSubstance: ForwardRefRenderFunction<ISelectable, Props> = (pr
   return (
     <li
       key={pageData._id}
-      className={`list-group-item p-0 ${styleListGroupItem} ${styleActive}`}
+      className={`list-group-item d-flex align-items-center px-3 px-md-1 ${styleListGroupItem} ${styleActive}`}
     >
       <div
-        className="text-break"
+        className="text-break w-100"
         onClick={clickHandler}
       >
         <div className="d-flex">
           {/* checkbox */}
           {onCheckboxChanged != null && (
-            <div className="d-flex align-items-center justify-content-center pl-md-2 pl-3">
+            <div className="d-flex align-items-center justify-content-center">
               <CustomInput
                 type="checkbox"
                 id={`cbSelect-${pageData._id}`}
@@ -164,7 +164,7 @@ const PageListItemLSubstance: ForwardRefRenderFunction<ISelectable, Props> = (pr
             </div>
           )}
 
-          <div className="flex-grow-1 p-md-3 pl-2 py-3 pr-3">
+          <div className="flex-grow-1 px-2 px-md-4">
             <div className="d-flex justify-content-between">
               {/* page path */}
               <PagePathHierarchicalLink


### PR DESCRIPTION
※ #5483 がマージ済みであることを確認お願いします。
┗マージされていたら、`Don't merge` labelを外してこのPRをマージお願いします。

## Task
- [89788](https://redmine.weseek.co.jp/issues/89788) [検索結果] ページリストのチェックボックスの位置を上下中央揃えにする
┗https://github.com/weseek/growi/pull/5484 -> 一度マージされましたがまだマージ先のブランチがマージされていなかったのでrevertしました。



## VRT
- CIのエラーは関係ない部分で出ているので気にしなくてよし
- list内のコンテンツが中央寄せになっていることを確認できます。


## [XD url](https://xd.adobe.com/view/cd3cb2f8-625d-4a6b-b6e4-917f75c675c5-986f/screen/9aa528ff-a75e-4e9a-adb9-b4b942647f29/specs/)
<img width="786" alt="Screen Shot 2022-03-07 at 15 34 18" src="https://user-images.githubusercontent.com/59536731/156980262-31c868bc-6d7b-47bb-8fc2-91c17345a933.png">

## ScreenShots
### Before
<img width="678" alt="Screen Shot 2022-03-07 at 15 28 47" src="https://user-images.githubusercontent.com/59536731/156981407-2489ff00-ef96-4f4e-a2f9-fe40f59dd428.png">


<img width="536" alt="Screen Shot 2022-03-07 at 15 28 55" src="https://user-images.githubusercontent.com/59536731/156979657-e470ac15-ee20-443c-a61a-0bc7cbfbac11.png">


### After
<img width="781" alt="Screen Shot 2022-03-07 at 15 24 39" src="https://user-images.githubusercontent.com/59536731/156979832-63ee225c-1679-4808-baf9-e18d077692ae.png">

<img width="647" alt="Screen Shot 2022-03-07 at 15 24 45" src="https://user-images.githubusercontent.com/59536731/156979513-1796e3a8-65c2-4490-bcd7-e27aa1093153.png">


