### PR TITLE
fix: 89954 rename input and count position

### DIFF
--- a/packages/app/src/components/Common/ClosableTextInput.tsx
+++ b/packages/app/src/components/Common/ClosableTextInput.tsx
@@ -16,7 +16,6 @@ export type AlertInfo = {
 }
 
 type ClosableTextInputProps = {
-  isShown: boolean
   value?: string
   placeholder?: string
   inputValidator?(text: string): AlertInfo | Promise<AlertInfo> | null
@@ -107,7 +106,7 @@ const ClosableTextInput: FC<ClosableTextInputProps> = memo((props: ClosableTextI
 
 
   return (
-    <div className={props.isShown ? 'd-block' : 'd-none'}>
+    <div className="d-block flex-fill">
       <input
         value={inputText || ''}
         ref={inputRef}

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -435,7 +435,7 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
             <p className={`text-truncate m-auto ${page.isEmpty && 'text-muted'}`}>{nodePath.basename(page.path ?? '') || '/'}</p>
           </a>
         )}
-        {(descendantCount > 0) && (
+        {descendantCount > 0 && !isRenameInputShown && (
           <div className="grw-pagetree-count-wrapper">
             <ItemCount descendantCount={descendantCount} />
           </div>

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -421,7 +421,7 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
           )}
         </div>
         { isRenameInputShown
-          && (
+          ? (
             <ClosableTextInput
               value={nodePath.basename(page.path ?? '')}
               placeholder={t('Input page name')}
@@ -430,12 +430,11 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
               inputValidator={inputValidator}
             />
           )
-        }
-        { !isRenameInputShown && (
-          <a href={`/${page._id}`} className="grw-pagetree-title-anchor flex-grow-1">
-            <p className={`text-truncate m-auto ${page.isEmpty && 'text-muted'}`}>{nodePath.basename(page.path ?? '') || '/'}</p>
-          </a>
-        )}
+          : (
+            <a href={`/${page._id}`} className="grw-pagetree-title-anchor flex-grow-1">
+              <p className={`text-truncate m-auto ${page.isEmpty && 'text-muted'}`}>{nodePath.basename(page.path ?? '') || '/'}</p>
+            </a>
+          )}
         {descendantCount > 0 && !isRenameInputShown && (
           <div className="grw-pagetree-count-wrapper">
             <ItemCount descendantCount={descendantCount} />

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -420,16 +420,17 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
             </button>
           )}
         </div>
-        { isRenameInputShown && (
-          <ClosableTextInput
-            isShown
-            value={nodePath.basename(page.path ?? '')}
-            placeholder={t('Input page name')}
-            onClickOutside={() => { setRenameInputShown(false) }}
-            onPressEnter={onPressEnterForRenameHandler}
-            inputValidator={inputValidator}
-          />
-        )}
+        { isRenameInputShown
+          && (
+            <ClosableTextInput
+              value={nodePath.basename(page.path ?? '')}
+              placeholder={t('Input page name')}
+              onClickOutside={() => { setRenameInputShown(false) }}
+              onPressEnter={onPressEnterForRenameHandler}
+              inputValidator={inputValidator}
+            />
+          )
+        }
         { !isRenameInputShown && (
           <a href={`/${page._id}`} className="grw-pagetree-title-anchor flex-grow-1">
             <p className={`text-truncate m-auto ${page.isEmpty && 'text-muted'}`}>{nodePath.basename(page.path ?? '') || '/'}</p>
@@ -464,9 +465,8 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
         </div>
       </li>
 
-      {isEnableActions && (
+      {isEnableActions && isNewPageInputShown && (
         <ClosableTextInput
-          isShown={isNewPageInputShown}
           placeholder={t('Input page name')}
           onClickOutside={() => { setNewPageInputShown(false) }}
           onPressEnter={onPressEnterForCreateHandler}


### PR DESCRIPTION
## Task
- [89954](https://redmine.weseek.co.jp/issues/89954) 修正

## Description
- renamenのinputが表示される時は子孫数カウントを表示しないようにしました
- inputの長さをサイドバーの横幅いっぱいまで伸ばすようにしました

## VRT
- ok(renameのinput部分は普段隠れているので検出されないです)
┗cypress のCIでエラー出ているが関係ない部分なので無視して大丈夫です

## ScreenShots
### Before
<img width="338" alt="Screen Shot 2022-03-10 at 15 31 50" src="https://user-images.githubusercontent.com/59536731/157602932-0edffc1b-daa2-4514-b1a0-7911fc28df5e.png">


### After
<img width="324" alt="Screen Shot 2022-03-10 at 15 31 05" src="https://user-images.githubusercontent.com/59536731/157602880-71e39ffc-ac91-4296-b2d6-71814c277872.png">

