### PR TITLE
imprv: btn-page-item-control ui

### DIFF
--- a/packages/app/src/components/Common/Dropdown/PageItemControl.tsx
+++ b/packages/app/src/components/Common/Dropdown/PageItemControl.tsx
@@ -257,7 +257,7 @@ export const PageItemControlSubstance = (props: PageItemControlSubstanceProps): 
     <Dropdown isOpen={isOpen} toggle={() => setIsOpen(!isOpen)} data-testid="open-page-item-control-btn">
       { children ?? (
         <DropdownToggle color="transparent" className="border-0 rounded btn-page-item-control d-flex align-items-center justify-content-center">
-          <i className="icon-options text-muted"></i>
+          <i className="icon-options"></i>
         </DropdownToggle>
       ) }
 

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -451,7 +451,7 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
           >
             {/* pass the color property to reactstrap dropdownToggle props. https://6-4-0--reactstrap.netlify.app/components/dropdowns/  */}
             <DropdownToggle color="transparent" className="border-0 rounded btn-page-item-control p-0 grw-visible-on-hover mr-1">
-              <i className="icon-options fa fa-rotate-90 text-muted p-1"></i>
+              <i className="icon-options fa fa-rotate-90 p-1"></i>
             </DropdownToggle>
           </PageItemControl>
           <button
@@ -459,7 +459,7 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
             className="border-0 rounded btn btn-page-item-control p-0 grw-visible-on-hover"
             onClick={onClickPlusButton}
           >
-            <i className="icon-plus text-muted d-block p-0" />
+            <i className="icon-plus d-block p-0" />
           </button>
         </div>
       </li>

--- a/packages/app/src/styles/theme/_apply-colors.scss
+++ b/packages/app/src/styles/theme/_apply-colors.scss
@@ -712,6 +712,7 @@ mark.rbt-highlight-text {
 
 // Page Management Dropdown icon
 .btn-page-item-control {
+  color: $gray-500;
   &:hover,
   &:focus {
     background-color: rgba($color-link, 0.15);


### PR DESCRIPTION
## Task
- [89998](https://redmine.weseek.co.jp/issues/89998) [PageItemControl] 3点ボタン, プラスボタンをクリックした際に3角アイコンと同じ挙動になるように修正する

## Description
- 対象: 3点ボタン、プラスボタン
- 変更箇所: hover時に、アイコンにprimary color色をつけるようにしました。
(Before / After のスクリーンショットを見るとわかりやすいです)


## [XD](https://xd.adobe.com/view/cd3cb2f8-625d-4a6b-b6e4-917f75c675c5-986f/screen/27a328ec-c82d-4fd1-b97a-1dc6cb549080/)
<img width="897" alt="Screen Shot 2022-03-08 at 17 07 33" src="https://user-images.githubusercontent.com/59536731/157193727-78969a32-9c58-4f48-9b1c-cac9d29d3e5d.png">


## ScreenShots
### Before
- hover時にアイコンに色がついていない
<img width="386" alt="Screen Shot 2022-03-08 at 17 15 53" src="https://user-images.githubusercontent.com/59536731/157195289-e4b5c61e-ec03-4fd4-a0e6-245655c39a02.png">


### After
- Pagetree
<img width="287" alt="Screen Shot 2022-03-08 at 17 08 25" src="https://user-images.githubusercontent.com/59536731/157193886-59f1b7fb-bd91-49f2-8f85-65d4b010f435.png">
- subnaviBar
<img width="78" alt="Screen Shot 2022-03-08 at 17 11 38" src="https://user-images.githubusercontent.com/59536731/157194384-e9f17a09-0767-49cb-a5ab-72aff56c14b2.png">
- pageListItemL
<img width="275" alt="Screen Shot 2022-03-08 at 17 11 42" src="https://user-images.githubusercontent.com/59536731/157194393-c7481356-6c8d-474d-92ec-7dd3ca9f864c.png">

