### PR TITLE
fix: Emoji picker modal scrolling up when opened

### DIFF
--- a/packages/app/src/components/PageEditor/EmojiPickerHelper.ts
+++ b/packages/app/src/components/PageEditor/EmojiPickerHelper.ts
@@ -18,8 +18,6 @@ setStyle = ():CSSProperties => {
   const emojiPickerHeight = 420;
   const cursorPos = this.editor.cursorCoords(true);
   const editorPos = this.editor.getWrapperElement().getBoundingClientRect();
-  // Prevent body scrolls up when modal opened
-  document.body.style.position = 'static';
   // Emoji Picker bottom position exceed editor's bottom position
   if (cursorPos.bottom + emojiPickerHeight > editorPos.bottom) {
     return {

--- a/packages/app/src/components/PageEditor/EmojiPickerHelper.ts
+++ b/packages/app/src/components/PageEditor/EmojiPickerHelper.ts
@@ -18,6 +18,8 @@ setStyle = ():CSSProperties => {
   const emojiPickerHeight = 420;
   const cursorPos = this.editor.cursorCoords(true);
   const editorPos = this.editor.getWrapperElement().getBoundingClientRect();
+  // Prevent body scrolls up when modal opened
+  document.body.style.position = 'static';
   // Emoji Picker bottom position exceed editor's bottom position
   if (cursorPos.bottom + emojiPickerHeight > editorPos.bottom) {
     return {

--- a/packages/app/src/styles/_override-bootstrap.scss
+++ b/packages/app/src/styles/_override-bootstrap.scss
@@ -115,7 +115,6 @@
 
   //Modals
   .modal-open {
-    position: fixed;
     width: 100%;
     padding-right: 0 !important;
   }


### PR DESCRIPTION
 **[bug] Emoji picker modal scrolling up when opened** 

## ScreenShot
### Before
Body scrolls up when emoji picker modal opened from comment editor

https://user-images.githubusercontent.com/92426728/167987119-344096e7-fa88-44a7-99bc-f9b02743e6fd.mp4


![image](https://user-images.githubusercontent.com/92426728/167986319-e794f6d5-b03d-440f-ac17-bb4a517aec16.png)

### After
Emoji picker position relative to comment editor

https://user-images.githubusercontent.com/92426728/167987557-8e286e89-ecf6-4c01-a3b0-53e77d6e5248.mp4


![image](https://user-images.githubusercontent.com/92426728/167986945-0c505af6-4f48-4cc1-b088-e2169b6d7f73.png)

https://youtrack.weseek.co.jp/issue/GW-7804
- Set body style position to static on modal opened