### PR TITLE
imprv: show specific err reason on put back modal

### DIFF
--- a/packages/app/src/server/routes/page.js
+++ b/packages/app/src/server/routes/page.js
@@ -1262,7 +1262,7 @@ module.exports = function(crowi, app) {
     }
     catch (err) {
       logger.error('Error occured while get setting', err);
-      return res.json(ApiResponse.error('Failed to revert deleted page.'));
+      return res.json(ApiResponse.error(err));
     }
 
     const result = {};


### PR DESCRIPTION
## Task
- [90656](https://redmine.weseek.co.jp/issues/90656) 修正
┗[5.x][Bug] Revert 修正


## Description
Revert時のエラーの原因がフロント側でもわかるように表示しました。

## ScreenShots
### Before
<img width="439" alt="Screen Shot 2022-03-15 at 17 05 23" src="https://user-images.githubusercontent.com/59536731/158332960-1e9a3789-31af-41e6-8f95-e781e050df11.png">


### After
<img width="464" alt="Screen Shot 2022-03-15 at 16 58 04" src="https://user-images.githubusercontent.com/59536731/158332362-19b51f2f-5d92-466d-b511-d2e432968adc.png">

