### PR TITLE
fix: hide plus btn on page tree item if the item is user page

### DIFF
--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -460,7 +460,7 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
               <i className="icon-options fa fa-rotate-90 p-1"></i>
             </DropdownToggle>
           </PageItemControl>
-          {!pagePathUtils.isUsersTopPage(`/${nodePath.basename(page.path ?? '')}`) && (
+          {!pagePathUtils.isUsersTopPage(page.path ?? '') && (
             <button
               type="button"
               className="border-0 rounded btn btn-page-item-control p-0 grw-visible-on-hover"

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -460,13 +460,15 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
               <i className="icon-options fa fa-rotate-90 p-1"></i>
             </DropdownToggle>
           </PageItemControl>
-          <button
-            type="button"
-            className="border-0 rounded btn btn-page-item-control p-0 grw-visible-on-hover"
-            onClick={onClickPlusButton}
-          >
-            <i className="icon-plus d-block p-0" />
-          </button>
+          {!pagePathUtils.isUsersTopPage(`/${nodePath.basename(page.path ?? '')}`) && (
+            <button
+              type="button"
+              className="border-0 rounded btn btn-page-item-control p-0 grw-visible-on-hover"
+              onClick={onClickPlusButton}
+            >
+              <i className="icon-plus d-block p-0" />
+            </button>
+          )}
         </div>
       </li>
 


### PR DESCRIPTION
![hide btn](https://user-images.githubusercontent.com/35527421/157819093-bd044d90-937c-4426-bf8c-9880c594f5e4.gif)
