### PR TITLE
fix: Update parent after page update & remove unnecessary empty pages

### DIFF
--- a/packages/app/src/server/models/page.ts
+++ b/packages/app/src/server/models/page.ts
@@ -818,7 +818,7 @@ schema.statics.removeLeafEmptyPagesRecursively = async function(pageId: ObjectId
     if (!page.isEmpty) {
       return pageIds;
     }
-    console.log(await self.find({ _id: { $ne: childPage?._id }, parent: page._id }));
+
     const isChildrenOtherThanTargetExist = await self.exists({ _id: { $ne: childPage?._id }, parent: page._id });
     if (isChildrenOtherThanTargetExist) {
       return pageIds;

--- a/packages/app/src/server/models/page.ts
+++ b/packages/app/src/server/models/page.ts
@@ -1053,9 +1053,10 @@ export default (crowi: Crowi): any => {
       throw Error('Crowi is not set up');
     }
 
+    const isExRestricted = pageData.grant === GRANT_RESTRICTED;
     const isPageMigrated = pageData.parent != null;
     const isV5Compatible = crowi.configManager.getConfig('crowi', 'app:isV5Compatible');
-    if (!isV5Compatible || !isPageMigrated) {
+    if (!isExRestricted && (!isV5Compatible || !isPageMigrated)) {
       // v4 compatible process
       return this.updatePageV4(pageData, body, previousBody, user, options);
     }
@@ -1087,6 +1088,11 @@ export default (crowi: Crowi): any => {
       }
       if (!isGrantNormalized) {
         throw Error('The selected grant or grantedGroup is not assignable to this page.');
+      }
+
+      if (isExRestricted) {
+        const newParent = await this.getParentAndFillAncestors(newPageData.path, user);
+        newPageData.parent = newParent._id;
       }
     }
 


### PR DESCRIPTION
Redmine(２つ): https://redmine.weseek.co.jp/issues/90463, https://redmine.weseek.co.jp/issues/90464

ページの更新を修正しました

## 修正内容
- GRANT_RESTRICTED のページをその他の grant にした場合、isV5Compatible true ならば parent をつけるようにした
- 逆に GRANT_RESTRICTED にした時、新しい空の親で子ページの parent を更新するようにしました
  - その際余分な空ページを削除するようにしました