### PR TITLE
fix: Activity is not generated when a page is created

### DIFF
--- a/packages/app/src/server/routes/apiv3/pages.js
+++ b/packages/app/src/server/routes/apiv3/pages.js
@@ -350,9 +350,9 @@ module.exports = (crowi) => {
         user: req.user._id,
         targetModel: SUPPORTED_TARGET_MODEL_TYPE.MODEL_PAGE,
         target: createdPage,
-        action: SUPPORTED_ACTION_TYPE.PAGE_CREATE,
+        action: SUPPORTED_ACTION_TYPE.ACTION_PAGE_CREATE,
       };
-      await crowi.activityService.createByParameter(parameters);
+      await crowi.activityService.createByParameters(parameters);
     }
     catch (err) {
       logger.error('Failed to create activity', err);


### PR DESCRIPTION
## Task

[#93769](https://redmine.weseek.co.jp/issues/93769) [GROWI] [AuditLog] ページを create した時に activity を作成できる
└ [#94211](https://redmine.weseek.co.jp/issues/94211) page を create した時に activity が作成されないバグ修正