### PR TITLE
imrpv: share page comment component between normal page and search page

### DIFF
--- a/packages/app/src/client/app.jsx
+++ b/packages/app/src/client/app.jsx
@@ -18,8 +18,8 @@ import TagsList from '../components/TagsList';
 import DisplaySwitcher from '../components/Page/DisplaySwitcher';
 import { defaultEditorOptions, defaultPreviewOptions } from '../components/PageEditor/OptionsSelector';
 import Page from '../components/Page';
-import PageComments from '../components/PageComments';
 import PageContentFooter from '../components/PageContentFooter';
+import PageCommentList from '../components/PageCommentList';
 import PageTimeline from '../components/PageTimeline';
 import CommentEditorLazyRenderer from '../components/PageComment/CommentEditorLazyRenderer';
 import ShareLinkAlert from '../components/Page/ShareLinkAlert';
@@ -120,8 +120,7 @@ Object.assign(componentMappings, {
 // additional definitions if data exists
 if (pageContainer.state.pageId != null) {
   Object.assign(componentMappings, {
-    // todo: replace PageComments by commonalizing PageComments and PageCommentList
-    'page-comments-list': <PageComments />,
+    'page-comments-list': <PageCommentList appContainer={appContainer} pageId={pageContainer.state.pageId} />,
     'page-comment-write': <CommentEditorLazyRenderer appContainer={appContainer} />,
     'page-content-footer': <PageContentFooter
       createdAt={new Date(pageContainer.state.createdAt)}

--- a/packages/app/src/components/PageComment/CommentEditorLazyRenderer.tsx
+++ b/packages/app/src/components/PageComment/CommentEditorLazyRenderer.tsx
@@ -10,10 +10,12 @@ type Props = {
 
 const CommentEditorLazyRenderer:FC<Props> = (props:Props):JSX.Element => {
 
-  const growiRenderer = props.appContainer.getRenderer('comment');
+  const { appContainer } = props;
+  const growiRenderer = appContainer.getRenderer('comment');
 
   return (
     <CommentEditor
+      appContainer={appContainer}
       growiRenderer={growiRenderer}
       replyTo={undefined}
       isForNewComment

--- a/packages/app/src/components/PageEditor.jsx
+++ b/packages/app/src/components/PageEditor.jsx
@@ -13,6 +13,8 @@ import { withUnstatedContainers } from './UnstatedUtils';
 import Editor from './PageEditor/Editor';
 import Preview from './PageEditor/Preview';
 import scrollSyncHelper from './PageEditor/ScrollSyncHelper';
+import { ConflictDiffModal } from './PageEditor/ConflictDiffModal';
+
 import EditorContainer from '~/client/services/EditorContainer';
 
 import { getOptionsToSave } from '~/client/util/editor';
@@ -329,34 +331,43 @@ class PageEditor extends React.Component {
     const emojiStrategy = this.props.appContainer.getEmojiStrategy();
 
     return (
-      <div className="d-flex flex-wrap">
-        <div className="page-editor-editor-container flex-grow-1 flex-basis-0 mw-0">
-          <Editor
-            ref={(c) => { this.editor = c }}
-            value={this.state.markdown}
-            noCdn={noCdn}
-            isMobile={this.props.appContainer.isMobile}
-            isUploadable={this.state.isUploadable}
-            isUploadableFile={this.state.isUploadableFile}
-            emojiStrategy={emojiStrategy}
-            onScroll={this.onEditorScroll}
-            onScrollCursorIntoView={this.onEditorScrollCursorIntoView}
-            onChange={this.onMarkdownChanged}
-            onUpload={this.onUpload}
-            onSave={this.onSaveWithShortcut}
-          />
+      <>
+        <div className="d-flex flex-wrap">
+          <div className="page-editor-editor-container flex-grow-1 flex-basis-0 mw-0">
+            <Editor
+              ref={(c) => { this.editor = c }}
+              value={this.state.markdown}
+              noCdn={noCdn}
+              isMobile={this.props.appContainer.isMobile}
+              isUploadable={this.state.isUploadable}
+              isUploadableFile={this.state.isUploadableFile}
+              emojiStrategy={emojiStrategy}
+              onScroll={this.onEditorScroll}
+              onScrollCursorIntoView={this.onEditorScrollCursorIntoView}
+              onChange={this.onMarkdownChanged}
+              onUpload={this.onUpload}
+              onSave={this.onSaveWithShortcut}
+            />
+          </div>
+          <div className="d-none d-lg-block page-editor-preview-container flex-grow-1 flex-basis-0 mw-0">
+            <Preview
+              markdown={this.state.markdown}
+              // eslint-disable-next-line no-return-assign
+              inputRef={(el) => { return this.previewElement = el }}
+              isMathJaxEnabled={this.state.isMathJaxEnabled}
+              renderMathJaxOnInit={false}
+              onScroll={this.onPreviewScroll}
+            />
+          </div>
         </div>
-        <div className="d-none d-lg-block page-editor-preview-container flex-grow-1 flex-basis-0 mw-0">
-          <Preview
-            markdown={this.state.markdown}
-            // eslint-disable-next-line no-return-assign
-            inputRef={(el) => { return this.previewElement = el }}
-            isMathJaxEnabled={this.state.isMathJaxEnabled}
-            renderMathJaxOnInit={false}
-            onScroll={this.onPreviewScroll}
-          />
-        </div>
-      </div>
+        <ConflictDiffModal
+          isOpen={this.props.pageContainer.state.isConflictDiffModalOpen}
+          onClose={() => this.props.pageContainer.setState({ isConflictDiffModalOpen: false })}
+          appContainer={this.props.appContainer}
+          pageContainer={this.props.pageContainer}
+          markdownOnEdit={this.state.markdown}
+        />
+      </>
     );
   }
 

--- a/packages/app/src/components/PageEditor/Editor.jsx
+++ b/packages/app/src/components/PageEditor/Editor.jsx
@@ -10,7 +10,6 @@ import {
 import Dropzone from 'react-dropzone';
 
 import EditorContainer from '~/client/services/EditorContainer';
-import PageContainer from '~/client/services/PageContainer';
 import AppContainer from '~/client/services/AppContainer';
 import { withUnstatedContainers } from '../UnstatedUtils';
 
@@ -20,7 +19,6 @@ import CodeMirrorEditor from './CodeMirrorEditor';
 import TextAreaEditor from './TextAreaEditor';
 
 import pasteHelper from './PasteHelper';
-import { ConflictDiffModal } from './ConflictDiffModal';
 
 class Editor extends AbstractEditor {
 
@@ -373,13 +371,7 @@ class Editor extends AbstractEditor {
           { this.renderCheatsheetModal() }
 
         </div>
-        <ConflictDiffModal
-          isOpen={this.props.pageContainer.state.isConflictDiffModalOpen}
-          onClose={() => this.props.pageContainer.setState({ isConflictDiffModalOpen: false })}
-          appContainer={this.props.appContainer}
-          pageContainer={this.props.pageContainer}
-          markdownOnEdit={this.props.value}
-        />
+
       </>
     );
   }
@@ -397,8 +389,7 @@ Editor.propTypes = Object.assign({
   onChange: PropTypes.func,
   onUpload: PropTypes.func,
   editorContainer: PropTypes.instanceOf(EditorContainer).isRequired,
-  pageContainer: PropTypes.instanceOf(PageContainer).isRequired,
   appContainer: PropTypes.instanceOf(AppContainer).isRequired,
 }, AbstractEditor.propTypes);
 
-export default withUnstatedContainers(Editor, [EditorContainer, PageContainer, AppContainer]);
+export default withUnstatedContainers(Editor, [EditorContainer, AppContainer]);

--- a/packages/app/src/components/PageEditor/Editor.jsx
+++ b/packages/app/src/components/PageEditor/Editor.jsx
@@ -371,7 +371,6 @@ class Editor extends AbstractEditor {
           { this.renderCheatsheetModal() }
 
         </div>
-
       </>
     );
   }

--- a/packages/app/src/components/SearchPage/SearchResultContent.tsx
+++ b/packages/app/src/components/SearchPage/SearchResultContent.tsx
@@ -17,6 +17,7 @@ import { toastSuccess } from '~/client/util/apiNotification';
 
 import PageContentFooter from '../PageContentFooter';
 import PageCommentList from '../PageCommentList';
+import CommentEditorLazyRenderer from '../PageComment/CommentEditorLazyRenderer';
 
 import RevisionLoader from '../Page/RevisionLoader';
 import AppContainer from '../../client/services/AppContainer';
@@ -220,7 +221,8 @@ export const SearchResultContent: FC<Props> = (props: Props) => {
           isRenderable
         />
         <PageCommentList appContainer={appContainer} pageId={page._id} highlightKeywords={highlightKeywords} />
-        {/* todo: insert adding comment feature by CommentEditorLazyRenderer */}
+        {/* todo: will be enable to run add comment feature */}
+        <CommentEditorLazyRenderer appContainer={appContainer} />
         <PageContentFooter
           createdAt={new Date(pageWithMeta.data.createdAt)}
           updatedAt={new Date(pageWithMeta.data.updatedAt)}

--- a/packages/app/src/components/SearchPage/SearchResultContent.tsx
+++ b/packages/app/src/components/SearchPage/SearchResultContent.tsx
@@ -17,7 +17,6 @@ import { toastSuccess } from '~/client/util/apiNotification';
 
 import PageContentFooter from '../PageContentFooter';
 import PageCommentList from '../PageCommentList';
-import CommentEditorLazyRenderer from '../PageComment/CommentEditorLazyRenderer';
 
 import RevisionLoader from '../Page/RevisionLoader';
 import AppContainer from '../../client/services/AppContainer';
@@ -221,8 +220,6 @@ export const SearchResultContent: FC<Props> = (props: Props) => {
           isRenderable
         />
         <PageCommentList appContainer={appContainer} pageId={page._id} highlightKeywords={highlightKeywords} />
-        {/* todo: will be enable to run add comment feature */}
-        <CommentEditorLazyRenderer appContainer={appContainer} />
         <PageContentFooter
           createdAt={new Date(pageWithMeta.data.createdAt)}
           updatedAt={new Date(pageWithMeta.data.updatedAt)}


### PR DESCRIPTION
## タスク

https://redmine.weseek.co.jp/issues/90683

## FB対応

- 検索結果ページから ` CommentEditorLazyRenderer` を除去 (不要と判明したため)
  - https://github.com/weseek/growi/pull/5568/commits/fbed15c5e9f8c5342d05ec8b6e30ef43c10b1ec8

## 行ったこと

- このタスクの差分ではほとんど変更を行っていませんが、後続タスクの方針決め（タスク作成）を行いました
  - 実際に試行錯誤しないと実装方針が決まらなかったため
- `PageComment.jsx` と `PageCommentList.tsx` を共通化するというよりも、`PageCommentList.tsx` を `PageComment.jsx`  の実装に寄せて同じ見た目と機能にする方針に決定しました