### PR TITLE
fix: Cannot register new users

### DIFF
--- a/packages/app/src/server/models/user.js
+++ b/packages/app/src/server/models/user.js
@@ -47,7 +47,7 @@ module.exports = function(crowi) {
     name: { type: String },
     username: { type: String, required: true, unique: true },
     email: { type: String, unique: true, sparse: true },
-    slackMemberId: { type: String, unique: true },
+    slackMemberId: { type: String, unique: true, sparse: true },
     // === Crowi settings
     // username: { type: String, index: true },
     // email: { type: String, required: true, index: true },


### PR DESCRIPTION
## Task
- [修正](https://redmine.weseek.co.jp/issues/92496)

### Story[backlog]
- sprint追加依頼済みですが、まだ追加されていないです
- [[GROWI][Bug] ユーザーを新規登録しようとすると、Failed to register.と表示され、登録に失敗する](https://redmine.weseek.co.jp/issues/92489)



## Description
- クリーンインストールしてユーザーAを作成
- SignupでユーザーBを作成
で成功することを確認しました。
