### PR TITLE
imprv: sidebar bg-color for default light

### DIFF
--- a/packages/app/src/styles/theme/default.scss
+++ b/packages/app/src/styles/theme/default.scss
@@ -72,7 +72,7 @@ html[light] {
   $bgcolor-resize-button-hover: lighten($bgcolor-resize-button, 5%);
   // Sidebar contents
   $color-sidebar-context: $color-global;
-  $bgcolor-sidebar-context: $gray-100;
+  $bgcolor-sidebar-context: lighten($primary, 77%);
   // Sidebar list group
   $bgcolor-sidebar-list-group: $gray-50; // optional
 


### PR DESCRIPTION
## Task
- [89770](https://redmine.weseek.co.jp/issues/89770) [サイドバー] [default light]サイドバーの背景色を変更する


## VRT
ok
┗サイドバーの色が変わっていることを確認できます
┗CIのcypressのエラーは関係ない部分なのでスルーして大丈夫です

## [XD url](https://xd.adobe.com/view/cd3cb2f8-625d-4a6b-b6e4-917f75c675c5-986f/screen/ca2fd6f5-dca4-43cc-9eb5-e26a1a307afa/specs/)
<img width="1711" alt="Screen Shot 2022-03-10 at 1 59 36" src="https://user-images.githubusercontent.com/59536731/157492063-5c4858f9-c6ea-4f77-a020-c555d7c59e23.png">


## ScreenShots
### Before
<img width="448" alt="Screen Shot 2022-03-10 at 2 00 47" src="https://user-images.githubusercontent.com/59536731/157492202-ab04704f-450c-4a0e-b4ae-b8a0c5613a8f.png">


### After
<img width="453" alt="Screen Shot 2022-03-10 at 1 52 07" src="https://user-images.githubusercontent.com/59536731/157492597-35e23eca-b159-4882-a542-e7a22364d64a.png">



## Note
- サイドバーのbgColorは、`$bgcolor-sidebar-context`という変数で各テーマにで指定されているので、今回の変更が他テーマには影響することはありません
![Screen Shot 2022-03-10 at 2 02 02](https://user-images.githubusercontent.com/59536731/157492614-442abfc6-9a66-48dc-a5da-e72c72b23b5b.png)

