### PR TITLE
imprv: private legacy pages UI when it's hovered

### DIFF
--- a/packages/app/src/components/Sidebar/PageTree.tsx
+++ b/packages/app/src/components/Sidebar/PageTree.tsx
@@ -76,7 +76,9 @@ const PageTree: FC = memo(() => {
 
       {!isGuestUser && migrationStatus?.migratablePagesCount != null && migrationStatus.migratablePagesCount !== 0 && (
         <div className="grw-pagetree-footer border-top p-3 w-100">
-          <PrivateLegacyPagesLink />
+          <div className="private-legacy-pages-link px-3 py-2">
+            <PrivateLegacyPagesLink />
+          </div>
         </div>
       )}
     </>

--- a/packages/app/src/styles/theme/_apply-colors-dark.scss
+++ b/packages/app/src/styles/theme/_apply-colors-dark.scss
@@ -280,6 +280,11 @@ ul.pagination {
       $gray-500
     );
   }
+  .grw-pagetree-footer {
+    &:hover {
+      background: $bgcolor-list-hover;
+    }
+  }
 }
 
 /*

--- a/packages/app/src/styles/theme/_apply-colors-dark.scss
+++ b/packages/app/src/styles/theme/_apply-colors-dark.scss
@@ -280,7 +280,7 @@ ul.pagination {
       $gray-500
     );
   }
-  .grw-pagetree-footer {
+  .private-legacy-pages-link {
     &:hover {
       background: $bgcolor-list-hover;
     }

--- a/packages/app/src/styles/theme/_apply-colors-light.scss
+++ b/packages/app/src/styles/theme/_apply-colors-light.scss
@@ -180,6 +180,11 @@ $border-color: $border-color-global;
       $gray-400
     );
   }
+  .grw-pagetree-footer {
+    &:hover {
+      background: $bgcolor-list-hover;
+    }
+  }
 }
 
 /*

--- a/packages/app/src/styles/theme/_apply-colors-light.scss
+++ b/packages/app/src/styles/theme/_apply-colors-light.scss
@@ -180,7 +180,7 @@ $border-color: $border-color-global;
       $gray-400
     );
   }
-  .grw-pagetree-footer {
+  .private-legacy-pages-link {
     &:hover {
       background: $bgcolor-list-hover;
     }


### PR DESCRIPTION
## Task
- [89825](https://redmine.weseek.co.jp/issues/89825) [ページツリー][待避所] マウスホバー時の見た目を変更する

## VRT 
Private Legacy Pagesのhover時の差分は検査されていないみたいです

## [XD url](https://xd.adobe.com/view/cd3cb2f8-625d-4a6b-b6e4-917f75c675c5-986f/screen/27a328ec-c82d-4fd1-b97a-1dc6cb549080/specs/)
<img width="959" alt="Screen Shot 2022-03-07 at 22 22 06" src="https://user-images.githubusercontent.com/59536731/157042372-655e64e8-733b-4dd0-a7e1-ef8de1babeae.png">


## ScreenShots
<img width="332" alt="Screen Shot 2022-03-07 at 22 03 44" src="https://user-images.githubusercontent.com/59536731/157039902-9eb2387f-5529-4c57-af61-d53b4c801643.png">

