### PR TITLE
imprv: i18n maintenance mode

### DIFF
--- a/packages/app/resource/locales/en_US/admin/admin.json
+++ b/packages/app/resource/locales/en_US/admin/admin.json
@@ -37,8 +37,9 @@
     "failed_to_end_maintenance_mode": "Failed to end maintenance mode",
     "successfully_started_maintenance_mode": "Succussfully started maintenance mode",
     "successfully_ended_maintenance_mode": "Succussfully ended maintenance mode",
-    "warning_message": "You will NOT able to access other than admin settings page. General users will NOT able to access to any contents until maintenance mode ends manually.",
-    "supplymentary_message": "As for the API, only the administrator API will be functional.",
+    "warning_message_to_start": "You will NOT able to access other than admin settings page. General users will NOT able to access to any contents until maintenance mode ends manually.",
+    "warning_message_to_end": "Please make sure that \"data importing\" or \"upgrading to v5\" is already done or not. If not, it is highly recommended to keep maintenance mode on.",
+    "supplymentary_message_to_start": "As for the API, only the administrator API will be functional.",
     "start_maintenance_mode": "Start maintenance mode",
     "end_maintenance_mode": "End maintenance mode",
     "description": "Maintenance mode restricts all user operations. Always start the maintenance mode before \"importing data\" and \"upgrading to V5\". To exit, go to \"Security Settings\" > \"Maintenance Mode\"."

--- a/packages/app/resource/locales/en_US/admin/admin.json
+++ b/packages/app/resource/locales/en_US/admin/admin.json
@@ -30,6 +30,19 @@
     "successfully_started": "Succeeded to start migration",
     "already_upgraded": "You have already completed upgrading"
   },
+  "maintenance_mode": {
+    "maintenance_mode": "Maintenance Mode",
+    "under_maintenance_mode": "Under Maintenance Mode",
+    "failed_to_start_maintenance_mode": "Failed to start maintenance mode",
+    "failed_to_end_maintenance_mode": "Failed to end maintenance mode",
+    "successfully_started_maintenance_mode": "Succussfully started maintenance mode",
+    "successfully_ended_maintenance_mode": "Succussfully ended maintenance mode",
+    "warning_message": "You will NOT able to access other than admin settings page. General users will NOT able to access to any contents until maintenance mode ends manually.",
+    "supplymentary_message": "As for the API, only the administrator API will be functional.",
+    "start_maintenance_mode": "Start maintenance mode",
+    "end_maintenance_mode": "End maintenance mode",
+    "description": "Maintenance mode restricts all user operations. Always start the maintenance mode before \"importing data\" and \"upgrading to V5\". To exit, go to \"Security Settings\" > \"Maintenance Mode\"."
+  },
   "app_setting": {
     "site_name": "Site name",
     "sitename_change": "You can change site name which is used for header and HTML title.",

--- a/packages/app/resource/locales/ja_JP/admin/admin.json
+++ b/packages/app/resource/locales/ja_JP/admin/admin.json
@@ -30,6 +30,19 @@
     "successfully_started": "正常にマイグレーションが開始されました",
     "already_upgraded": "アップグレードは既に完了しています"
   },
