### PR TITLE
Fixed the bug of auto-filling unintended values into the Email field of the User settings at version 4.5.x

### DIFF
--- a/packages/app/src/components/Me/PasswordSettings.jsx
+++ b/packages/app/src/components/Me/PasswordSettings.jsx
@@ -98,9 +98,6 @@ class PasswordSettings extends React.Component {
           <div className="row mb-3">
             <label htmlFor="oldPassword" className="col-md-3 text-md-right">{ t('personal_settings.current_password') }</label>
             <div className="col-md-5">
-              {/* to prevent autocomplete username into userForm[email] in BasicInfoSettings component */}
-              {/* https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion */}
-              <input type="password" autoComplete="new-password" style={{ display: 'none' }} />
               <input
                 className="form-control"
                 type="password"
@@ -114,6 +111,9 @@ class PasswordSettings extends React.Component {
         <div className="row mb-3">
           <label htmlFor="newPassword" className="col-md-3 text-md-right">{t('personal_settings.new_password') }</label>
           <div className="col-md-5">
+            {/* to prevent autocomplete username into userForm[email] in BasicInfoSettings component */}
+            {/* https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion */}
+            <input type="password" autoComplete="new-password" style={{ display: 'none' }} />
             <input
               className="form-control"
               type="password"


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/95682 
version 5以降ではすでに解決している、User SettingsにおいてGoogleの自動入力が誤動作してしまいEmailフィールドにusernameが入力されてしまうバグの修正。

以下#Issue2152リンク
https://github.com/weseek/growi/issues/2152