### PR TITLE
fix: Remove "Anyone with the link page" completely

### DIFF
--- a/packages/app/src/components/Page/TrashPageAlert.jsx
+++ b/packages/app/src/components/Page/TrashPageAlert.jsx
@@ -64,6 +64,7 @@ const TrashPageAlert = (props) => {
         revision: revisionId,
         path,
       },
+      meta: pageInfo,
     };
     openDeleteModal(
       [pageToDelete],


### PR DESCRIPTION
## Task
[#91291](https://redmine.weseek.co.jp/issues/91291) [5.x] Anyone with the link のページをゴミ箱に入れたあと、完全削除できない問題を修正する
┗ [#91297](https://redmine.weseek.co.jp/issues/91297) 修正