### PR TITLE
imprv: Adjust pagelist and comment position

### DIFF
--- a/packages/app/src/components/Page/DisplaySwitcher.tsx
+++ b/packages/app/src/components/Page/DisplaySwitcher.tsx
@@ -70,7 +70,9 @@ const DisplaySwitcher = (): JSX.Element => {
                         className="btn btn-block btn-outline-secondary grw-btn-page-accessories rounded-pill d-flex justify-content-between align-items-center"
                         onClick={() => openDescendantPageListModal(currentPath)}
                       >
-                        <PageListIcon />
+                        <div className="grw-page-accessories-control-icon">
+                          <PageListIcon />
+                        </div>
                         {t('page_list')}
                         <span></span> {/* for a count badge */}
                       </button>
@@ -79,13 +81,13 @@ const DisplaySwitcher = (): JSX.Element => {
 
                   {/* Comments */}
                   { getCommentListDom != null && !isTopPagePath && (
-                    <div className="mt-2">
+                    <div className="grw-page-accessories-control mt-2">
                       <button
                         type="button"
                         className="btn btn-block btn-outline-secondary grw-btn-page-accessories rounded-pill d-flex justify-content-between align-items-center"
                         onClick={() => smoothScrollIntoView(getCommentListDom, WIKI_HEADER_LINK)}
                       >
-                        <i className="mr-2 icon-fw icon-bubbles"></i>
+                        <i className="icon-fw icon-bubbles grw-page-accessories-control-icon"></i>
                         <span>Comments</span>
                         <span></span> {/* for a count badge */}
                       </button>

--- a/packages/app/src/styles/_page-accessories-control.scss
+++ b/packages/app/src/styles/_page-accessories-control.scss
@@ -8,4 +8,9 @@
       height: 16px;
     }
   }
+  .grw-page-accessories-control-icon {
+    display: flex;
+    justify-content: center;
+    width: 20px;
+  }
 }


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/91816

各言語それぞれ、左アイコンの位置と width は合わせて、テキストは中央寄せ

<img width="248" alt="image" src="https://user-images.githubusercontent.com/35527421/162374260-7eaeca99-81bd-4b9e-9b33-8309d1c5e9ba.png">

<img width="248" alt="image" src="https://user-images.githubusercontent.com/35527421/162374394-2a175d27-decd-43eb-93e7-7320cae5b450.png">
