### PR TITLE
fix: Normalize parent so it does not include siblings

### DIFF
--- a/packages/app/resource/locales/en_US/translation.json
+++ b/packages/app/resource/locales/en_US/translation.json
@@ -171,6 +171,7 @@
   "you_can_not_create_page_with_this_name": "You can not create page with this name",
   "not_allowed_to_see_this_page": "You cannot see this page",
   "Confirm": "Confirm",
+  "Successfully requested": "Successfully requested.",
   "personal_dropdown": {
     "home": "Home",
     "settings": "Settings",

--- a/packages/app/resource/locales/ja_JP/translation.json
+++ b/packages/app/resource/locales/ja_JP/translation.json
@@ -173,6 +173,7 @@
   "you_can_not_create_page_with_this_name": "この名前でページを作成することはできません",
   "not_allowed_to_see_this_page": "このページは閲覧できません",
   "Confirm": "確認",
+  "Successfully requested": "正常に処理を受け付けました",
   "personal_dropdown": {
     "home": "ホーム",
     "settings": "設定",

--- a/packages/app/resource/locales/zh_CN/translation.json
+++ b/packages/app/resource/locales/zh_CN/translation.json
@@ -179,6 +179,7 @@
   "you_can_not_create_page_with_this_name": "您无法使用此名称创建页面",
   "not_allowed_to_see_this_page": "你不能看到这个页面",
   "Confirm": "确定",
+  "Successfully requested": "进程成功接受",
 	"form_validation": {
 		"error_message": "有些值不正确",
 		"required": "%s 是必需的",

--- a/packages/app/src/components/PrivateLegacyPages.tsx
+++ b/packages/app/src/components/PrivateLegacyPages.tsx
@@ -204,7 +204,7 @@ export const PrivateLegacyPages = (props: Props): JSX.Element => {
     openModal(
       selectedPages,
       () => {
-        toastSuccess('success');
+        toastSuccess(t('Successfully requested'));
         closeModal();
         mutate();
       },

--- a/packages/app/src/server/service/page-grant.ts
+++ b/packages/app/src/server/service/page-grant.ts
@@ -74,7 +74,7 @@ class PageGrantService {
     // GRANT_OWNER
     else if (ancestor.grant === Page.GRANT_OWNER) {
       if (target.grantedUserIds?.length !== 1) {
-        throw Error('grantedUserIds must have one user');
+        return false;
       }
 
       if (target.grant !== Page.GRANT_OWNER) { // only GRANT_OWNER page can exist under GRANT_OWNER page

--- a/packages/app/src/server/service/page.ts
+++ b/packages/app/src/server/service/page.ts
@@ -2386,7 +2386,7 @@ class PageService {
     // Save prevDescendantCount for sub-operation
     const Page = mongoose.model('Page') as unknown as PageModel;
     const { PageQueryBuilder } = Page;
-    const builder = new PageQueryBuilder(Page.findOne());
+    const builder = new PageQueryBuilder(Page.findOne(), true);
     builder.addConditionAsMigrated();
     builder.addConditionToListByPageIdsArray([page._id]);
     const exPage = await builder.query.exec();

--- a/packages/app/src/server/service/page.ts
+++ b/packages/app/src/server/service/page.ts
@@ -2698,6 +2698,9 @@ class PageService {
               {
                 path: { $regex: new RegExp(`^${parentPathEscaped}(\\/[^/]+)\\/?$`, 'i') }, // see: regexr.com/6889f (e.g. /parent/any_child or /any_level1)
               },
+              {
+                path: { $in: pathOrRegExps.concat(publicPathsToNormalize) },
+              },
               filterForApplicableAncestors,
               grantFiltersByUser,
             ],

--- a/packages/app/src/server/service/page.ts
+++ b/packages/app/src/server/service/page.ts
@@ -2371,7 +2371,14 @@ class PageService {
         logger.error('Failed to create PageOperation document.', err);
         throw err;
       }
-      await this.normalizeParentRecursivelyMainOperation(page, user, pageOp._id);
+
+      try {
+        await this.normalizeParentRecursivelyMainOperation(page, user, pageOp._id);
+      }
+      catch (err) {
+        logger.err('Failed to run normalizeParentRecursivelyMainOperation.', err);
+        throw err;
+      }
     }
   }
 
@@ -2379,8 +2386,9 @@ class PageService {
     // Save prevDescendantCount for sub-operation
     const Page = mongoose.model('Page') as unknown as PageModel;
     const { PageQueryBuilder } = Page;
-    const builder = new PageQueryBuilder(Page.findOne(), true);
+    const builder = new PageQueryBuilder(Page.findOne());
     builder.addConditionAsMigrated();
+    builder.addConditionToListByPageIdsArray([page._id]);
     const exPage = await builder.query.exec();
     const options = { prevDescendantCount: exPage?.descendantCount ?? 0 };
 

--- a/packages/app/src/server/service/page.ts
+++ b/packages/app/src/server/service/page.ts
@@ -2358,6 +2358,17 @@ class PageService {
         throw Error(`Cannot operate normalizeParentRecursiively to path "${page.path}" right now.`);
       }
 
+      const Page = mongoose.model('Page') as unknown as PageModel;
+      const { PageQueryBuilder } = Page;
+      const builder = new PageQueryBuilder(Page.findOne());
+      builder.addConditionAsMigrated();
+      builder.addConditionToListByPathsArray([page.path]);
+      const existingPage = await builder.query.exec();
+
+      if (existingPage?.parent != null) {
+        throw Error('This page has already converted.');
+      }
+
       let pageOp;
       try {
         pageOp = await PageOperation.create({

--- a/packages/app/test/integration/service/v5.migration.test.js
+++ b/packages/app/test/integration/service/v5.migration.test.js
@@ -340,7 +340,7 @@ describe('V5 page migration', () => {
 
   });
 
-  describe.only('should normalize only selected pages recursively (while observing the page permission rule)', () => {
+  describe('should normalize only selected pages recursively (while observing the page permission rule)', () => {
     /*
      * # Test flow 1
      * - Existing pages
@@ -498,9 +498,9 @@ describe('V5 page migration', () => {
       ]);
     });
 
-    test('should1', async() => {
+    test('should not run normalization when the target page is GRANT_USER_GROUP surrounded by public pages', async() => {
       const mockMainOperation = jest.spyOn(crowi.pageService, 'normalizeParentRecursivelyMainOperation').mockImplementation(v => v);
-      const _page1 = await Page.findOne(public({ path: '/deep_path/normalize_a' }));
+      const _page1 = await Page.findOne(public({ path: '/deep_path/normalize_a', ...empty }));
       const _page2 = await Page.findOne(public({ path: '/deep_path/normalize_a/normalize_b', ...normalized }));
       const _page3 = await Page.findOne(testUser1Group({ path: '/deep_path/normalize_a', ...notNormalized }));
       const _page4 = await Page.findOne(testUser1Group({ path: '/deep_path/normalize_c', ...notNormalized }));
@@ -518,7 +518,7 @@ describe('V5 page migration', () => {
       mockMainOperation.mockRestore();
     });
 
-    test('should2', async() => {
+    test('should not include siblings', async() => {
       const _page1 = await Page.findOne(public({ path: '/normalize_d', ...empty }));
       const _page2 = await Page.findOne(testUser1Group({ path: '/normalize_d/normalize_e', ...normalized }));
       const _page3 = await Page.findOne(testUser1Group({ path: '/normalize_d', ...notNormalized }));
@@ -553,7 +553,7 @@ describe('V5 page migration', () => {
       expect(page3.descendantCount).toBe(0); // should not be normalized
     });
 
-    test('should3', async() => {
+    test('should replace all unnecessary empty pages and normalization succeeds', async() => {
       const _pageG = await Page.findOne(public({ path: '/normalize_g', ...normalized }));
       const _pageGH = await Page.findOne(owned({ path: '/normalize_g/normalize_h', ...notNormalized }));
       const _pageGI = await Page.findOne(owned({ path: '/normalize_g/normalize_i', ...notNormalized }));


### PR DESCRIPTION
Redmine(２つ): https://redmine.weseek.co.jp/issues/92269, https://redmine.weseek.co.jp/issues/92282

待避所からのマイグレーションで兄弟ページが巻き込まれるのを修正しました
テストコードも追記しました