### PR TITLE
improve sedebar bgColor on default dark

### DIFF
--- a/packages/app/src/styles/theme/default.scss
+++ b/packages/app/src/styles/theme/default.scss
@@ -172,7 +172,7 @@ html[dark] {
   $color-resize-button-hover: white;
   $bgcolor-resize-button-hover: darken($bgcolor-resize-button, 5%);
   // Sidebar contents
-  $bgcolor-sidebar-context: #111d2f;
+  $bgcolor-sidebar-context: lighten($bgcolor-global, 10%);
   $color-sidebar-context: $color-global;
   // Sidebar list group
   $bgcolor-sidebar-list-group: #1c2a3e; // optional


### PR DESCRIPTION
## Task
- [90330](https://redmine.weseek.co.jp/issues/90330) [Pagetree][default dark] サイドバーの背景色をXD通りに変更

## VRT
OK

## [XD url](https://xd.adobe.com/view/cd3cb2f8-625d-4a6b-b6e4-917f75c675c5-986f/screen/ca2fd6f5-dca4-43cc-9eb5-e26a1a307afa/specs/)
<img width="591" alt="Screen Shot 2022-03-10 at 20 04 54" src="https://user-images.githubusercontent.com/59536731/157649295-6ece0935-6dd3-45f7-92c1-682aa0182d5e.png">


## ScreenShots
### Before
<img width="497" alt="Screen Shot 2022-03-10 at 20 03 43" src="https://user-images.githubusercontent.com/59536731/157649133-7ac84bdb-3db2-47d2-ab79-330d7851c5e8.png">

### After
<img width="622" alt="Screen Shot 2022-03-10 at 20 01 01" src="https://user-images.githubusercontent.com/59536731/157649169-d41df724-9450-4e88-b31e-d2e50adaa86b.png">

### Note
各テーマで`  $bgcolor-sidebar-context`の変数に色を指定しているので、default themeを変えたことにより他のテーマの背景色が変わることはないです。


