### PR TITLE
fix: Swiping to previous/next page for Mac users (4.5.x)

### DIFF
--- a/packages/app/src/styles/_layout.scss
+++ b/packages/app/src/styles/_layout.scss
@@ -1,6 +1,6 @@
 body {
   overflow-y: scroll !important;
-  overscroll-behavior: none;
+  overscroll-behavior-y: none;
 }
 
 body:not(.growi-layout-fluid) .grw-container-convertible {


### PR DESCRIPTION
タスク：https://redmine.weseek.co.jp/issues/93339

トラックパッドで左右にジェスチャーをした際、ページを進んだり戻ったりできるようにしました。

レビューをお願いします。