### PR TITLE
fix: Guest user cannot access share link pages

### DIFF
--- a/packages/app/src/components/User/SeenUserInfo.tsx
+++ b/packages/app/src/components/User/SeenUserInfo.tsx
@@ -4,6 +4,7 @@ import { Button, Popover, PopoverBody } from 'reactstrap';
 
 import UserPictureList from './UserPictureList';
 import FootstampIcon from '../FootstampIcon';
+import { useShareLinkId } from '~/stores/context';
 import { useSWRxPageInfo } from '~/stores/page';
 import { useSWRxUsersList } from '~/stores/user';
 
@@ -17,10 +18,11 @@ const SeenUserInfo: FC<Props> = (props: Props) => {
 
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
 
-  const { data: pageInfo } = useSWRxPageInfo(pageId);
+  const { data: shareLinkId } = useShareLinkId();
+  const { data: pageInfo } = useSWRxPageInfo(pageId, shareLinkId);
   const likerIds = pageInfo?.likerIds != null ? pageInfo.likerIds.slice(0, 15) : [];
   const seenUserIds = pageInfo?.seenUserIds != null ? pageInfo.seenUserIds.slice(0, 15) : [];
-  const sumOfSeenUserIds = pageInfo?.seenUserIds.length || 0;
+  const sumOfSeenUsers = pageInfo?.seenUserIds != null ? pageInfo.seenUserIds.length : 0;
 
   // Put in a mixture of seenUserIds and likerIds data to make the cache work
   const { data: usersList } = useSWRxUsersList([...likerIds, ...seenUserIds]);
@@ -34,7 +36,7 @@ const SeenUserInfo: FC<Props> = (props: Props) => {
         <span className="mr-1 footstamp-icon">
           <FootstampIcon />
         </span>
-        <span className="seen-user-count">{sumOfSeenUserIds}</span>
+        <span className="seen-user-count">{sumOfSeenUsers}</span>
       </Button>
       <Popover placement="bottom" isOpen={isPopoverOpen} target="po-seen-user" toggle={togglePopover} trigger="legacy" disabled={disabled}>
         <PopoverBody className="seen-user-popover">

--- a/packages/app/src/server/routes/apiv3/page.js
+++ b/packages/app/src/server/routes/apiv3/page.js
@@ -165,6 +165,7 @@ module.exports = (crowi) => {
   const loginRequired = require('../../middlewares/login-required')(crowi, true);
   const loginRequiredStrictly = require('../../middlewares/login-required')(crowi);
   const csrf = require('../../middlewares/csrf')(crowi);
+  const certifySharedPage = require('../../middlewares/certify-shared-page')(crowi);
   const apiV3FormValidator = require('../../middlewares/apiv3-form-validator')(crowi);
 
   const globalNotificationService = crowi.getGlobalNotificationService();
@@ -361,7 +362,7 @@ module.exports = (crowi) => {
    *          500:
    *            description: Internal server error.
    */
-  router.get('/info', loginRequired, validator.info, apiV3FormValidator, async(req, res) => {
+  router.get('/info', certifySharedPage, loginRequired, validator.info, apiV3FormValidator, async(req, res) => {
     const { pageId } = req.query;
 
     try {

--- a/packages/app/src/stores/page.tsx
+++ b/packages/app/src/stores/page.tsx
@@ -1,4 +1,5 @@
 import useSWR, { SWRResponse } from 'swr';
+import useSWRImmutable from 'swr/immutable';
 
 import { apiv3Get } from '~/client/util/apiv3-client';
 import { HasObjectId } from '~/interfaces/has-object-id';
@@ -63,9 +64,16 @@ export const useSWRxSubscriptionStatus = <Data, Error>(pageId: string): SWRRespo
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export const useSWRxPageInfo = <Data, Error>(pageId: string): SWRResponse<IPageInfo, Error> => {
-  return useSWR(
-    ['/page/info', pageId],
-    (endpoint, pageId) => apiv3Get(endpoint, { pageId }).then(response => response.data),
+export const useSWRxPageInfo = (
+    pageId: string | null | undefined,
+    shareLinkId?: string | null,
+): SWRResponse<IPageInfo, Error> => {
+
+  // assign null if shareLinkId is undefined in order to identify SWR key only by pageId
+  const fixedShareLinkId = shareLinkId ?? null;
+
+  return useSWRImmutable(
+    pageId != null ? ['/page/info', pageId, fixedShareLinkId] : null,
+    (endpoint, pageId, shareLinkId) => apiv3Get(endpoint, { pageId, shareLinkId }).then(response => response.data),
   );
 };


### PR DESCRIPTION
### [94545](https://redmine.weseek.co.jp/issues/94545) [GROWI][Bug][4.0.xでのみ再現] 非ログインユーザーがShareLinkにアクセスできない
┗ [94566](https://redmine.weseek.co.jp/issues/94566) 修正

close #5815


## ScreenShots
### Before
<img width="1128" alt="Screen Shot 2022-05-11 at 18 13 24" src="https://user-images.githubusercontent.com/59536731/167814426-c37844ce-f8ca-4009-bb30-ff012b1aa696.png">


```
SeenUserInfo.tsx?9e58:23 Uncaught TypeError: Cannot read properties of undefined (reading 'length')
    at SeenUserInfo (SeenUserInfo.tsx?9e58:23:1)
    at renderWithHooks (VM42678 react-dom.development.js:14803:18)
    at updateFunctionComponent (VM42678 react-dom.development.js:17034:20)
    at beginWork (VM42678 react-dom.development.js:18610:16)
    at HTMLUnknownElement.callCallback (VM42678 react-dom.development.js:188:14)
    at Object.invokeGuardedCallbackDev (VM42678 react-dom.development.js:237:16)
    at invokeGuardedCallback (VM42678 react-dom.development.js:292:31)
    at beginWork$1 (VM42678 react-dom.development.js:23203:7)
    at performUnitOfWork (VM42678 react-dom.development.js:22157:12)
    at workLoopSync (VM42678 react-dom.development.js:22130:22)
```

### After
<img width="1128" alt="Screen Shot 2022-05-11 at 18 12 08" src="https://user-images.githubusercontent.com/59536731/167814450-c5c262be-d260-4666-a963-3b8a56d8916d.png">


