### PR TITLE
fix: Switch v4 v5 process testcode

### DIFF
--- a/packages/app/src/components/Me/ProfileImageSettings.jsx
+++ b/packages/app/src/components/Me/ProfileImageSettings.jsx
@@ -116,8 +116,8 @@ class ProfileImageSettings extends React.Component {
                   checked={isGravatarEnabled}
                   onChange={() => { personalContainer.changeIsGravatarEnabled(true) }}
                 />
-                <label className="custom-control-label" htmlFor="radioGravatar" data-hide-in-vrt>
-                  <img src="https://gravatar.com/avatar/00000000000000000000000000000000?s=24" /> Gravatar
+                <label className="custom-control-label" htmlFor="radioGravatar">
+                  <img src="https://gravatar.com/avatar/00000000000000000000000000000000?s=24" data-hide-in-vrt /> Gravatar
                 </label>
                 <a href="https://gravatar.com/">
                   <small><i className="icon-arrow-right-circle" aria-hidden="true"></i></small>

--- a/packages/app/test/cypress/integration/6-home/home.spec.ts
+++ b/packages/app/test/cypress/integration/6-home/home.spec.ts
@@ -62,10 +62,10 @@ context('Access User settings', () => {
     cy.get('.toast').should('be.visible').invoke('attr', 'style', 'opacity: 1');
     cy.screenshot(`${ssPrefix}-external-account-3`);
     cy.get('.toast-close-button').click({ multiple: true }); // close toast alert
+    cy.get('.toast').should('not.exist');
     cy.getByTestid('grw-associate-modal').find('.close').click();
     cy.screenshot(`${ssPrefix}-external-account-4`);
 
-    cy.get('.toast-close-button').click({ multiple: true }); // close toast alert
     cy.get('.toast').should('not.exist');
 
     // Access Password setting

--- a/packages/app/test/integration/models/v5.page.test.js
+++ b/packages/app/test/integration/models/v5.page.test.js
@@ -883,6 +883,7 @@ describe('Page', () => {
 
     });
     test('should find parent while NOT creating unnecessary empty pages with all v4 public pages', async() => {
+      // All pages does not have parent (v4 schema)
       const _pageA = await Page.findOne({ path: '/get_parent_A', grant: Page.GRANT_PUBLIC, isEmpty: false });
       const _pageAB = await Page.findOne({ path: '/get_parent_A/get_parent_B', grant: Page.GRANT_PUBLIC, isEmpty: false });
       const _emptyA = await Page.findOne({ path: '/get_parent_A', grant: Page.GRANT_PUBLIC, isEmpty: true });
@@ -936,9 +937,12 @@ describe('Page', () => {
       expect(emptyC).toBeNull();
       expect(emptyCD).toBeNull();
 
-      // -- Check parent
-      expect(pageC.parent).not.toBeNull();
-      expect(pageCD.parent).not.toBeNull();
+      // -- Check parent attribute
+      expect(pageC.parent).toStrictEqual(rootPage._id);
+      expect(pageCD.parent).toStrictEqual(pageC._id);
+
+      // -- Check the found parent
+      expect(parent).toStrictEqual(pageCD);
     });
   });
 });

--- a/packages/app/test/integration/models/v5.page.test.js
+++ b/packages/app/test/integration/models/v5.page.test.js
@@ -884,10 +884,28 @@ describe('Page', () => {
     });
     test('should find parent while NOT creating unnecessary empty pages with all v4 public pages', async() => {
       // All pages does not have parent (v4 schema)
-      const _pageA = await Page.findOne({ path: '/get_parent_A', grant: Page.GRANT_PUBLIC, isEmpty: false, parent: null });
-      const _pageAB = await Page.findOne({ path: '/get_parent_A/get_parent_B', grant: Page.GRANT_PUBLIC, isEmpty: false, parent: null });
-      const _emptyA = await Page.findOne({ path: '/get_parent_A', grant: Page.GRANT_PUBLIC, isEmpty: true });
-      const _emptyAB = await Page.findOne({ path: '/get_parent_A/get_parent_B', grant: Page.GRANT_PUBLIC, isEmpty: true });
+      const _pageA = await Page.findOne({
+        path: '/get_parent_A',
+        grant: Page.GRANT_PUBLIC,
+        isEmpty: false,
+        parent: null,
+      });
+      const _pageAB = await Page.findOne({
+        path: '/get_parent_A/get_parent_B',
+        grant: Page.GRANT_PUBLIC,
+        isEmpty: false,
+        parent: null,
+      });
+      const _emptyA = await Page.findOne({
+        path: '/get_parent_A',
+        grant: Page.GRANT_PUBLIC,
+        isEmpty: true,
+      });
+      const _emptyAB = await Page.findOne({
+        path: '/get_parent_A/get_parent_B',
+        grant: Page.GRANT_PUBLIC,
+        isEmpty: true,
+      });
 
       expect(_pageA).not.toBeNull();
       expect(_pageAB).not.toBeNull();

--- a/packages/app/test/integration/models/v5.page.test.js
+++ b/packages/app/test/integration/models/v5.page.test.js
@@ -868,7 +868,7 @@ describe('Page', () => {
       expect(page2.parent).toStrictEqual(parent._id);
 
     });
-    test("should find parent while NOT creating unnecessary empty pages", async() => {
+    test('should find parent while NOT creating unnecessary empty pages', async() => {
       const _pageA = await Page.findOne({ path: '/get_parent_A', grant: Page.GRANT_PUBLIC, isEmpty: false });
       const _pageAB = await Page.findOne({ path: '/get_parent_A/get_parent_B', grant: Page.GRANT_PUBLIC, isEmpty: false });
       const _emptyA = await Page.findOne({ path: '/get_parent_A', grant: Page.GRANT_PUBLIC, isEmpty: true });

--- a/packages/app/test/integration/models/v5.page.test.js
+++ b/packages/app/test/integration/models/v5.page.test.js
@@ -940,10 +940,27 @@ describe('Page', () => {
       expect(pageAB.parent).not.toBeNull();
     });
     test('should find parent while NOT creating unnecessary empty pages with some v5 public pages', async() => {
-      const _pageC = await Page.findOne({ path: '/get_parent_C', grant: Page.GRANT_PUBLIC, isEmpty: false, parent: { $ne: null } });
-      const _pageCD = await Page.findOne({ path: '/get_parent_C/get_parent_D', grant: Page.GRANT_PUBLIC, isEmpty: false });
-      const _emptyC = await Page.findOne({ path: '/get_parent_C', grant: Page.GRANT_PUBLIC, isEmpty: true });
-      const _emptyCD = await Page.findOne({ path: '/get_parent_C/get_parent_D', grant: Page.GRANT_PUBLIC, isEmpty: true });
+      const _pageC = await Page.findOne({
+        path: '/get_parent_C',
+        grant: Page.GRANT_PUBLIC,
+        isEmpty: false,
+        parent: { $ne: null },
+      });
+      const _pageCD = await Page.findOne({
+        path: '/get_parent_C/get_parent_D',
+        grant: Page.GRANT_PUBLIC,
+        isEmpty: false,
+      });
+      const _emptyC = await Page.findOne({
+        path: '/get_parent_C',
+        grant: Page.GRANT_PUBLIC,
+        isEmpty: true,
+      });
+      const _emptyCD = await Page.findOne({
+        path: '/get_parent_C/get_parent_D',
+        grant: Page.GRANT_PUBLIC,
+        isEmpty: true,
+      });
 
       expect(_pageC).not.toBeNull();
       expect(_pageCD).not.toBeNull();

--- a/packages/app/test/integration/models/v5.page.test.js
+++ b/packages/app/test/integration/models/v5.page.test.js
@@ -789,7 +789,7 @@ describe('Page', () => {
 
   });
 
-  describe.only('getParentAndFillAncestors', () => {
+  describe('getParentAndFillAncestors', () => {
     test('return parent if exist', async() => {
       const page1 = await Page.findOne({ path: '/PAF1' });
       const parent = await Page.getParentAndFillAncestors(page1.path, dummyUser1);
@@ -868,7 +868,7 @@ describe('Page', () => {
       expect(page2.parent).toStrictEqual(parent._id);
 
     });
-    test.only("should find parent while NOT creating unnecessary empty pages", async() => {
+    test("should find parent while NOT creating unnecessary empty pages", async() => {
       const _pageA = await Page.findOne({ path: '/get_parent_A', grant: Page.GRANT_PUBLIC, isEmpty: false });
       const _pageAB = await Page.findOne({ path: '/get_parent_A/get_parent_B', grant: Page.GRANT_PUBLIC, isEmpty: false });
       const _emptyA = await Page.findOne({ path: '/get_parent_A', grant: Page.GRANT_PUBLIC, isEmpty: true });

--- a/packages/app/test/integration/models/v5.page.test.js
+++ b/packages/app/test/integration/models/v5.page.test.js
@@ -477,11 +477,25 @@ describe('Page', () => {
         path: '/get_parent_A',
         creator: dummyUser1,
         lastUpdateUser: dummyUser1,
+        parent: null,
       },
       {
         path: '/get_parent_A/get_parent_B',
         creator: dummyUser1,
         lastUpdateUser: dummyUser1,
+        parent: null,
+      },
+      {
+        path: '/get_parent_C',
+        creator: dummyUser1,
+        lastUpdateUser: dummyUser1,
+        parent: rootPage._id,
+      },
+      {
+        path: '/get_parent_C/get_parent_D',
+        creator: dummyUser1,
+        lastUpdateUser: dummyUser1,
+        parent: null,
       },
     ]);
 
@@ -868,7 +882,7 @@ describe('Page', () => {
       expect(page2.parent).toStrictEqual(parent._id);
 
     });
-    test('should find parent while NOT creating unnecessary empty pages', async() => {
+    test('should find parent while NOT creating unnecessary empty pages with all v4 public pages', async() => {
       const _pageA = await Page.findOne({ path: '/get_parent_A', grant: Page.GRANT_PUBLIC, isEmpty: false });
       const _pageAB = await Page.findOne({ path: '/get_parent_A/get_parent_B', grant: Page.GRANT_PUBLIC, isEmpty: false });
       const _emptyA = await Page.findOne({ path: '/get_parent_A', grant: Page.GRANT_PUBLIC, isEmpty: true });
@@ -887,6 +901,7 @@ describe('Page', () => {
       const emptyAB = await Page.findOne({ path: '/get_parent_A/get_parent_B', grant: Page.GRANT_PUBLIC, isEmpty: true });
 
       // -- Check existance
+      expect(parent).not.toBeNull();
       expect(pageA).not.toBeNull();
       expect(pageAB).not.toBeNull();
       expect(emptyA).toBeNull();
@@ -895,6 +910,35 @@ describe('Page', () => {
       // -- Check parent
       expect(pageA.parent).not.toBeNull();
       expect(pageAB.parent).not.toBeNull();
+    });
+    test('should find parent while NOT creating unnecessary empty pages with some v5 public pages', async() => {
+      const _pageC = await Page.findOne({ path: '/get_parent_C', grant: Page.GRANT_PUBLIC, isEmpty: false, parent: { $ne: null } });
+      const _pageCD = await Page.findOne({ path: '/get_parent_C/get_parent_D', grant: Page.GRANT_PUBLIC, isEmpty: false });
+      const _emptyC = await Page.findOne({ path: '/get_parent_C', grant: Page.GRANT_PUBLIC, isEmpty: true });
+      const _emptyCD = await Page.findOne({ path: '/get_parent_C/get_parent_D', grant: Page.GRANT_PUBLIC, isEmpty: true });
+
+      expect(_pageC).not.toBeNull();
+      expect(_pageCD).not.toBeNull();
+      expect(_emptyC).toBeNull();
+      expect(_emptyCD).toBeNull();
+
+      const parent = await Page.getParentAndFillAncestors('/get_parent_C/get_parent_D/get_parent_E', dummyUser1);
+
+      const pageC = await Page.findOne({ path: '/get_parent_C', grant: Page.GRANT_PUBLIC, isEmpty: false });
+      const pageCD = await Page.findOne({ path: '/get_parent_C/get_parent_D', grant: Page.GRANT_PUBLIC, isEmpty: false });
+      const emptyC = await Page.findOne({ path: '/get_parent_C', grant: Page.GRANT_PUBLIC, isEmpty: true });
+      const emptyCD = await Page.findOne({ path: '/get_parent_C/get_parent_D', grant: Page.GRANT_PUBLIC, isEmpty: true });
+
+      // -- Check existance
+      expect(parent).not.toBeNull();
+      expect(pageC).not.toBeNull();
+      expect(pageCD).not.toBeNull();
+      expect(emptyC).toBeNull();
+      expect(emptyCD).toBeNull();
+
+      // -- Check parent
+      expect(pageC.parent).not.toBeNull();
+      expect(pageCD.parent).not.toBeNull();
     });
   });
 });

--- a/packages/app/test/integration/models/v5.page.test.js
+++ b/packages/app/test/integration/models/v5.page.test.js
@@ -53,13 +53,22 @@ describe('Page', () => {
     const pModelUserId3 = new mongoose.Types.ObjectId();
     await User.insertMany([
       {
-        _id: pModelUserId1, name: 'pmodelUser1', username: 'pmodelUser1', email: 'pmodelUser1@example.com',
+        _id: pModelUserId1,
+        name: 'pmodelUser1',
+        username: 'pmodelUser1',
+        email: 'pmodelUser1@example.com',
       },
       {
-        _id: pModelUserId2, name: 'pmodelUser2', username: 'pmodelUser2', email: 'pmodelUser2@example.com',
+        _id: pModelUserId2,
+        name: 'pmodelUser2',
+        username: 'pmodelUser2',
+        email: 'pmodelUser2@example.com',
       },
       {
-        _id: pModelUserId3, name: 'pModelUser3', username: 'pModelUser3', email: 'pModelUser3@example.com',
+        _id: pModelUserId3,
+        name: 'pModelUser3',
+        username: 'pModelUser3',
+        email: 'pModelUser3@example.com',
       },
     ]);
     pModelUser1 = await User.findOne({ _id: pModelUserId1 });

--- a/packages/app/test/integration/models/v5.page.test.js
+++ b/packages/app/test/integration/models/v5.page.test.js
@@ -884,8 +884,8 @@ describe('Page', () => {
     });
     test('should find parent while NOT creating unnecessary empty pages with all v4 public pages', async() => {
       // All pages does not have parent (v4 schema)
-      const _pageA = await Page.findOne({ path: '/get_parent_A', grant: Page.GRANT_PUBLIC, isEmpty: false });
-      const _pageAB = await Page.findOne({ path: '/get_parent_A/get_parent_B', grant: Page.GRANT_PUBLIC, isEmpty: false });
+      const _pageA = await Page.findOne({ path: '/get_parent_A', grant: Page.GRANT_PUBLIC, isEmpty: false, parent: null });
+      const _pageAB = await Page.findOne({ path: '/get_parent_A/get_parent_B', grant: Page.GRANT_PUBLIC, isEmpty: false, parent: null });
       const _emptyA = await Page.findOne({ path: '/get_parent_A', grant: Page.GRANT_PUBLIC, isEmpty: true });
       const _emptyAB = await Page.findOne({ path: '/get_parent_A/get_parent_B', grant: Page.GRANT_PUBLIC, isEmpty: true });
 


### PR DESCRIPTION
Redmine: https://redmine.weseek.co.jp/issues/93977, https://redmine.weseek.co.jp/issues/93978

getParentAndFillAncestors が不必要な空ページを生成しないことを確かめるテストコードを追記しました
ci は test のみ無視でお願いします