+  "maintenance_mode": {
+    "maintenance_mode": "メンテナンスモード",
+    "under_maintenance_mode": "メンテナンスモード中",
+    "failed_to_start_maintenance_mode": "メンテナンスモードを開始できませんでした",
+    "failed_to_end_maintenance_mode": "メンテナンスモードを終了できませんでした",
+    "successfully_started_maintenance_mode": "メンテナンスモードを開始しました",
+    "successfully_ended_maintenance_mode": "メンテナンスモードを終了しました",
+    "warning_message": "メンテナンスモード中は管理画面にしかアクセスできなくなり、一般ユーザーは全ての操作が不能になります。",
+    "supplymentary_message": "API についても管理者用 API しか機能しなくなります。",
+    "start_maintenance_mode": "メンテナンスモードを開始する",
+    "end_maintenance_mode": "メンテナンスモードを終了する",
+    "description": "メンテナンスモードでは、ユーザーのあらゆる操作を制限します。「データのインポート」および「V5 へのアップグレード」の際には必ずメンテナンスモードを開始してから行ってください。終了するには「セキュリティ設定」>「メンテナンスモード」から操作してください。"
+  },
   "app_setting": {
     "site_name": "サイト名",
     "sitename_change": "ヘッダーや HTML タイトルに使用されるサイト名を変更できます。",

--- a/packages/app/resource/locales/ja_JP/admin/admin.json
+++ b/packages/app/resource/locales/ja_JP/admin/admin.json
@@ -37,8 +37,9 @@
     "failed_to_end_maintenance_mode": "メンテナンスモードを終了できませんでした",
     "successfully_started_maintenance_mode": "メンテナンスモードを開始しました",
     "successfully_ended_maintenance_mode": "メンテナンスモードを終了しました",
-    "warning_message": "メンテナンスモード中は管理画面にしかアクセスできなくなり、一般ユーザーは全ての操作が不能になります。",
-    "supplymentary_message": "API についても管理者用 API しか機能しなくなります。",
+    "warning_message_to_start": "メンテナンスモード中は管理画面にしかアクセスできなくなり、一般ユーザーは全ての操作が不能になります。",
+    "warning_message_to_end": "「データのインポート」および「V5 へのアップグレード」が進行中の場合は、処理が終了するまでメンテナンスモードを終了しないようにすることを推奨します。",
+    "supplymentary_message_to_start": "API についても管理者用 API しか機能しなくなります。",
     "start_maintenance_mode": "メンテナンスモードを開始する",
     "end_maintenance_mode": "メンテナンスモードを終了する",
     "description": "メンテナンスモードでは、ユーザーのあらゆる操作を制限します。「データのインポート」および「V5 へのアップグレード」の際には必ずメンテナンスモードを開始してから行ってください。終了するには「セキュリティ設定」>「メンテナンスモード」から操作してください。"

--- a/packages/app/resource/locales/zh_CN/admin/admin.json
+++ b/packages/app/resource/locales/zh_CN/admin/admin.json
@@ -37,8 +37,9 @@
     "failed_to_end_maintenance_mode": "结束维护模式失败",
     "successfully_started_maintenance_mode": "成功地启动了维护模式",
     "successfully_ended_maintenance_mode": "成功地结束了维护模式",
-    "warning_message": "你将无法访问管理员设置以外的页面。普通用户将无法访问任何内容，直到维护模式手动结束。",
-    "supplymentary_message": "至于API，只有管理员的API将是有效的。",
+    "warning_message_to_start": "你将无法访问管理员设置以外的页面。普通用户将无法访问任何内容，直到维护模式手动结束。",
+    "warning_message_to_end": "如果 \"数据导入 \"和 \"升级到V5 \"正在进行中，建议在该过程完成之前不要退出维护模式。",
+    "supplymentary_message_to_start": "至于API，只有管理员的API将是有效的。",
     "start_maintenance_mode": "启动维护模式",
     "end_maintenance_mode": "结束维护模式",
     "description": "维护模式限制了所有的用户操作。 在执行 \"数据导入 \"和 \"升级到V5 \"之前，务必启动维护模式。 要退出，进入 \"安全设置\">\"维护模式\"。"

--- a/packages/app/resource/locales/zh_CN/admin/admin.json
+++ b/packages/app/resource/locales/zh_CN/admin/admin.json
@@ -30,6 +30,19 @@
     "successfully_started": "Succeeded to start migration",
     "already_upgraded": "You have already completed upgrading"
   },
