### PR TITLE
imprv: show personal dropdown over search control

### DIFF
--- a/packages/app/src/components/SearchPage/SearchControl.tsx
+++ b/packages/app/src/components/SearchPage/SearchControl.tsx
@@ -61,7 +61,7 @@ const SearchControl: FC <Props> = React.memo((props: Props) => {
   }, [invokeSearch]);
 
   return (
-    <div className="position-sticky shadow-sm">
+    <div className="position-sticky fixed-top shadow-sm">
       <div className="grw-search-page-nav d-flex py-3 align-items-center">
         <div className="flex-grow-1 mx-4">
           <SearchForm

--- a/packages/app/src/components/SearchPage/SearchControl.tsx
+++ b/packages/app/src/components/SearchPage/SearchControl.tsx
@@ -61,7 +61,7 @@ const SearchControl: FC <Props> = React.memo((props: Props) => {
   }, [invokeSearch]);
 
   return (
-    <div className="position-sticky fixed-top shadow-sm">
+    <div className="position-sticky shadow-sm">
       <div className="grw-search-page-nav d-flex py-3 align-items-center">
         <div className="flex-grow-1 mx-4">
           <SearchForm

--- a/packages/app/src/components/SearchPage/SearchControl.tsx
+++ b/packages/app/src/components/SearchPage/SearchControl.tsx
@@ -61,7 +61,7 @@ const SearchControl: FC <Props> = React.memo((props: Props) => {
   }, [invokeSearch]);
 
   return (
-    <div className="position-sticky fixed-top shadow-sm">
+    <div className="position-sticky sticky-top shadow-sm">
       <div className="grw-search-page-nav d-flex py-3 align-items-center">
         <div className="flex-grow-1 mx-4">
           <SearchForm

--- a/packages/app/src/styles/_navbar.scss
+++ b/packages/app/src/styles/_navbar.scss
@@ -1,7 +1,7 @@
 .grw-navbar {
   top: -$grw-navbar-height !important;
 
-  z-index: $grw-navbar-z-index-amount !important; // should be higher than SubNavigation
+  z-index: $grw-navbar-z-index !important;
   max-height: $grw-navbar-height + $grw-navbar-border-width;
   border-top: 0;
   border-right: 0;

--- a/packages/app/src/styles/_navbar.scss
+++ b/packages/app/src/styles/_navbar.scss
@@ -1,7 +1,7 @@
 .grw-navbar {
   top: -$grw-navbar-height !important;
 
-  z-index: 1035 !important; // should be higher than SubNavigation
+  z-index: $grw-navbar-z-index-amount !important; // should be higher than SubNavigation
   max-height: $grw-navbar-height + $grw-navbar-border-width;
   border-top: 0;
   border-right: 0;

--- a/packages/app/src/styles/_navbar.scss
+++ b/packages/app/src/styles/_navbar.scss
@@ -1,6 +1,7 @@
 .grw-navbar {
   top: -$grw-navbar-height !important;
 
+  z-index: 1035 !important; // should be higher than SubNavigation
   max-height: $grw-navbar-height + $grw-navbar-border-width;
   border-top: 0;
   border-right: 0;

--- a/packages/app/src/styles/_variables.scss
+++ b/packages/app/src/styles/_variables.scss
@@ -36,3 +36,7 @@ $grw-logomark-width: 36px;
 $grw-nav-main-left-tab-width: 95px;
 $grw-nav-main-left-tab-width-mobile: 50px;
 $grw-nav-main-tab-height: 42px;
+
+// slightly larger than $zindex-fixed
+// https://getbootstrap.jp/docs/4.5/layout/overview/#z-index
+$grw-navbar-z-index-amount: 1030;

--- a/packages/app/src/styles/_variables.scss
+++ b/packages/app/src/styles/_variables.scss
@@ -15,6 +15,9 @@ $font-family-monospace-not-strictly: Monaco, Menlo, Consolas, 'Courier New', Mei
 //== Layout
 $grw-navbar-height: 52px;
 $grw-navbar-border-width: 3.3333px;
+// slightly larger than $zindex-sticky
+// https://getbootstrap.jp/docs/4.5/layout/overview/#z-index
+$grw-navbar-z-index: 1025;
 
 $grw-subnav-min-height: 95px;
 $grw-subnav-min-height-md: 115px;
@@ -36,7 +39,3 @@ $grw-logomark-width: 36px;
 $grw-nav-main-left-tab-width: 95px;
 $grw-nav-main-left-tab-width-mobile: 50px;
 $grw-nav-main-tab-height: 42px;
-
-// slightly larger than $zindex-fixed
-// https://getbootstrap.jp/docs/4.5/layout/overview/#z-index
-$grw-navbar-z-index-amount: 1035;

--- a/packages/app/src/styles/_variables.scss
+++ b/packages/app/src/styles/_variables.scss
@@ -39,4 +39,4 @@ $grw-nav-main-tab-height: 42px;
 
 // slightly larger than $zindex-fixed
 // https://getbootstrap.jp/docs/4.5/layout/overview/#z-index
-$grw-navbar-z-index-amount: 1030;
+$grw-navbar-z-index-amount: 1035;


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/90046

z-idnex の値
1020:  navbar
1030:  SearchControl
1000:  ユーザのメニュー（ホーム等）
<img width="473" alt="image" src="https://user-images.githubusercontent.com/35527421/157217229-50697940-b757-4793-ba8e-69180cb13e24.png">

1020 の navbar が SearchControl より高くないと 1000 のメニュー部分が下に隠れてしまう