### PR TITLE
fix: Change the execution user of the official docker image to root

### DIFF
--- a/packages/app/docker/Dockerfile
+++ b/packages/app/docker/Dockerfile
@@ -159,6 +159,7 @@ RUN rm node_modules.tar packages.tar
 
 COPY --chown=node:node --chmod=700 packages/app/docker/docker-entrypoint.sh /
 
+USER root
 WORKDIR ${appDir}/packages/app
 
 VOLUME /data


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/94637