### PR TITLE
fix: Show full text on presentation mode

### DIFF
--- a/packages/app/src/styles/style-presentation.scss
+++ b/packages/app/src/styles/style-presentation.scss
@@ -12,6 +12,15 @@
     font-family: Lato, -apple-system, BlinkMacSystemFont, 'Hiragino Kaku Gothic ProN', Meiryo, sans-serif !important;
   }
 
+  .present {
+    height: 100%;
+  }
+
+  .code-line {
+    max-height: 100%;
+    overflow-y: scroll;
+  }
+
   .slides > section {
     //text-align: left;
     padding: 0;

--- a/packages/app/src/styles/style-presentation.scss
+++ b/packages/app/src/styles/style-presentation.scss
@@ -13,10 +13,6 @@
   }
 
   .present {
-    height: 100%;
-  }
-
-  .code-line {
     max-height: 100%;
     overflow-y: scroll;
   }


### PR DESCRIPTION
Redmine: https://redmine.weseek.co.jp/issues/91787

プレゼンテーションモードで文章が長い場合に全て表示しきれない問題を修正しました
縦スクロールできるようにしました

# dev wiki (ver 4.x) と比較
初め dev wiki から始まります

https://user-images.githubusercontent.com/58432773/160992733-d8ce50d8-b662-4a50-9fc7-ad8abd592093.mov

