### PR TITLE
imprv: Remove user population

### DIFF
--- a/packages/app/src/server/models/activity.ts
+++ b/packages/app/src/server/models/activity.ts
@@ -111,7 +111,6 @@ activitySchema.statics.getPaginatedActivity = async function(limit: number, offs
       limit,
       offset,
       sort: { createdAt: -1 },
-      populate: 'user',
     },
   );
   return paginateResult;

--- a/packages/app/src/server/routes/apiv3/activity.ts
+++ b/packages/app/src/server/routes/apiv3/activity.ts
@@ -84,21 +84,7 @@ module.exports = (crowi: Crowi): Router => {
 
     try {
       const paginationResult = await Activity.getPaginatedActivity(limit, offset, query);
-
-      const User = crowi.model('User');
-      const serializedDocs = paginationResult.docs.map((doc: IActivity) => {
-        if (doc.user != null && doc.user instanceof User) {
-          doc.user = serializeUserSecurely(doc.user);
-        }
-        return doc;
-      });
-
-      const serializedPaginationResult = {
-        ...paginationResult,
-        docs: serializedDocs,
-      };
-
-      return res.apiv3({ serializedPaginationResult });
+      return res.apiv3({ paginationResult });
     }
     catch (err) {
       logger.error('Failed to get paginated activity', err);

--- a/packages/app/src/stores/activity.ts
+++ b/packages/app/src/stores/activity.ts
@@ -16,6 +16,6 @@ export const useSWRxActivityList = (limit?: number, offset?: number, searchFilte
   return useSWRImmutable(
     ['/activity', limit, offset, stringifiedSearchFilter],
     (endpoint, limit, offset, stringifiedSearchFilter) => apiv3Get(endpoint, { limit, offset, searchFilter: stringifiedSearchFilter })
-      .then(result => result.data.serializedPaginationResult),
+      .then(result => result.data.paginationResult),
   );
 };


### PR DESCRIPTION
## Task
[#93429](https://redmine.weseek.co.jp/issues/93429) [GROWI] [AuditLog] 管理画面に AuditLog の view を追加して、Activity をテーブルに一覧表示できる
└ [#95203](https://redmine.weseek.co.jp/issues/95203) [backend] /activity で行っている User ドキュメントの populate 処理を消す