### PR TITLE
fix: Can not toggle textlint function on v4.5.x

### DIFF
--- a/packages/app/src/components/PageEditor/OptionsSelector.jsx
+++ b/packages/app/src/components/PageEditor/OptionsSelector.jsx
@@ -146,9 +146,7 @@ class OptionsSelector extends React.Component {
     const { editorContainer } = this.props;
     const newVal = !editorContainer.state.isTextlintEnabled;
     editorContainer.setState({ isTextlintEnabled: newVal });
-    if (this.state.isSkipAskingAgainChecked) {
-      this.updateIsTextlintEnabledToDB(newVal);
-    }
+    this.updateIsTextlintEnabledToDB(newVal);
   }
 
   switchTextlintEnabledHandler() {


### PR DESCRIPTION
## Task
[GROWI][Issue][Bug] Editor画面でtextlintをoff にして別ページに遷移した後に再度Editor画面を開くと textlint設定がONになってしまう
┗ [95047 修正(4.5.x)](https://redmine.weseek.co.jp/issues/95266)

## Description
v5での修正をv4にも反映

close #5407