### PR TITLE
imprv: Display snippet of restricted page in center of search results

### DIFF
--- a/packages/app/src/server/service/search.ts
+++ b/packages/app/src/server/service/search.ts
@@ -468,10 +468,6 @@ class SearchService implements SearchQueryParser, SearchResolver {
     const testGrantedUser = pageData.grantedUsers?.[0];
     const testGrantedGroup = pageData.grantedGroup;
 
-    if (testGrant === Page.GRANT_RESTRICTED) {
-      return false;
-    }
-
     if (testGrant === Page.GRANT_OWNER) {
       if (user == null) return false;
 


### PR DESCRIPTION
## Task

[#92157](https://redmine.weseek.co.jp/issues/92157) Anyone with the link ページの挙動がおかしい問題を修正する
┗ [#92553](https://redmine.weseek.co.jp/issues/92553) Anyone with the link で作成されたページを検索結果の中央でスニペットを表示できる

## Screenshot
<img width="778" alt="ScreenShot 2022-04-08 18 52 25" src="https://user-images.githubusercontent.com/34241526/162412200-a34d62ad-ff47-4426-9257-0b659afb8380.png">

