### PR TITLE
feat: 90457 Show spinner until page tree has finished loading

### DIFF
--- a/packages/app/src/components/Sidebar/PageTree.tsx
+++ b/packages/app/src/components/Sidebar/PageTree.tsx
@@ -27,8 +27,8 @@ const PageTree: FC = memo(() => {
         <div className="grw-sidebar-content-header p-3">
           <h3 className="mb-0">{t('Page Tree')}</h3>
         </div>
-        <div className="text-muted text-center">
-          <i className="fa fa-2x fa-spinner fa-pulse mr-1"></i>
+        <div className="text-muted text-center mt-3">
+          <i className="fa fa-lg fa-spinner fa-pulse mr-1"></i>
         </div>
       </>
     );
@@ -65,7 +65,6 @@ const PageTree: FC = memo(() => {
         <h3 className="mb-0">{t('Page Tree')}</h3>
       </div>
 
-      <div className="grw-sidebar-content-body">
         <ItemsTree
           isEnableActions={!isGuestUser}
           targetPath={path}

--- a/packages/app/src/components/Sidebar/PageTree.tsx
+++ b/packages/app/src/components/Sidebar/PageTree.tsx
@@ -65,13 +65,12 @@ const PageTree: FC = memo(() => {
         <h3 className="mb-0">{t('Page Tree')}</h3>
       </div>
 
-        <ItemsTree
-          isEnableActions={!isGuestUser}
-          targetPath={path}
-          targetPathOrId={targetPathOrId}
-          targetAndAncestorsData={targetAndAncestorsData}
-        />
-      </div>
+      <ItemsTree
+        isEnableActions={!isGuestUser}
+        targetPath={path}
+        targetPathOrId={targetPathOrId}
+        targetAndAncestorsData={targetAndAncestorsData}
+      />
 
       {!isGuestUser && migrationStatus?.migratablePagesCount != null && migrationStatus.migratablePagesCount !== 0 && (
         <div className="grw-pagetree-footer border-top p-3 w-100">

--- a/packages/app/src/components/Sidebar/PageTree.tsx
+++ b/packages/app/src/components/Sidebar/PageTree.tsx
@@ -27,8 +27,8 @@ const PageTree: FC = memo(() => {
         <div className="grw-sidebar-content-header p-3">
           <h3 className="mb-0">{t('Page Tree')}</h3>
         </div>
-        <div className="mt-5 mx-2 text-center">
-          <h3 className="text-gray">Page Tree now loading...</h3>
+        <div className="text-muted text-center">
+          <i className="fa fa-2x fa-spinner fa-pulse mr-1"></i>
         </div>
       </>
     );

--- a/packages/app/src/components/Sidebar/RecentChanges.tsx
+++ b/packages/app/src/components/Sidebar/RecentChanges.tsx
@@ -165,7 +165,7 @@ const RecentChanges = (): JSX.Element => {
           </div>
         </div>
       </div>
-      <div className="grw-sidebar-content-body grw-recent-changes p-3">
+      <div className="grw-recent-changes p-3">
         <ul className="list-group list-group-flush">
           {(pages || []).map(page => (isRecentChangesSidebarSmall
             ? <SmallPageItem key={page._id} page={page} />


### PR DESCRIPTION
## Task
[#90457](https://redmine.weseek.co.jp/issues/90457) [5.x][PageTree] Open時に spinner を表示する

https://user-images.githubusercontent.com/34241526/157813031-5da7cefd-9085-45cc-a5fc-b8baf3384c90.mov


