### PR TITLE
feat: 96274 96275 connect to mongo and refactor config system

### DIFF
--- a/packages/app/src/server/interfaces/api-rate-limit-config.ts
+++ b/packages/app/src/server/interfaces/api-rate-limit-config.ts
@@ -1,6 +1,6 @@
 export type IApiRateLimitConfig = {
   [endpoint: string]: {
     method: string,
-    consumePoints: number
+    maxRequests: number
   }
 }

--- a/packages/app/src/server/middlewares/api-rate-limiter.ts
+++ b/packages/app/src/server/middlewares/api-rate-limiter.ts
@@ -44,19 +44,16 @@ module.exports = () => {
     try {
       if (customizedConfig === undefined) {
         await consumePoints(rateLimiter, key, defaultMaxRequests);
-        next();
-        return;
+        return next();
       }
 
       if (customizedConfig.method.includes(req.method) || customizedConfig.method === 'ALL') {
         await consumePoints(rateLimiter, key, customizedConfig.maxRequests);
-        next();
-        return;
+        return next();
       }
 
       await consumePoints(rateLimiter, key, defaultMaxRequests);
-      next();
-      return;
+      return next();
     }
     catch {
       logger.error(`too many request at ${key}`);

--- a/packages/app/src/server/middlewares/api-rate-limiter.ts
+++ b/packages/app/src/server/middlewares/api-rate-limiter.ts
@@ -60,6 +60,7 @@ module.exports = () => {
     }
     catch {
       logger.error(`too many request at ${key}`);
+      return res.sendStatus(429);
     }
   };
 };

--- a/packages/app/src/server/middlewares/api-rate-limiter.ts
+++ b/packages/app/src/server/middlewares/api-rate-limiter.ts
@@ -1,5 +1,6 @@
 import { NextFunction, Request, Response } from 'express';
-import { RateLimiterMemory } from 'rate-limiter-flexible';
+import mongoose from 'mongoose';
+import { RateLimiterMongo } from 'rate-limiter-flexible';
 
 import loggerFactory from '~/utils/logger';
 
@@ -12,15 +13,16 @@ const defaultMaxPoints = 100;
 const defaultConsumePoints = 10;
 const defaultDuration = 1;
 const opts = {
+  storeClient: mongoose.connection,
   points: defaultMaxPoints, // set default value
   duration: defaultDuration, // set default value
 };
-const rateLimiter = new RateLimiterMemory(opts);
+const rateLimiter = new RateLimiterMongo(opts);
 
 // generate ApiRateLimitConfig for api rate limiter
 const apiRateLimitConfig = generateApiRateLimitConfig();
 
