### PR TITLE
fix: Not create unnecessary empty pages when ancestors are public

### DIFF
--- a/packages/app/src/server/models/page.ts
+++ b/packages/app/src/server/models/page.ts
@@ -495,6 +495,7 @@ schema.statics.createEmptyPagesByPaths = async function(paths: string[], user: a
     aggregationPipeline.push({
       $match: {
         $or: [
+          { grant: GRANT_PUBLIC },
           { parent: { $ne: null } },
           { path: '/' },
         ],


### PR DESCRIPTION
Redmine: https://redmine.weseek.co.jp/issues/93978

祖先の位置に v4 のパブリックページが存在する際に不必要な空ページが生成されるバグを修正しました