### PR TITLE
imprv: Added permanent link on the editing tag

### DIFF
--- a/packages/app/src/components/RevisionComparer/RevisionComparer.jsx
+++ b/packages/app/src/components/RevisionComparer/RevisionComparer.jsx
@@ -33,16 +33,17 @@ const RevisionComparer = (props) => {
 
   const { t, revisionComparerContainer } = props;
 
+  const { path, pageId } = revisionComparerContainer.pageContainer.state;
+
   function toggleDropdown() {
     setDropdownOpen(!dropdownOpen);
   }
 
   const urlGenerator = (content) => {
     const { origin } = window.location;
-    const { path, pageId } = revisionComparerContainer.pageContainer.state;
     const { sourceRevision, targetRevision } = revisionComparerContainer.state;
 
-    const url = content === 'path' ? new URL(path, origin) : new URL(pageId, origin);
+    const url = new URL(content, origin);
 
     if (sourceRevision != null && targetRevision != null) {
       const urlParams = `${sourceRevision._id}...${targetRevision._id}`;
@@ -78,15 +79,15 @@ const RevisionComparer = (props) => {
           </DropdownToggle>
           <DropdownMenu positionFixed right modifiers={{ preventOverflow: { boundariesElement: undefined } }}>
             {/* Page path URL */}
-            <CopyToClipboard text={urlGenerator('path')}>
+            <CopyToClipboard text={urlGenerator(path)}>
               <DropdownItem className="px-3">
-                <DropdownItemContents title={t('copy_to_clipboard.Page URL')} contents={urlGenerator('path')} />
+                <DropdownItemContents title={t('copy_to_clipboard.Page URL')} contents={urlGenerator(path)} />
               </DropdownItem>
             </CopyToClipboard>
             {/* Permanent Link URL */}
-            <CopyToClipboard text={urlGenerator('pageId')}>
+            <CopyToClipboard text={urlGenerator(pageId)}>
               <DropdownItem className="px-3">
-                <DropdownItemContents title={t('copy_to_clipboard.Permanent link')} contents={urlGenerator('pageId')} />
+                <DropdownItemContents title={t('copy_to_clipboard.Permanent link')} contents={urlGenerator(pageId)} />
               </DropdownItem>
             </CopyToClipboard>
             <DropdownItem divider className="my-0"></DropdownItem>

--- a/packages/app/src/components/RevisionComparer/RevisionComparer.jsx
+++ b/packages/app/src/components/RevisionComparer/RevisionComparer.jsx
@@ -51,6 +51,21 @@ const RevisionComparer = (props) => {
     return encodeSpaces(decodeURI(url));
   };
 
+  const permalink = () => {
+    const { origin } = window.location;
+    const { pageId } = revisionComparerContainer.pageContainer.state;
+    const { sourceRevision, targetRevision } = revisionComparerContainer.state;
+
+    const url = new URL(pageId, origin);
+
+    if (sourceRevision != null && targetRevision != null) {
+      const urlParams = `${sourceRevision._id}...${targetRevision._id}`;
+      url.searchParams.set('compare', urlParams);
+    }
+
+    return encodeSpaces(decodeURI(url));
+  };
+
   const { sourceRevision, targetRevision } = revisionComparerContainer.state;
 
   if (sourceRevision == null || targetRevision == null) {
@@ -79,6 +94,11 @@ const RevisionComparer = (props) => {
             <CopyToClipboard text={pagePathUrl()}>
               <DropdownItem className="px-3">
                 <DropdownItemContents title={t('copy_to_clipboard.Page URL')} contents={pagePathUrl()} />
+              </DropdownItem>
+            </CopyToClipboard>
+            <CopyToClipboard text={permalink()}>
+              <DropdownItem className="px-3">
+                <DropdownItemContents title={t('copy_to_clipboard.Permanent link')} contents={permalink()} />
               </DropdownItem>
             </CopyToClipboard>
             <DropdownItem divider className="my-0"></DropdownItem>

--- a/packages/app/src/components/RevisionComparer/RevisionComparer.jsx
+++ b/packages/app/src/components/RevisionComparer/RevisionComparer.jsx
@@ -39,11 +39,11 @@ const RevisionComparer = (props) => {
     setDropdownOpen(!dropdownOpen);
   }
 
-  const urlGenerator = (content) => {
+  const generateURL = (pathName) => {
     const { origin } = window.location;
     const { sourceRevision, targetRevision } = revisionComparerContainer.state;
 
-    const url = new URL(content, origin);
+    const url = new URL(pathName, origin);
 
     if (sourceRevision != null && targetRevision != null) {
       const urlParams = `${sourceRevision._id}...${targetRevision._id}`;
@@ -79,15 +79,15 @@ const RevisionComparer = (props) => {
           </DropdownToggle>
           <DropdownMenu positionFixed right modifiers={{ preventOverflow: { boundariesElement: undefined } }}>
             {/* Page path URL */}
-            <CopyToClipboard text={urlGenerator(path)}>
+            <CopyToClipboard text={generateURL(path)}>
               <DropdownItem className="px-3">
-                <DropdownItemContents title={t('copy_to_clipboard.Page URL')} contents={urlGenerator(path)} />
+                <DropdownItemContents title={t('copy_to_clipboard.Page URL')} contents={generateURL(path)} />
               </DropdownItem>
             </CopyToClipboard>
             {/* Permanent Link URL */}
-            <CopyToClipboard text={urlGenerator(pageId)}>
+            <CopyToClipboard text={generateURL(pageId)}>
               <DropdownItem className="px-3">
-                <DropdownItemContents title={t('copy_to_clipboard.Permanent link')} contents={urlGenerator(pageId)} />
+                <DropdownItemContents title={t('copy_to_clipboard.Permanent link')} contents={generateURL(pageId)} />
               </DropdownItem>
             </CopyToClipboard>
             <DropdownItem divider className="my-0"></DropdownItem>

--- a/packages/app/src/components/RevisionComparer/RevisionComparer.jsx
+++ b/packages/app/src/components/RevisionComparer/RevisionComparer.jsx
@@ -1,18 +1,19 @@
 import React, { useState } from 'react';
+
+import { pagePathUtils } from '@growi/core';
 import PropTypes from 'prop-types';
-import { withTranslation } from 'react-i18next';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
+import { withTranslation } from 'react-i18next';
 import {
   Dropdown, DropdownToggle, DropdownMenu, DropdownItem,
 } from 'reactstrap';
 
-import { pagePathUtils } from '@growi/core';
-
-import { withUnstatedContainers } from '../UnstatedUtils';
 
 import RevisionComparerContainer from '~/client/services/RevisionComparerContainer';
 
 import RevisionDiff from '../PageHistory/RevisionDiff';
+import { withUnstatedContainers } from '../UnstatedUtils';
+
 
 const { encodeSpaces } = pagePathUtils;
 
@@ -36,12 +37,12 @@ const RevisionComparer = (props) => {
     setDropdownOpen(!dropdownOpen);
   }
 
-  const pagePathUrl = () => {
+  const urlGenerator = (content) => {
     const { origin } = window.location;
-    const { path } = revisionComparerContainer.pageContainer.state;
+    const { path, pageId } = revisionComparerContainer.pageContainer.state;
     const { sourceRevision, targetRevision } = revisionComparerContainer.state;
 
-    const url = new URL(path, origin);
+    const url = content === 'path' ? new URL(path, origin) : new URL(pageId, origin);
 
     if (sourceRevision != null && targetRevision != null) {
       const urlParams = `${sourceRevision._id}...${targetRevision._id}`;
@@ -49,21 +50,7 @@ const RevisionComparer = (props) => {
     }
 
     return encodeSpaces(decodeURI(url));
-  };
 
-  const permalink = () => {
-    const { origin } = window.location;
-    const { pageId } = revisionComparerContainer.pageContainer.state;
-    const { sourceRevision, targetRevision } = revisionComparerContainer.state;
-
-    const url = new URL(pageId, origin);
-
-    if (sourceRevision != null && targetRevision != null) {
-      const urlParams = `${sourceRevision._id}...${targetRevision._id}`;
-      url.searchParams.set('compare', urlParams);
-    }
-
-    return encodeSpaces(decodeURI(url));
   };
 
   const { sourceRevision, targetRevision } = revisionComparerContainer.state;
@@ -91,14 +78,15 @@ const RevisionComparer = (props) => {
           </DropdownToggle>
           <DropdownMenu positionFixed right modifiers={{ preventOverflow: { boundariesElement: undefined } }}>
             {/* Page path URL */}
-            <CopyToClipboard text={pagePathUrl()}>
+            <CopyToClipboard text={urlGenerator('path')}>
               <DropdownItem className="px-3">
-                <DropdownItemContents title={t('copy_to_clipboard.Page URL')} contents={pagePathUrl()} />
+                <DropdownItemContents title={t('copy_to_clipboard.Page URL')} contents={urlGenerator('path')} />
               </DropdownItem>
             </CopyToClipboard>
-            <CopyToClipboard text={permalink()}>
+            {/* Permanent Link URL */}
+            <CopyToClipboard text={urlGenerator('pageId')}>
               <DropdownItem className="px-3">
-                <DropdownItemContents title={t('copy_to_clipboard.Permanent link')} contents={permalink()} />
+                <DropdownItemContents title={t('copy_to_clipboard.Permanent link')} contents={urlGenerator('pageId')} />
               </DropdownItem>
             </CopyToClipboard>
             <DropdownItem divider className="my-0"></DropdownItem>


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/95488 

ページ更新履歴からページ更新後のurlを取得するときにパーマリンクを作成してクリップボードにコピーできるようにする。

すでにパーマリンクを取得できるDropDownMenuがあるのでそちらを参照してデザインも統一
<img width="1202" alt="127607429-db81f413-2a56-4272-86e7-19bdd7e8f180" src="https://user-images.githubusercontent.com/94808195/169759817-4b2302d1-f0d6-4f6f-a1a7-64c9456cac6b.png">
<img width="1147" alt="Screen Shot 2022-05-23 at 15 44 25" src="https://user-images.githubusercontent.com/94808195/169759832-e08fd1a1-d408-49aa-b9a8-f08f57582de0.png">



