### PR TITLE
support: creating test file for v5 updateGroup 

### DIFF
--- a/packages/app/src/server/crowi/index.js
+++ b/packages/app/src/server/crowi/index.js
@@ -130,7 +130,7 @@ Crowi.prototype.init = async function() {
     this.setUpAcl(),
     this.setUpCustomize(),
     this.setUpRestQiitaAPI(),
-    this.setupUserGroup(),
+    this.setupUserGroupService(),
     this.setupExport(),
     this.setupImport(),
     this.setupPageService(),
@@ -644,7 +644,7 @@ Crowi.prototype.setUpRestQiitaAPI = async function() {
   }
 };
 
-Crowi.prototype.setupUserGroup = async function() {
+Crowi.prototype.setupUserGroupService = async function() {
   const UserGroupService = require('../service/user-group');
   if (this.userGroupService == null) {
     this.userGroupService = new UserGroupService(this);

--- a/packages/app/src/server/service/user-group.ts
+++ b/packages/app/src/server/service/user-group.ts
@@ -25,7 +25,6 @@ class UserGroupService {
     return UserGroupRelation.removeAllInvalidRelations();
   }
 
-  // TODO 85062: write test code
   // ref: https://dev.growi.org/61b2cdabaa330ce7d8152844
   async updateGroup(id, name?: string, description?: string, parentId?: string | null, forceUpdateParents = false) {
     const userGroup = await UserGroup.findById(id);

--- a/packages/app/test/integration/service/user-groups.test.ts
+++ b/packages/app/test/integration/service/user-groups.test.ts
@@ -14,7 +14,6 @@ describe('UserGroupService', () => {
 
   beforeAll(async() => {
     crowi = await getInstance();
-    await crowi.configManager.updateConfigsInTheSameNamespace('crowi', { 'app:isV5Compatible': true });
 
     UserGroup = mongoose.model('UserGroup');
 

--- a/packages/app/test/integration/service/v5.user-groups.test.ts
+++ b/packages/app/test/integration/service/v5.user-groups.test.ts
@@ -60,8 +60,12 @@ describe('UserGroupService', () => {
   });
 
   test('Should throw an error when trying to set existing group name', async() => {
-    const userGroup = await UserGroup.findOne({ _id: groupId1 });
-    await expect(crowi.userGroupService.updateGroup(userGroup._id, 'v5_group2')).rejects.toThrow('The group name is already taken');
+    const userGroup1 = await UserGroup.findOne({ _id: groupId1 });
+    const userGroup2 = await UserGroup.findOne({ _id: groupId2 });
+
+    const result = crowi.userGroupService.updateGroup(userGroup1._id, userGroup2.name);
+
+    await expect(result).rejects.toThrow('The group name is already taken');
   });
 
   test('Parent should be null when parent group is released', async() => {

--- a/packages/app/test/integration/service/v5.user-groups.test.ts
+++ b/packages/app/test/integration/service/v5.user-groups.test.ts
@@ -56,9 +56,9 @@ describe('UserGroupService', () => {
   });
 
   /*
-     * Update UserGroup
-     */
-  test('Can update user group basic info', async() => {
+    * Update UserGroup
+    */
+  test('Can update user group basic info (name, description, parent)', async() => {
     const userGroup = await UserGroup.findOne({ _id: groupId1 });
 
     const newGroupName = 'v5_group1_new';
@@ -75,6 +75,13 @@ describe('UserGroupService', () => {
   test('Cannot update to existing group name', async() => {
     const userGroup = await UserGroup.findOne({ _id: groupId1 });
     await expect(crowi.userGroupService.updateGroup(userGroup._id, 'v5_group2')).rejects.toThrow('The group name is already taken');
+  });
+
+  test('Parent will be null If parent group is released', async() => {
+    const userGroup = await UserGroup.findOne({ _id: groupId3 });
+    const updatedUserGroup = await crowi.userGroupService.updateGroup(userGroup._id, userGroup.name, userGroup.description, null);
+
+    expect(updatedUserGroup.parent).toBeNull();
   });
 
 });

--- a/packages/app/test/integration/service/v5.user-groups.test.ts
+++ b/packages/app/test/integration/service/v5.user-groups.test.ts
@@ -1,0 +1,69 @@
+
+import mongoose from 'mongoose';
+
+import { getInstance } from '../setup-crowi';
+
+describe('UserGroupService', () => {
+  // let dummyUser1;
+  // let dummyUser2;
+
+  let crowi;
+  let UserGroup;
+
+
+  beforeAll(async() => {
+    crowi = await getInstance();
+    await crowi.configManager.updateConfigsInTheSameNamespace('crowi', { 'app:isV5Compatible': true });
+
+    UserGroup = mongoose.model('UserGroup');
+
+    /*
+     * Common
+     */
+
+    // dummyUser1 = await UserGroup.findOne({ username: 'v5DummyUser1' });
+    // dummyUser2 = await UserGroup.findOne({ username: 'v5DummyUser2' });
+
+    // xssSpy = jest.spyOn(crowi.xss, 'process').mockImplementation(path => path);
+
+
+    const groupId1 = new mongoose.Types.ObjectId();
+    const groupId2 = new mongoose.Types.ObjectId();
+    const groupId3 = new mongoose.Types.ObjectId();
+
+
+    // Create Groups
+    await UserGroup.insertMany([
+      // no parent
+      {
+        _id: groupId1,
+        name: 'v5_group1',
+        description: 'description1',
+      },
+      // no parent
+      {
+        _id: groupId2,
+        name: 'v5_group2',
+        description: 'description2',
+      },
+      {
+        _id: groupId3,
+        name: 'v5_group3',
+        parent: groupId1,
+        description: 'description3',
+      },
+    ]);
+  });
+
+  /*
+     * Update UserGroup
+     */
+  test('Can update user group basic info', async() => {
+    const userGroup = await UserGroup.findOne({ name: 'v5_group1' });
+    await crowi.serGroupService.updateGroup(userGroup.id, 'v5_group1_new', 'description1_new');
+
+    expect(userGroup.name).toBe('v5_group1_new');
+    expect(userGroup.description).toBe('description1_new');
+  });
+
+});

--- a/packages/app/test/integration/service/v5.user-groups.test.ts
+++ b/packages/app/test/integration/service/v5.user-groups.test.ts
@@ -64,7 +64,7 @@ describe('UserGroupService', () => {
     await expect(crowi.userGroupService.updateGroup(userGroup._id, 'v5_group2')).rejects.toThrow('The group name is already taken');
   });
 
-  test('Parent will be null If parent group is released', async() => {
+  test('Parent should be null when parent group is released', async() => {
     const userGroup = await UserGroup.findOne({ _id: groupId3 });
     const updatedUserGroup = await crowi.userGroupService.updateGroup(userGroup._id, userGroup.name, userGroup.description, null);
 

--- a/packages/app/test/integration/service/v5.user-groups.test.ts
+++ b/packages/app/test/integration/service/v5.user-groups.test.ts
@@ -59,17 +59,22 @@ describe('UserGroupService', () => {
      * Update UserGroup
      */
   test('Can update user group basic info', async() => {
-    const userGroup = await UserGroup.findOne({ name: 'v5_group1' });
+    const userGroup = await UserGroup.findOne({ _id: groupId1 });
 
     const newGroupName = 'v5_group1_new';
     const newGroupDescription = 'description1_new';
     const newParentId = groupId2;
 
-    const updatedUserGroup = await crowi.userGroupService.updateGroup(userGroup.id, newGroupName, newGroupDescription, newParentId);
+    const updatedUserGroup = await crowi.userGroupService.updateGroup(userGroup._id, newGroupName, newGroupDescription, newParentId);
 
     expect(updatedUserGroup.name).toBe(newGroupName);
     expect(updatedUserGroup.description).toBe(newGroupDescription);
     expect(updatedUserGroup.parent).toStrictEqual(newParentId);
+  });
+
+  test('Cannot update to existing group name', async() => {
+    const userGroup = await UserGroup.findOne({ _id: groupId1 });
+    await expect(crowi.userGroupService.updateGroup(userGroup._id, 'v5_group2')).rejects.toThrow('The group name is already taken');
   });
 
 });

--- a/packages/app/test/integration/service/v5.user-groups.test.ts
+++ b/packages/app/test/integration/service/v5.user-groups.test.ts
@@ -4,12 +4,8 @@ import mongoose from 'mongoose';
 import { getInstance } from '../setup-crowi';
 
 describe('UserGroupService', () => {
-  // let dummyUser1;
-  // let dummyUser2;
-
   let crowi;
   let UserGroup;
-
 
   const groupId1 = new mongoose.Types.ObjectId();
   const groupId2 = new mongoose.Types.ObjectId();
@@ -22,25 +18,16 @@ describe('UserGroupService', () => {
 
     UserGroup = mongoose.model('UserGroup');
 
-    /*
-     * Common
-     */
-
-    // dummyUser1 = await UserGroup.findOne({ username: 'v5DummyUser1' });
-    // dummyUser2 = await UserGroup.findOne({ username: 'v5DummyUser2' });
-
-    // xssSpy = jest.spyOn(crowi.xss, 'process').mockImplementation(path => path);
-
 
     // Create Groups
     await UserGroup.insertMany([
-      // no parent
+      // No parent
       {
         _id: groupId1,
         name: 'v5_group1',
         description: 'description1',
       },
-      // no parent
+      // No parent
       {
         _id: groupId2,
         name: 'v5_group2',
@@ -72,7 +59,7 @@ describe('UserGroupService', () => {
     expect(updatedUserGroup.parent).toStrictEqual(newParentId);
   });
 
-  test('Cannot update to existing group name', async() => {
+  test('Should throw an error when trying to set existing group name', async() => {
     const userGroup = await UserGroup.findOne({ _id: groupId1 });
     await expect(crowi.userGroupService.updateGroup(userGroup._id, 'v5_group2')).rejects.toThrow('The group name is already taken');
   });

--- a/packages/app/test/integration/service/v5.user-groups.test.ts
+++ b/packages/app/test/integration/service/v5.user-groups.test.ts
@@ -60,10 +60,14 @@ describe('UserGroupService', () => {
      */
   test('Can update user group basic info', async() => {
     const userGroup = await UserGroup.findOne({ name: 'v5_group1' });
-    await crowi.serGroupService.updateGroup(userGroup.id, 'v5_group1_new', 'description1_new');
 
-    expect(userGroup.name).toBe('v5_group1_new');
-    expect(userGroup.description).toBe('description1_new');
+    const newGroupName = 'v5_group1_new';
+    const newGroupDescription = 'description1_new';
+
+    const updatedUserGroup = await crowi.userGroupService.updateGroup(userGroup.id, newGroupName, newGroupDescription);
+
+    expect(updatedUserGroup.name).toBe(newGroupName);
+    expect(updatedUserGroup.description).toBe(newGroupDescription);
   });
 
 });

--- a/packages/app/test/integration/service/v5.user-groups.test.ts
+++ b/packages/app/test/integration/service/v5.user-groups.test.ts
@@ -11,6 +11,11 @@ describe('UserGroupService', () => {
   let UserGroup;
 
 
+  const groupId1 = new mongoose.Types.ObjectId();
+  const groupId2 = new mongoose.Types.ObjectId();
+  const groupId3 = new mongoose.Types.ObjectId();
+
+
   beforeAll(async() => {
     crowi = await getInstance();
     await crowi.configManager.updateConfigsInTheSameNamespace('crowi', { 'app:isV5Compatible': true });
@@ -25,11 +30,6 @@ describe('UserGroupService', () => {
     // dummyUser2 = await UserGroup.findOne({ username: 'v5DummyUser2' });
 
     // xssSpy = jest.spyOn(crowi.xss, 'process').mockImplementation(path => path);
-
-
-    const groupId1 = new mongoose.Types.ObjectId();
-    const groupId2 = new mongoose.Types.ObjectId();
-    const groupId3 = new mongoose.Types.ObjectId();
 
 
     // Create Groups
@@ -63,11 +63,13 @@ describe('UserGroupService', () => {
 
     const newGroupName = 'v5_group1_new';
     const newGroupDescription = 'description1_new';
+    const newParentId = groupId2;
 
-    const updatedUserGroup = await crowi.userGroupService.updateGroup(userGroup.id, newGroupName, newGroupDescription);
+    const updatedUserGroup = await crowi.userGroupService.updateGroup(userGroup.id, newGroupName, newGroupDescription, newParentId);
 
     expect(updatedUserGroup.name).toBe(newGroupName);
     expect(updatedUserGroup.description).toBe(newGroupDescription);
+    expect(updatedUserGroup.parent).toStrictEqual(newParentId);
   });
 
 });

--- a/packages/app/test/integration/service/v5.user-groups.test.ts
+++ b/packages/app/test/integration/service/v5.user-groups.test.ts
@@ -45,7 +45,7 @@ describe('UserGroupService', () => {
   /*
     * Update UserGroup
     */
-  test('Can update user group basic info (name, description, parent)', async() => {
+  test('Updated values should be reflected. (name, description, parent)', async() => {
     const userGroup = await UserGroup.findOne({ _id: groupId1 });
 
     const newGroupName = 'v5_group1_new';

--- a/packages/app/test/integration/setup-crowi.js
+++ b/packages/app/test/integration/setup-crowi.js
@@ -23,6 +23,7 @@ const initCrowi = async(crowi) => {
     crowi.setupPageService(),
     crowi.setupInAppNotificationService(),
     crowi.setupActivityService(),
+    crowi.setupUserGroupService(),
   ]);
 };
 


### PR DESCRIPTION
## Task
- [85131](https://redmine.weseek.co.jp/issues/85131) [updateUserGroup] testfileを新規作成し基本的なテストを記述する(変更された値の反映, nameの重複, 親解除)

## Description
タスク分割しました

### チェック項目
- name, description, parentIdの変更が反映される
- 更新したい名前が既存のグループ名とかぶっている場合、throw err される
- 親を解除した時、parentがnullになる



