### PR TITLE
fix: Hide spinner after page creation failure

### DIFF
--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -353,8 +353,6 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
         createFromPageTree: true,
       });
 
-      setCreating(false);
-
       mutateChildren();
 
       if (!hasDescendants) {

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -366,6 +366,9 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
     catch (err) {
       toastError(err);
     }
+    finally {
+      setCreating(false);
+    }
   };
 
   const inputValidator = (title: string | null): AlertInfo | null => {


### PR DESCRIPTION
## Task
[#90724](https://redmine.weseek.co.jp/issues/90724) PageTree からページの作成に失敗した時に spinner を非表示できる