### PR TITLE
fix: Normalize parent when empty pages already exist

### DIFF
--- a/packages/app/src/server/models/page.ts
+++ b/packages/app/src/server/models/page.ts
@@ -864,7 +864,7 @@ schema.statics.takeOffFromTree = async function(pageId: ObjectIdLike) {
 };
 
 schema.statics.removeEmptyPages = async function(pageIdsToNotRemove: ObjectIdLike[], paths: string[]): Promise<void> {
-  const result = await this.deleteMany({
+  await this.deleteMany({
     _id: {
       $nin: pageIdsToNotRemove,
     },
@@ -873,8 +873,6 @@ schema.statics.removeEmptyPages = async function(pageIdsToNotRemove: ObjectIdLik
     },
     isEmpty: true,
   });
-
-  console.log('りさると', result);
 };
 
 schema.statics.PageQueryBuilder = PageQueryBuilder as any; // mongoose does not support constructor type as statics attrs type

--- a/packages/app/src/server/models/page.ts
+++ b/packages/app/src/server/models/page.ts
@@ -372,6 +372,17 @@ class PageQueryBuilder {
     return this;
   }
 
+  addConditionToExcludeByPageIdsArray(pageIds) {
+    this.query = this.query
+      .and({
+        _id: {
+          $nin: pageIds,
+        },
+      });
+
+    return this;
+  }
+
   populateDataToList(userPublicFields) {
     this.query = this.query
       .populate({
@@ -853,7 +864,7 @@ schema.statics.takeOffFromTree = async function(pageId: ObjectIdLike) {
 };
 
 schema.statics.removeEmptyPages = async function(pageIdsToNotRemove: ObjectIdLike[], paths: string[]): Promise<void> {
-  await this.deleteMany({
+  const result = await this.deleteMany({
     _id: {
       $nin: pageIdsToNotRemove,
     },
@@ -862,6 +873,8 @@ schema.statics.removeEmptyPages = async function(pageIdsToNotRemove: ObjectIdLik
     },
     isEmpty: true,
   });
+
+  console.log('りさると', result);
 };
 
 schema.statics.PageQueryBuilder = PageQueryBuilder as any; // mongoose does not support constructor type as statics attrs type


### PR DESCRIPTION
Redmine: https://redmine.weseek.co.jp/issues/90060

待避所からのマイグレーション処理を修正しました
一応連絡として、https://github.com/weseek/growi/pull/5485 で椎名さんがテスト拡充してくれています