### PR TITLE
imprv: Use latest BuildKit feature and GHA for faster/lighter docker build

### DIFF
--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -43,14 +43,6 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
 
-    - name: Cache Docker layers
-      uses: actions/cache@v3
-      with:
-        path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx-app-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-buildx-app-
-
     - name: Build and push
       uses: docker/build-push-action@v2
       with:
@@ -58,8 +50,9 @@ jobs:
         file: ./packages/app/docker/Dockerfile
         platforms: linux/amd64
         push: true
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
+        builder: ${{ steps.buildx.outputs.name }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
         tags: ${{ steps.meta.outputs.tags }}
 
     - name: Move cache

--- a/.github/workflows/release-slackbot-proxy.yml
+++ b/.github/workflows/release-slackbot-proxy.yml
@@ -56,14 +56,6 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
 
-    - name: Cache Docker layers
-      uses: actions/cache@v3
-      with:
-        path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx-slackbot-proxy-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-buildx-slackbot-proxy-
-
     - name: Build and push
       uses: docker/build-push-action@v2
       with:
@@ -71,8 +63,9 @@ jobs:
         file: ./packages/slackbot-proxy/docker/Dockerfile
         platforms: linux/amd64
         push: true
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
+        builder: ${{ steps.buildx.outputs.name }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
         tags: ${{ steps.meta.outputs.tags }}
 
     - name: Move cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,15 +169,6 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
 
-    - name: Cache Docker layers
-      uses: actions/cache@v3
-      with:
-        path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx-app-${{ matrix.flavor }}-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-buildx-app-${{ matrix.flavor }}-
-          ${{ runner.os }}-buildx-app-
-
     - name: Build and push
       uses: docker/build-push-action@v2
       with:
@@ -187,8 +178,9 @@ jobs:
         push: true
         build-args: |
           flavor=${{ matrix.flavor }}
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
+        builder: ${{ steps.buildx.outputs.name }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
         tags: ${{ steps.meta.outputs.tags }}
 
     - name: Move cache

--- a/packages/app/docker/Dockerfile
+++ b/packages/app/docker/Dockerfile
@@ -1,4 +1,4 @@
-# syntax = docker/dockerfile:1
+# syntax = docker/dockerfile:1.4
 
 ARG flavor=default
 
@@ -157,11 +157,7 @@ RUN tar -xf node_modules.tar
 RUN tar -xf packages.tar
 RUN rm node_modules.tar packages.tar
 
-USER root
-
-COPY packages/app/docker/docker-entrypoint.sh /
-RUN chmod 700 /docker-entrypoint.sh
-RUN chown node:node ${appDir}
+COPY --chown=node:node --chmod=700 packages/app/docker/docker-entrypoint.sh /
 
 WORKDIR ${appDir}/packages/app
 

--- a/packages/slackbot-proxy/docker/Dockerfile
+++ b/packages/slackbot-proxy/docker/Dockerfile
@@ -1,4 +1,4 @@
-# syntax = docker/dockerfile:1
+# syntax = docker/dockerfile:1.4
 
 ##
 ## packages-json-picker
@@ -103,18 +103,16 @@ ENV NODE_ENV production
 ENV optDir /opt
 ENV appDir ${optDir}
 
-# copy artifacts
-COPY --from=deps-resolver-prod --chown=node:node \
-  ${optDir}/dependencies.tar ${appDir}/
-COPY --from=builder --chown=node:node \
-  ${optDir}/packages.tar ${appDir}/
-
-RUN chown node:node ${appDir}
-
 USER node
 
-# extract artifacts
 WORKDIR ${appDir}
+# copy artifacts
+COPY --from=deps-resolver-prod --chown=node:node \
+  ${optDir}/dependencies.tar ./
+COPY --from=builder --chown=node:node \
+  ${optDir}/packages.tar ./
+
+# extract artifacts
 RUN tar -xf dependencies.tar
 RUN tar -xf packages.tar
 RUN rm dependencies.tar packages.tar


### PR DESCRIPTION
This PR adds the following improvements to Docker Build to Growi

- Use GHA native cache in GHA including the build stage image layers (brings sugnificant build speed improvemetnt)
  - `type=gha,mode=max`
- chmod and chown can be with COPY and it makes the image layer lighter

Planning future work
- Add `--link` options to `COPY` ref. https://codezine.jp/article/detail/15745