### PR TITLE
imprv: vrt page attachment data bootstrap4

### DIFF
--- a/packages/app/src/components/Navbar/GrowiContextualSubNavigation.tsx
+++ b/packages/app/src/components/Navbar/GrowiContextualSubNavigation.tsx
@@ -102,6 +102,7 @@ const AdditionalMenuItems = (props: AdditionalMenuItemsProps): JSX.Element => {
 
       <DropdownItem
         onClick={() => openAccessoriesModal(PageAccessoriesModalContents.Attachment)}
+        data-testid="open-page-accessories-modal-btn-with-attachment-data-tab"
       >
         <span className="mr-1"><AttachmentIcon /></span>
         {t('attachment_data')}

--- a/packages/app/src/components/Navbar/GrowiContextualSubNavigation.tsx
+++ b/packages/app/src/components/Navbar/GrowiContextualSubNavigation.tsx
@@ -95,6 +95,7 @@ const AdditionalMenuItems = (props: AdditionalMenuItemsProps): JSX.Element => {
       <DropdownItem
         onClick={() => openAccessoriesModal(PageAccessoriesModalContents.PageHistory)}
         disabled={isGuestUser || isSharedUser}
+        data-testid="open-page-accessories-modal-btn-with-history-tab"
       >
         <span className="mr-1"><HistoryIcon /></span>
         {t('History')}

--- a/packages/app/src/components/PageAccessoriesModal.tsx
+++ b/packages/app/src/components/PageAccessoriesModal.tsx
@@ -106,6 +106,7 @@ const PageAccessoriesModal = (props: Props): JSX.Element => {
       size="xl"
       isOpen={isOpened}
       toggle={close}
+      data-testid="page-accessories-modal"
       className={`grw-page-accessories-modal ${isWindowExpanded ? 'grw-modal-expanded' : ''} `}
     >
       <ModalHeader className="p-0" toggle={close} close={buttons}>

--- a/packages/app/src/components/PageAttachment.jsx
+++ b/packages/app/src/components/PageAttachment.jsx
@@ -113,7 +113,11 @@ class PageAttachment extends React.Component {
   render() {
     const { t } = this.props;
     if (this.state.attachments.length === 0) {
-      return t('No_attachments_yet');
+      return (
+        <div data-testid="page-attachment">
+          {t('No_attachments_yet')}
+        </div>
+      );
     }
 
     let deleteAttachmentModal = '';
@@ -144,7 +148,7 @@ class PageAttachment extends React.Component {
     }
 
     return (
-      <>
+      <div data-testid="page-attachment">
         <PageAttachmentList
           attachments={this.state.attachments}
           inUse={this.state.inUse}
@@ -161,7 +165,7 @@ class PageAttachment extends React.Component {
           pagingLimit={this.state.limit}
           align="center"
         />
-      </>
+      </div>
     );
   }
 

--- a/packages/app/src/components/PageHistory.jsx
+++ b/packages/app/src/components/PageHistory.jsx
@@ -68,7 +68,7 @@ function PageHistory(props) {
   }
 
   return (
-    <div className="revision-history">
+    <div className="revision-history" data-testid="page-history">
       <PageRevisionTable
         pageHistoryContainer={pageHistoryContainer}
         revisionComparerContainer={revisionComparerContainer}

--- a/packages/app/test/cypress/integration/2-basic-features/open-page-accessories-modal.spec.ts
+++ b/packages/app/test/cypress/integration/2-basic-features/open-page-accessories-modal.spec.ts
@@ -1,6 +1,6 @@
 context('Open Page Accessories Modal', () => {
 
-  const ssPrefix = 'access-to-page-accessories-modal-with-history-tab';
+  const ssPrefix = 'access-to-page-accessories-modal';
 
   let connectSid: string | undefined;
 
@@ -33,7 +33,7 @@ context('Open Page Accessories Modal', () => {
      cy.getByTestid('page-history').should('be.visible')
      cy.screenshot(`${ssPrefix}-open-bootstrap4`);
   });
-  it('Page History is shown successfully', () => {
+  it('Page Attachment Data is shown successfully', () => {
      cy.visit('/Sandbox/Bootstrap4', {  });
      cy.get('#grw-subnav-container').within(() => {
        cy.getByTestid('open-page-item-control-btn').click();
@@ -42,7 +42,7 @@ context('Open Page Accessories Modal', () => {
 
      cy.getByTestid('page-accessories-modal').should('be.visible')
      cy.getByTestid('page-history').should('be.visible')
-     cy.screenshot(`${ssPrefix}-open-bootstrap4`);
+     cy.screenshot(`${ssPrefix}-open-attachment-data-bootstrap4`);
   });
 
 });

--- a/packages/app/test/cypress/integration/2-basic-features/open-page-accessories-modal.spec.ts
+++ b/packages/app/test/cypress/integration/2-basic-features/open-page-accessories-modal.spec.ts
@@ -1,0 +1,37 @@
+context('Open Page Accessories Modal', () => {
+
+  const ssPrefix = 'access-to-page-accessories-modal-with-history-tab';
+
+  let connectSid: string | undefined;
+
+  before(() => {
+    // login
+    cy.fixture("user-admin.json").then(user => {
+      cy.login(user.username, user.password);
+    });
+    cy.getCookie('connect.sid').then(cookie => {
+      connectSid = cookie?.value;
+    });
+    // collapse sidebar
+    cy.collapseSidebar(true);
+  });
+
+  beforeEach(() => {
+    if (connectSid != null) {
+      cy.setCookie('connect.sid', connectSid);
+    }
+  });
+
+  it('Page History is shown successfully', () => {
+     cy.visit('/Sandbox/Bootstrap4', {  });
+     cy.get('#grw-subnav-container').within(() => {
+       cy.getByTestid('open-page-item-control-btn').click();
+       cy.getByTestid('open-page-accessories-modal-btn-with-history-tab').click();
+    });
+
+     cy.getByTestid('page-accessories-modal').should('be.visible')
+     cy.getByTestid('page-history').should('be.visible')
+     cy.screenshot(`${ssPrefix}-open-bootstrap4`);
+  });
+
+});

--- a/packages/app/test/cypress/integration/2-basic-features/open-page-accessories-modal.spec.ts
+++ b/packages/app/test/cypress/integration/2-basic-features/open-page-accessories-modal.spec.ts
@@ -31,18 +31,18 @@ context('Open Page Accessories Modal', () => {
 
      cy.getByTestid('page-accessories-modal').should('be.visible')
      cy.getByTestid('page-history').should('be.visible')
-     cy.screenshot(`${ssPrefix}-open-bootstrap4`);
+     cy.screenshot(`${ssPrefix}-open-page-history-bootstrap4`);
   });
   it('Page Attachment Data is shown successfully', () => {
      cy.visit('/Sandbox/Bootstrap4', {  });
      cy.get('#grw-subnav-container').within(() => {
        cy.getByTestid('open-page-item-control-btn').click();
-       cy.getByTestid('open-page-accessories-modal-btn-with-history-tab').click();
+       cy.getByTestid('open-page-accessories-modal-btn-with-attachment-data-tab').click();
     });
 
      cy.getByTestid('page-accessories-modal').should('be.visible')
-     cy.getByTestid('page-history').should('be.visible')
-     cy.screenshot(`${ssPrefix}-open-attachment-data-bootstrap4`);
+     cy.getByTestid('page-attachment').should('be.visible')
+     cy.screenshot(`${ssPrefix}-open-page-attachment-data-bootstrap4`);
   });
 
 });

--- a/packages/app/test/cypress/integration/2-basic-features/open-page-accessories-modal.spec.ts
+++ b/packages/app/test/cypress/integration/2-basic-features/open-page-accessories-modal.spec.ts
@@ -33,5 +33,16 @@ context('Open Page Accessories Modal', () => {
      cy.getByTestid('page-history').should('be.visible')
      cy.screenshot(`${ssPrefix}-open-bootstrap4`);
   });
+  it('Page History is shown successfully', () => {
+     cy.visit('/Sandbox/Bootstrap4', {  });
+     cy.get('#grw-subnav-container').within(() => {
+       cy.getByTestid('open-page-item-control-btn').click();
+       cy.getByTestid('open-page-accessories-modal-btn-with-history-tab').click();
+    });
+
+     cy.getByTestid('page-accessories-modal').should('be.visible')
+     cy.getByTestid('page-history').should('be.visible')
+     cy.screenshot(`${ssPrefix}-open-bootstrap4`);
+  });
 
 });


### PR DESCRIPTION
## Task
[GW-7760](https://youtrack.weseek.co.jp/issue/GW-7761) サブナビゲーションからのattachment_dataの表示
┗ VRT化
![access-to-page-accessories-modal-open-page-attachment-data-bootstrap4](https://user-images.githubusercontent.com/97593712/160795456-cd55bbaf-f73a-41f0-8263-ef45420844cd.png)
## Others 
imprv/vrt-move-rename-bootstrap4 のPRがマージされてからマージお願いします。
https://github.com/weseek/growi/pull/5589