+  "maintenance_mode": {
+    "maintenance_mode": "维护模式",
+    "under_maintenance_mode": "在维护模式下",
+    "failed_to_start_maintenance_mode": "启动维护模式失败",
+    "failed_to_end_maintenance_mode": "结束维护模式失败",
+    "successfully_started_maintenance_mode": "成功地启动了维护模式",
+    "successfully_ended_maintenance_mode": "成功地结束了维护模式",
+    "warning_message": "你将无法访问管理员设置以外的页面。普通用户将无法访问任何内容，直到维护模式手动结束。",
+    "supplymentary_message": "至于API，只有管理员的API将是有效的。",
+    "start_maintenance_mode": "启动维护模式",
+    "end_maintenance_mode": "结束维护模式",
+    "description": "维护模式限制了所有的用户操作。 在执行 \"数据导入 \"和 \"升级到V5 \"之前，务必启动维护模式。 要退出，进入 \"安全设置\">\"维护模式\"。"
+  },
   "app_setting": {
     "site_name": "网站名称 ",
     "sitename_change": "您可以更改用于标题和HTML标题的网站名称。",

--- a/packages/app/src/components/Admin/App/AppSettingsPageContents.jsx
+++ b/packages/app/src/components/Admin/App/AppSettingsPageContents.jsx
@@ -26,15 +26,15 @@ class AppSettingsPageContents extends React.Component {
           adminAppContainer.state.isMaintenanceMode && (
             <div className="alert alert-danger alert-link" role="alert">
               <h3 className="alert-heading">
-                {t('maintenance_mode.maintenance_mode')}
+                {t('admin:maintenance_mode.maintenance_mode')}
               </h3>
               <p>
-                {t('maintenance_mode.description')}
+                {t('admin:maintenance_mode.description')}
               </p>
               <hr />
               <a className="btn-link" href="#maintenance-mode" rel="noopener noreferrer">
                 <i className="fa fa-fw fa-arrow-down ml-1" aria-hidden="true"></i>
-                <strong>{t('maintenance_mode.end_maintenance_mode')}</strong>
+                <strong>{t('admin:maintenance_mode.end_maintenance_mode')}</strong>
               </a>
             </div>
           )

--- a/packages/app/src/components/Admin/App/AppSettingsPageContents.jsx
+++ b/packages/app/src/components/Admin/App/AppSettingsPageContents.jsx
@@ -88,7 +88,7 @@ class AppSettingsPageContents extends React.Component {
 
         <div className="row">
           <div className="col-lg-12">
-            <h2 className="admin-setting-header" id="maintenance-mode">{t('Maintenance Mode')}</h2>
+            <h2 className="admin-setting-header" id="maintenance-mode">{t('admin:maintenance_mode.maintenance_mode')}</h2>
             <MaintenanceMode />
           </div>
         </div>

--- a/packages/app/src/components/Admin/App/ConfirmModal.tsx
+++ b/packages/app/src/components/Admin/App/ConfirmModal.tsx
@@ -8,7 +8,7 @@ import { TFunctionResult } from 'i18next';
 type ConfirmModalProps = {
   isModalOpen: boolean
   warningMessage: TFunctionResult
-  supplymentaryMessage: TFunctionResult
+  supplymentaryMessage: TFunctionResult | null
   confirmButtonTitle: TFunctionResult
   onConfirm?: () => Promise<void>
   onCancel?: () => void
@@ -31,18 +31,25 @@ export const ConfirmModal: FC<ConfirmModalProps> = (props: ConfirmModalProps) =>
 
   return (
     <Modal isOpen={props.isModalOpen} toggle={onCancel} className="">
-      <ModalHeader tag="h4" toggle={onCancel} className="bg-warning">
+      <ModalHeader tag="h4" toggle={onCancel} className="bg-danger">
         <i className="icon-fw icon-question" />
         {t('Warning')}
       </ModalHeader>
       <ModalBody>
         {props.warningMessage}
-        <br />
-        <br />
-        <span className="text-danger">
-          <i className="icon-exclamation icon-fw"></i>
-          {props.supplymentaryMessage}
-        </span>
+        {
+          props.supplymentaryMessage != null && (
+            <>
+              <br />
+              <br />
+              <span className="text-warning">
+                <i className="icon-exclamation icon-fw"></i>
+                {props.supplymentaryMessage}
+              </span>
+            </>
+          )
+        }
+
       </ModalBody>
       <ModalFooter>
         <button

--- a/packages/app/src/components/Admin/App/MaintenanceMode.tsx
+++ b/packages/app/src/components/Admin/App/MaintenanceMode.tsx
@@ -50,8 +50,9 @@ const MaintenanceMode: FC<Props> = (props: Props) => {
     <div className="mb-5">
       <ConfirmModal
         isModalOpen={isModalOpen}
-        warningMessage={t('admin:maintenance_mode.warning_message')}
-        supplymentaryMessage={t('admin:maintenance_mode.supplymentary_message')}
+        warningMessage={isMaintenanceMode ? t('admin:maintenance_mode.warning_message_to_end') : t('admin:maintenance_mode.warning_message_to_start')}
+        // eslint-disable-next-line max-len
+        supplymentaryMessage={isMaintenanceMode ? null : t('admin:maintenance_mode.supplymentary_message_to_start')}
         confirmButtonTitle={isMaintenanceMode ? t('admin:maintenance_mode.end_maintenance_mode') : t('admin:maintenance_mode.start_maintenance_mode')}
         onConfirm={onConfirmHandler}
         onCancel={() => closeModal()}
@@ -62,7 +63,7 @@ const MaintenanceMode: FC<Props> = (props: Props) => {
         <br />
         <span className="text-warning">
           <i className="icon-exclamation icon-fw"></i>
-          {t('admin:maintenance_mode.supplymentary_message')}
+          {t('admin:maintenance_mode.supplymentary_message_to_start')}
         </span>
       </p>
       <div className="row my-3">

--- a/packages/app/src/components/Admin/App/MaintenanceMode.tsx
+++ b/packages/app/src/components/Admin/App/MaintenanceMode.tsx
@@ -39,10 +39,11 @@ const MaintenanceMode: FC<Props> = (props: Props) => {
       }
     }
     catch (err) {
-      toastError(isMaintenanceMode ? t('maintenance_mode.failed_to_end_maintenance_mode') : t('maintenance_mode.failed_to_start_maintenance_mode'));
+      toastError(isMaintenanceMode ? t('admin:maintenance_mode.failed_to_end_maintenance_mode') : t('admin:maintenance_mode.failed_to_start_maintenance_mode'));
     }
 
-    toastSuccess(isMaintenanceMode ? t('maintenance_mode.successfully_ended_maintenance_mode') : t('maintenance_mode.successfully_started_maintenance_mode'));
+    // eslint-disable-next-line max-len
+    toastSuccess(isMaintenanceMode ? t('admin:maintenance_mode.successfully_ended_maintenance_mode') : t('admin:maintenance_mode.successfully_started_maintenance_mode'));
   }, [isMaintenanceMode, adminAppContainer, closeModal]);
 
   return (
@@ -51,7 +52,7 @@ const MaintenanceMode: FC<Props> = (props: Props) => {
         isModalOpen={isModalOpen}
         warningMessage={t('admin:maintenance_mode.warning_message')}
         supplymentaryMessage={t('admin:maintenance_mode.supplymentary_message')}
-        confirmButtonTitle={isMaintenanceMode ? t('maintenance_mode.end_maintenance_mode') : t('maintenance_mode.start_maintenance_mode')}
+        confirmButtonTitle={isMaintenanceMode ? t('admin:maintenance_mode.end_maintenance_mode') : t('admin:maintenance_mode.start_maintenance_mode')}
         onConfirm={onConfirmHandler}
         onCancel={() => closeModal()}
       />
@@ -67,7 +68,7 @@ const MaintenanceMode: FC<Props> = (props: Props) => {
       <div className="row my-3">
         <div className="mx-auto">
           <button type="button" className="btn btn-success" onClick={() => openModal()}>
-            {isMaintenanceMode ? t('maintenance_mode.end_maintenance_mode') : t('maintenance_mode.start_maintenance_mode')}
+            {isMaintenanceMode ? t('admin:maintenance_mode.end_maintenance_mode') : t('admin:maintenance_mode.start_maintenance_mode')}
           </button>
         </div>
       </div>


### PR DESCRIPTION
Redmine: https://redmine.weseek.co.jp/issues/90232

メンテナンスモードを i18n しました

## スクショ
セクション
<img width="1459" alt="Screen Shot 2022-03-11 at 15 02 07" src="https://user-images.githubusercontent.com/58432773/157811540-61ad3e04-6a18-49d1-9c5e-54bb5140438b.png">

開始時モーダル
<img width="663" alt="Screen Shot 2022-03-11 at 15 02 12" src="https://user-images.githubusercontent.com/58432773/157811546-48fc4645-d0d8-4db9-a6a0-8e043e76fbb3.png">

成功時トースター(エラーなどもありますが参考までに)
<img width="340" alt="Screen Shot 2022-03-11 at 15 02 17" src="https://user-images.githubusercontent.com/58432773/157811555-47dba800-56aa-40fa-8eef-68907d33e2fc.png">

メンテ中の表示
<img width="1455" alt="Screen Shot 2022-03-11 at 15 02 27" src="https://user-images.githubusercontent.com/58432773/157811559-fbc2c985-720a-408a-8fdc-b720d9299908.png">

終了時モーダル
<img width="594" alt="Screen Shot 2022-03-11 at 15 02 36" src="https://user-images.githubusercontent.com/58432773/157811563-c4427c02-220d-4f74-bc8d-1326f0a50f11.png">

