### PR TITLE
feat: 94476 Show Activity Counter

### DIFF
--- a/packages/app/src/components/Admin/AuditLogManagement.tsx
+++ b/packages/app/src/components/Admin/AuditLogManagement.tsx
@@ -56,10 +56,12 @@ export const AuditLogManagement: FC = () => {
     setActionMap(new Map(actionMap.entries()));
   }, [actionMap, setActionMap]);
 
+  // eslint-disable-next-line max-len
+  const activityCounter = `<b>${activityList.length === 0 ? 0 : offset + 1}</b> - <b>${(PAGING_LIMIT * activePage) - (PAGING_LIMIT - activityList.length)}</b> of <b>${totalActivityNum}<b/>`;
+
   return (
     <div data-testid="admin-auditlog">
-      <h2>{t('AuditLog')}</h2>
-
+      <h2 className="admin-setting-header mb-3">{t('AuditLog')}</h2>
       <SelectActionDropdown
         dropdownItems={[
           { actionCategory: 'Page', actionNames: PageActions },
@@ -78,6 +80,11 @@ export const AuditLogManagement: FC = () => {
         )
         : (
           <>
+            <p
+              className="ml-2"
+              // eslint-disable-next-line react/no-danger
+              dangerouslySetInnerHTML={{ __html: activityCounter }}
+            />
             <ActivityTable activityList={activityList} />
             <PaginationWrapper
               activePage={activePage}


### PR DESCRIPTION
## Task
[#93429](https://redmine.weseek.co.jp/issues/93429) [GROWI] [AuditLog] 管理画面に AuditLog の view を追加して、Activity をテーブルに一覧表示できる
└ [#94476](https://redmine.weseek.co.jp/issues/94476) [Front] 現在のページ数、表示している activity 数、全ての activity 数を表示できる

## Screenshot
<img width="374" alt="ScreenShot 2022-05-11 18 41 56" src="https://user-images.githubusercontent.com/34241526/167820065-8b2c379b-f982-45c9-b471-b01ed4c693e3.png">

