### PR TITLE
imprv: Set Content-Length header in response of attachment

### DIFF
--- a/packages/app/src/server/routes/attachment.js
+++ b/packages/app/src/server/routes/attachment.js
@@ -7,7 +7,6 @@ const logger = loggerFactory('growi:routes:attachment');
 
 const { serializePageSecurely } = require('../models/serializers/page-serializer');
 const { serializeRevisionSecurely } = require('../models/serializers/revision-serializer');
-
 const ApiResponse = require('../util/apiResponse');
 
 /**
@@ -229,6 +228,7 @@ module.exports = function(crowi, app) {
     res.set({
       ETag: `Attachment-${attachment._id}`,
       'Last-Modified': attachment.createdAt.toUTCString(),
+      'Content-Length': attachment.fileSize,
     });
 
     // download

--- a/packages/app/src/server/routes/attachment.js
+++ b/packages/app/src/server/routes/attachment.js
@@ -228,8 +228,13 @@ module.exports = function(crowi, app) {
     res.set({
       ETag: `Attachment-${attachment._id}`,
       'Last-Modified': attachment.createdAt.toUTCString(),
-      'Content-Length': attachment.fileSize,
     });
+
+    if (!attachment.fileSize) {
+      res.set({
+        'Content-Length': attachment.fileSize,
+      });
+    }
 
     // download
     if (forceDownload) {


### PR DESCRIPTION
96384 [GROWI] attachmentルートのレスポンスヘッダにContent-Lengthをセットする
https://redmine.weseek.co.jp/issues/96690

説明はここに
https://redmine.weseek.co.jp/issues/96384