-const consumePoints = async(rateLimiter: RateLimiterMemory, key: string, points: number, next: NextFunction) => {
+const consumePoints = async(rateLimiter: RateLimiterMongo, key: string, points: number, next: NextFunction) => {
   await rateLimiter.consume(key, points)
     .then(() => {
       next();

--- a/packages/app/src/server/middlewares/api-rate-limiter.ts
+++ b/packages/app/src/server/middlewares/api-rate-limiter.ts
@@ -1,4 +1,5 @@
 import { NextFunction, Request, Response } from 'express';
+import { md5 } from 'md5';
 import mongoose from 'mongoose';
 import { RateLimiterMongo } from 'rate-limiter-flexible';
 
@@ -37,7 +38,7 @@ module.exports = () => {
   return async(req: Request, res: Response, next: NextFunction) => {
 
     const endpoint = req.path;
-    const key = req.ip + endpoint;
+    const key = md5(req.ip + endpoint);
 
     const customizedConfig = apiRateLimitConfig[endpoint];
 
@@ -56,7 +57,7 @@ module.exports = () => {
       return next();
     }
     catch {
-      logger.error(`too many request at ${key}`);
+      logger.error(`${req.ip}: too many request at ${endpoint}`);
       return res.sendStatus(429);
     }
   };

--- a/packages/app/src/server/middlewares/api-rate-limiter.ts
+++ b/packages/app/src/server/middlewares/api-rate-limiter.ts
@@ -40,8 +40,6 @@ module.exports = () => {
     const endpoint = req.path;
     const key = md5(req.ip + endpoint);
 
-    logger.info(`key: ${key}`);
-
     const customizedConfig = apiRateLimitConfig[endpoint];
 
     try {

--- a/packages/app/src/server/middlewares/api-rate-limiter.ts
+++ b/packages/app/src/server/middlewares/api-rate-limiter.ts
@@ -29,13 +29,13 @@ const apiRateLimitConfig = generateApiRateLimitConfig();
 
 const consumePoints = async(rateLimiter: RateLimiterMongo, key: string, points: number, next: NextFunction) => {
   const consumePoints = defaultMaxPoints / points;
-  await rateLimiter.consume(key, consumePoints)
-    .then(() => {
-      next();
-    })
-    .catch(() => {
-      logger.error(`too many request at ${key}`);
-    });
+  try {
+    await rateLimiter.consume(key, consumePoints);
+    next();
+  }
+  catch {
+    logger.error(`too many request at ${key}`);
+  }
 };
 
 module.exports = () => {

--- a/packages/app/src/server/middlewares/api-rate-limiter.ts
+++ b/packages/app/src/server/middlewares/api-rate-limiter.ts
@@ -1,5 +1,5 @@
 import { NextFunction, Request, Response } from 'express';
-import { md5 } from 'md5';
+import md5 from 'md5';
 import mongoose from 'mongoose';
 import { RateLimiterMongo } from 'rate-limiter-flexible';
 
@@ -39,6 +39,8 @@ module.exports = () => {
 
     const endpoint = req.path;
     const key = md5(req.ip + endpoint);
+
+    logger.info(`key: ${key}`);
 
     const customizedConfig = apiRateLimitConfig[endpoint];
 

--- a/packages/app/src/server/util/generateApiRateLimitConfig.ts
+++ b/packages/app/src/server/util/generateApiRateLimitConfig.ts
@@ -16,15 +16,15 @@ const generateApiRateLimitConfigFromEndpoint = (envVar: NodeJS.ProcessEnv, endpo
 
     const target = getTargetFromKey(key);
     const method = envVar[`API_RATE_LIMIT_${target}_METHODS`] ?? 'ALL';
-    const consumePoints = Number(envVar[`API_RATE_LIMIT_${target}_CONSUME_POINTS`]);
+    const maxRequests = Number(envVar[`API_RATE_LIMIT_${target}_MAX_REQUESTS`]);
 
-    if (endpoint == null || consumePoints == null) {
+    if (endpoint == null || maxRequests == null) {
       return;
     }
 
     const config = {
       method,
-      consumePoints,
+      maxRequests,
     };
 
     apiRateLimitConfig[endpoint] = config;
@@ -51,7 +51,7 @@ export const generateApiRateLimitConfig = (): IApiRateLimitConfig => {
   // default setting e.g. healthchack
   apiRateLimitConfig['/_api/v3/healthcheck'] = {
     method: 'GET',
-    consumePoints: 0,
+    maxRequests: 0,
   };
 
   return apiRateLimitConfig;


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/96274
https://redmine.weseek.co.jp/issues/96275

- apiの制限をmongoDBで管理する
- 利用者が一定時間の回数でリクエストを制限できるようにする
現在のデフォルト設定
1秒間に10回

環境変数による設定の例
API_RATE_LIMIT_010_FOO_ENDPOINT=/_api/v3/foo
API_RATE_LIMIT_010_FOO_METHODS=GET,POST
API_RATE_LIMIT_010_FOO_MAX_REQUESTS=10 ← 1秒間の最大リクエスト回数


無制限にするエンドポイント決めたり、デフォルト値を考えるのは後続タスクでやります。