### PR TITLE
fix:  footstamp-icon size

### DIFF
--- a/packages/app/src/styles/_page_list.scss
+++ b/packages/app/src/styles/_page_list.scss
@@ -53,7 +53,6 @@ body .page-list {
         svg {
           width: 14px;
           height: 14px;
-          margin-right: 2px;
         }
       }
       .seen-users-count {

--- a/packages/app/src/styles/_page_list.scss
+++ b/packages/app/src/styles/_page_list.scss
@@ -49,6 +49,13 @@ body .page-list {
         margin-right: 2px;
       }
 
+      .footstamp-icon {
+        svg {
+          width: 14px;
+          height: 14px;
+          margin-right: 2px;
+        }
+      }
       .seen-users-count {
         &.strength-1 {
           font-weight: bold;
@@ -77,17 +84,6 @@ body .page-list {
   .list-group {
     .list-group-item {
       min-height: 136px;
-
-      .page-list-meta {
-        .meta-icon {
-          width: 14px;
-          height: 14px;
-          margin-right: 14px;
-        }
-        .footstamp-icon {
-          margin-right: 2px;
-        }
-      }
 
       .page-list-updated-at {
         font-size: 12px;


### PR DESCRIPTION
## Task
- [93647](https://redmine.weseek.co.jp/issues/93647) 修正
┗[GROWI] user home の Bookmarks と Rescently Created の足跡が大きすぎる

## ScreenShots
## Before
<img width="552" alt="Screen Shot 2022-04-25 at 15 11 25" src="https://user-images.githubusercontent.com/59536731/165030496-64b99bdc-036f-4d5b-99c6-b8af7867b89a.png">
<img width="297" alt="Screen Shot 2022-04-25 at 15 12 17" src="https://user-images.githubusercontent.com/59536731/165030554-bcbafb94-6ff0-4964-adf4-aad9ca44ce53.png">


## After
<img width="539" alt="Screen Shot 2022-04-25 at 15 07 09" src="https://user-images.githubusercontent.com/59536731/165030272-ed9f292b-4822-4e3e-b66b-76411a056379.png">

### デグレしていないかのチェック
<img width="369" alt="Screen Shot 2022-04-25 at 15 06 34" src="https://user-images.githubusercontent.com/59536731/165030291-3c9e6f9b-eceb-4663-9a3e-9517ce984e6c.png">

<img width="908" alt="Screen Shot 2022-04-25 at 15 13 46" src="https://user-images.githubusercontent.com/59536731/165030767-f6a39e92-ec83-4023-a586-9fd26ceed5f4.png">

<img width="250" alt="Screen Shot 2022-04-25 at 15 16 15" src="https://user-images.githubusercontent.com/59536731/165031003-6b6c86e7-9d40-4a3f-b215-85698234ba0f.png">

