### PR TITLE
imprv: dark theme form color

### DIFF
--- a/packages/app/src/styles/theme/_apply-colors-dark.scss
+++ b/packages/app/src/styles/theme/_apply-colors-dark.scss
@@ -38,8 +38,9 @@ $border-color: $border-color-global;
   */
 input.form-control,
 select.form-control,
+select.custom-select,
 textarea.form-control {
-  color: lighten($color-global, 30%);
+  color: $color-global;
   background-color: darken($bgcolor-global, 5%);
   border-color: $border-color-global;
   &:focus {
@@ -67,6 +68,10 @@ textarea.form-control {
 
 .input-group input {
   border-color: $border-color-global;
+}
+
+label.custom-control-label::before {
+  background-color: darken($bgcolor-global, 5%);
 }
 
 /*


### PR DESCRIPTION
## Task
- [90000](https://redmine.weseek.co.jp/issues/90000) [dark theme] inputの色が明るすぎるのを修正

## VRT
ok

## ScreenShots
### Before
<img width="774" alt="Screen Shot 2022-03-08 at 14 16 48" src="https://user-images.githubusercontent.com/59536731/157172163-0f7d9d47-a0a8-4f1e-ac46-e6d91b02524b.png">



### After
<img width="670" alt="Screen Shot 2022-03-08 at 14 15 31" src="https://user-images.githubusercontent.com/59536731/157170877-26a53cd5-3c09-4568-aefa-0b880a0a33b2.png">

<img width="768" alt="Screen Shot 2022-03-08 at 14 38 51" src="https://user-images.githubusercontent.com/59536731/157173588-02c5f111-eccb-4599-be0a-e79787e4c66b.png">

<img width="917" alt="Screen Shot 2022-03-08 at 14 40 10" src="https://user-images.githubusercontent.com/59536731/157173575-82c23e4b-9d94-4df4-8907-8987ba28aaff.png">

