### PR TITLE
fix: isCreatablePage pattern

### DIFF
--- a/packages/core/src/utils/page-path-utils.ts
+++ b/packages/core/src/utils/page-path-utils.ts
@@ -100,6 +100,7 @@ const restrictedPatternsToCreate: Array<RegExp> = [
   /(\/\.\.)\/?/, // see: https://github.com/weseek/growi/issues/3582
   /^\/(_search|_private-legacy-pages)(\/.*|$)/,
   /^\/(installer|register|login|logout|admin|me|files|trash|paste|comments|tags|share)(\/.*|$)/,
+  /^\/user\/[^/]+$/, // see: https://regex101.com/r/utVQct/1
 ];
 export const isCreatablePage = (path: string): boolean => {
   return !restrictedPatternsToCreate.some(pattern => path.match(pattern));


### PR DESCRIPTION
## Task
- [90563](https://redmine.weseek.co.jp/issues/90563)[backend] /user直下にはページをcreate / renameできないようにする

## ScreenShots
- create
<img width="939" alt="Screen Shot 2022-03-11 at 17 58 53" src="https://user-images.githubusercontent.com/59536731/157836198-3deeba31-a26d-4842-bbc6-46cb5f1281e1.png">

- rename
<img width="725" alt="Screen Shot 2022-03-11 at 18 00 03" src="https://user-images.githubusercontent.com/59536731/157836206-ddfc3e28-02d9-4b40-917e-3da2291828d1.png">

- pagetree
<img width="312" alt="Screen Shot 2022-03-11 at 18 05 38" src="https://user-images.githubusercontent.com/59536731/157836401-a451bb8b-cade-4745-a66e-1d7d43cdf02a.png">


## Note
`/user/hoge/xxxx`
は作成できる

<img width="299" alt="Screen Shot 2022-03-11 at 18 09 22" src="https://user-images.githubusercontent.com/59536731/157837030-1b54c9f3-8034-4236-92f8-6f65a99dc4d6.png">

