### PR TITLE
imprv: Initial rendering when opening Custom Sidebar

### DIFF
--- a/packages/app/src/components/Sidebar/CustomSidebar.tsx
+++ b/packages/app/src/components/Sidebar/CustomSidebar.tsx
@@ -13,7 +13,11 @@ const logger = loggerFactory('growi:cli:CustomSidebar');
 
 const SidebarNotFound = () => {
   return (
-    <div className="grw-sidebar-content-header h5 text-center p-3"></div>
+    <div className="grw-sidebar-content-header h5 text-center p-3">
+      <a href="/Sidebar#edit">
+        <i className="icon-magic-wand"></i> Create <strong>/Sidebar</strong> page
+      </a>
+    </div>
   );
 };
 

--- a/packages/app/src/components/Sidebar/CustomSidebar.tsx
+++ b/packages/app/src/components/Sidebar/CustomSidebar.tsx
@@ -13,11 +13,7 @@ const logger = loggerFactory('growi:cli:CustomSidebar');
 
 const SidebarNotFound = () => {
   return (
-    <div className="grw-sidebar-content-header h5 text-center p-3">
-      <a href="/Sidebar#edit">
-        <i className="icon-magic-wand"></i> Create <strong>/Sidebar</strong> page
-      </a>
-    </div>
+    <div className="grw-sidebar-content-header h5 text-center p-3"></div>
   );
 };
 

--- a/packages/app/src/components/Sidebar/CustomSidebar.tsx
+++ b/packages/app/src/components/Sidebar/CustomSidebar.tsx
@@ -57,7 +57,7 @@ const CustomSidebar: FC<Props> = (props: Props) => {
       }
 
       {
-        !isLoading && markdown != null ? (
+        (!isLoading && markdown != null) && (
           <div className="p-3">
             <RevisionRenderer
               growiRenderer={renderer}
@@ -66,7 +66,11 @@ const CustomSidebar: FC<Props> = (props: Props) => {
               additionalClassName="grw-custom-sidebar-content"
             />
           </div>
-        ) : (
+        )
+      }
+
+      {
+        (!isLoading && markdown === undefined) && (
           <SidebarNotFound />
         )
       }


### PR DESCRIPTION
[94345](https://redmine.weseek.co.jp/issues/94345) カスタムサイドバーを開いた後の loading 中に "Create /Sidebar page" というリンクを表示しない
┗ [94640](https://redmine.weseek.co.jp/issues/94640) 実装