### PR TITLE
imprv: Item Count Badge

### DIFF
--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -101,7 +101,7 @@ type ItemCountProps = {
 const ItemCount: FC<ItemCountProps> = (props:ItemCountProps) => {
   return (
     <>
-      <span className="grw-pagetree-count px-0 badge badge-pill badge-light">
+      <span className="grw-pagetree-count px-2 badge badge-pill badge-light">
         {props.descendantCount}
       </span>
     </>

--- a/packages/app/src/styles/_page-tree.scss
+++ b/packages/app/src/styles/_page-tree.scss
@@ -50,7 +50,7 @@ $grw-pagetree-item-padding-left: 10px;
       }
 
       .grw-pagetree-count {
-        width: 26px;
+        width: auto;
         padding: 0.1rem 0;
         font-size: 12px;
       }


### PR DESCRIPTION
## Task

[#91529](https://redmine.weseek.co.jp/issues/91529) [PageTree][UI 改善] 子孫数の表示が４桁以上の時にはみ出さないようにできる
┗ [#91550](https://redmine.weseek.co.jp/issues/91550) 実装

## Screenshot
<img width="327" alt="ScreenShot 2022-03-29 11 52 15" src="https://user-images.githubusercontent.com/34241526/160523951-204683a2-1937-4847-ba41-e1a64ab21064.png">

