### PR TITLE
fix: Can not toggle textlint function on v5.0.x

### DIFF
--- a/packages/app/src/components/PageEditor/OptionsSelector.jsx
+++ b/packages/app/src/components/PageEditor/OptionsSelector.jsx
@@ -1,16 +1,17 @@
 import React from 'react';
+
 import PropTypes from 'prop-types';
-
 import { withTranslation } from 'react-i18next';
-
 import {
   Dropdown, DropdownToggle, DropdownMenu, DropdownItem,
 } from 'reactstrap';
 
-import { withUnstatedContainers } from '../UnstatedUtils';
 import AppContainer from '~/client/services/AppContainer';
 import EditorContainer from '~/client/services/EditorContainer';
 import { toastError } from '~/client/util/apiNotification';
+
+import { withUnstatedContainers } from '../UnstatedUtils';
+
 import { DownloadDictModal } from './DownloadDictModal';
 
 
@@ -146,9 +147,7 @@ class OptionsSelector extends React.Component {
     const { editorContainer } = this.props;
     const newVal = !editorContainer.state.isTextlintEnabled;
     editorContainer.setState({ isTextlintEnabled: newVal });
-    if (this.state.isSkipAskingAgainChecked) {
-      this.updateIsTextlintEnabledToDB(newVal);
-    }
+    this.updateIsTextlintEnabledToDB(newVal);
   }
 
   switchTextlintEnabledHandler() {


### PR DESCRIPTION
## Task
[GROWI][Issue][Bug] Editor画面でtextlintをoff にして別ページに遷移した後に再度Editor画面を開くと textlint設定がONになってしまう
┗ [95047 修正(5.0.x)](https://redmine.weseek.co.jp/issues/95047)

## ScreenRecording
textlint をoff にしてページ更新 -> 再度編集画面に戻ると、textlintがoffになっている
textlint をon にしてページ更新 -> 再度編集画面に戻ると、textlintがonになっている

https://user-images.githubusercontent.com/59536731/168740165-920d926a-fbfd-4f97-868b-df4eee55ff61.mov



close #5407