### PR TITLE
feat: fix grant alert show grant in modal

### DIFF
--- a/packages/app/resource/locales/en_US/translation.json
+++ b/packages/app/resource/locales/en_US/translation.json
@@ -1049,6 +1049,11 @@
     "modal": {
       "no_grant_available": "The list of selectable permissions could not be found. Please modify the permissions on the parent page first and try again.",
       "need_to_fix_grant": "The permissions associated with this page must be modified in order to use the functionality correctly. <br> Please select from the options below to make the change.",
+      "grant_label": {
+        "isNotForbidden": "Authority not allowed to view",
+        "currentPageGrantLabel": "Authorization for this page: ",
+        "parentPageGrantLabel": "Authority of parent page: "
+      },
       "radio_btn": {
         "restrected": "Only those who know the link",
         "only_me": "only to oneself",

--- a/packages/app/resource/locales/en_US/translation.json
+++ b/packages/app/resource/locales/en_US/translation.json
@@ -1050,7 +1050,7 @@
       "no_grant_available": "The list of selectable permissions could not be found. Please modify the permissions on the parent page first and try again.",
       "need_to_fix_grant": "The permissions associated with this page must be modified in order to use the functionality correctly. <br> Please select from the options below to make the change.",
       "grant_label": {
-        "isNotForbidden": "Authority not allowed to view",
+        "isForbidden": "Authority not allowed to view",
         "currentPageGrantLabel": "Authorization for this page: ",
         "parentPageGrantLabel": "Authority of parent page: ",
         "docLink": "For more information on modifying permissions, please refer to <a href='https://docs.growi.org/ja/admin-guide/admin-cookbook/integrate-with-hackmd.html'>こちらのリンク</a>"

--- a/packages/app/resource/locales/en_US/translation.json
+++ b/packages/app/resource/locales/en_US/translation.json
@@ -1052,7 +1052,8 @@
       "grant_label": {
         "isNotForbidden": "Authority not allowed to view",
         "currentPageGrantLabel": "Authorization for this page: ",
-        "parentPageGrantLabel": "Authority of parent page: "
+        "parentPageGrantLabel": "Authority of parent page: ",
+        "docLink": "For more information on modifying permissions, please refer to <a href='https://docs.growi.org/ja/admin-guide/admin-cookbook/integrate-with-hackmd.html'>こちらのリンク</a>"
       },
       "radio_btn": {
         "restrected": "Only those who know the link",

--- a/packages/app/resource/locales/ja_JP/translation.json
+++ b/packages/app/resource/locales/ja_JP/translation.json
@@ -1045,7 +1045,8 @@
       "grant_label": {
         "isNotForbidden": "権限の閲覧が許可されていません",
         "currentPageGrantLabel": "このページの権限: ",
-        "parentPageGrantLabel": "親のページの権限: "
+        "parentPageGrantLabel": "親のページの権限: ",
+        "docLink": "権限の修正についての詳細は<a href='https://docs.growi.org/ja/admin-guide/admin-cookbook/integrate-with-hackmd.html'>こちらのリンク</a>を参照してください"
       },
       "radio_btn": {
         "restrected": "リンクを知っている人のみ",

--- a/packages/app/resource/locales/ja_JP/translation.json
+++ b/packages/app/resource/locales/ja_JP/translation.json
@@ -1043,7 +1043,7 @@
       "no_grant_available": "選択可能な権限のリストが見つかりませんでした。まず親ページの権限を修正したのちに再試行してください。",
       "need_to_fix_grant": "正しく機能を使用するためにはこのページに紐づく権限を修正する必要があります。 <br> 下記の選択肢から選んで変更してください。",
       "grant_label": {
-        "isNotForbidden": "権限の閲覧が許可されていません",
+        "isForbidden": "権限の閲覧が許可されていません",
         "currentPageGrantLabel": "このページの権限: ",
         "parentPageGrantLabel": "親のページの権限: ",
         "docLink": "権限の修正についての詳細は<a href='https://docs.growi.org/ja/admin-guide/admin-cookbook/integrate-with-hackmd.html'>こちらのリンク</a>を参照してください"

--- a/packages/app/resource/locales/ja_JP/translation.json
+++ b/packages/app/resource/locales/ja_JP/translation.json
@@ -1042,6 +1042,11 @@
     "modal": {
       "no_grant_available": "選択可能な権限のリストが見つかりませんでした。まず親ページの権限を修正したのちに再試行してください。",
       "need_to_fix_grant": "正しく機能を使用するためにはこのページに紐づく権限を修正する必要があります。 <br> 下記の選択肢から選んで変更してください。",
+      "grant_label": {
+        "isNotForbidden": "権限の閲覧が許可されていません",
+        "currentPageGrantLabel": "このページの権限: ",
+        "parentPageGrantLabel": "親のページの権限: "
+      },
       "radio_btn": {
         "restrected": "リンクを知っている人のみ",
         "only_me": "自分のみ",

--- a/packages/app/resource/locales/zh_CN/translation.json
+++ b/packages/app/resource/locales/zh_CN/translation.json
@@ -1052,6 +1052,11 @@
     "modal": {
       "no_grant_available": "无法找到可选择的权限列表。 请先修改父页的权限，然后再试一次。",
       "need_to_fix_grant": "为了正确使用该功能，需要修改与该页面相关的权限。 <br> 请从以下选项中选择进行更改。",
+      "grant_label": {
+        "isNotForbidden": "无权查看的机构",
+        "currentPageGrantLabel": "本页的权限: ",
+        "parentPageGrantLabel": "父页的权限: "
+      },
       "radio_btn": {
         "restrected": "只有那些知道链接的人",
         "only_me": "只对自己说",

--- a/packages/app/resource/locales/zh_CN/translation.json
+++ b/packages/app/resource/locales/zh_CN/translation.json
@@ -1055,7 +1055,8 @@
       "grant_label": {
         "isNotForbidden": "无权查看的机构",
         "currentPageGrantLabel": "本页的权限: ",
-        "parentPageGrantLabel": "父页的权限: "
+        "parentPageGrantLabel": "父页的权限: ",
+        "docLink": "关于修改授权的更多信息，请参见此<a href='https://docs.growi.org/ja/admin-guide/admin-cookbook/integrate-with-hackmd.html'>此链接</a>"
       },
       "radio_btn": {
         "restrected": "只有那些知道链接的人",

--- a/packages/app/resource/locales/zh_CN/translation.json
+++ b/packages/app/resource/locales/zh_CN/translation.json
@@ -1053,7 +1053,7 @@
       "no_grant_available": "无法找到可选择的权限列表。 请先修改父页的权限，然后再试一次。",
       "need_to_fix_grant": "为了正确使用该功能，需要修改与该页面相关的权限。 <br> 请从以下选项中选择进行更改。",
       "grant_label": {
-        "isNotForbidden": "无权查看的机构",
+        "isForbidden": "无权查看的机构",
         "currentPageGrantLabel": "本页的权限: ",
         "parentPageGrantLabel": "父页的权限: ",
         "docLink": "关于修改授权的更多信息，请参见此<a href='https://docs.growi.org/ja/admin-guide/admin-cookbook/integrate-with-hackmd.html'>此链接</a>"

--- a/packages/app/src/components/Page/FixPageGrantAlert.tsx
+++ b/packages/app/src/components/Page/FixPageGrantAlert.tsx
@@ -8,7 +8,7 @@ import {
 import { toastError, toastSuccess } from '~/client/util/apiNotification';
 import { apiv3Put } from '~/client/util/apiv3-client';
 import { PageGrant } from '~/interfaces/page';
-import { IRecordApplicableGrant } from '~/interfaces/page-grant';
+import { IRecordApplicableGrant, IResIsGrantNormalizedGrantData } from '~/interfaces/page-grant';
 import { useCurrentPageId, useHasParent } from '~/stores/context';
 import { useSWRxApplicableGrant, useSWRxIsGrantNormalized } from '~/stores/page';
 
@@ -16,6 +16,7 @@ type ModalProps = {
   isOpen: boolean
   pageId: string
   dataApplicableGrant: IRecordApplicableGrant
+  grantData: IResIsGrantNormalizedGrantData
   close(): void
 }
 
@@ -194,7 +195,7 @@ const FixPageGrantAlert = (): JSX.Element => {
   if (!hasParent) {
     return <></>;
   }
-  if (dataIsGrantNormalized?.isGrantNormalized == null || dataIsGrantNormalized.isGrantNormalized) {
+  if (dataIsGrantNormalized?.grantData == null || dataIsGrantNormalized?.isGrantNormalized == null || dataIsGrantNormalized.isGrantNormalized) {
     return <></>;
   }
 
@@ -218,6 +219,7 @@ const FixPageGrantAlert = (): JSX.Element => {
             isOpen={isOpen}
             pageId={pageId}
             dataApplicableGrant={dataApplicableGrant}
+            grantData={dataIsGrantNormalized.grantData}
             close={() => setOpen(false)}
           />
         )

--- a/packages/app/src/components/Page/FixPageGrantAlert.tsx
+++ b/packages/app/src/components/Page/FixPageGrantAlert.tsx
@@ -69,11 +69,11 @@ const FixPageGrantModal = (props: ModalProps): JSX.Element => {
   const getGrantLabel = useCallback((isForbidden: boolean, grantData?: IPageGrantData): string => {
 
     if (isForbidden) {
-      return t('fix_page_grant.modal.grant_label.isNotForbidden');
+      return t('fix_page_grant.modal.grant_label.isForbidden');
     }
 
     if (grantData == null) {
-      return t('fix_page_grant.modal.grant_label.isNotForbidden');
+      return t('fix_page_grant.modal.grant_label.isForbidden');
     }
 
     if (grantData.grant === 4) {
@@ -82,12 +82,12 @@ const FixPageGrantModal = (props: ModalProps): JSX.Element => {
 
     if (grantData.grant === 5) {
       if (grantData.grantedGroup == null) {
-        return t('fix_page_grant.modal.grant_label.isNotForbidden');
+        return t('fix_page_grant.modal.grant_label.isForbidden');
       }
       return `${t('fix_page_grant.modal.radio_btn.grant_group')}: (${grantData.grantedGroup.name})`;
     }
 
-    return t('fix_page_grant.modal.grant_label.isNotForbidden');
+    throw Error('cannnot get grant label'); // this error can't be throwed
   }, [t]);
 
   const renderGrantDataLabel = useCallback(() => {

--- a/packages/app/src/components/Page/FixPageGrantAlert.tsx
+++ b/packages/app/src/components/Page/FixPageGrantAlert.tsx
@@ -73,7 +73,7 @@ const FixPageGrantModal = (props: ModalProps): JSX.Element => {
     }
 
     if (grantData == null) {
-      return '';
+      return t('fix_page_grant.modal.grant_label.isNotForbidden');
     }
 
     if (grantData.grant === 4) {
@@ -81,11 +81,13 @@ const FixPageGrantModal = (props: ModalProps): JSX.Element => {
     }
 
     if (grantData.grant === 5) {
-      if (grantData.grantedGroup == null) { return '' }
+      if (grantData.grantedGroup == null) {
+        return t('fix_page_grant.modal.grant_label.isNotForbidden');
+      }
       return `${t('fix_page_grant.modal.radio_btn.grant_group')}: (${grantData.grantedGroup.name})`;
     }
 
-    return '';
+    return t('fix_page_grant.modal.grant_label.isNotForbidden');
   };
 
   const renderGrantDataLabel = () => {

--- a/packages/app/src/components/Page/FixPageGrantAlert.tsx
+++ b/packages/app/src/components/Page/FixPageGrantAlert.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 
 import { useTranslation } from 'react-i18next';
 import {
@@ -66,7 +66,7 @@ const FixPageGrantModal = (props: ModalProps): JSX.Element => {
     }
   };
 
-  const grantLabel = (isForbidden: boolean, grantData?: IPageGrantData): string => {
+  const grantLabel = useCallback((isForbidden: boolean, grantData?: IPageGrantData): string => {
 
     if (!isForbidden) {
       return t('fix_page_grant.modal.grant_label.isNotForbidden');
@@ -88,9 +88,9 @@ const FixPageGrantModal = (props: ModalProps): JSX.Element => {
     }
 
     return t('fix_page_grant.modal.grant_label.isNotForbidden');
-  };
+  }, [t]);
 
-  const renderGrantDataLabel = () => {
+  const renderGrantDataLabel = useCallback(() => {
     const { isForbidden, currentPageGrant, parentPageGrant } = currentAndParentPageGrantData;
 
     const currentGrantLabel = grantLabel(true, currentPageGrant);
@@ -104,7 +104,7 @@ const FixPageGrantModal = (props: ModalProps): JSX.Element => {
         <p dangerouslySetInnerHTML={{ __html: t('fix_page_grant.modal.grant_label.docLink') }} />
       </>
     );
-  };
+  }, [t, currentAndParentPageGrantData, grantLabel]);
 
   const renderModalBodyAndFooter = () => {
     const isGrantAvailable = Object.keys(dataApplicableGrant || {}).length > 0;

--- a/packages/app/src/components/Page/FixPageGrantAlert.tsx
+++ b/packages/app/src/components/Page/FixPageGrantAlert.tsx
@@ -68,7 +68,7 @@ const FixPageGrantModal = (props: ModalProps): JSX.Element => {
 
   const getGrantLabel = useCallback((isForbidden: boolean, grantData?: IPageGrantData): string => {
 
-    if (!isForbidden) {
+    if (isForbidden) {
       return t('fix_page_grant.modal.grant_label.isNotForbidden');
     }
 
@@ -93,7 +93,7 @@ const FixPageGrantModal = (props: ModalProps): JSX.Element => {
   const renderGrantDataLabel = useCallback(() => {
     const { isForbidden, currentPageGrant, parentPageGrant } = currentAndParentPageGrantData;
 
-    const currentGrantLabel = getGrantLabel(true, currentPageGrant);
+    const currentGrantLabel = getGrantLabel(false, currentPageGrant);
     const parentGrantLabel = getGrantLabel(isForbidden, parentPageGrant);
 
     return (

--- a/packages/app/src/components/Page/FixPageGrantAlert.tsx
+++ b/packages/app/src/components/Page/FixPageGrantAlert.tsx
@@ -7,8 +7,8 @@ import {
 
 import { toastError, toastSuccess } from '~/client/util/apiNotification';
 import { apiv3Put } from '~/client/util/apiv3-client';
-import { PageGrant } from '~/interfaces/page';
-import { IRecordApplicableGrant, IResIsGrantNormalizedGrantData, IPageGrantData } from '~/interfaces/page-grant';
+import { PageGrant, IPageGrantData } from '~/interfaces/page';
+import { IRecordApplicableGrant, IResIsGrantNormalizedGrantData } from '~/interfaces/page-grant';
 import { useCurrentPageId, useHasParent } from '~/stores/context';
 import { useSWRxApplicableGrant, useSWRxIsGrantNormalized } from '~/stores/page';
 

--- a/packages/app/src/components/Page/FixPageGrantAlert.tsx
+++ b/packages/app/src/components/Page/FixPageGrantAlert.tsx
@@ -66,7 +66,7 @@ const FixPageGrantModal = (props: ModalProps): JSX.Element => {
     }
   };
 
-  const grantLabel = useCallback((isForbidden: boolean, grantData?: IPageGrantData): string => {
+  const getGrantLabel = useCallback((isForbidden: boolean, grantData?: IPageGrantData): string => {
 
     if (!isForbidden) {
       return t('fix_page_grant.modal.grant_label.isNotForbidden');
@@ -93,8 +93,8 @@ const FixPageGrantModal = (props: ModalProps): JSX.Element => {
   const renderGrantDataLabel = useCallback(() => {
     const { isForbidden, currentPageGrant, parentPageGrant } = currentAndParentPageGrantData;
 
-    const currentGrantLabel = grantLabel(true, currentPageGrant);
-    const parentGrantLabel = grantLabel(isForbidden, parentPageGrant);
+    const currentGrantLabel = getGrantLabel(true, currentPageGrant);
+    const parentGrantLabel = getGrantLabel(isForbidden, parentPageGrant);
 
     return (
       <>
@@ -104,7 +104,7 @@ const FixPageGrantModal = (props: ModalProps): JSX.Element => {
         <p dangerouslySetInnerHTML={{ __html: t('fix_page_grant.modal.grant_label.docLink') }} />
       </>
     );
-  }, [t, currentAndParentPageGrantData, grantLabel]);
+  }, [t, currentAndParentPageGrantData, getGrantLabel]);
 
   const renderModalBodyAndFooter = () => {
     const isGrantAvailable = Object.keys(dataApplicableGrant || {}).length > 0;

--- a/packages/app/src/components/Page/FixPageGrantAlert.tsx
+++ b/packages/app/src/components/Page/FixPageGrantAlert.tsx
@@ -98,8 +98,10 @@ const FixPageGrantModal = (props: ModalProps): JSX.Element => {
 
     return (
       <>
-        <p>{ t('fix_page_grant.modal.grant_label.parentPageGrantLabel') + parentGrantLabel }</p>
+        <p className="mt-3">{ t('fix_page_grant.modal.grant_label.parentPageGrantLabel') + parentGrantLabel }</p>
         <p>{ t('fix_page_grant.modal.grant_label.currentPageGrantLabel') + currentGrantLabel }</p>
+        {/* eslint-disable-next-line react/no-danger */}
+        <p dangerouslySetInnerHTML={{ __html: t('fix_page_grant.modal.grant_label.docLink') }} />
       </>
     );
   };

--- a/packages/app/src/components/Page/FixPageGrantAlert.tsx
+++ b/packages/app/src/components/Page/FixPageGrantAlert.tsx
@@ -69,7 +69,7 @@ const FixPageGrantModal = (props: ModalProps): JSX.Element => {
   const grantLabel = (isForbidden: boolean, grantData?: IPageGrantData): string => {
 
     if (!isForbidden) {
-      return '権限の表示が許可されていません';
+      return t('fix_page_grant.modal.grant_label.isNotForbidden');
     }
 
     if (grantData == null) {
@@ -96,8 +96,8 @@ const FixPageGrantModal = (props: ModalProps): JSX.Element => {
 
     return (
       <>
-        <p>親のページの権限: {parentGrantLabel}</p>
-        <p>このページの権限: {currentGrantLabel}</p>
+        <p>{ t('fix_page_grant.modal.grant_label.parentPageGrantLabel') + parentGrantLabel }</p>
+        <p>{ t('fix_page_grant.modal.grant_label.currentPageGrantLabel') + currentGrantLabel }</p>
       </>
     );
   };

--- a/packages/app/src/interfaces/page-grant.ts
+++ b/packages/app/src/interfaces/page-grant.ts
@@ -1,4 +1,4 @@
-import { PageGrant } from './page';
+import { PageGrant, IPageGrantData } from './page';
 
 export type IDataApplicableGroup = {
   applicableGroups?: {_id: string, name: string}[] // TODO: Typescriptize model
@@ -8,13 +8,6 @@ export type IDataApplicableGrant = null | IDataApplicableGroup;
 export type IRecordApplicableGrant = Record<PageGrant, IDataApplicableGrant>
 export type IResApplicableGrant = {
   data?: IRecordApplicableGrant
-}
-export type IPageGrantData = {
-  grant: number,
-  grantedGroup?: {
-    id: string,
-    name: string
-  }
 }
 export type IResIsGrantNormalizedGrantData = {
   isForbidden: boolean,

--- a/packages/app/src/interfaces/page-grant.ts
+++ b/packages/app/src/interfaces/page-grant.ts
@@ -9,3 +9,19 @@ export type IRecordApplicableGrant = Record<PageGrant, IDataApplicableGrant>
 export type IResApplicableGrant = {
   data?: IRecordApplicableGrant
 }
+type IPageGrantData = {
+  grant: number,
+  grantedGroup?: {
+    id: string,
+    name: string
+  }
+}
+export type IResIsGrantNormalizedGrantData = {
+  isForbidden: boolean,
+  currentPageGrant: IPageGrantData,
+  parentPageGrant?: IPageGrantData
+}
+export type IResIsGrantNormalized = {
+  isGrantNormalized: boolean,
+  grantData: IResIsGrantNormalizedGrantData
+};

--- a/packages/app/src/interfaces/page-grant.ts
+++ b/packages/app/src/interfaces/page-grant.ts
@@ -9,7 +9,7 @@ export type IRecordApplicableGrant = Record<PageGrant, IDataApplicableGrant>
 export type IResApplicableGrant = {
   data?: IRecordApplicableGrant
 }
-type IPageGrantData = {
+export type IPageGrantData = {
   grant: number,
   grantedGroup?: {
     id: string,

--- a/packages/app/src/interfaces/page.ts
+++ b/packages/app/src/interfaces/page.ts
@@ -1,9 +1,9 @@
 import { Ref, Nullable } from './common';
-import { IUser } from './user';
-import { IRevision, HasRevisionShortbody } from './revision';
-import { ITag } from './tag';
 import { HasObjectId } from './has-object-id';
+import { IRevision, HasRevisionShortbody } from './revision';
 import { SubscriptionStatusType } from './subscription';
+import { ITag } from './tag';
+import { IUser } from './user';
 
 
 export interface IPage {
@@ -116,6 +116,14 @@ export type IPageWithMeta<M = IPageInfoAll> = IDataWithMeta<IPageHasId, M>;
 
 export type IPageToDeleteWithMeta = IDataWithMeta<HasObjectId & (IPage | { path: string, revision: string }), IPageInfoForEntity | unknown>;
 export type IPageToRenameWithMeta = IPageToDeleteWithMeta;
+
+export type IPageGrantData = {
+  grant: number,
+  grantedGroup?: {
+    id: string,
+    name: string
+  }
+}
 
 export type IDeleteSinglePageApiv1Result = {
   ok: boolean

--- a/packages/app/src/server/models/obsolete-page.js
+++ b/packages/app/src/server/models/obsolete-page.js
@@ -375,7 +375,7 @@ export const getPageSchema = (crowi) => {
 
     const builder = new this.PageQueryBuilder(this.findOne({ path }), includeEmpty);
 
-    return builder.query.exec();
+    return builder.query;
   };
 
   /**

--- a/packages/app/src/server/models/obsolete-page.js
+++ b/packages/app/src/server/models/obsolete-page.js
@@ -375,7 +375,7 @@ export const getPageSchema = (crowi) => {
 
     const builder = new this.PageQueryBuilder(this.findOne({ path }), includeEmpty);
 
-    return builder.query;
+    return builder.query.exec();
   };
 
   /**

--- a/packages/app/src/server/routes/apiv3/page.js
+++ b/packages/app/src/server/routes/apiv3/page.js
@@ -458,7 +458,7 @@ module.exports = (crowi) => {
 
     if (parentPage == null) {
       const grantData = {
-        isForbidden: false,
+        isForbidden: true,
         currentPageGrant,
         parentPageGrant: null,
       };
@@ -477,7 +477,7 @@ module.exports = (crowi) => {
     };
 
     const grantData = {
-      isForbidden: true,
+      isForbidden: false,
       currentPageGrant,
       parentPageGrant,
     };

--- a/packages/app/src/server/routes/apiv3/page.js
+++ b/packages/app/src/server/routes/apiv3/page.js
@@ -2,6 +2,7 @@ import { pagePathUtils } from '@growi/core';
 
 import { AllSubscriptionStatusType } from '~/interfaces/subscription';
 import Subscription from '~/server/models/subscription';
+import UserGroup from '~/server/models/user-group';
 import loggerFactory from '~/utils/logger';
 
 import { apiV3FormValidator } from '../../middlewares/apiv3-form-validator';
@@ -444,22 +445,25 @@ module.exports = (crowi) => {
       return res.apiv3Err(err, 500);
     }
 
+    const currentPageUserGroup = await UserGroup.findOne({ _id: grantedGroup });
+    const parentPageUserGroup = await UserGroup.findOne({ _id: parentPage.grantedGroup });
+
     const currentPageGrant = {
       grant,
-      grantedGroup: grantedGroup != null
+      grantedGroup: currentPageUserGroup != null
         ? {
-          id: grantedGroup._id,
-          name: grantedGroup.name,
+          id: currentPageUserGroup._id,
+          name: currentPageUserGroup.name,
         }
         : null,
     };
 
     const parentPageGrant = {
       grant: parentPage.grant,
-      grantedGroup: parentPage.grantedGroup != null
+      grantedGroup: parentPageUserGroup != null
         ? {
-          id: parentPage.grantedGroup._id,
-          name: parentPage.grantedGroup.name,
+          id: parentPageUserGroup._id,
+          name: parentPageUserGroup.name,
         }
         : null,
     };

--- a/packages/app/src/server/routes/apiv3/page.js
+++ b/packages/app/src/server/routes/apiv3/page.js
@@ -426,7 +426,6 @@ module.exports = (crowi) => {
 
     const Page = crowi.model('Page');
     const page = await Page.findByIdAndViewer(pageId, req.user, null, false);
-    const parentPage = await Page.findByIdAndViewer(page.parent, req.user, null, false);
 
     if (page == null) {
       return res.apiv3Err(new ErrorV3('Page is unreachable or empty.', 'page_unreachable_or_empty'), 400);
@@ -456,6 +455,19 @@ module.exports = (crowi) => {
         : null,
     };
 
+    // page doesn't have parent page
+    if (page.parent == null) {
+      const grantData = {
+        isForbidden: false,
+        currentPageGrant,
+        parentPageGrant: null,
+      };
+      return res.apiv3({ isGrantNormalized, grantData });
+    }
+
+    const parentPage = await Page.findByIdAndViewer(page.parent, req.user, null, false);
+
+    // user isn't allowed to see parent's grant
     if (parentPage == null) {
       const grantData = {
         isForbidden: true,

--- a/packages/app/src/server/routes/apiv3/page.js
+++ b/packages/app/src/server/routes/apiv3/page.js
@@ -446,8 +446,6 @@ module.exports = (crowi) => {
     }
 
     const currentPageUserGroup = await UserGroup.findOne({ _id: grantedGroup });
-    const parentPageUserGroup = await UserGroup.findOne({ _id: parentPage.grantedGroup });
-
     const currentPageGrant = {
       grant,
       grantedGroup: currentPageUserGroup != null
@@ -458,6 +456,16 @@ module.exports = (crowi) => {
         : null,
     };
 
+    if (parentPage == null) {
+      const grantData = {
+        isForbidden: false,
+        currentPageGrant,
+        parentPageGrant: null,
+      };
+      return res.apiv3({ isGrantNormalized, grantData });
+    }
+
+    const parentPageUserGroup = await UserGroup.findOne({ _id: parentPage.grantedGroup });
     const parentPageGrant = {
       grant: parentPage.grant,
       grantedGroup: parentPageUserGroup != null
@@ -469,9 +477,9 @@ module.exports = (crowi) => {
     };
 
     const grantData = {
-      isForbidden: parentPage != null,
+      isForbidden: true,
       currentPageGrant,
-      parentPageGrant: parentPage != null ? parentPageGrant : null,
+      parentPageGrant,
     };
 
     return res.apiv3({ isGrantNormalized, grantData });

--- a/packages/app/src/stores/page.tsx
+++ b/packages/app/src/stores/page.tsx
@@ -7,7 +7,7 @@ import { HasObjectId } from '~/interfaces/has-object-id';
 import {
   IPageInfo, IPageHasId, IPageInfoForOperation, IPageInfoForListing, IDataWithMeta,
 } from '~/interfaces/page';
-import { IRecordApplicableGrant } from '~/interfaces/page-grant';
+import { IRecordApplicableGrant, IResIsGrantNormalized } from '~/interfaces/page-grant';
 import { IPagingResult } from '~/interfaces/paging-result';
 
 import { apiGet } from '../client/util/apiv1-client';
@@ -151,7 +151,6 @@ export const useSWRxPageInfoForList = (
 /*
  * Grant normalization fetching hooks
  */
-export type IResIsGrantNormalized = { isGrantNormalized: boolean };
 export const useSWRxIsGrantNormalized = (
     pageId: string | null | undefined,
 ): SWRResponse<IResIsGrantNormalized, Error> => {


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/95249

実装前の画像
<img width="727" alt="スクリーンショット 2022-05-19 162258" src="https://user-images.githubusercontent.com/65263895/169235752-ab702e81-c71b-47ea-81fd-2750144b5734.png">



実装後の画像
<img width="725" alt="スクリーンショット 2022-05-19 162157" src="https://user-images.githubusercontent.com/65263895/169235739-660ae56f-fca0-4a2b-9c94-d9dc72ec445f.png">

- 権限修正モーダルの中で、現在のページの権限と親のページの権限を表示する機能を実装
- 親のページの権限を閲覧可能な場合は表示、閲覧できない場合は表示しない機能を実装