### PR TITLE
fix: scroll target item class name

### DIFF
--- a/packages/app/src/components/Sidebar/PageTree/ItemsTree.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/ItemsTree.tsx
@@ -184,7 +184,7 @@ const ItemsTree = (props: ItemsTreeProps): JSX.Element => {
 
   // ***************************  Scroll on init ***************************
   const scrollOnInit = useCallback(() => {
-    const scrollTargetElement = document.getElementById('grw-pagetree-is-target');
+    const scrollTargetElement = document.getElementById('grw-pagetree-current-page-item');
 
     if (sidebarScrollerRef?.current == null || scrollTargetElement == null) {
       return;


### PR DESCRIPTION
## Task
- [90436](https://redmine.weseek.co.jp/issues/90436) 修正
┗[PageTree] レンダリング後に Target ページまで自動スクロールできる

## ScreenRecording
https://user-images.githubusercontent.com/59536731/157801136-728fd8d7-ee13-46cb-b34d-7d83c3399291.mov


