### PR TITLE
imprv: show error message in case page path is set directory under user page

### DIFF
--- a/packages/app/src/components/PageRenameModal.tsx
+++ b/packages/app/src/components/PageRenameModal.tsx
@@ -197,7 +197,7 @@ const PageRenameModal = (): JSX.Element => {
     : !isRenameRecursively; // v4 data
 
 
-  const submitButtonDisabled = isDirectoryUnderUserPage && submitButtonDisabledForV5;
+  const submitButtonDisabled = isDirectoryUnderUserPage || submitButtonDisabledForV5;
 
 
   return (
@@ -228,7 +228,6 @@ const PageRenameModal = (): JSX.Element => {
             </form>
           </div>
         </div>
-
 
         { isTargetPageDuplicate && (
           <p className="text-danger">Error: Target path is duplicated.</p>

--- a/packages/app/src/components/PageRenameModal.tsx
+++ b/packages/app/src/components/PageRenameModal.tsx
@@ -55,6 +55,7 @@ const PageRenameModal = (): JSX.Element => {
   const [isRemainMetadata, setIsRemainMetadata] = useState(false);
   const [expandOtherOptions, setExpandOtherOptions] = useState(false);
   const [subordinatedError] = useState(null);
+  const [isMatchedWithUserHomePagePath, setIsMatchedWithUserHomePagePath] = useState(false);
 
   const updateSubordinatedList = useCallback(async() => {
     if (page == null) {
@@ -133,21 +134,17 @@ const PageRenameModal = (): JSX.Element => {
     }
   }, [page, t]);
 
-  const checkIsPagePathRenameable = useCallback((pageNameInput) => {
-    if (page == null) {
-      return;
-    }
-    return isUsersHomePage(pageNameInput);
-
-  }, [isUsersHomePage, page]);
-
   const checkExistPathsDebounce = useMemo(() => {
     return debounce(1000, checkExistPaths);
   }, [checkExistPaths]);
 
   const checkIsUsersHomePageDebounce = useMemo(() => {
+    const checkIsPagePathRenameable = () => {
+      setIsMatchedWithUserHomePagePath(isUsersHomePage(pageNameInput));
+    };
+
     return debounce(1000, checkIsPagePathRenameable);
-  }, [checkIsPagePathRenameable]);
+  }, [isUsersHomePage, pageNameInput]);
 
   useEffect(() => {
     if (page != null && pageNameInput !== page.data.path) {
@@ -191,11 +188,10 @@ const PageRenameModal = (): JSX.Element => {
 
   const { path } = page.data;
   const isTargetPageDuplicate = existingPaths.includes(pageNameInput);
-  const isDirectoryUnderUserPage = isUsersHomePage(pageNameInput);
 
   let isSubmitButtonDisabled = false;
 
-  if (isDirectoryUnderUserPage) {
+  if (isMatchedWithUserHomePagePath) {
     isSubmitButtonDisabled = true;
   }
   else if (isV5Compatible(page.meta)) {
@@ -238,7 +234,7 @@ const PageRenameModal = (): JSX.Element => {
         { isTargetPageDuplicate && (
           <p className="text-danger">Error: Target path is duplicated.</p>
         ) }
-        { isDirectoryUnderUserPage && (
+        { isMatchedWithUserHomePagePath && (
           <p className="text-danger">Error: Cannot move to directory under /user page.</p>
         ) }
 

--- a/packages/app/src/components/PageRenameModal.tsx
+++ b/packages/app/src/components/PageRenameModal.tsx
@@ -196,9 +196,7 @@ const PageRenameModal = (): JSX.Element => {
     ? existingPaths.length !== 0 // v5 data
     : !isRenameRecursively; // v4 data
 
-
   const isSubmitButtonDisabled = isDirectoryUnderUserPage || isSubmitButtonDisabledV4orV5;
-
 
   return (
     <Modal size="lg" isOpen={isOpened} toggle={closeRenameModal} autoFocus={false}>

--- a/packages/app/src/components/PageRenameModal.tsx
+++ b/packages/app/src/components/PageRenameModal.tsx
@@ -33,7 +33,6 @@ const PageRenameModal = (): JSX.Element => {
   const { isUsersHomePage } = pagePathUtils;
   const { data: siteUrl } = useSiteUrl();
   const { data: renameModalData, close: closeRenameModal } = usePageRenameModal();
-  const [isPagePathRenameable, setIsPagePathRenameableh] = useState();
 
   const isOpened = renameModalData?.isOpened ?? false;
   const page = renameModalData?.page;

--- a/packages/app/src/components/PageRenameModal.tsx
+++ b/packages/app/src/components/PageRenameModal.tsx
@@ -235,7 +235,7 @@ const PageRenameModal = (): JSX.Element => {
           <p className="text-danger">Error: Target path is duplicated.</p>
         ) }
         { isDirectoryUnderUserPage && (
-          <p className="text-danger">Error: Cannot to move to directory under /user page.</p>
+          <p className="text-danger">Error: Cannot move to directory under /user page.</p>
         ) }
 
         { !isV5Compatible(page.meta) && (

--- a/packages/app/src/components/PageRenameModal.tsx
+++ b/packages/app/src/components/PageRenameModal.tsx
@@ -189,16 +189,16 @@ const PageRenameModal = (): JSX.Element => {
   const { path } = page.data;
   const isTargetPageDuplicate = existingPaths.includes(pageNameInput);
 
-  let isSubmitButtonDisabled = false;
+  let submitButtonDisabled = false;
 
   if (isMatchedWithUserHomePagePath) {
-    isSubmitButtonDisabled = true;
+    submitButtonDisabled = true;
   }
   else if (isV5Compatible(page.meta)) {
-    isSubmitButtonDisabled = existingPaths.length !== 0; // v5 data
+    submitButtonDisabled = existingPaths.length !== 0; // v5 data
   }
   else {
-    isSubmitButtonDisabled = !isRenameRecursively; // v4 data
+    submitButtonDisabled = !isRenameRecursively; // v4 data
   }
 
 
@@ -319,7 +319,7 @@ const PageRenameModal = (): JSX.Element => {
           type="button"
           className="btn btn-primary"
           onClick={rename}
-          disabled={isSubmitButtonDisabled}
+          disabled={submitButtonDisabled}
         >Rename
         </button>
       </ModalFooter>

--- a/packages/app/src/components/PageRenameModal.tsx
+++ b/packages/app/src/components/PageRenameModal.tsx
@@ -192,12 +192,12 @@ const PageRenameModal = (): JSX.Element => {
   const { path } = page.data;
   const isTargetPageDuplicate = existingPaths.includes(pageNameInput);
   const isDirectoryUnderUserPage = isUsersHomePage(pageNameInput);
-  const submitButtonDisabledForV5 = isV5Compatible(page.meta)
+  const isSubmitButtonDisabledV4orV5 = isV5Compatible(page.meta)
     ? existingPaths.length !== 0 // v5 data
     : !isRenameRecursively; // v4 data
 
 
-  const submitButtonDisabled = isDirectoryUnderUserPage || submitButtonDisabledForV5;
+  const isSubmitButtonDisabled = isDirectoryUnderUserPage || isSubmitButtonDisabledV4orV5;
 
 
   return (
@@ -317,7 +317,7 @@ const PageRenameModal = (): JSX.Element => {
           type="button"
           className="btn btn-primary"
           onClick={rename}
-          disabled={submitButtonDisabled}
+          disabled={isSubmitButtonDisabled}
         >Rename
         </button>
       </ModalFooter>

--- a/packages/app/src/components/PageRenameModal.tsx
+++ b/packages/app/src/components/PageRenameModal.tsx
@@ -192,11 +192,19 @@ const PageRenameModal = (): JSX.Element => {
   const { path } = page.data;
   const isTargetPageDuplicate = existingPaths.includes(pageNameInput);
   const isDirectoryUnderUserPage = isUsersHomePage(pageNameInput);
-  const isSubmitButtonDisabledV4orV5 = isV5Compatible(page.meta)
-    ? existingPaths.length !== 0 // v5 data
-    : !isRenameRecursively; // v4 data
 
-  const isSubmitButtonDisabled = isDirectoryUnderUserPage || isSubmitButtonDisabledV4orV5;
+  let isSubmitButtonDisabled = false;
+
+  if (isDirectoryUnderUserPage) {
+    isSubmitButtonDisabled = true;
+  }
+  else if (isV5Compatible(page.meta)) {
+    isSubmitButtonDisabled = existingPaths.length !== 0; // v5 data
+  }
+  else {
+    isSubmitButtonDisabled = !isRenameRecursively; // v4 data
+  }
+
 
   return (
     <Modal size="lg" isOpen={isOpened} toggle={closeRenameModal} autoFocus={false}>


### PR DESCRIPTION
## Task
- [90506](https://redmine.weseek.co.jp/issues/90506) PageRenameModalで、/user/hoge にrenameしようとした時に、エラーの表示をし、submitボタンをdisabledにする

## ScreenRecording
https://user-images.githubusercontent.com/59536731/158578902-d94f6518-034a-4cb6-aaf0-09a5021fb35f.mov



## ScreenShots
- user page直下にパスをrenameしようとした時
┗rename不可能
<img width="745" alt="Screen Shot 2022-03-14 at 23 39 52" src="https://user-images.githubusercontent.com/59536731/158195375-62d6542a-35fe-472e-9555-d1ab4c1c68e6.png">

- user page直下にパスをrenameしようとした時
かつ
- 重複したページパスになってしまっている時
┗rename不可能
<img width="774" alt="Screen Shot 2022-03-14 at 23 39 57" src="https://user-images.githubusercontent.com/59536731/158195386-34217754-e630-4562-b73c-f80a39ffcd29.png">

- `/user/${user_name}/hoge` の場合
┗rename可能
<img width="681" alt="Screen Shot 2022-03-14 at 23 40 11" src="https://user-images.githubusercontent.com/59536731/158195391-9e115eb6-6ae7-44ff-831d-46b77e6cb1d8.png">

