### PR TITLE
imprv: i18n for already_exists error in PutBackPageModal

### DIFF
--- a/packages/app/resource/locales/en_US/translation.json
+++ b/packages/app/resource/locales/en_US/translation.json
@@ -394,7 +394,7 @@
   },
   "page_api_error": {
     "notfound_or_forbidden": "Original page is not found or forbidden.",
-    "already_exists": "New page is already exists.",
+    "already_exists": "Page with the path already exists.",
     "outdated": "Page is updated someone and now outdated.",
     "user_not_admin": "Only admin user can delete"
   },

--- a/packages/app/resource/locales/ja_JP/translation.json
+++ b/packages/app/resource/locales/ja_JP/translation.json
@@ -393,7 +393,7 @@
   },
   "page_api_error": {
     "notfound_or_forbidden": "元のページが見つからないか、アクセス権がありません。",
-    "already_exists": "新しいページが既に存在しています。",
+    "already_exists": "そのパスを持つページは既に存在しています。",
     "outdated": "ページが他のユーザーによって更新されました。",
     "user_not_admin": "権限のあるユーザーのみが削除できます"
   },

--- a/packages/app/resource/locales/zh_CN/translation.json
+++ b/packages/app/resource/locales/zh_CN/translation.json
@@ -372,7 +372,7 @@
   },
 	"page_api_error": {
 		"notfound_or_forbidden": "未找到或禁止原始页。",
-		"already_exists": "新建页面已存在",
+		"already_exists": "具有该路径的页面已存在",
 		"outdated": "页面已被某人更新，现在已过时。",
 		"user_not_admin": "仅管理员用户可以删除"
   },

--- a/packages/app/src/components/PutbackPageModal.jsx
+++ b/packages/app/src/components/PutbackPageModal.jsx
@@ -1,13 +1,14 @@
 import React, { useState } from 'react';
 
+
+import { useTranslation } from 'react-i18next';
 import {
   Modal, ModalHeader, ModalBody, ModalFooter,
 } from 'reactstrap';
 
-import { useTranslation } from 'react-i18next';
-
-import { usePutBackPageModal } from '~/stores/modal';
 import { apiPost } from '~/client/util/apiv1-client';
+import { PathAlreadyExistsError } from '~/server/models/errors';
+import { usePutBackPageModal } from '~/stores/modal';
 
 import ApiErrorMessageList from './PageManagement/ApiErrorMessageList';
 
@@ -46,7 +47,7 @@ const PutBackPageModal = () => {
       closePutBackPageModal();
     }
     catch (err) {
-      setErrs(err);
+      setErrs([err]);
     }
   }
 

--- a/packages/app/src/components/PutbackPageModal.jsx
+++ b/packages/app/src/components/PutbackPageModal.jsx
@@ -21,6 +21,7 @@ const PutBackPageModal = () => {
   const onPutBacked = pageDataToRevert.opts?.onPutBacked;
 
   const [errs, setErrs] = useState(null);
+  const [targetPath, setTargetPath] = useState(null);
 
   const [isPutbackRecursively, setIsPutbackRecursively] = useState(true);
 
@@ -47,6 +48,7 @@ const PutBackPageModal = () => {
       closePutBackPageModal();
     }
     catch (err) {
+      setTargetPath(err.data);
       setErrs([err]);
     }
   }
