### PR TITLE
imprv: convert withTranslation to useTranslation 10 jsx files

### DIFF
--- a/packages/app/src/components/ArchiveCreateModal.jsx
+++ b/packages/app/src/components/ArchiveCreateModal.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback } from 'react';
 
 import PropTypes from 'prop-types';
-import { withTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 import {
   Modal, ModalHeader, ModalBody, ModalFooter,
 } from 'reactstrap';
@@ -233,8 +233,6 @@ const ArchiveCreateModal = (props) => {
   );
 };
 
-const ArchiveCreateModalWrapper = withUnstatedContainers(ArchiveCreateModal, [AppContainer]);
-
 ArchiveCreateModal.propTypes = {
   t: PropTypes.func.isRequired, //  i18next
   appContainer: PropTypes.instanceOf(AppContainer).isRequired,
@@ -245,4 +243,14 @@ ArchiveCreateModal.propTypes = {
   errorMessage: PropTypes.string,
 };
 
-export default withTranslation()(ArchiveCreateModalWrapper);
+const ArchiveCreateModalWrapperFC = (props) => {
+  const { t } = useTranslation();
+  return <ArchiveCreateModal t={t} {...props} />;
+};
+
+/**
+ * Wrapper component for using unstated
+ */
+const ArchiveCreateModalWrapper = withUnstatedContainers(ArchiveCreateModalWrapperFC, [AppContainer]);
+
+export default ArchiveCreateModalWrapper;

--- a/packages/app/src/components/ArchiveCreateModal.jsx
+++ b/packages/app/src/components/ArchiveCreateModal.jsx
@@ -14,7 +14,8 @@ import { withUnstatedContainers } from './UnstatedUtils';
 
 
 const ArchiveCreateModal = (props) => {
-  const { t, appContainer } = props;
+  const { t } = useTranslation();
+  const { appContainer } = props;
   const [isCommentDownload, setIsCommentDownload] = useState(false);
   const [isAttachmentFileDownload, setIsAttachmentFileDownload] = useState(false);
   const [isSubordinatedPageDownload, setIsSubordinatedPageDownload] = useState(false);
@@ -243,14 +244,9 @@ ArchiveCreateModal.propTypes = {
   errorMessage: PropTypes.string,
 };
 
-const ArchiveCreateModalWrapperFC = (props) => {
-  const { t } = useTranslation();
-  return <ArchiveCreateModal t={t} {...props} />;
-};
-
 /**
  * Wrapper component for using unstated
  */
-const ArchiveCreateModalWrapper = withUnstatedContainers(ArchiveCreateModalWrapperFC, [AppContainer]);
+const ArchiveCreateModalWrapper = withUnstatedContainers(ArchiveCreateModal, [AppContainer]);
 
 export default ArchiveCreateModalWrapper;

--- a/packages/app/src/components/CreateTemplateModal.jsx
+++ b/packages/app/src/components/CreateTemplateModal.jsx
@@ -7,7 +7,8 @@ import { Modal, ModalHeader, ModalBody } from 'reactstrap';
 import urljoin from 'url-join';
 
 const CreateTemplateModal = (props) => {
-  const { t, path } = props;
+  const { t } = useTranslation();
+  const { path } = props;
 
   const parentPath = pathUtils.addTrailingSlash(path);
 
@@ -68,9 +69,4 @@ CreateTemplateModal.propTypes = {
   onClose: PropTypes.func.isRequired,
 };
 
-const CreateTemplateModalWrapperFC = (props) => {
-  const { t } = useTranslation();
-  return <CreateTemplateModal t={t} {...props} />;
-};
-
-export default CreateTemplateModalWrapperFC;
+export default CreateTemplateModal;

--- a/packages/app/src/components/CreateTemplateModal.jsx
+++ b/packages/app/src/components/CreateTemplateModal.jsx
@@ -6,13 +6,9 @@ import { useTranslation } from 'react-i18next';
 import { Modal, ModalHeader, ModalBody } from 'reactstrap';
 import urljoin from 'url-join';
 
-type Props = {
-  path?: string,
-};
-
-const CreateTemplateModal = (props: Props) => {
+const CreateTemplateModal = (props) => {
   const { t } = useTranslation();
-  const { path } = props;
+  const { path } = props!;
 
   const parentPath = pathUtils.addTrailingSlash(path);
 

--- a/packages/app/src/components/CreateTemplateModal.jsx
+++ b/packages/app/src/components/CreateTemplateModal.jsx
@@ -8,7 +8,6 @@ import urljoin from 'url-join';
 
 const CreateTemplateModal = (props) => {
   const { t } = useTranslation();
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const { path } = props;
 
   const parentPath = pathUtils.addTrailingSlash(path);
@@ -65,7 +64,7 @@ const CreateTemplateModal = (props) => {
 
 CreateTemplateModal.propTypes = {
   t: PropTypes.func.isRequired, //  i18next
-  path: PropTypes.string.isRequired,
+  path: PropTypes.string,
   isOpen: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,
 };

--- a/packages/app/src/components/CreateTemplateModal.jsx
+++ b/packages/app/src/components/CreateTemplateModal.jsx
@@ -63,7 +63,7 @@ const CreateTemplateModal = (props) => {
 };
 
 CreateTemplateModal.propTypes = {
-  t: PropTypes.func.isRequired, //  i18next
+  // t: PropTypes.func.isRequired, //  i18next
   path: PropTypes.string,
   isOpen: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,

--- a/packages/app/src/components/CreateTemplateModal.jsx
+++ b/packages/app/src/components/CreateTemplateModal.jsx
@@ -63,7 +63,7 @@ const CreateTemplateModal = (props) => {
 };
 
 CreateTemplateModal.propTypes = {
-  // t: PropTypes.func.isRequired, //  i18next
+  // t: PropTypes.func.isRequired, //  i18next // avoided type error
   path: PropTypes.string,
   isOpen: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,

--- a/packages/app/src/components/CreateTemplateModal.jsx
+++ b/packages/app/src/components/CreateTemplateModal.jsx
@@ -9,7 +9,7 @@ import urljoin from 'url-join';
 const CreateTemplateModal = (props) => {
   const { t } = useTranslation();
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  const { path } = props!;
+  const { path } = props;
 
   const parentPath = pathUtils.addTrailingSlash(path);
 

--- a/packages/app/src/components/CreateTemplateModal.jsx
+++ b/packages/app/src/components/CreateTemplateModal.jsx
@@ -6,7 +6,11 @@ import { useTranslation } from 'react-i18next';
 import { Modal, ModalHeader, ModalBody } from 'reactstrap';
 import urljoin from 'url-join';
 
-const CreateTemplateModal = (props) => {
+type Props = {
+  path?: string,
+};
+
+const CreateTemplateModal = (props: Props) => {
   const { t } = useTranslation();
   const { path } = props;
 

--- a/packages/app/src/components/CreateTemplateModal.jsx
+++ b/packages/app/src/components/CreateTemplateModal.jsx
@@ -8,6 +8,7 @@ import urljoin from 'url-join';
 
 const CreateTemplateModal = (props) => {
   const { t } = useTranslation();
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const { path } = props!;
 
   const parentPath = pathUtils.addTrailingSlash(path);

--- a/packages/app/src/components/CreateTemplateModal.jsx
+++ b/packages/app/src/components/CreateTemplateModal.jsx
@@ -1,12 +1,10 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
-import { Modal, ModalHeader, ModalBody } from 'reactstrap';
-
-import { withTranslation } from 'react-i18next';
 import { pathUtils } from '@growi/core';
+import PropTypes from 'prop-types';
+import { useTranslation } from 'react-i18next';
+import { Modal, ModalHeader, ModalBody } from 'reactstrap';
 import urljoin from 'url-join';
-
 
 const CreateTemplateModal = (props) => {
   const { t, path } = props;
@@ -63,7 +61,6 @@ const CreateTemplateModal = (props) => {
   );
 };
 
-
 CreateTemplateModal.propTypes = {
   t: PropTypes.func.isRequired, //  i18next
   path: PropTypes.string.isRequired,
@@ -71,4 +68,9 @@ CreateTemplateModal.propTypes = {
   onClose: PropTypes.func.isRequired,
 };
 
-export default withTranslation()(CreateTemplateModal);
+const CreateTemplateModalWrapperFC = (props) => {
+  const { t } = useTranslation();
+  return <CreateTemplateModal t={t} {...props} />;
+};
+
+export default CreateTemplateModalWrapperFC;

--- a/packages/app/src/components/Drawio.jsx
+++ b/packages/app/src/components/Drawio.jsx
@@ -4,12 +4,10 @@ import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
 import { debounce } from 'throttle-debounce';
 
-
 import AppContainer from '~/client/services/AppContainer';
 
 import NotAvailableForGuest from './NotAvailableForGuest';
 import { withUnstatedContainers } from './UnstatedUtils';
-
 
 class Drawio extends React.Component {
 

--- a/packages/app/src/components/Drawio.jsx
+++ b/packages/app/src/components/Drawio.jsx
@@ -1,15 +1,15 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
+import PropTypes from 'prop-types';
+import { useTranslation } from 'react-i18next';
 import { debounce } from 'throttle-debounce';
 
-import { withTranslation } from 'react-i18next';
 
 import AppContainer from '~/client/services/AppContainer';
 
+import NotAvailableForGuest from './NotAvailableForGuest';
 import { withUnstatedContainers } from './UnstatedUtils';
 
-import NotAvailableForGuest from './NotAvailableForGuest';
 
 class Drawio extends React.Component {
 
@@ -105,4 +105,11 @@ Drawio.propTypes = {
   rangeLineNumberOfMarkdown: PropTypes.object.isRequired,
 };
 
-export default withTranslation()(withUnstatedContainers(Drawio, [AppContainer]));
+const DrawioWrapperFC = (props) => {
+  const { t } = useTranslation();
+  return <Drawio t={t} {...props} />;
+};
+
+const DrawioWrapper = withUnstatedContainers(DrawioWrapperFC, [AppContainer]);
+
+export default DrawioWrapper;

--- a/packages/app/src/components/InstallerForm.jsx
+++ b/packages/app/src/components/InstallerForm.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import i18next from 'i18next';
-import { withTranslation } from 'react-i18next';
+import PropTypes from 'prop-types';
+import { useTranslation } from 'react-i18next';
 
 import { localeMetadatas } from '~/client/util/i18n';
 
@@ -214,4 +214,9 @@ InstallerForm.propTypes = {
   csrf: PropTypes.string,
 };
 
-export default withTranslation()(InstallerForm);
+const InstallerFormWrapperFC = (props) => {
+  const { t } = useTranslation();
+  return <InstallerForm t={t} {...props} />;
+};
+
+export default InstallerFormWrapperFC;

--- a/packages/app/src/components/LoginForm.jsx
+++ b/packages/app/src/components/LoginForm.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
+
 import PropTypes from 'prop-types';
 import ReactCardFlip from 'react-card-flip';
-
-import { withTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 
 import AppContainer from '~/client/services/AppContainer';
+
 import { withUnstatedContainers } from './UnstatedUtils';
 
 class LoginForm extends React.Component {
@@ -327,11 +328,6 @@ class LoginForm extends React.Component {
 
 }
 
-/**
- * Wrapper component for using unstated
- */
-const LoginFormWrapper = withUnstatedContainers(LoginForm, [AppContainer]);
-
 LoginForm.propTypes = {
   // i18next
   t: PropTypes.func.isRequired,
@@ -351,4 +347,14 @@ LoginForm.propTypes = {
   objOfIsExternalAuthEnableds: PropTypes.object,
 };
 
-export default withTranslation()(LoginFormWrapper);
+const LoginFormWrapperFC = (props) => {
+  const { t } = useTranslation();
+  return <LoginForm t={t} {...props} />;
+};
+
+/**
+ * Wrapper component for using unstated
+ */
+const LoginFormWrapper = withUnstatedContainers(LoginFormWrapperFC, [AppContainer]);
+
+export default LoginFormWrapper;

--- a/packages/app/src/components/Me/BasicInfoSettings.jsx
+++ b/packages/app/src/components/Me/BasicInfoSettings.jsx
@@ -2,7 +2,7 @@
 import React, { Fragment } from 'react';
 
 import PropTypes from 'prop-types';
-import { withTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 
 import PersonalContainer from '~/client/services/PersonalContainer';
 import { toastSuccess, toastError } from '~/client/util/apiNotification';
@@ -163,11 +163,19 @@ class BasicInfoSettings extends React.Component {
 
 }
 
-const BasicInfoSettingsWrapper = withUnstatedContainers(BasicInfoSettings, [PersonalContainer]);
-
 BasicInfoSettings.propTypes = {
   t: PropTypes.func.isRequired, // i18next
   personalContainer: PropTypes.instanceOf(PersonalContainer).isRequired,
 };
 
-export default withTranslation()(BasicInfoSettingsWrapper);
+const BasicInfoSettingsWrapperFC = (props) => {
+  const { t } = useTranslation();
+  return <BasicInfoSettings t={t} {...props} />;
+};
+
+/**
+ * Wrapper component for using unstated
+ */
+const BasicInfoSettingsWrapper = withUnstatedContainers(BasicInfoSettingsWrapperFC, [PersonalContainer]);
+
+export default BasicInfoSettingsWrapper;

--- a/packages/app/src/components/Navbar/GrowiContextualSubNavigation.tsx
+++ b/packages/app/src/components/Navbar/GrowiContextualSubNavigation.tsx
@@ -1,45 +1,42 @@
 import React, { useState, useCallback } from 'react';
-import { useTranslation } from 'react-i18next';
+
 import PropTypes from 'prop-types';
-
-
+import { useTranslation } from 'react-i18next';
 import { DropdownItem } from 'reactstrap';
 
-import { OnDuplicatedFunction, OnRenamedFunction, OnDeletedFunction } from '~/interfaces/ui';
-import { IPageHasId, IPageToRenameWithMeta, IPageWithMeta } from '~/interfaces/page';
-
-import { withUnstatedContainers } from '../UnstatedUtils';
 import EditorContainer from '~/client/services/EditorContainer';
-import {
-  EditorMode, useDrawerMode, useEditorMode, useIsDeviceSmallerThanMd, useIsAbleToShowPageManagement, useIsAbleToShowTagLabel,
-  useIsAbleToShowPageEditorModeManager, useIsAbleToShowPageAuthors,
-} from '~/stores/ui';
-import {
-  usePageAccessoriesModal, PageAccessoriesModalContents, IPageForPageDuplicateModal,
-  usePageDuplicateModal, usePageRenameModal, usePageDeleteModal, usePagePresentationModal,
-} from '~/stores/modal';
-
-
+import { exportAsMarkdown } from '~/client/services/page-operation';
+import { toastSuccess, toastError } from '~/client/util/apiNotification';
+import { apiPost } from '~/client/util/apiv1-client';
+import { IPageHasId, IPageToRenameWithMeta, IPageWithMeta } from '~/interfaces/page';
+import { OnDuplicatedFunction, OnRenamedFunction, OnDeletedFunction } from '~/interfaces/ui';
 import {
   useCurrentCreatedAt, useCurrentUpdatedAt, useCurrentPageId, useRevisionId, useCurrentPagePath,
   useCreator, useRevisionAuthor, useCurrentUser, useIsGuestUser, useIsSharedUser, useShareLinkId,
 } from '~/stores/context';
+import {
+  usePageAccessoriesModal, PageAccessoriesModalContents, IPageForPageDuplicateModal,
+  usePageDuplicateModal, usePageRenameModal, usePageDeleteModal, usePagePresentationModal,
+} from '~/stores/modal';
 import { useSWRTagsInfo } from '~/stores/page';
+import {
+  EditorMode, useDrawerMode, useEditorMode, useIsDeviceSmallerThanMd, useIsAbleToShowPageManagement, useIsAbleToShowTagLabel,
+  useIsAbleToShowPageEditorModeManager, useIsAbleToShowPageAuthors,
+} from '~/stores/ui';
 
-
-import { toastSuccess, toastError } from '~/client/util/apiNotification';
-import { apiPost } from '~/client/util/apiv1-client';
-
-import HistoryIcon from '../Icons/HistoryIcon';
-import AttachmentIcon from '../Icons/AttachmentIcon';
-import ShareLinkIcon from '../Icons/ShareLinkIcon';
 import { AdditionalMenuItemsRendererProps } from '../Common/Dropdown/PageItemControl';
-import { SubNavButtons } from './SubNavButtons';
-import PageEditorModeManager from './PageEditorModeManager';
+import AttachmentIcon from '../Icons/AttachmentIcon';
+import HistoryIcon from '../Icons/HistoryIcon';
+import { withUnstatedContainers } from '../UnstatedUtils';
+
+import ShareLinkIcon from '../Icons/ShareLinkIcon';
+
 import { GrowiSubNavigation } from './GrowiSubNavigation';
+import PageEditorModeManager from './PageEditorModeManager';
+import { SubNavButtons } from './SubNavButtons';
+
 import PresentationIcon from '../Icons/PresentationIcon';
 import CreateTemplateModal from '../CreateTemplateModal';
-import { exportAsMarkdown } from '~/client/services/page-operation';
 
 
 type AdditionalMenuItemsProps = AdditionalMenuItemsRendererProps & {

--- a/packages/app/src/components/PageAccessoriesModalControl.jsx
+++ b/packages/app/src/components/PageAccessoriesModalControl.jsx
@@ -1,19 +1,18 @@
 import React, { Fragment, useMemo } from 'react';
+
 import PropTypes from 'prop-types';
-
-import { withTranslation } from 'react-i18next';
-
+import { useTranslation } from 'react-i18next';
 import { UncontrolledTooltip } from 'reactstrap';
 
-import PageListIcon from './Icons/PageListIcon';
-import TimeLineIcon from './Icons/TimeLineIcon';
-import HistoryIcon from './Icons/HistoryIcon';
-import AttachmentIcon from './Icons/AttachmentIcon';
-import ShareLinkIcon from './Icons/ShareLinkIcon';
+import { useCurrentPageId } from '~/stores/context';
 
+import AttachmentIcon from './Icons/AttachmentIcon';
+import HistoryIcon from './Icons/HistoryIcon';
+import PageListIcon from './Icons/PageListIcon';
+import ShareLinkIcon from './Icons/ShareLinkIcon';
+import TimeLineIcon from './Icons/TimeLineIcon';
 import { withUnstatedContainers } from './UnstatedUtils';
 
-import { useCurrentPageId } from '~/stores/context';
 
 const PageAccessoriesModalControl = (props) => {
   const {
@@ -92,10 +91,6 @@ const PageAccessoriesModalControl = (props) => {
     </div>
   );
 };
-/**
- * Wrapper component for using unstated
- */
-const PageAccessoriesModalControlWrapper = withUnstatedContainers(PageAccessoriesModalControl, []);
 
 PageAccessoriesModalControl.propTypes = {
   t: PropTypes.func.isRequired, //  i18next
@@ -106,4 +101,14 @@ PageAccessoriesModalControl.propTypes = {
   isSharedUser: PropTypes.bool.isRequired,
 };
 
-export default withTranslation()(PageAccessoriesModalControlWrapper);
+const PageAccessoriesModalControlWrapperFC = (props) => {
+  const { t } = useTranslation();
+  return <PageAccessoriesModalControl t={t} {...props} />;
+};
+
+/**
+ * Wrapper component for using unstated
+ */
+const PageAccessoriesModalControlWrapper = withUnstatedContainers(PageAccessoriesModalControlWrapperFC, []);
+
+export default PageAccessoriesModalControlWrapper;

--- a/packages/app/src/components/PageAccessoriesModalControl.jsx
+++ b/packages/app/src/components/PageAccessoriesModalControl.jsx
@@ -15,8 +15,9 @@ import { withUnstatedContainers } from './UnstatedUtils';
 
 
 const PageAccessoriesModalControl = (props) => {
+  const { t } = useTranslation();
   const {
-    t, pageAccessoriesContainer, isGuestUser, isSharedUser,
+    pageAccessoriesContainer, isGuestUser, isSharedUser,
   } = props;
   const isLinkSharingDisabled = pageAccessoriesContainer.appContainer.config.disableLinkSharing;
 
@@ -101,14 +102,9 @@ PageAccessoriesModalControl.propTypes = {
   isSharedUser: PropTypes.bool.isRequired,
 };
 
-const PageAccessoriesModalControlWrapperFC = (props) => {
-  const { t } = useTranslation();
-  return <PageAccessoriesModalControl t={t} {...props} />;
-};
-
 /**
  * Wrapper component for using unstated
  */
-const PageAccessoriesModalControlWrapper = withUnstatedContainers(PageAccessoriesModalControlWrapperFC, []);
+const PageAccessoriesModalControlWrapper = withUnstatedContainers(PageAccessoriesModalControl, []);
 
 export default PageAccessoriesModalControlWrapper;

--- a/packages/app/src/components/PageAttachment.jsx
+++ b/packages/app/src/components/PageAttachment.jsx
@@ -2,7 +2,7 @@
 import React from 'react';
 
 import PropTypes from 'prop-types';
-import { withTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 
 import AppContainer from '~/client/services/AppContainer';
 import PageContainer from '~/client/services/PageContainer';
@@ -172,16 +172,20 @@ class PageAttachment extends React.Component {
 
 }
 
-/**
- * Wrapper component for using unstated
- */
-const PageAttachmentWrapper = withUnstatedContainers(PageAttachment, [AppContainer, PageContainer]);
-
-
 PageAttachment.propTypes = {
   t: PropTypes.func.isRequired,
   appContainer: PropTypes.instanceOf(AppContainer).isRequired,
   pageContainer: PropTypes.instanceOf(PageContainer).isRequired,
 };
 
-export default withTranslation()(PageAttachmentWrapper);
+const PageAttachmentWrapperFC = (props) => {
+  const { t } = useTranslation();
+  return <PageAttachment t={t} {...props} />;
+};
+
+/**
+ * Wrapper component for using unstated
+ */
+const PageAttachmentWrapper = withUnstatedContainers(PageAttachmentWrapperFC, [AppContainer, PageContainer]);
+
+export default PageAttachmentWrapper;

--- a/packages/app/src/components/PageCreateModal.jsx
+++ b/packages/app/src/components/PageCreateModal.jsx
@@ -23,7 +23,8 @@ const {
 } = pagePathUtils;
 
 const PageCreateModal = (props) => {
-  const { t, appContainer } = props;
+  const { t } = useTranslation();
+  const { appContainer } = props;
 
   const { data: pageCreateModalData, close: closeCreateModal } = usePageCreateModal();
   const { isOpened, path } = pageCreateModalData;
@@ -312,14 +313,9 @@ PageCreateModal.propTypes = {
   appContainer: PropTypes.instanceOf(AppContainer).isRequired,
 };
 
-const PageCreateModalWrapperFC = (props) => {
-  const { t } = useTranslation();
-  return <PageCreateModal t={t} {...props} />;
-};
-
 /**
  * Wrapper component for using unstated
  */
-const PageCreateModalWrapper = withUnstatedContainers(PageCreateModalWrapperFC, [AppContainer]);
+const PageCreateModalWrapper = withUnstatedContainers(PageCreateModal, [AppContainer]);
 
 export default PageCreateModalWrapper;

--- a/packages/app/src/components/PageCreateModal.jsx
+++ b/packages/app/src/components/PageCreateModal.jsx
@@ -5,7 +5,7 @@ import React, {
 import { pagePathUtils, pathUtils } from '@growi/core';
 import { format } from 'date-fns';
 import PropTypes from 'prop-types';
-import { withTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 import { Modal, ModalHeader, ModalBody } from 'reactstrap';
 import { debounce } from 'throttle-debounce';
 
@@ -307,16 +307,19 @@ const PageCreateModal = (props) => {
   );
 };
 
-
-/**
- * Wrapper component for using unstated
- */
-const ModalControlWrapper = withUnstatedContainers(PageCreateModal, [AppContainer]);
-
-
 PageCreateModal.propTypes = {
   t: PropTypes.func.isRequired, //  i18next
   appContainer: PropTypes.instanceOf(AppContainer).isRequired,
 };
 
-export default withTranslation()(ModalControlWrapper);
+const PageCreateModalWrapperFC = (props) => {
+  const { t } = useTranslation();
+  return <PageCreateModal t={t} {...props} />;
+};
+
+/**
+ * Wrapper component for using unstated
+ */
+const PageCreateModalWrapper = withUnstatedContainers(PageCreateModalWrapperFC, [AppContainer]);
+
+export default PageCreateModalWrapper;

--- a/packages/app/src/components/PageEditorByHackmd.jsx
+++ b/packages/app/src/components/PageEditorByHackmd.jsx
@@ -424,6 +424,11 @@ class PageEditorByHackmd extends React.Component {
 
 }
 
+/**
+ * Wrapper component for using unstated
+ */
+const PageEditorByHackmdHOCWrapper = withUnstatedContainers(PageEditorByHackmd, [AppContainer, PageContainer, EditorContainer]);
+
 PageEditorByHackmd.propTypes = {
   t: PropTypes.func.isRequired, // i18next
 
@@ -440,7 +445,7 @@ PageEditorByHackmd.propTypes = {
   grantGroupName: PropTypes.string,
 };
 
-const PageEditorByHackmdWrapperFC = React.forwardRef((props, ref) => {
+const PageEditorByHackmdWrapper = (props) => {
   const { t } = useTranslation();
   const { data: editorMode } = useEditorMode();
   const { data: isSlackEnabled } = useIsSlackEnabled();
@@ -454,8 +459,7 @@ const PageEditorByHackmdWrapperFC = React.forwardRef((props, ref) => {
   }
 
   return (
-    <PageEditorByHackmd
-      ref={ref}
+    <PageEditorByHackmdHOCWrapper
       {...props}
       t={t}
       editorMode={editorMode}
@@ -466,11 +470,6 @@ const PageEditorByHackmdWrapperFC = React.forwardRef((props, ref) => {
       grantGroupName={grantGroupName}
     />
   );
-});
-
-/**
- * Wrapper component for using unstated
- */
-const PageEditorByHackmdWrapper = withUnstatedContainers(PageEditorByHackmdWrapperFC, [AppContainer, PageContainer, EditorContainer]);
+};
 
 export default PageEditorByHackmdWrapper;

--- a/packages/app/src/components/PageEditorByHackmd.jsx
+++ b/packages/app/src/components/PageEditorByHackmd.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import PropTypes from 'prop-types';
-import { withTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 
 
 import AppContainer from '~/client/services/AppContainer';
@@ -424,12 +424,8 @@ class PageEditorByHackmd extends React.Component {
 
 }
 
-/**
- * Wrapper component for using unstated
- */
-const PageEditorByHackmdHOCWrapper = withUnstatedContainers(PageEditorByHackmd, [AppContainer, PageContainer, EditorContainer]);
-
-const PageEditorByHackmdWrapper = (props) => {
+const PageEditorByHackmdWrapperFC = React.forwardRef((props, ref) => {
+  const { t } = useTranslation();
   const { data: editorMode } = useEditorMode();
   const { data: isSlackEnabled } = useIsSlackEnabled();
   const { data: slackChannels } = useSlackChannels();
@@ -442,8 +438,10 @@ const PageEditorByHackmdWrapper = (props) => {
   }
 
   return (
-    <PageEditorByHackmdHOCWrapper
+    <PageEditorByHackmd
+      ref={ref}
       {...props}
+      t={t}
       editorMode={editorMode}
       isSlackEnabled={isSlackEnabled}
       slackChannels={slackChannels}
@@ -452,7 +450,12 @@ const PageEditorByHackmdWrapper = (props) => {
       grantGroupName={grantGroupName}
     />
   );
-};
+});
+
+/**
+ * Wrapper component for using unstated
+ */
+const PageEditorByHackmdWrapper = withUnstatedContainers(PageEditorByHackmdWrapperFC, [AppContainer, PageContainer, EditorContainer]);
 
 PageEditorByHackmd.propTypes = {
   t: PropTypes.func.isRequired, // i18next
@@ -470,4 +473,4 @@ PageEditorByHackmd.propTypes = {
   grantGroupName: PropTypes.string,
 };
 
-export default withTranslation()(PageEditorByHackmdWrapper);
+export default PageEditorByHackmdWrapper;

--- a/packages/app/src/components/PageEditorByHackmd.jsx
+++ b/packages/app/src/components/PageEditorByHackmd.jsx
@@ -424,6 +424,22 @@ class PageEditorByHackmd extends React.Component {
 
 }
 
+PageEditorByHackmd.propTypes = {
+  t: PropTypes.func.isRequired, // i18next
+
+  appContainer: PropTypes.instanceOf(AppContainer).isRequired,
+  pageContainer: PropTypes.instanceOf(PageContainer).isRequired,
+  editorContainer: PropTypes.instanceOf(EditorContainer).isRequired,
+
+  // TODO: remove this when omitting unstated is completed
+  editorMode: PropTypes.string.isRequired,
+  isSlackEnabled: PropTypes.bool.isRequired,
+  slackChannels: PropTypes.string.isRequired,
+  grant: PropTypes.number.isRequired,
+  grantGroupId: PropTypes.string,
+  grantGroupName: PropTypes.string,
+};
+
 const PageEditorByHackmdWrapperFC = React.forwardRef((props, ref) => {
   const { t } = useTranslation();
   const { data: editorMode } = useEditorMode();
@@ -456,21 +472,5 @@ const PageEditorByHackmdWrapperFC = React.forwardRef((props, ref) => {
  * Wrapper component for using unstated
  */
 const PageEditorByHackmdWrapper = withUnstatedContainers(PageEditorByHackmdWrapperFC, [AppContainer, PageContainer, EditorContainer]);
-
-PageEditorByHackmd.propTypes = {
-  t: PropTypes.func.isRequired, // i18next
-
-  appContainer: PropTypes.instanceOf(AppContainer).isRequired,
-  pageContainer: PropTypes.instanceOf(PageContainer).isRequired,
-  editorContainer: PropTypes.instanceOf(EditorContainer).isRequired,
-
-  // TODO: remove this when omitting unstated is completed
-  editorMode: PropTypes.string.isRequired,
-  isSlackEnabled: PropTypes.bool.isRequired,
-  slackChannels: PropTypes.string.isRequired,
-  grant: PropTypes.number.isRequired,
-  grantGroupId: PropTypes.string,
-  grantGroupName: PropTypes.string,
-};
 
 export default PageEditorByHackmdWrapper;


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/96331

withTranslationからuseTranslationへの変更, 10ファイル.
-  基本的にComment.jsxを参考に変更.
-  [CreateTemplateModal.jsx, InstallerForm.jsx]はwithUnstatedContainersなしの場合で、そのままWrapperFCをexport.
-  PageEditorByHackmd.jsxのみforwardRefを使用.