### PR TITLE
Fix/issue 5754 1 change var

### DIFF
--- a/packages/app/src/server/util/middlewares.js
+++ b/packages/app/src/server/util/middlewares.js
@@ -4,10 +4,10 @@ import loggerFactory from '~/utils/logger';
 // all new middlewares should be an independent file under /server/middlewares
 // eslint-disable-next-line no-unused-vars
 
-const { formatDistanceStrict } = require('date-fns');
 const { pathUtils } = require('@growi/core');
-const md5 = require('md5');
+const { formatDistanceStrict } = require('date-fns');
 const entities = require('entities');
+const md5 = require('md5');
 
 // eslint-disable-next-line no-unused-vars
 const logger = loggerFactory('growi:lib:middlewares');
@@ -151,6 +151,11 @@ module.exports = (crowi) => {
 
       swig.setFilter('slice', (list, start, end) => {
         return list.slice(start, end);
+      });
+
+      swig.setFilter('push', (list, element) => {
+        list.push(element);
+        return list;
       });
 
       next();

--- a/packages/app/src/server/views/layout/layout.html
+++ b/packages/app/src/server/views/layout/layout.html
@@ -59,11 +59,11 @@
 {% endblock %}
 
 {% block html_body %}
-{% if getConfig('crowi', 'customize:isContainerFluid') && additionalBodyClass == NULL %}
-  {% set additionalBodyClass = 'growi-layout-fluid' %}
+{% if getConfig('crowi', 'customize:isContainerFluid') %}
+  {% set additionalFluidBodyClass = 'growi-layout-fluid' %}
 {% endif %}
 <body
-  class="{% block html_base_css %}{% endblock %} growi {{ additionalBodyClass }}"
+  class="{% block html_base_css %}{% endblock %} growi {{ additionalBodyClass }} {{ additionalFluidBodyClass }}"
   data-is-admin="{{ user.admin }}"
   data-plugin-enabled="{{ getConfig('crowi', 'plugin:isEnabledPlugins') }}"
   {% block html_base_attr %}{% endblock %}

--- a/packages/app/src/server/views/layout/layout.html
+++ b/packages/app/src/server/views/layout/layout.html
@@ -59,11 +59,13 @@
 {% endblock %}
 
 {% block html_body %}
+{% set additionalBodyClasses = []; %}
+{% block html_additional_body_classes %}{% endblock %}
 {% if getConfig('crowi', 'customize:isContainerFluid') %}
-  {% set additionalFluidBodyClass = 'growi-layout-fluid' %}
+  {% set additionalBodyClasses = additionalBodyClasses|push('growi-layout-fluid') %}
 {% endif %}
 <body
-  class="{% block html_base_css %}{% endblock %} growi {{ additionalBodyClass }} {{ additionalFluidBodyClass }}"
+  class="{% block html_base_css %}{% endblock %} growi {{ additionalBodyClasses|join(' ') }}"
   data-is-admin="{{ user.admin }}"
   data-plugin-enabled="{{ getConfig('crowi', 'plugin:isEnabledPlugins') }}"
   {% block html_base_attr %}{% endblock %}

--- a/packages/app/src/server/views/layout/layout.html
+++ b/packages/app/src/server/views/layout/layout.html
@@ -60,10 +60,10 @@
 
 {% block html_body %}
 {% if getConfig('crowi', 'customize:isContainerFluid') %}
-  {% set additionalBodyClass = 'growi-layout-fluid' %}
+  {% set fluidBodyClass = 'growi-layout-fluid' %}
 {% endif %}
 <body
-  class="{% block html_base_css %}{% endblock %} growi {{ additionalBodyClass }}"
+  class="{% block html_base_css %}{% endblock %} growi {{ additionalBodyClass }} {{ fluidBodyClass }}"
   data-is-admin="{{ user.admin }}"
   data-plugin-enabled="{{ getConfig('crowi', 'plugin:isEnabledPlugins') }}"
   {% block html_base_attr %}{% endblock %}

--- a/packages/app/src/server/views/layout/layout.html
+++ b/packages/app/src/server/views/layout/layout.html
@@ -59,11 +59,11 @@
 {% endblock %}
 
 {% block html_body %}
-{% if getConfig('crowi', 'customize:isContainerFluid') %}
-  {% set fluidBodyClass = 'growi-layout-fluid' %}
+{% if getConfig('crowi', 'customize:isContainerFluid') && additionalBodyClass == NULL %}
+  {% set additionalBodyClass = 'growi-layout-fluid' %}
 {% endif %}
 <body
-  class="{% block html_base_css %}{% endblock %} growi {{ additionalBodyClass }} {{ fluidBodyClass }}"
+  class="{% block html_base_css %}{% endblock %} growi {{ additionalBodyClass }}"
   data-is-admin="{{ user.admin }}"
   data-plugin-enabled="{{ getConfig('crowi', 'plugin:isEnabledPlugins') }}"
   {% block html_base_attr %}{% endblock %}

--- a/packages/app/src/server/views/private-legacy-pages.html
+++ b/packages/app/src/server/views/private-legacy-pages.html
@@ -12,7 +12,9 @@
 {% endblock %}
 
 <!-- add .on-search to body tag class in layout -->
-{% set additionalBodyClass = 'on-search' %}
+{% block html_additional_body_classes %}
+  {% set additionalBodyClasses = additionalBodyClasses|push('on-search') %}
+{% endblock %}
 
 {% block layout_main %}
 <div id="grw-fav-sticky-trigger" class="sticky-top"></div>

--- a/packages/app/src/server/views/search.html
+++ b/packages/app/src/server/views/search.html
@@ -12,7 +12,9 @@
 {% endblock %}
 
 <!-- add .on-search to body tag class in layout -->
-{% set additionalBodyClass = 'on-search' %}
+{% block html_additional_body_classes %}
+  {% set additionalBodyClasses = additionalBodyClasses|push('on-search') %}
+{% endblock %}
 
 {% block layout_main %}
 <div id="grw-fav-sticky-trigger" class="sticky-top"></div>


### PR DESCRIPTION
対象ストーリ: https://redmine.weseek.co.jp/issues/95622
対象issue: https://github.com/weseek/growi/issues/5754

＜原因＞
・search-result-contentなどの検索画面のCSSクラス'on-search'が読み込めていない.
・private-legacy-pages.htmlとsearch.htmlにて, additionalBodyClass変数に'on-search'がsetされ,
body classにadditionalBodyClassで読み込まれることによって検索画面のCSSが実現している.
・「コンテンツ幅100%」に設定した場合, layout.htmlでadditionalBodyClass変数に'growi-layout-fluid'クラスがsetされるため, additionalBodyClassが上書きされていた.

＜前提＞
・現状でadditionalBodyClassは'on-search', 'growi-layout-fluid'のみの代入用で使用されている.
・'on-search'と'growi-layout-fluid'両方のCSSクラスが必要なページがない前提.
・layout.htmlはレイアウトテンプレートのため不要なクラスは読み込まないようにしたい.

＜変更箇所＞
layout.html
62行目 （条件分岐を追加）

＜説明＞
前提より, 「コンテンツ幅100%」設定でもadditionalBodyClassにすでに何かがsetされていたら'growi-layout-fluid'をsetしない.
・growi-layout-fluidは優先されない.
・この実装では, additionalBodyClassで使用するクラスを同時に使いたい場合に対応できない.