### PR TITLE
imprv: pagetree count colors

### DIFF
--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -102,7 +102,7 @@ type ItemCountProps = {
 const ItemCount: FC<ItemCountProps> = (props:ItemCountProps) => {
   return (
     <>
-      <span className="grw-pagetree-count px-0 badge badge-pill badge-light text-muted">
+      <span className="grw-pagetree-count px-0 badge badge-pill badge-light">
         {props.descendantCount}
       </span>
     </>

--- a/packages/app/src/styles/theme/_apply-colors-dark.scss
+++ b/packages/app/src/styles/theme/_apply-colors-dark.scss
@@ -284,6 +284,10 @@ ul.pagination {
       lighten($bgcolor-list-hover, 5%),
       $gray-500
     );
+    .grw-pagetree-count {
+      color: $gray-400;
+      background: $gray-700;
+    }
   }
   .private-legacy-pages-link {
     &:hover {

--- a/packages/app/src/styles/theme/_apply-colors-light.scss
+++ b/packages/app/src/styles/theme/_apply-colors-light.scss
@@ -179,6 +179,10 @@ $border-color: $border-color-global;
       $bgcolor-list-active,
       $gray-400
     );
+    .grw-pagetree-count {
+      color: $gray-500;
+      background: $gray-200;
+    }
   }
   .private-legacy-pages-link {
     &:hover {

--- a/packages/app/src/styles/theme/mixins/_list-group.scss
+++ b/packages/app/src/styles/theme/mixins/_list-group.scss
@@ -38,9 +38,6 @@
     &.grw-pagetree-is-target {
       background: $bgcolor-hover;
     }
-    .grw-pagetree-count {
-      background: $bgcolor;
-    }
     .grw-pagetree-button {
       &:not(:hover) {
         svg {


### PR DESCRIPTION
## Task
- [89863](https://redmine.weseek.co.jp/issues/89863) [ページツリー][子孫数] 文字色 / 背景色をXD通りに変更する

## Description
このPRでは、default theme(light / dark) に色指定をしています。
┗default (light / dark) で設定した色が他のテーマにも適用されていますが何かが見えづらくなるとかはないので問題はないと思っています。
┗後続でmosさんが各テーマカラーの提案をするとのことです。


## VRT
- 子孫数に関する色が変わっていることを見ることができます。
- CIのcypressに関するエラーは本PRとは関係ない部分なので無視して大丈夫です

## [XD url](https://xd.adobe.com/view/cd3cb2f8-625d-4a6b-b6e4-917f75c675c5-986f/screen/ca2fd6f5-dca4-43cc-9eb5-e26a1a307afa/specs/)
<img width="886" alt="Screen Shot 2022-03-10 at 3 54 14" src="https://user-images.githubusercontent.com/59536731/157511526-f54b29dd-827f-4254-aab9-ab86a08e9b90.png">


## ScreenShots
### Before
<img width="391" alt="Screen Shot 2022-03-10 at 3 58 23" src="https://user-images.githubusercontent.com/59536731/157512317-f25b0930-3732-4a5e-bd21-8df20af760a6.png">
<img width="362" alt="Screen Shot 2022-03-10 at 3 58 31" src="https://user-images.githubusercontent.com/59536731/157512326-1528836a-08de-471a-ba10-5f20ddce14da.png">


### After
<img width="473" alt="Screen Shot 2022-03-10 at 3 55 01" src="https://user-images.githubusercontent.com/59536731/157511692-fe8b6c7a-f0c4-481d-8a8b-aa6b332e2fd2.png">
<img width="529" alt="Screen Shot 2022-03-10 at 3 54 53" src="https://user-images.githubusercontent.com/59536731/157511709-cc4c953b-4277-4d95-b097-f03bbd92a797.png">

<img width="336" alt="Screen Shot 2022-03-10 at 3 56 05" src="https://user-images.githubusercontent.com/59536731/157512059-374b6dfa-bf27-471e-b0b1-43d1eafc9455.png">
<img width="374" alt="Screen Shot 2022-03-10 at 3 56 34" src="https://user-images.githubusercontent.com/59536731/157512070-757dea94-eadd-4277-ace7-c0ef63a21d48.png">
<img width="379" alt="Screen Shot 2022-03-10 at 3 57 04" src="https://user-images.githubusercontent.com/59536731/157512429-e36c68aa-0edc-4e0e-a785-9597ab06d3cd.png">
<img width="360" alt="Screen Shot 2022-03-10 at 3 57 12" src="https://user-images.githubusercontent.com/59536731/157512438-00a6bda1-4d6c-48f7-abb3-ab68697a5152.png">






