### PR TITLE
imprv: Dark theme color optimization

### DIFF
--- a/packages/app/src/styles/theme/_apply-colors-dark.scss
+++ b/packages/app/src/styles/theme/_apply-colors-dark.scss
@@ -277,19 +277,30 @@ ul.pagination {
   // Pagetree
   .grw-pagetree {
     @include override-list-group-item-for-pagetree(
-      $color-list,
+      $gray-200,
       $bgcolor-sidebar-list-group,
-      $color-list-hover,
-      $bgcolor-list-hover,
-      $color-list-active,
-      lighten($bgcolor-list-hover, 5%)
+      $gray-200,
+      lighten($bgcolor-sidebar-context, 8%),
+      $gray-200,
+      lighten($bgcolor-sidebar-context, 15%)
     );
     .grw-pagetree-triangle-btn {
       @include button-outline-svg-icon-variant($secondary, $gray-200);
     }
     .grw-pagetree-count {
       color: $gray-400;
-      background: $gray-700;
+      background: lighten($bgcolor-sidebar-context, 15%);
+    }
+    .btn-page-item-control {
+      @include button-outline-variant($gray-500, $gray-500, $secondary, transparent);
+      @include hover() {
+        background-color: lighten($bgcolor-sidebar-context, 20%);
+      }
+      &:not(:disabled):not(.disabled):active,
+      &:not(:disabled):not(.disabled).active {
+        background-color: lighten($bgcolor-sidebar-context, 34%);
+      }
+      box-shadow: none !important;
     }
   }
   .private-legacy-pages-link {
@@ -302,11 +313,12 @@ ul.pagination {
 .btn.btn-page-item-control {
   @include button-outline-variant($gray-500, $gray-500, $secondary, transparent);
   @include hover() {
-    background-color: $gray-600;
+    background-color: $gray-700;
   }
   &:not(:disabled):not(.disabled):active,
   &:not(:disabled):not(.disabled).active {
     color: $gray-200;
+    background-color: $gray-600;
   }
   box-shadow: none !important;
 }


### PR DESCRIPTION
## default dark
![image](https://user-images.githubusercontent.com/20252919/164174778-b60dd25d-6f12-4b5f-a320-e1f244d2fade.png)
## mono-blue dark
![image](https://user-images.githubusercontent.com/20252919/164174868-5189c885-b6c3-45a4-b462-4d33e0b158f8.png)
## hufflepuff dark
![image](https://user-images.githubusercontent.com/20252919/164174888-bb7a18bb-c97e-4b03-9a2b-f3238fa9a0e0.png)
## fire-red dark
![image](https://user-images.githubusercontent.com/20252919/164174917-43f081f2-1134-414a-ac8e-a6ae636c7985.png)
## jade-green dark
![image](https://user-images.githubusercontent.com/20252919/164174938-1277a4f6-8bc5-499d-9ad6-2dcfe5216517.png)
## future
![image](https://user-images.githubusercontent.com/20252919/164174968-889cc12b-0019-4c57-8e7a-63e3e3b2db23.png)
## halloween
![image](https://user-images.githubusercontent.com/20252919/164174997-4e312cec-0fcb-497e-8220-82364d47579f.png)
