### PR TITLE
imprv: remove min-width from search-sort-option-btn

### DIFF
--- a/packages/app/src/components/SearchPage/SortControl.tsx
+++ b/packages/app/src/components/SearchPage/SortControl.tsx
@@ -38,7 +38,7 @@ const SortControl: FC <Props> = (props: Props) => {
         <div className="border rounded-right">
           <button
             type="button"
-            className="btn dropdown-toggle search-sort-option-btn py-1"
+            className="btn dropdown-toggle py-1"
             data-toggle="dropdown"
           >
             <span className="mr-2 text-secondary">{t(`search_result.sort_axis.${sort}`)}</span>

--- a/packages/app/src/styles/_search.scss
+++ b/packages/app/src/styles/_search.scss
@@ -142,10 +142,6 @@
     padding-bottom: unset;
   }
 
-  // To fix the sort options position
-  .search-sort-option-btn {
-    min-width: 150px;
-  }
   .search-control-include-options {
     .card-body {
       padding: 5px 10px;


### PR DESCRIPTION
## Task
- [90589](https://redmine.weseek.co.jp/issues/90589) SortボタンのスタイルをXD通りに修正

## Screenshots
### Before
- 固定
<img width="756" alt="Screen Shot 2022-04-04 at 20 15 55" src="https://user-images.githubusercontent.com/59536731/161532875-9eb03a99-fb27-43d5-ac93-a27c09914af3.png">


### After
- textの長さによって、横幅が変化する
┗ それに伴い左側の要素(input)の横幅も可変する
┗mosさんには確認済み
<img width="760" alt="Screen Shot 2022-04-04 at 20 16 01" src="https://user-images.githubusercontent.com/59536731/161532877-dff2e76b-451e-4c9c-b1b8-efa37b6f3640.png">
<img width="751" alt="Screen Shot 2022-04-04 at 20 18 02" src="https://user-images.githubusercontent.com/59536731/161533058-6759be86-f191-4f85-958b-9b6d97ea4af9.png">
<img width="743" alt="Screen Shot 2022-04-04 at 20 18 08" src="https://user-images.githubusercontent.com/59536731/161533062-893f760c-d4c5-48fd-9782-4f8f34331035.png">


