### PR TITLE
imprv: 95892 add swr

### DIFF
--- a/packages/app/src/components/PageHistory.jsx
+++ b/packages/app/src/components/PageHistory.jsx
@@ -39,18 +39,18 @@ function PageHistory(props) {
     })();
   }, [props.revisionComparerContainer]);
 
-  if (revisionsData == null) {
-    return (
-      <div className="text-muted text-center">
-        <i className="fa fa-2x fa-spinner fa-pulse mt-3"></i>
-      </div>
-    );
-  }
-
   if (errorMessage != null) {
     return (
       <div className="my-5">
         <div className="text-danger">{errorMessage}</div>
+      </div>
+    );
+  }
+
+  if (revisionsData == null) {
+    return (
+      <div className="text-muted text-center">
+        <i className="fa fa-2x fa-spinner fa-pulse mt-3"></i>
       </div>
     );
   }

--- a/packages/app/src/components/PageHistory.jsx
+++ b/packages/app/src/components/PageHistory.jsx
@@ -21,7 +21,7 @@ function PageHistory(props) {
   const [activePage, setActivePage] = useState(1);
   const [errorMessage, setErrorMessage] = useState(null);
   const { data: currentPageId } = useCurrentPageId();
-  const { data: revisionsData } = useSWRxPageRevisions(currentPageId, 1, 10);
+  const { data: revisionsData } = useSWRxPageRevisions(currentPageId, activePage, 10);
   const pagingLimit = 10;
 
   const { revisionComparerContainer } = props;

--- a/packages/app/src/components/PageHistory.jsx
+++ b/packages/app/src/components/PageHistory.jsx
@@ -2,7 +2,6 @@ import React, { useState, useCallback, useEffect } from 'react';
 
 import PropTypes from 'prop-types';
 
-import PageHistroyContainer from '~/client/services/PageHistoryContainer';
 import RevisionComparerContainer from '~/client/services/RevisionComparerContainer';
 import { toastError } from '~/client/util/apiNotification';
 import { useCurrentPageId } from '~/stores/context';
@@ -25,7 +24,7 @@ function PageHistory(props) {
   const { data: revisionsData } = useSWRxPageRevisions(currentPageId, 1, 10);
   const pagingLimit = 10;
 
-  const { pageHistoryContainer, revisionComparerContainer } = props;
+  const { revisionComparerContainer } = props;
 
   useEffect(() => {
     throw new Promise(async() => {
@@ -64,7 +63,6 @@ function PageHistory(props) {
   return (
     <div className="revision-history">
       <PageRevisionTable
-        pageHistoryContainer={pageHistoryContainer}
         revisionComparerContainer={revisionComparerContainer}
         revisions={revisionsData.revisions}
         pagingLimit
@@ -78,10 +76,9 @@ function PageHistory(props) {
 
 }
 
-const RenderPageHistoryWrapper = withUnstatedContainers(withLoadingSppiner(PageHistory), [PageHistroyContainer, RevisionComparerContainer]);
+const RenderPageHistoryWrapper = withUnstatedContainers(withLoadingSppiner(PageHistory), [RevisionComparerContainer]);
 
 PageHistory.propTypes = {
-  pageHistoryContainer: PropTypes.instanceOf(PageHistroyContainer).isRequired,
   revisionComparerContainer: PropTypes.instanceOf(RevisionComparerContainer).isRequired,
 };
 

--- a/packages/app/src/components/PageHistory.jsx
+++ b/packages/app/src/components/PageHistory.jsx
@@ -19,7 +19,7 @@ const logger = loggerFactory('growi:PageHistory');
 
 function PageHistory(props) {
   const [activePage, setActivePage] = useState(1);
-  const [errorMessage, setErrorMessage] = useState('');
+  const [errorMessage, setErrorMessage] = useState(null);
   const { data: currentPageId } = useCurrentPageId();
   const { data: revisionsData } = useSWRxPageRevisions(currentPageId, 1, 10);
   const pagingLimit = 10;
@@ -27,7 +27,7 @@ function PageHistory(props) {
   const { revisionComparerContainer } = props;
 
   useEffect(() => {
-    throw new Promise(async() => {
+    (async() => {
       try {
         await props.revisionComparerContainer.initRevisions();
       }
@@ -36,9 +36,16 @@ function PageHistory(props) {
         setErrorMessage(err.message);
         logger.error(err);
       }
-    });
+    })();
   }, [props.revisionComparerContainer]);
 
+  if (revisionsData == null) {
+    return (
+      <div className="text-muted text-center">
+        <i className="fa fa-2x fa-spinner fa-pulse mt-3"></i>
+      </div>
+    );
+  }
 
   if (errorMessage != null) {
     return (
@@ -65,7 +72,7 @@ function PageHistory(props) {
       <PageRevisionTable
         revisionComparerContainer={revisionComparerContainer}
         revisions={revisionsData.revisions}
-        pagingLimit
+        pagingLimit={pagingLimit}
       />
       <div className="my-3">
         {pager()}

--- a/packages/app/src/components/PageHistory.jsx
+++ b/packages/app/src/components/PageHistory.jsx
@@ -67,6 +67,7 @@ function PageHistory(props) {
         pageHistoryContainer={pageHistoryContainer}
         revisionComparerContainer={revisionComparerContainer}
         revisions={revisionsData.revisions}
+        pagingLimit
       />
       <div className="my-3">
         {pager()}

--- a/packages/app/src/components/PageHistory/PageRevisionTable.jsx
+++ b/packages/app/src/components/PageHistory/PageRevisionTable.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
+import PropTypes from 'prop-types';
 import { withTranslation } from 'react-i18next';
+
 import PageHistroyContainer from '~/client/services/PageHistoryContainer';
 import RevisionComparerContainer from '~/client/services/RevisionComparerContainer';
 
@@ -20,7 +21,6 @@ class PageRevisionTable extends React.Component {
     const { revisionComparerContainer, t } = this.props;
     const { latestRevision, oldestRevision } = this.props.pageHistoryContainer.state;
     const revisionId = revision._id;
-    const revisionDiffOpened = this.props.diffOpened[revisionId] || false;
     const { sourceRevision, targetRevision } = revisionComparerContainer.state;
 
     const handleCompareLatestRevisionButton = () => {
@@ -41,7 +41,6 @@ class PageRevisionTable extends React.Component {
               t={this.props.t}
               revision={revision}
               isLatestRevision={revision === latestRevision}
-              revisionDiffOpened={revisionDiffOpened}
               hasDiff={hasDiff}
               key={`revision-history-rev-${revisionId}`}
             />
@@ -159,7 +158,6 @@ PageRevisionTable.propTypes = {
   revisionComparerContainer: PropTypes.instanceOf(RevisionComparerContainer).isRequired,
 
   revisions: PropTypes.array,
-  diffOpened: PropTypes.object,
 };
 
 export default withTranslation()(PageRevisionTable);

--- a/packages/app/src/components/PageHistory/PageRevisionTable.jsx
+++ b/packages/app/src/components/PageHistory/PageRevisionTable.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { withTranslation } from 'react-i18next';
 
-import PageHistroyContainer from '~/client/services/PageHistoryContainer';
 import RevisionComparerContainer from '~/client/services/RevisionComparerContainer';
 
 import Revision from './Revision';
@@ -17,9 +16,11 @@ class PageRevisionTable extends React.Component {
    * @param {boolean} hasDiff whether revision has difference to previousRevision
    * @param {boolean} isContiguousNodiff true if the current 'hasDiff' and one of previous row is both false
    */
-  renderRow(revision, previousRevision, hasDiff, isContiguousNodiff) {
+  renderRow(revisions, index, previousRevision, hasDiff, isContiguousNodiff) {
     const { revisionComparerContainer, t } = this.props;
-    const { latestRevision, oldestRevision } = this.props.pageHistoryContainer.state;
+    const revision = revisions[index];
+    const latestRevision = revisions[0];
+    const oldestRevision = revisions[revision.length - 1];
     const revisionId = revision._id;
     const { sourceRevision, targetRevision } = revisionComparerContainer.state;
 
@@ -104,7 +105,7 @@ class PageRevisionTable extends React.Component {
   }
 
   render() {
-    const { t, pageHistoryContainer } = this.props;
+    const { t, pagingLimit } = this.props;
 
     const revisions = this.props.revisions;
     const revisionCount = this.props.revisions.length;
@@ -113,7 +114,7 @@ class PageRevisionTable extends React.Component {
 
     const revisionList = this.props.revisions.map((revision, idx) => {
       // Returns null because the last revision is for the bottom diff display
-      if (idx === pageHistoryContainer.state.pagingLimit) {
+      if (idx === pagingLimit) {
         return null;
       }
 
@@ -131,7 +132,7 @@ class PageRevisionTable extends React.Component {
 
       hasDiffPrev = hasDiff;
 
-      return this.renderRow(revision, previousRevision, hasDiff, isContiguousNodiff);
+      return this.renderRow(revisions, idx, previousRevision, hasDiff, isContiguousNodiff);
     });
 
     return (
@@ -154,10 +155,10 @@ class PageRevisionTable extends React.Component {
 
 PageRevisionTable.propTypes = {
   t: PropTypes.func.isRequired, // i18next
-  pageHistoryContainer: PropTypes.instanceOf(PageHistroyContainer).isRequired,
   revisionComparerContainer: PropTypes.instanceOf(RevisionComparerContainer).isRequired,
 
   revisions: PropTypes.array,
+  pagingLimit: PropTypes.number,
 };
 
 export default withTranslation()(PageRevisionTable);

--- a/packages/app/src/components/PageHistory/PageRevisionTable.jsx
+++ b/packages/app/src/components/PageHistory/PageRevisionTable.jsx
@@ -16,11 +16,8 @@ class PageRevisionTable extends React.Component {
    * @param {boolean} hasDiff whether revision has difference to previousRevision
    * @param {boolean} isContiguousNodiff true if the current 'hasDiff' and one of previous row is both false
    */
-  renderRow(revisions, index, previousRevision, hasDiff, isContiguousNodiff) {
+  renderRow(revision, previousRevision, latestRevision, oldestRevision, hasDiff, isContiguousNodiff) {
     const { revisionComparerContainer, t } = this.props;
-    const revision = revisions[index];
-    const latestRevision = revisions[0];
-    const oldestRevision = revisions[revision.length - 1];
     const revisionId = revision._id;
     const { sourceRevision, targetRevision } = revisionComparerContainer.state;
 
@@ -109,6 +106,8 @@ class PageRevisionTable extends React.Component {
 
     const revisions = this.props.revisions;
     const revisionCount = this.props.revisions.length;
+    const latestRevision = revisions[0];
+    const oldestRevision = revisions[revisions.length - 1];
 
     let hasDiffPrev;
 
@@ -132,7 +131,7 @@ class PageRevisionTable extends React.Component {
 
       hasDiffPrev = hasDiff;
 
-      return this.renderRow(revisions, idx, previousRevision, hasDiff, isContiguousNodiff);
+      return this.renderRow(revision, previousRevision, latestRevision, oldestRevision, hasDiff, isContiguousNodiff);
     });
 
     return (

--- a/packages/app/src/components/PageHistory/Revision.jsx
+++ b/packages/app/src/components/PageHistory/Revision.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import { UserPicture } from '@growi/ui';
+import PropTypes from 'prop-types';
+
 import UserDate from '../User/UserDate';
 import Username from '../User/Username';
 
@@ -83,6 +84,5 @@ Revision.propTypes = {
   t: PropTypes.func.isRequired, // i18next
   revision: PropTypes.object,
   isLatestRevision: PropTypes.bool.isRequired,
-  revisionDiffOpened: PropTypes.bool.isRequired,
   hasDiff: PropTypes.bool.isRequired,
 };

--- a/packages/app/src/interfaces/revision.ts
+++ b/packages/app/src/interfaces/revision.ts
@@ -8,6 +8,11 @@ export type IRevision = {
   updatedAt: Date,
 }
 
+export type IRevisionsForPagination = {
+  revisions: IRevision[], // revisions in one pagination
+  totalCounts: number // total counts
+}
+
 export type IRevisionOnConflict = {
   revisionId: string,
   revisionBody: string,

--- a/packages/app/src/stores/page.tsx
+++ b/packages/app/src/stores/page.tsx
@@ -9,6 +9,7 @@ import {
 } from '~/interfaces/page';
 import { IRecordApplicableGrant, IResIsGrantNormalized } from '~/interfaces/page-grant';
 import { IPagingResult } from '~/interfaces/paging-result';
+import { IRevision } from '~/interfaces/revision';
 
 import { apiGet } from '../client/util/apiv1-client';
 import { IPageTagsInfo } from '../interfaces/pageTagsInfo';
@@ -146,6 +147,20 @@ export const useSWRxPageInfoForList = (
       });
     },
   };
+};
+
+export const useSWRxPageRevisions = (
+    pageId: string,
+    page: number, // page number of pagination
+    limit: number, // max number of pages in one paginate
+): SWRResponse<IRevision, Error> => {
+
+  return useSWRImmutable<IRevision, Error>(
+    ['/revisions/list', pageId, page, limit],
+    (endpoint, pageId, page, limit) => {
+      return apiv3Get(endpoint, { pageId, page, limit }).then(response => response.data.docs);
+    },
+  );
 };
 
 /*

--- a/packages/app/src/stores/page.tsx
+++ b/packages/app/src/stores/page.tsx
@@ -9,7 +9,7 @@ import {
 } from '~/interfaces/page';
 import { IRecordApplicableGrant, IResIsGrantNormalized } from '~/interfaces/page-grant';
 import { IPagingResult } from '~/interfaces/paging-result';
-import { IRevision } from '~/interfaces/revision';
+import { IRevisionsForPagination } from '~/interfaces/revision';
 
 import { apiGet } from '../client/util/apiv1-client';
 import { IPageTagsInfo } from '../interfaces/pageTagsInfo';
@@ -153,12 +153,18 @@ export const useSWRxPageRevisions = (
     pageId: string,
     page: number, // page number of pagination
     limit: number, // max number of pages in one paginate
-): SWRResponse<IRevision, Error> => {
+): SWRResponse<IRevisionsForPagination, Error> => {
 
-  return useSWRImmutable<IRevision, Error>(
+  return useSWRImmutable<IRevisionsForPagination, Error>(
     ['/revisions/list', pageId, page, limit],
     (endpoint, pageId, page, limit) => {
-      return apiv3Get(endpoint, { pageId, page, limit }).then(response => response.data.docs);
+      return apiv3Get(endpoint, { pageId, page, limit }).then((response) => {
+        const revisions = {
+          revisions: response.data.docs,
+          totalCounts: response.data.totalDocs,
+        };
+        return revisions;
+      });
     },
   );
 };


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/95892

- PageHistoryContainerの中にあったロジックをstateとswrでPageHistoryの中に移動、PageHistoryContainerがなくても正常に動作するようにした（PageHistoryContainerは次のPRで消します）