### PR TITLE
feat: Add more conditions to canOperate in PageOperation service and apply the condition to sub operation

### DIFF
--- a/packages/app/src/server/models/page-operation.ts
+++ b/packages/app/src/server/models/page-operation.ts
@@ -1,11 +1,12 @@
+import { getOrCreateModel } from '@growi/core';
 import mongoose, {
   Schema, Model, Document, QueryOptions, FilterQuery,
 } from 'mongoose';
-import { getOrCreateModel } from '@growi/core';
 
 import {
   IPageForResuming, IUserForResuming, IOptionsForResuming,
 } from '~/server/interfaces/page-operation';
+
 import { ObjectIdLike } from '../interfaces/mongoose-utils';
 
 type IObjectId = mongoose.Types.ObjectId;
@@ -47,7 +48,6 @@ export type PageOperationDocumentHasId = PageOperationDocument & { _id: ObjectId
 
 export interface PageOperationModel extends Model<PageOperationDocument> {
   findByIdAndUpdatePageActionStage(pageOpId: ObjectIdLike, stage: PageActionStage): Promise<PageOperationDocumentHasId | null>
-  findMainOps(filter?: FilterQuery<PageOperationDocument>, projection?: any, options?: QueryOptions): Promise<PageOperationDocumentHasId[]>
 }
 
 const pageSchemaForResuming = new Schema<IPageForResuming>({
@@ -103,17 +103,6 @@ schema.statics.findByIdAndUpdatePageActionStage = async function(
   return this.findByIdAndUpdate(pageOpId, {
     $set: { actionStage: stage },
   }, { new: true });
-};
-
-schema.statics.findMainOps = async function(
-    filter?: FilterQuery<PageOperationDocument>, projection?: any, options?: QueryOptions,
-): Promise<PageOperationDocumentHasId[]> {
-
-  return this.find(
-    { ...filter, actionStage: PageActionStage.Main },
-    projection,
-    options,
-  );
 };
 
 export default getOrCreateModel<PageOperationDocument, PageOperationModel>('PageOperation', schema);

--- a/packages/app/src/server/models/page-operation.ts
+++ b/packages/app/src/server/models/page-operation.ts
@@ -105,4 +105,15 @@ schema.statics.findByIdAndUpdatePageActionStage = async function(
   }, { new: true });
 };
 
+schema.statics.findMainOps = async function(
+    filter?: FilterQuery<PageOperationDocument>, projection?: any, options?: QueryOptions,
+): Promise<PageOperationDocumentHasId[]> {
+
+  return this.find(
+    { ...filter, actionStage: PageActionStage.Main },
+    projection,
+    options,
+  );
+};
+
 export default getOrCreateModel<PageOperationDocument, PageOperationModel>('PageOperation', schema);

--- a/packages/app/src/server/service/page-operation.ts
+++ b/packages/app/src/server/service/page-operation.ts
@@ -33,27 +33,30 @@ class PageOperationService {
 
     const fromPaths = pageOperations.map(op => op.fromPath).filter((p): p is string => p != null);
     const toPaths = pageOperations.map(op => op.toPath).filter((p): p is string => p != null);
-    const fromAndToPaths = [...fromPaths, ...toPaths];
 
     if (isRecursively) {
       if (fromPathToOp != null && !isTrashPage(fromPathToOp)) {
-        const flag = fromAndToPaths.some(p => isEitherOfPathAreaOverlap(p, fromPathToOp));
-        if (flag) return false;
+        const fromFlag = fromPaths.some(p => isEitherOfPathAreaOverlap(p, fromPathToOp));
+        const toFlag = toPaths.some(p => isEitherOfPathAreaOverlap(p, fromPathToOp));
+        if (fromFlag || toFlag) return false;
       }
       if (toPathToOp != null && !isTrashPage(toPathToOp)) {
-        const flag = fromAndToPaths.some(p => isPathAreaOverlap(p, toPathToOp));
-        if (flag) return false;
+        const fromFlag = fromPaths.some(p => isPathAreaOverlap(p, toPathToOp));
+        const toFlag = toPaths.some(p => isPathAreaOverlap(p, toPathToOp));
+        if (fromFlag || toFlag) return false;
       }
 
     }
     else {
       if (fromPathToOp != null && !isTrashPage(fromPathToOp)) {
-        const flag = fromAndToPaths.some(p => isPathAreaOverlap(p, fromPathToOp));
-        if (flag) return false;
+        const fromFlag = fromPaths.some(p => isPathAreaOverlap(p, fromPathToOp));
+        const toFlag = toPaths.some(p => isPathAreaOverlap(p, fromPathToOp));
+        if (fromFlag || toFlag) return false;
       }
       if (toPathToOp != null && !isTrashPage(toPathToOp)) {
-        const flag = fromAndToPaths.some(p => isPathAreaOverlap(p, toPathToOp));
-        if (flag) return false;
+        const fromFlag = fromPaths.some(p => isPathAreaOverlap(p, toPathToOp));
+        const toFlag = toPaths.some(p => isPathAreaOverlap(p, toPathToOp));
+        if (fromFlag || toFlag) return false;
       }
     }
 

--- a/packages/app/src/server/service/page-operation.ts
+++ b/packages/app/src/server/service/page-operation.ts
@@ -33,51 +33,26 @@ class PageOperationService {
 
     const fromPaths = pageOperations.map(op => op.fromPath).filter((p): p is string => p != null);
     const toPaths = pageOperations.map(op => op.toPath).filter((p): p is string => p != null);
+    const fromAndToPaths = [...fromPaths, ...toPaths];
 
     if (isRecursively) {
-      // fromPaths
       if (fromPathToOp != null && !isTrashPage(fromPathToOp)) {
-        const flag = fromPaths.some(p => isEitherOfPathAreaOverlap(p, fromPathToOp));
+        const flag = fromAndToPaths.some(p => isEitherOfPathAreaOverlap(p, fromPathToOp));
         if (flag) return false;
       }
-      // toPaths
-      if (fromPathToOp != null && !isTrashPage(fromPathToOp)) {
-        const flag = toPaths.some(p => isEitherOfPathAreaOverlap(p, fromPathToOp));
-        if (flag) return false;
-      }
-
-      // fromPaths
       if (toPathToOp != null && !isTrashPage(toPathToOp)) {
-        const flag = fromPaths.some(p => isPathAreaOverlap(p, toPathToOp));
-        if (flag) return false;
-      }
-      // toPaths
-      if (toPathToOp != null && !isTrashPage(toPathToOp)) {
-        const flag = toPaths.some(p => isPathAreaOverlap(p, toPathToOp));
+        const flag = fromAndToPaths.some(p => isPathAreaOverlap(p, toPathToOp));
         if (flag) return false;
       }
 
     }
     else {
-      // fromPaths
       if (fromPathToOp != null && !isTrashPage(fromPathToOp)) {
-        const flag = fromPaths.some(p => isPathAreaOverlap(p, fromPathToOp));
+        const flag = fromAndToPaths.some(p => isPathAreaOverlap(p, fromPathToOp));
         if (flag) return false;
       }
-      // toPaths
-      if (fromPathToOp != null && !isTrashPage(fromPathToOp)) {
-        const flag = toPaths.some(p => isPathAreaOverlap(p, fromPathToOp));
-        if (flag) return false;
-      }
-
-      // fromPaths
       if (toPathToOp != null && !isTrashPage(toPathToOp)) {
-        const flag = fromPaths.some(p => isPathAreaOverlap(p, toPathToOp));
-        if (flag) return false;
-      }
-      // toPaths
-      if (toPathToOp != null && !isTrashPage(toPathToOp)) {
-        const flag = toPaths.some(p => isPathAreaOverlap(p, toPathToOp));
+        const flag = fromAndToPaths.some(p => isPathAreaOverlap(p, toPathToOp));
         if (flag) return false;
       }
     }

--- a/packages/app/src/server/service/page-operation.ts
+++ b/packages/app/src/server/service/page-operation.ts
@@ -25,21 +25,33 @@ class PageOperationService {
    * @returns boolean
    */
   async canOperate(isRecursively: boolean, fromPathToOp: string | null, toPathToOp: string | null): Promise<boolean> {
-    const mainOps = await PageOperation.findMainOps();
+    const pageOperations = await PageOperation.find();
 
-    if (mainOps.length === 0) {
+    if (pageOperations.length === 0) {
       return true;
     }
 
-    const toPaths = mainOps.map(op => op.toPath).filter((p): p is string => p != null);
+    const fromPaths = pageOperations.map(op => op.fromPath).filter((p): p is string => p != null);
+    const toPaths = pageOperations.map(op => op.toPath).filter((p): p is string => p != null);
 
     if (isRecursively) {
-
+      // fromPaths
+      if (fromPathToOp != null && !isTrashPage(fromPathToOp)) {
+        const flag = fromPaths.some(p => isEitherOfPathAreaOverlap(p, fromPathToOp));
+        if (flag) return false;
+      }
+      // toPaths
       if (fromPathToOp != null && !isTrashPage(fromPathToOp)) {
         const flag = toPaths.some(p => isEitherOfPathAreaOverlap(p, fromPathToOp));
         if (flag) return false;
       }
 
+      // fromPaths
+      if (toPathToOp != null && !isTrashPage(toPathToOp)) {
+        const flag = fromPaths.some(p => isPathAreaOverlap(p, toPathToOp));
+        if (flag) return false;
+      }
+      // toPaths
       if (toPathToOp != null && !isTrashPage(toPathToOp)) {
         const flag = toPaths.some(p => isPathAreaOverlap(p, toPathToOp));
         if (flag) return false;
@@ -47,17 +59,27 @@ class PageOperationService {
 
     }
     else {
-
+      // fromPaths
+      if (fromPathToOp != null && !isTrashPage(fromPathToOp)) {
+        const flag = fromPaths.some(p => isPathAreaOverlap(p, fromPathToOp));
+        if (flag) return false;
+      }
+      // toPaths
       if (fromPathToOp != null && !isTrashPage(fromPathToOp)) {
         const flag = toPaths.some(p => isPathAreaOverlap(p, fromPathToOp));
         if (flag) return false;
       }
 
+      // fromPaths
+      if (toPathToOp != null && !isTrashPage(toPathToOp)) {
+        const flag = fromPaths.some(p => isPathAreaOverlap(p, toPathToOp));
+        if (flag) return false;
+      }
+      // toPaths
       if (toPathToOp != null && !isTrashPage(toPathToOp)) {
         const flag = toPaths.some(p => isPathAreaOverlap(p, toPathToOp));
         if (flag) return false;
       }
-
     }
 
     return true;

--- a/packages/app/src/server/service/page-operation.ts
+++ b/packages/app/src/server/service/page-operation.ts
@@ -37,26 +37,36 @@ class PageOperationService {
     if (isRecursively) {
       if (fromPathToOp != null && !isTrashPage(fromPathToOp)) {
         const fromFlag = fromPaths.some(p => isEitherOfPathAreaOverlap(p, fromPathToOp));
+        if (fromFlag) return false;
+
         const toFlag = toPaths.some(p => isEitherOfPathAreaOverlap(p, fromPathToOp));
-        if (fromFlag || toFlag) return false;
+        if (toFlag) return false;
       }
+
       if (toPathToOp != null && !isTrashPage(toPathToOp)) {
         const fromFlag = fromPaths.some(p => isPathAreaOverlap(p, toPathToOp));
+        if (fromFlag) return false;
+
         const toFlag = toPaths.some(p => isPathAreaOverlap(p, toPathToOp));
-        if (fromFlag || toFlag) return false;
+        if (toFlag) return false;
       }
 
     }
     else {
       if (fromPathToOp != null && !isTrashPage(fromPathToOp)) {
         const fromFlag = fromPaths.some(p => isPathAreaOverlap(p, fromPathToOp));
+        if (fromFlag) return false;
+
         const toFlag = toPaths.some(p => isPathAreaOverlap(p, fromPathToOp));
-        if (fromFlag || toFlag) return false;
+        if (toFlag) return false;
       }
+
       if (toPathToOp != null && !isTrashPage(toPathToOp)) {
         const fromFlag = fromPaths.some(p => isPathAreaOverlap(p, toPathToOp));
+        if (fromFlag) return false;
+
         const toFlag = toPaths.some(p => isPathAreaOverlap(p, toPathToOp));
-        if (fromFlag || toFlag) return false;
+        if (toFlag) return false;
       }
     }
 


### PR DESCRIPTION
Tasks
- https://redmine.weseek.co.jp/issues/95309
- https://redmine.weseek.co.jp/issues/95418
- https://redmine.weseek.co.jp/issues/95419

内容
- PageOperation の fromPath から始まるページパスの Rename は不可
- PageOperation の fromPath の直系の祖先にあたるページパスの Rename は不可
- PageOperation の fromPath から始まるページパスへの Rename は不可

canOperate を参照している delete なども上記同様に制限を受けるようになっている