### PR TITLE
fix: Page items disappear when dnd

### DIFF
--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -195,6 +195,10 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
 
       await mutateChildren();
 
+      if (onRenamed != null) {
+        onRenamed();
+      }
+
       // force open
       setIsOpen(true);
     }
@@ -208,6 +212,9 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
       else {
         toastError(t('pagetree.something_went_wrong_with_moving_page'));
       }
+    }
+    finally {
+      console.log('==============================');
     }
   };
 

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -213,9 +213,6 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
         toastError(t('pagetree.something_went_wrong_with_moving_page'));
       }
     }
-    finally {
-      console.log('==============================');
-    }
   };
 
   const [{ isOver }, drop] = useDrop<ItemNode, Promise<void>, { isOver: boolean }>(() => ({


### PR DESCRIPTION
## Task

[#90903](https://redmine.weseek.co.jp/issues/90903) [5.x][Bug][ReactDnd] dndした時にページアイテムが消えてしまう
┗ [#90872](https://redmine.weseek.co.jp/issues/90872) 修正

## ScreenRecord
before

https://user-images.githubusercontent.com/34241526/161475564-65e04462-36f4-456e-a002-f02b29d43cbe.mov

after 

https://user-images.githubusercontent.com/34241526/161475589-b8aab244-9f34-4a4f-b3c8-35e220c0130f.mov