### PR TITLE
imprv: Mixin of argument-of-override-list-group-item-for-pagetree for dark theme

### DIFF
--- a/packages/app/src/styles/theme/_apply-colors-dark.scss
+++ b/packages/app/src/styles/theme/_apply-colors-dark.scss
@@ -277,11 +277,11 @@ ul.pagination {
   // Pagetree
   .grw-pagetree {
     @include override-list-group-item-for-pagetree(
-      $gray-200,
+      $color-sidebar-context,
       lighten($bgcolor-sidebar-context, 8%),
       lighten($bgcolor-sidebar-context, 15%),
-      $gray-500,
-      $gray-200,
+      darken($color-sidebar-context, 15%),
+      darken($color-sidebar-context, 10%),
       lighten($bgcolor-sidebar-context, 18%),
       lighten($bgcolor-sidebar-context, 24%)
     );


### PR DESCRIPTION

# 作業task
- https://redmine.weseek.co.jp/issues/90392

# ミッション・考え方
- dark themeにおけるoverride-list-group-item-for-pagetreeをgrayを使わない記述にする
- 文字色($color-sidebar-context)と背景色($bgcolor-sidebar-context)の2つさえ確定すれば自動的に決まるようにした

# 各テーマの見た目
## Default
![image](https://user-images.githubusercontent.com/20252919/170442332-5a7746ff-9719-4c75-b497-334b0ab624b1.png)

## mono-blue
![image](https://user-images.githubusercontent.com/20252919/170442417-a09b4d2b-dba7-4030-85a3-94287f1cacca.png)

## hufflepuff
![image](https://user-images.githubusercontent.com/20252919/170442496-65000e8b-8c41-450a-ab3e-2f0e44a91fc5.png)

## fire-red
![image](https://user-images.githubusercontent.com/20252919/170442581-1c1db593-af83-46e4-8c4d-4950c5d41ef7.png)

## jade-green
![image](https://user-images.githubusercontent.com/20252919/170442650-49a24c6d-63ce-4e18-8bc8-b6304ee71a7f.png)
## future
![image](https://user-images.githubusercontent.com/20252919/170442893-b32825e9-035e-470b-8538-909cab69faf1.png)

## halloween
![image](https://user-images.githubusercontent.com/20252919/170442963-e9be05fe-6633-4c2d-bb8b-45b16edfce3c.png)

## blackboard
![image](https://user-images.githubusercontent.com/20252919/170443073-0ac0383b-14e4-4b43-b2de-4ee969746e70.png)
