### PR TITLE
fix: Trim space when copying password to a clipboard

### DIFF
--- a/packages/app/src/components/Admin/Users/UserInviteModal.jsx
+++ b/packages/app/src/components/Admin/Users/UserInviteModal.jsx
@@ -171,7 +171,7 @@ class UserInviteModal extends React.Component {
     return (
       <ul>
         {userList.map((user) => {
-          const copyText = `Email:${user.email} Password:${user.password} `;
+          const copyText = `Email:${user.email} Password:${user.password}`;
           return (
             <div className="my-1" key={user.email}>
               <CopyToClipboard text={copyText} onCopy={this.showToaster}>


### PR DESCRIPTION
タスクなし

クリップボードにパスワードをコピーする際の余計な余白を取り除きました