@@ -79,7 +81,7 @@ const PutBackPageModal = () => {
         </div>
       </ModalBody>
       <ModalFooter>
-        <ApiErrorMessageList errs={errs} />
+        <ApiErrorMessageList errs={errs} targetPath={targetPath} />
         <button type="button" className="btn btn-info" onClick={putbackPageButtonHandler}>
           <i className="icon-action-undo mr-2" aria-hidden="true"></i> { t('Put Back') }
         </button>

--- a/packages/app/src/server/models/errors.ts
+++ b/packages/app/src/server/models/errors.ts
@@ -1,3 +1,12 @@
 import ExtensibleCustomError from 'extensible-custom-error';
 
-export class PathAlreadyExistsError extends ExtensibleCustomError {}
+export class PathAlreadyExistsError extends ExtensibleCustomError {
+
+  targetPath: string;
+
+  constructor(message: string, targetPath: string) {
+    super(message);
+    this.targetPath = targetPath;
+  }
+
+}

--- a/packages/app/src/server/models/errors.ts
+++ b/packages/app/src/server/models/errors.ts
@@ -1,0 +1,3 @@
+import ExtensibleCustomError from 'extensible-custom-error';
+
+export class PathAlreadyExists extends ExtensibleCustomError {}

--- a/packages/app/src/server/models/errors.ts
+++ b/packages/app/src/server/models/errors.ts
@@ -1,3 +1,3 @@
 import ExtensibleCustomError from 'extensible-custom-error';
 
-export class PathAlreadyExists extends ExtensibleCustomError {}
+export class PathAlreadyExistsError extends ExtensibleCustomError {}

--- a/packages/app/src/server/routes/page.js
+++ b/packages/app/src/server/routes/page.js
@@ -1,9 +1,11 @@
 import { pagePathUtils } from '@growi/core';
-import urljoin from 'url-join';
 import { body } from 'express-validator';
 import mongoose from 'mongoose';
+import urljoin from 'url-join';
 
 import loggerFactory from '~/utils/logger';
+
+import { PathAlreadyExistsError } from '../models/errors';
 import UpdatePost from '../models/update-post';
 
 const { isCreatablePage, isTopPage, isUsersHomePage } = pagePathUtils;
@@ -1261,6 +1263,9 @@ module.exports = function(crowi, app) {
       page = await crowi.pageService.revertDeletedPage(page, req.user, {}, isRecursively);
     }
     catch (err) {
+      if (err instanceof PathAlreadyExistsError) {
+        return res.json(ApiResponse.error(('Page exists', 'already_exists')));
+      }
       logger.error('Error occured while get setting', err);
       return res.json(ApiResponse.error(err));
     }

--- a/packages/app/src/server/routes/page.js
+++ b/packages/app/src/server/routes/page.js
@@ -1264,7 +1264,7 @@ module.exports = function(crowi, app) {
     }
     catch (err) {
       if (err instanceof PathAlreadyExistsError) {
-        logger.error('Page exists', err);
+        logger.error('Path already exists', err);
         return res.json(ApiResponse.error(err, 'already_exists', err.targetPath));
       }
       logger.error('Error occured while get setting', err);

--- a/packages/app/src/server/routes/page.js
+++ b/packages/app/src/server/routes/page.js
@@ -1264,7 +1264,8 @@ module.exports = function(crowi, app) {
     }
     catch (err) {
       if (err instanceof PathAlreadyExistsError) {
-        return res.json(ApiResponse.error(('Page exists', 'already_exists')));
+        logger.error('Page exists', err);
+        return res.json(ApiResponse.error(err, 'already_exists'));
       }
       logger.error('Error occured while get setting', err);
       return res.json(ApiResponse.error(err));

--- a/packages/app/src/server/routes/page.js
+++ b/packages/app/src/server/routes/page.js
@@ -1265,7 +1265,7 @@ module.exports = function(crowi, app) {
     catch (err) {
       if (err instanceof PathAlreadyExistsError) {
         logger.error('Page exists', err);
-        return res.json(ApiResponse.error(err, 'already_exists'));
+        return res.json(ApiResponse.error(err, 'already_exists', err.targetPath));
       }
       logger.error('Error occured while get setting', err);
       return res.json(ApiResponse.error(err));

--- a/packages/app/src/server/service/page.ts
+++ b/packages/app/src/server/service/page.ts
@@ -1883,8 +1883,7 @@ class PageService {
 
     // throw if any page already exists
     if (originPage != null) {
-      const err:{code: string, targetPath: string} = { code: 'already_exists', targetPath: originPage.path };
-      throw new PathAlreadyExistsError(err);
+      throw new PathAlreadyExistsError('already_exists', originPage.path);
     }
 
     // 2. Revert target
@@ -1978,8 +1977,7 @@ class PageService {
     const newPath = Page.getRevertDeletedPageName(page.path);
     const originPage = await Page.findByPath(newPath);
     if (originPage != null) {
-      const err:{code: string, targetPath: string} = { code: 'already_exists', targetPath: originPage.path };
-      throw new PathAlreadyExistsError(err);
+      throw new PathAlreadyExistsError('already_exists', originPage.path);
     }
 
     if (isRecursively) {

--- a/packages/app/src/server/service/page.ts
+++ b/packages/app/src/server/service/page.ts
@@ -1,33 +1,37 @@
-import { pagePathUtils, pathUtils } from '@growi/core';
-import mongoose, { ObjectId, QueryCursor } from 'mongoose';
-import escapeStringRegexp from 'escape-string-regexp';
-import streamToPromise from 'stream-to-promise';
 import pathlib from 'path';
 import { Readable, Writable } from 'stream';
 
-import { createBatchStream } from '~/server/util/batch-stream';
-import loggerFactory from '~/utils/logger';
-import {
-  CreateMethod, PageCreateOptions, PageModel, PageDocument,
-} from '~/server/models/page';
-import { stringifySnapshot } from '~/models/serializers/in-app-notification-snapshot/page';
+import { pagePathUtils, pathUtils } from '@growi/core';
+import escapeStringRegexp from 'escape-string-regexp';
+import mongoose, { ObjectId, QueryCursor } from 'mongoose';
+import streamToPromise from 'stream-to-promise';
+
+import { Ref } from '~/interfaces/common';
+import { HasObjectId } from '~/interfaces/has-object-id';
 import {
   IPage, IPageInfo, IPageInfoForEntity, IPageWithMeta,
 } from '~/interfaces/page';
-import { serializePageSecurely } from '../models/serializers/page-serializer';
-import { PageRedirectModel } from '../models/page-redirect';
-import Subscription from '../models/subscription';
-import { ObjectIdLike } from '../interfaces/mongoose-utils';
-import { IUserHasId } from '~/interfaces/user';
-import { Ref } from '~/interfaces/common';
-import { HasObjectId } from '~/interfaces/has-object-id';
-import { SocketEventName, UpdateDescCountRawData } from '~/interfaces/websocket';
 import {
   PageDeleteConfigValue, IPageDeleteConfigValueToProcessValidation,
 } from '~/interfaces/page-delete-config';
-import PageOperation, { PageActionStage, PageActionType } from '../models/page-operation';
-import ActivityDefine from '../util/activityDefine';
+import { IUserHasId } from '~/interfaces/user';
+import { SocketEventName, UpdateDescCountRawData } from '~/interfaces/websocket';
+import { stringifySnapshot } from '~/models/serializers/in-app-notification-snapshot/page';
+import {
+  CreateMethod, PageCreateOptions, PageModel, PageDocument,
+} from '~/server/models/page';
+import { createBatchStream } from '~/server/util/batch-stream';
+import loggerFactory from '~/utils/logger';
 import { prepareDeleteConfigValuesForCalc } from '~/utils/page-delete-config';
+
+import { ObjectIdLike } from '../interfaces/mongoose-utils';
+import { PathAlreadyExistsError } from '../models/errors';
+import PageOperation, { PageActionStage, PageActionType } from '../models/page-operation';
+import { PageRedirectModel } from '../models/page-redirect';
+import { serializePageSecurely } from '../models/serializers/page-serializer';
+import Subscription from '../models/subscription';
+import ActivityDefine from '../util/activityDefine';
+
 
 const debug = require('debug')('growi:services:page');
 
@@ -1879,7 +1883,8 @@ class PageService {
 
     // throw if any page already exists
     if (originPage != null) {
-      throw Error(`This page cannot be reverted since a page with path "${originPage.path}" already exists. Rename the existing pages first.`);
+      const err:{code: string, targetPath: string} = { code: 'already_exists', targetPath: originPage.path };
+      throw new PathAlreadyExistsError(err);
     }
 
     // 2. Revert target
@@ -1973,7 +1978,8 @@ class PageService {
     const newPath = Page.getRevertDeletedPageName(page.path);
     const originPage = await Page.findByPath(newPath);
     if (originPage != null) {
-      throw Error(`This page cannot be reverted since a page with path "${originPage.path}" already exists.`);
+      const err:{code: string, targetPath: string} = { code: 'already_exists', targetPath: originPage.path };
+      throw new PathAlreadyExistsError(err);
     }
 
     if (isRecursively) {


### PR DESCRIPTION
## Task
- [i18n対応](https://redmine.weseek.co.jp/issues/92989)

## Description
- revert時のエラーのi18n対応をしました。
- 既存の`already_exists` コードを使用しています。
- エラーメッセージを変更したので、Duplicateなどの他のモーダルにも変更が反映されています。


## ScreenShots
## Before
- PutBackPageModal
<img width="442" alt="Screen Shot 2022-04-22 at 11 29 24" src="https://user-images.githubusercontent.com/59536731/164584493-f09d4bf2-663c-4ece-9814-f353072284a7.png">

- DuplicateModal
<img width="707" alt="Screen Shot 2022-04-22 at 11 29 55" src="https://user-images.githubusercontent.com/59536731/164584575-d35bba6d-bbb9-4870-a792-10153b02b7e1.png">



## After
<img width="652" alt="Screen Shot 2022-04-22 at 11 23 28" src="https://user-images.githubusercontent.com/59536731/164583930-4966ca19-78d4-4e4e-b893-b02327d3803b.png">
<img width="708" alt="Screen Shot 2022-04-22 at 11 31 59" src="https://user-images.githubusercontent.com/59536731/164584764-464f0b6a-edb5-445c-9c09-8dd4c4c1c958.png">



