### PR TITLE
imprv: Adjust layout for PageTree Descendant Count

### DIFF
--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -101,7 +101,7 @@ type ItemCountProps = {
 const ItemCount: FC<ItemCountProps> = (props:ItemCountProps) => {
   return (
     <>
-      <span className="grw-pagetree-count px-2 badge badge-pill badge-light">
+      <span className="grw-pagetree-count badge badge-pill badge-light">
         {props.descendantCount}
       </span>
     </>

--- a/packages/app/src/styles/_page-tree.scss
+++ b/packages/app/src/styles/_page-tree.scss
@@ -51,6 +51,7 @@ $grw-pagetree-item-padding-left: 10px;
 
       .grw-pagetree-count {
         width: auto;
+        min-width: 28px;
         padding: 0.1rem 0;
         font-size: 12px;
       }

--- a/packages/app/src/styles/_page-tree.scss
+++ b/packages/app/src/styles/_page-tree.scss
@@ -51,7 +51,7 @@ $grw-pagetree-item-padding-left: 10px;
 
       .grw-pagetree-count {
         min-width: 28px;
-        padding: 0.1rem 0;
+        padding: 0.1rem 0.5rem;
         font-size: 12px;
       }
     }

--- a/packages/app/src/styles/_page-tree.scss
+++ b/packages/app/src/styles/_page-tree.scss
@@ -50,7 +50,7 @@ $grw-pagetree-item-padding-left: 10px;
       }
 
       .grw-pagetree-count {
-        width: auto;
+        // width: auto;
         min-width: 28px;
         padding: 0.1rem 0;
         font-size: 12px;

--- a/packages/app/src/styles/_page-tree.scss
+++ b/packages/app/src/styles/_page-tree.scss
@@ -50,7 +50,6 @@ $grw-pagetree-item-padding-left: 10px;
       }
 
       .grw-pagetree-count {
-        // width: auto;
         min-width: 28px;
         padding: 0.1rem 0;
         font-size: 12px;


### PR DESCRIPTION
## Task

[#90587](https://redmine.weseek.co.jp/issues/90587) [5.x][UI/UX改善] 第２回デザイナーチェックででたFB修正(色関連以外)
┗ [#91994](https://redmine.weseek.co.jp/issues/90587) 子孫数カウントの badge の横幅を2桁までは同じにする

## Screenshot
<img width="394" alt="ScreenShot 2022-04-06 9 52 03" src="https://user-images.githubusercontent.com/34241526/161874513-afaa7544-fdf5-450f-893a-4bcf87f6aeb5.png">


