### PR TITLE
feat: 94310 page path auto complete function for page rename modal

### DIFF
--- a/packages/app/src/components/PageCreateModal.jsx
+++ b/packages/app/src/components/PageCreateModal.jsx
@@ -82,14 +82,6 @@ const PageCreateModal = (props) => {
   }
 
   /**
-   * change pageNameInput
-   * @param {string} value
-   */
-  function inputChangeHandler(value) {
-    setPageNameInput(value);
-  }
-
-  /**
    * change template
    * @param {string} value
    */
@@ -206,7 +198,7 @@ const PageCreateModal = (props) => {
                     initializedPath={pageNameInput}
                     addTrailingSlash
                     onSubmit={ppacSubmitHandler}
-                    onInputChange={inputChangeHandler}
+                    onInputChange={value => setPageNameInput(value)}
                     autoFocus
                   />
                 )
@@ -217,7 +209,7 @@ const PageCreateModal = (props) => {
                       value={pageNameInput}
                       className="form-control flex-fill"
                       placeholder={t('Input page name')}
-                      onChange={e => inputChangeHandler(e.target.value)}
+                      onChange={e => setPageNameInput(e.target.value)}
                       required
                     />
                   </form>

--- a/packages/app/src/components/PageCreateModal.jsx
+++ b/packages/app/src/components/PageCreateModal.jsx
@@ -1,24 +1,22 @@
 import React, {
   useEffect, useState, useMemo, useCallback,
 } from 'react';
-import PropTypes from 'prop-types';
 
+import { pagePathUtils, pathUtils } from '@growi/core';
+import { format } from 'date-fns';
+import PropTypes from 'prop-types';
+import { withTranslation } from 'react-i18next';
 import { Modal, ModalHeader, ModalBody } from 'reactstrap';
 import { debounce } from 'throttle-debounce';
 
-import { withTranslation } from 'react-i18next';
-import { format } from 'date-fns';
-
-import { pagePathUtils, pathUtils } from '@growi/core';
-
 
 import AppContainer from '~/client/services/AppContainer';
-import { withUnstatedContainers } from './UnstatedUtils';
 import { toastError } from '~/client/util/apiNotification';
-
 import { usePageCreateModal } from '~/stores/modal';
 
 import PagePathAutoComplete from './PagePathAutoComplete';
+import { withUnstatedContainers } from './UnstatedUtils';
+
 
 const {
   userPageRoot, isCreatablePage, generateEditorPath, isUsersHomePage,
@@ -87,7 +85,7 @@ const PageCreateModal = (props) => {
    * change pageNameInput
    * @param {string} value
    */
-  function onChangePageNameInputHandler(value) {
+  function inputChangeHandler(value) {
     setPageNameInput(value);
   }
 
@@ -129,10 +127,6 @@ const PageCreateModal = (props) => {
    */
   function createInputPage() {
     redirectToEditor(pageNameInput);
-  }
-
-  function ppacInputChangeHandler(value) {
-    setPageNameInput(value);
   }
 
   function ppacSubmitHandler(input) {
@@ -212,7 +206,7 @@ const PageCreateModal = (props) => {
                     initializedPath={pageNameInput}
                     addTrailingSlash
                     onSubmit={ppacSubmitHandler}
-                    onInputChange={ppacInputChangeHandler}
+                    onInputChange={inputChangeHandler}
                     autoFocus
                   />
                 )
@@ -223,7 +217,7 @@ const PageCreateModal = (props) => {
                       value={pageNameInput}
                       className="form-control flex-fill"
                       placeholder={t('Input page name')}
-                      onChange={e => onChangePageNameInputHandler(e.target.value)}
+                      onChange={e => inputChangeHandler(e.target.value)}
                       required
                     />
                   </form>

--- a/packages/app/src/components/PageDuplicateModal.tsx
+++ b/packages/app/src/components/PageDuplicateModal.tsx
@@ -2,22 +2,20 @@ import React, {
   useState, useEffect, useCallback, useMemo,
 } from 'react';
 
+import { useTranslation } from 'react-i18next';
 import {
   Modal, ModalHeader, ModalBody, ModalFooter,
 } from 'reactstrap';
-
-import { useTranslation } from 'react-i18next';
 import { debounce } from 'throttle-debounce';
 
-import { apiv3Get, apiv3Post } from '~/client/util/apiv3-client';
 import { toastError } from '~/client/util/apiNotification';
-
-import { usePageDuplicateModal } from '~/stores/modal';
+import { apiv3Get, apiv3Post } from '~/client/util/apiv3-client';
 import { useIsSearchServiceReachable, useSiteUrl } from '~/stores/context';
+import { usePageDuplicateModal } from '~/stores/modal';
 
-import PagePathAutoComplete from './PagePathAutoComplete';
-import ApiErrorMessageList from './PageManagement/ApiErrorMessageList';
 import DuplicatePathsTable from './DuplicatedPathsTable';
+import ApiErrorMessageList from './PageManagement/ApiErrorMessageList';
+import PagePathAutoComplete from './PagePathAutoComplete';
 
 
 const PageDuplicateModal = (): JSX.Element => {
@@ -81,15 +79,6 @@ const PageDuplicateModal = (): JSX.Element => {
       checkExistPathsDebounce(page.path, pageNameInput);
     }
   }, [pageNameInput, subordinatedPages, checkExistPathsDebounce, page]);
-
-  /**
-   * change pageNameInput for PagePathAutoComplete
-   * @param {string} value
-   */
-  function ppacInputChangeHandler(value) {
-    setErrs(null);
-    setPageNameInput(value);
-  }
 
   /**
    * change pageNameInput
@@ -183,7 +172,7 @@ const PageDuplicateModal = (): JSX.Element => {
                   <PagePathAutoComplete
                     initializedPath={path}
                     onSubmit={duplicate}
-                    onInputChange={ppacInputChangeHandler}
+                    onInputChange={inputChangeHandler}
                     autoFocus
                   />
                 )

--- a/packages/app/src/components/PageDuplicateModal.tsx
+++ b/packages/app/src/components/PageDuplicateModal.tsx
@@ -81,6 +81,15 @@ const PageDuplicateModal = (): JSX.Element => {
   }, [pageNameInput, subordinatedPages, checkExistPathsDebounce, page]);
 
   /**
+   * change pageNameInput for PagePathAutoComplete
+   * @param {string} value
+   */
+  function ppacInputChangeHandler(value) {
+    setErrs(null);
+    setPageNameInput(value);
+  }
+
+  /**
    * change pageNameInput
    * @param {string} value
    */
@@ -172,7 +181,7 @@ const PageDuplicateModal = (): JSX.Element => {
                   <PagePathAutoComplete
                     initializedPath={path}
                     onSubmit={duplicate}
-                    onInputChange={inputChangeHandler}
+                    onInputChange={ppacInputChangeHandler}
                     autoFocus
                   />
                 )

--- a/packages/app/src/components/PageRenameModal.tsx
+++ b/packages/app/src/components/PageRenameModal.tsx
@@ -155,6 +155,11 @@ const PageRenameModal = (): JSX.Element => {
   }, [pageNameInput, subordinatedPages, checkExistPathsDebounce, page, checkIsUsersHomePageDebounce]);
 
 
+  function ppacInputChangeHandler(value) {
+    setErrs(null);
+    setPageNameInput(value);
+  }
+
   /**
    * change pageNameInput
    * @param {string} value
@@ -225,7 +230,7 @@ const PageRenameModal = (): JSX.Element => {
                   <PagePathAutoComplete
                     initializedPath={path}
                     onSubmit={rename}
-                    onInputChange={inputChangeHandler}
+                    onInputChange={ppacInputChangeHandler}
                     autoFocus
                   />
                 )

--- a/packages/app/src/components/PageRenameModal.tsx
+++ b/packages/app/src/components/PageRenameModal.tsx
@@ -2,24 +2,24 @@ import React, {
   useState, useEffect, useCallback, useMemo,
 } from 'react';
 
+
+import { pagePathUtils } from '@growi/core';
+import { useTranslation } from 'react-i18next';
 import {
   Collapse, Modal, ModalHeader, ModalBody, ModalFooter,
 } from 'reactstrap';
-
-import { useTranslation } from 'react-i18next';
-
 import { debounce } from 'throttle-debounce';
-import { pagePathUtils } from '@growi/core';
-import { usePageRenameModal } from '~/stores/modal';
+
 import { toastError } from '~/client/util/apiNotification';
-
 import { apiv3Get, apiv3Put } from '~/client/util/apiv3-client';
-
-import ApiErrorMessageList from './PageManagement/ApiErrorMessageList';
-import DuplicatedPathsTable from './DuplicatedPathsTable';
-import { useSiteUrl } from '~/stores/context';
 import { isIPageInfoForEntity } from '~/interfaces/page';
+import { useSiteUrl, useIsSearchServiceReachable } from '~/stores/context';
+import { usePageRenameModal } from '~/stores/modal';
 import { useSWRxPageInfo } from '~/stores/page';
+
+import DuplicatedPathsTable from './DuplicatedPathsTable';
+import ApiErrorMessageList from './PageManagement/ApiErrorMessageList';
+import PagePathAutoComplete from './PagePathAutoComplete';
 
 
 const isV5Compatible = (meta: unknown): boolean => {
@@ -33,6 +33,7 @@ const PageRenameModal = (): JSX.Element => {
   const { isUsersHomePage } = pagePathUtils;
   const { data: siteUrl } = useSiteUrl();
   const { data: renameModalData, close: closeRenameModal } = usePageRenameModal();
+  const { data: isReachable } = useIsSearchServiceReachable();
 
   const isOpened = renameModalData?.isOpened ?? false;
   const page = renameModalData?.page;
@@ -219,14 +220,25 @@ const PageRenameModal = (): JSX.Element => {
               <span className="input-group-text">{siteUrl}</span>
             </div>
             <form className="flex-fill" onSubmit={(e) => { e.preventDefault(); rename() }}>
-              <input
-                type="text"
-                value={pageNameInput}
-                className="form-control"
-                onChange={e => inputChangeHandler(e.target.value)}
-                required
-                autoFocus
-              />
+              {isReachable
+                ? (
+                  <PagePathAutoComplete
+                    initializedPath={path}
+                    onSubmit={rename}
+                    onInputChange={inputChangeHandler}
+                    autoFocus
+                  />
+                )
+                : (
+                  <input
+                    type="text"
+                    value={pageNameInput}
+                    className="form-control"
+                    onChange={e => inputChangeHandler(e.target.value)}
+                    required
+                    autoFocus
+                  />
+                )}
             </form>
           </div>
         </div>


### PR DESCRIPTION
## Task
[94310](https://redmine.weseek.co.jp/issues/94310) 検索結果のページリスト上でのリネーム時にページのサジェストが表示されるようにする

## Description
- PageRenameModalにpagePathAutoComplete 機能を追加しました。
 
<img width="687" alt="Screen Shot 2022-05-06 at 12 16 21" src="https://user-images.githubusercontent.com/59536731/167061177-23ba5c74-e4a0-41b9-b0d6-9b41a2fd3688.png">


## ScreenRecording

https://user-images.githubusercontent.com/59536731/167061017-afadcfd9-e101-4e64-ab7b-0f404d6aae9d.mov



