### PR TITLE
feat/94400 error handling

### DIFF
--- a/packages/app/resource/locales/en_US/translation.json
+++ b/packages/app/resource/locales/en_US/translation.json
@@ -445,7 +445,7 @@
   "modal_empty":{
     "empty_the_trash": "Empty The Trash",
     "empty_the_trash_button": "Empty The Trash",
-    "not_deletable_notice": "Some pages cannot be removed due to lack of rights.",
+    "not_deletable_notice": "Some pages cannot be removed due to lack of permission.",
     "notice": "The pages deleted completely are unrecoverable."
   },
   "modal_duplicate": {

--- a/packages/app/resource/locales/en_US/translation.json
+++ b/packages/app/resource/locales/en_US/translation.json
@@ -445,6 +445,7 @@
   "modal_empty":{
     "empty_the_trash": "Empty The Trash",
     "empty_the_trash_button": "Empty The Trash",
+    "not_deletable_notice": "Some pages cannot be removed due to lack of rights.",
     "notice": "The pages deleted completely are unrecoverable."
   },
   "modal_duplicate": {

--- a/packages/app/resource/locales/ja_JP/translation.json
+++ b/packages/app/resource/locales/ja_JP/translation.json
@@ -444,6 +444,7 @@
   "modal_empty":{
     "empty_the_trash": "ゴミ箱を空にする",
     "empty_the_trash_button": "空にする",
+    "not_deletable_notice": "権利がないため、いくつかのページは削除できません",
     "notice": "完全削除したページは元に戻すことができません"
   },
   "modal_duplicate": {

--- a/packages/app/resource/locales/ja_JP/translation.json
+++ b/packages/app/resource/locales/ja_JP/translation.json
@@ -444,7 +444,7 @@
   "modal_empty":{
     "empty_the_trash": "ゴミ箱を空にする",
     "empty_the_trash_button": "空にする",
-    "not_deletable_notice": "権利がないため、いくつかのページは削除できません",
+    "not_deletable_notice": "権限がないため、いくつかのページは削除できません",
     "notice": "完全削除したページは元に戻すことができません"
   },
   "modal_duplicate": {

--- a/packages/app/resource/locales/zh_CN/translation.json
+++ b/packages/app/resource/locales/zh_CN/translation.json
@@ -423,6 +423,7 @@
 	"modal_empty": {
 		"empty_the_trash": "清空垃圾",
     "empty_the_trash_button": "清空垃圾",
+    "not_deletable_notice": "由于缺乏权限，一些页面不能被删除",
 		"notice": "完全删除的页面是不可恢复的。"
 	},
 	"modal_duplicate": {

--- a/packages/app/src/components/EmptyTrashButton.tsx
+++ b/packages/app/src/components/EmptyTrashButton.tsx
@@ -31,6 +31,8 @@ const EmptyTrashButton = () => {
     pageWithMetas = injectTo(dataWithMetas);
   }
 
+  const deletablePages = pageWithMetas.filter(page => page.meta?.isAbleToDeleteCompletely);
+
   const onEmptiedTrashHandler = useCallback(() => {
     toastSuccess(t('empty_trash'));
 
@@ -38,7 +40,8 @@ const EmptyTrashButton = () => {
   }, [t, mutate]);
 
   const emptyTrashClickHandler = () => {
-    openEmptyTrashModal(pageWithMetas, { onEmptiedTrash: onEmptiedTrashHandler });
+    if (deletablePages.length === 0) { return }
+    openEmptyTrashModal(deletablePages, { onEmptiedTrash: onEmptiedTrashHandler, canDelepeAllPages: pagingResult?.totalCount === deletablePages.length });
   };
 
   return (

--- a/packages/app/src/components/EmptyTrashModal.tsx
+++ b/packages/app/src/components/EmptyTrashModal.tsx
@@ -19,6 +19,8 @@ const EmptyTrashModal: FC = () => {
 
   const isOpened = emptyTrashModalData?.isOpened ?? false;
 
+  const canDeleteAllpages = emptyTrashModalData?.opts?.canDelepeAllPages ?? false;
+
   const [errs, setErrs] = useState<Error[] | null>(null);
 
   async function emptyTrash() {
@@ -68,6 +70,7 @@ const EmptyTrashModal: FC = () => {
           {/* Todo: change the way to show path on modal when too many pages are selected */}
           {renderPagePaths()}
         </div>
+        {!canDeleteAllpages && t('modal_empty.not_deletable_notice')}<br />
         {t('modal_empty.notice')}
       </ModalBody>
       <ModalFooter>

--- a/packages/app/src/server/routes/apiv3/pages.js
+++ b/packages/app/src/server/routes/apiv3/pages.js
@@ -560,7 +560,8 @@ module.exports = (crowi) => {
     // when some pages are not deletable
     if (deletablePages.length < pagesInTrash.length) {
       try {
-        await crowi.pageService.deleteMultipleCompletely(deletablePages, req.user);
+        const options = { isCompletely: true, isRecursively: true };
+        await crowi.pageService.deleteMultiplePages(deletablePages, req.user, options);
         return res.apiv3({ deletablePages });
       }
       catch (err) {

--- a/packages/app/src/stores/modal.tsx
+++ b/packages/app/src/stores/modal.tsx
@@ -78,6 +78,7 @@ export const usePageDeleteModal = (status?: DeleteModalStatus): SWRResponse<Dele
 */
 type IEmptyTrashModalOption = {
   onEmptiedTrash?: () => void,
+  canDelepeAllPages: boolean,
 }
 
 type EmptyTrashModalStatus = {


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/94400

<img width="1039" alt="スクリーンショット 2022-05-10 130444" src="https://user-images.githubusercontent.com/65263895/167540486-7d5761e8-343b-45de-b226-4768e1370cf2.png">


- ゴミ箱を空にするモーダルに削除できるパスのみを表示するように仕様変更
- 空にするボタンを押したときに削除可能なページのみを削除し、それ以外はゴミ箱に残す仕様に変更