### PR TITLE
fix: Slack channels are not automatically filled after setting up user trigger notification on v4.5.x

### DIFF
--- a/packages/app/src/client/services/CommentContainer.js
+++ b/packages/app/src/client/services/CommentContainer.js
@@ -27,10 +27,6 @@ export default class CommentContainer extends Container {
 
     this.state = {
       comments: [],
-
-      // settings shared among all of CommentEditor
-      isSlackEnabled: false,
-      slackChannels: mainContent.getAttribute('data-slack-channels') || '',
     };
 
     this.retrieveComments = this.retrieveComments.bind(this);

--- a/packages/app/src/client/services/ContextExtractor.tsx
+++ b/packages/app/src/client/services/ContextExtractor.tsx
@@ -1,19 +1,18 @@
-import React, { FC, useEffect, useState } from 'react';
 import { pagePathUtils } from '@growi/core';
+import React, { FC, useEffect, useState } from 'react';
 
+import { IUserUISettings } from '~/interfaces/user-ui-settings';
 import {
   useCurrentCreatedAt, useDeleteUsername, useDeletedAt, useHasChildren, useHasDraftOnHackmd, useIsAbleToDeleteCompletely,
   useIsDeletable, useIsDeleted, useIsNotCreatable, useIsPageExist, useIsTrashPage, useIsUserPage, useLastUpdateUsername,
   usePageId, usePageIdOnHackmd, usePageUser, useCurrentPagePath, useRevisionCreatedAt, useRevisionId, useRevisionIdHackmdSynced,
   useShareLinkId, useShareLinksNumber, useTemplateTagData, useCurrentUpdatedAt, useCreator, useRevisionAuthor, useCurrentUser,
-  useSlackChannels,
 } from '~/stores/context';
 import {
   useIsDeviceSmallerThanMd,
   usePreferDrawerModeByUser, usePreferDrawerModeOnEditByUser, useSidebarCollapsed, useCurrentSidebarContents, useCurrentProductNavWidth,
   useSelectedGrant, useSelectedGrantGroupId, useSelectedGrantGroupName,
 } from '~/stores/ui';
-import { IUserUISettings } from '~/interfaces/user-ui-settings';
 
 const { isTrashPage: _isTrashPage } = pagePathUtils;
 
@@ -68,7 +67,6 @@ const ContextExtractorOnce: FC = () => {
   const hasDraftOnHackmd = !!mainContent?.getAttribute('data-page-has-draft-on-hackmd');
   const creator = JSON.parse(mainContent?.getAttribute('data-page-creator') || jsonNull);
   const revisionAuthor = JSON.parse(mainContent?.getAttribute('data-page-revision-author') || jsonNull);
-  const slackChannels = mainContent?.getAttribute('data-slack-channels') || '';
   const grant = +(mainContent?.getAttribute('data-page-grant') || 1);
   const grantGroupId = mainContent?.getAttribute('data-page-grant-group') || null;
   const grantGroupName = mainContent?.getAttribute('data-page-grant-group-name') || null;
@@ -119,7 +117,6 @@ const ContextExtractorOnce: FC = () => {
   useIsDeviceSmallerThanMd();
 
   // Editor
-  useSlackChannels(slackChannels);
   useSelectedGrant(grant);
   useSelectedGrantGroupId(grantGroupId);
   useSelectedGrantGroupName(grantGroupName);

--- a/packages/app/src/components/Page.jsx
+++ b/packages/app/src/components/Page.jsx
@@ -23,8 +23,8 @@ import { getOptionsToSave } from '~/client/util/editor';
 import {
   useEditorMode, useSelectedGrant, useSelectedGrantGroupId, useSelectedGrantGroupName,
 } from '~/stores/ui';
-import { useIsSlackEnabled } from '~/stores/editor';
-import { useSlackChannels } from '~/stores/context';
+import { useIsSlackEnabled, useSWRxSlackChannels } from '~/stores/editor';
+import { useCurrentPagePath } from '~/stores/context';
 
 const logger = loggerFactory('growi:Page');
 
@@ -182,8 +182,9 @@ Page.propTypes = {
 
 const PageWrapper = (props) => {
   const { data: editorMode } = useEditorMode();
+  const { data: currentPagePath } = useCurrentPagePath();
   const { data: isSlackEnabled } = useIsSlackEnabled();
-  const { data: slackChannels } = useSlackChannels();
+  const { data: slackChannelsData } = useSWRxSlackChannels(currentPagePath);
   const { data: grant } = useSelectedGrant();
   const { data: grantGroupId } = useSelectedGrantGroupId();
   const { data: grantGroupName } = useSelectedGrantGroupName();
@@ -198,7 +199,7 @@ const PageWrapper = (props) => {
       {...props}
       editorMode={editorMode}
       isSlackEnabled={isSlackEnabled}
-      slackChannels={slackChannels}
+      slackChannels={slackChannelsData.toString()}
       grant={grant}
       grantGroupId={grantGroupId}
       grantGroupName={grantGroupName}

--- a/packages/app/src/components/PageComment/CommentEditor.jsx
+++ b/packages/app/src/components/PageComment/CommentEditor.jsx
@@ -1,21 +1,19 @@
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 
 import {
   Button,
   TabContent, TabPane,
 } from 'reactstrap';
-
 import * as toastr from 'toastr';
-
 import { UserPicture } from '@growi/ui';
+import { withUnstatedContainers } from '../UnstatedUtils';
 import AppContainer from '~/client/services/AppContainer';
 import PageContainer from '~/client/services/PageContainer';
 import CommentContainer from '~/client/services/CommentContainer';
 import EditorContainer from '~/client/services/EditorContainer';
 import GrowiRenderer from '~/client/util/GrowiRenderer';
 
-import { withUnstatedContainers } from '../UnstatedUtils';
 import Editor from '../PageEditor/Editor';
 import { SlackNotification } from '../SlackNotification';
 
@@ -82,6 +80,7 @@ class CommentEditor extends React.Component {
     this.renderHtml = this.renderHtml.bind(this);
     this.handleSelect = this.handleSelect.bind(this);
     this.onSlackEnabledFlagChange = this.onSlackEnabledFlagChange.bind(this);
+    this.onSlackChannelsChange = this.onSlackChannelsChange.bind(this);
     this.fetchSlackChannels = this.fetchSlackChannels.bind(this);
   }
 
@@ -179,8 +178,8 @@ class CommentEditor extends React.Component {
           this.state.comment,
           this.state.isMarkdown,
           replyTo,
-          commentContainer.state.isSlackEnabled,
-          commentContainer.state.slackChannels,
+          this.props.isSlackEnabled,
+          this.state.slackChannels,
         );
       }
       this.initializeEditor();

--- a/packages/app/src/components/PageComment/CommentEditor.jsx
+++ b/packages/app/src/components/PageComment/CommentEditor.jsx
@@ -63,6 +63,7 @@ class CommentEditor extends React.Component {
       isUploadableFile,
       errorMessage: undefined,
       isSlackConfigured: config.isSlackConfigured,
+      slackChannels: this.props.slackChannels,
     };
 
     this.updateState = this.updateState.bind(this);
@@ -77,11 +78,21 @@ class CommentEditor extends React.Component {
     this.renderHtml = this.renderHtml.bind(this);
     this.handleSelect = this.handleSelect.bind(this);
     this.onSlackEnabledFlagChange = this.onSlackEnabledFlagChange.bind(this);
-    this.onSlackChannelsChange = this.onSlackChannelsChange.bind(this);
+    this.fetchSlackChannels = this.fetchSlackChannels.bind(this);
   }
 
   updateState(value) {
     this.setState({ comment: value });
+  }
+
+  fetchSlackChannels(slackChannels) {
+    this.setState({ slackChannels });
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.props.slackChannels !== prevProps.slackChannels) {
+      this.fetchSlackChannels(this.props.slackChannels);
+    }
   }
 
   updateStateCheckbox(event) {
@@ -101,7 +112,7 @@ class CommentEditor extends React.Component {
   }
 
   onSlackChannelsChange(slackChannels) {
-    this.props.commentContainer.setState({ slackChannels });
+    this.setState({ slackChannels });
   }
 
   initializeEditor() {
@@ -358,9 +369,9 @@ class CommentEditor extends React.Component {
               && (
                 <div className="form-inline align-self-center mr-md-2">
                   <SlackNotification
-                    isSlackEnabled={commentContainer.state.isSlackEnabled}
-                    slackChannels={commentContainer.state.slackChannels}
-                    onEnabledFlagChange={this.onSlackEnabledFlagChange}
+                    isSlackEnabled={this.props.isSlackEnabled}
+                    slackChannels={this.state.slackChannels}
+                    onEnabledFlagChange={this.props.onSlackEnabledFlagChange}
                     onChannelChange={this.onSlackChannelsChange}
                     id="idForComment"
                   />
@@ -411,6 +422,8 @@ CommentEditor.propTypes = {
   editorContainer: PropTypes.instanceOf(EditorContainer).isRequired,
   commentContainer: PropTypes.instanceOf(CommentContainer).isRequired,
 
+  slackChannels: PropTypes.string.isRequired,
+  isSlackEnabled: PropTypes.bool.isRequired,
   growiRenderer: PropTypes.instanceOf(GrowiRenderer).isRequired,
   isForNewComment: PropTypes.bool,
   replyTo: PropTypes.string,
@@ -419,6 +432,7 @@ CommentEditor.propTypes = {
   commentCreator: PropTypes.string,
   onCancelButtonClicked: PropTypes.func,
   onCommentButtonClicked: PropTypes.func,
+  onSlackEnabledFlagChange: PropTypes.func,
 };
 
 /**

--- a/packages/app/src/components/PageEditor.jsx
+++ b/packages/app/src/components/PageEditor.jsx
@@ -21,8 +21,8 @@ import { getOptionsToSave } from '~/client/util/editor';
 import {
   useEditorMode, useSelectedGrant, useSelectedGrantGroupId, useSelectedGrantGroupName,
 } from '~/stores/ui';
-import { useIsEditable, useSlackChannels } from '~/stores/context';
-import { useIsSlackEnabled } from '~/stores/editor';
+import { useIsEditable, useCurrentPagePath } from '~/stores/context';
+import { useIsSlackEnabled, useSWRxSlackChannels } from '~/stores/editor';
 
 const logger = loggerFactory('growi:PageEditor');
 
@@ -371,7 +371,8 @@ const PageEditorWrapper = (props) => {
   const { data: isEditable } = useIsEditable();
   const { data: editorMode } = useEditorMode();
   const { data: isSlackEnabled } = useIsSlackEnabled();
-  const { data: slackChannels } = useSlackChannels();
+  const { data: currentPagePath } = useCurrentPagePath();
+  const { data: slackChannelsData } = useSWRxSlackChannels(currentPagePath);
   const { data: grant, mutate: mutateGrant } = useSelectedGrant();
   const { data: grantGroupId } = useSelectedGrantGroupId();
   const { data: grantGroupName } = useSelectedGrantGroupName();
@@ -379,6 +380,8 @@ const PageEditorWrapper = (props) => {
   if (isEditable == null || editorMode == null) {
     return null;
   }
+
+  const slackChannels = slackChannelsData ? slackChannelsData.toString() : '';
 
   return (
     <PageEditorHOCWrapper

--- a/packages/app/src/components/PageEditor/EditorNavbarBottom.tsx
+++ b/packages/app/src/components/PageEditor/EditorNavbarBottom.tsx
@@ -1,9 +1,7 @@
-import React, { useCallback, useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-
+import React, { useCallback, useState, useEffect } from 'react';
 import { Collapse, Button } from 'reactstrap';
 
-import EditorContainer from '~/client/services/EditorContainer';
 import AppContainer from '~/client/services/AppContainer';
 import {
   EditorMode, useDrawerOpened, useEditorMode, useIsDeviceSmallerThanMd,
@@ -16,6 +14,7 @@ import { withUnstatedContainers } from '../UnstatedUtils';
 import SavePageControls from '../SavePageControls';
 
 import OptionsSelector from './OptionsSelector';
+import EditorContainer from '~/client/services/EditorContainer';
 import { useCurrentPagePath } from '~/stores/context';
 import { useIsSlackEnabled, useSWRxSlackChannels } from '~/stores/editor';
 

--- a/packages/app/src/components/PageEditor/EditorNavbarBottom.tsx
+++ b/packages/app/src/components/PageEditor/EditorNavbarBottom.tsx
@@ -51,13 +51,6 @@ const EditorNavbarBottom = (props) => {
   const slackChannelsChangedHandler = useCallback((slackChannels: string) => {
     setSlackChannelsStr(slackChannels);
   }, []);
-  // const isSlackEnabledToggleHandler = useCallback(
-  //   (bool: boolean) => mutateIsSlackEnabled(bool), [mutateIsSlackEnabled],
-  // );
-
-  // const slackChannelsChangedHandler = useCallback(
-  //   (slackChannels: string) => mutateSlackChannels(slackChannels), [mutateSlackChannels],
-  // );
 
   const renderDrawerButton = () => (
     <button

--- a/packages/app/src/components/PageEditorByHackmd.jsx
+++ b/packages/app/src/components/PageEditorByHackmd.jsx
@@ -17,8 +17,8 @@ import { getOptionsToSave } from '~/client/util/editor';
 import {
   useEditorMode, useSelectedGrant, useSelectedGrantGroupId, useSelectedGrantGroupName,
 } from '~/stores/ui';
-import { useSlackChannels } from '~/stores/context';
-import { useIsSlackEnabled } from '~/stores/editor';
+import { useCurrentPagePath } from '~/stores/context';
+import { useSWRxSlackChannels, useIsSlackEnabled } from '~/stores/editor';
 
 const logger = loggerFactory('growi:PageEditorByHackmd');
 
@@ -432,8 +432,9 @@ const PageEditorByHackmdHOCWrapper = withUnstatedContainers(PageEditorByHackmd, 
 
 const PageEditorByHackmdWrapper = (props) => {
   const { data: editorMode } = useEditorMode();
+  const { data: currentPagePath } = useCurrentPagePath();
+  const { data: slackChannelsData } = useSWRxSlackChannels(currentPagePath);
   const { data: isSlackEnabled } = useIsSlackEnabled();
-  const { data: slackChannels } = useSlackChannels();
   const { data: grant } = useSelectedGrant();
   const { data: grantGroupId } = useSelectedGrantGroupId();
   const { data: grantGroupName } = useSelectedGrantGroupName();
@@ -447,7 +448,7 @@ const PageEditorByHackmdWrapper = (props) => {
       {...props}
       editorMode={editorMode}
       isSlackEnabled={isSlackEnabled}
-      slackChannels={slackChannels}
+      slackChannels={slackChannelsData.toString()}
       grant={grant}
       grantGroupId={grantGroupId}
       grantGroupName={grantGroupName}

--- a/packages/app/src/components/SavePageControls.jsx
+++ b/packages/app/src/components/SavePageControls.jsx
@@ -142,8 +142,6 @@ const SavePageControlsHOCWrapper = withUnstatedContainers(SavePageControls, [App
 const SavePageControlsWrapper = (props) => {
   const { data: isEditable } = useIsEditable();
   const { data: editorMode } = useEditorMode();
-  const { data: isSlackEnabled } = useIsSlackEnabled();
-  const { data: slackChannels } = useSlackChannels();
   const { data: grant, mutate: mutateGrant } = useSelectedGrant();
   const { data: grantGroupId, mutate: mutateGrantGroupId } = useSelectedGrantGroupId();
   const { data: grantGroupName, mutate: mutateGrantGroupName } = useSelectedGrantGroupName();
@@ -161,8 +159,6 @@ const SavePageControlsWrapper = (props) => {
     <SavePageControlsHOCWrapper
       {...props}
       editorMode={editorMode}
-      isSlackEnabled={isSlackEnabled}
-      slackChannels={slackChannels}
       grant={grant}
       grantGroupId={grantGroupId}
       grantGroupName={grantGroupName}

--- a/packages/app/src/interfaces/common.ts
+++ b/packages/app/src/interfaces/common.ts
@@ -5,3 +5,5 @@
 
 // Foreign key field
 export type Ref<T> = string | T;
+
+export type Nullable<T> = T | null | undefined;

--- a/packages/app/src/interfaces/user-trigger-notification.ts
+++ b/packages/app/src/interfaces/user-trigger-notification.ts
@@ -1,0 +1,2 @@
+type SlackChannel = string;
+export type SlackChannels = {[updatePost: string]: SlackChannel[]}

--- a/packages/app/src/server/models/page.js
+++ b/packages/app/src/server/models/page.js
@@ -51,7 +51,6 @@ const pageSchema = new mongoose.Schema({
   liker: [{ type: ObjectId, ref: 'User' }],
   seenUsers: [{ type: ObjectId, ref: 'User' }],
   commentCount: { type: Number, default: 0 },
-  slackChannels: { type: String },
   pageIdOnHackmd: String,
   revisionHackmdSynced: { type: ObjectId, ref: 'Revision' }, // the revision that is synced to HackMD
   hasDraftOnHackmd: { type: Boolean }, // set true if revision and revisionHackmdSynced are same but HackMD document has modified

--- a/packages/app/src/server/service/user-notification/index.ts
+++ b/packages/app/src/server/service/user-notification/index.ts
@@ -49,7 +49,6 @@ export class UserNotificationService {
 
     // "dev,slacktest" => [dev,slacktest]
     const slackChannels: (string|null)[] = toArrayFromCsv(slackChannelsStr);
-    await this.putDefaultChannelIfEmpty(page.path, slackChannels);
 
     const appTitle = appService.getAppTitle();
     const siteUrl = appService.getSiteUrl();
@@ -67,16 +66,6 @@ export class UserNotificationService {
     });
 
     return Promise.allSettled(promises);
-  }
-
-  private async putDefaultChannelIfEmpty(pagePath:string, slackChannels: (string|null)[]): Promise<void> {
-    const updatePosts = await UpdatePost.findSettingsByPath(pagePath);
-    slackChannels.push(...(updatePosts).map(up => up.channel));
-
-    // insert null if empty to notify once
-    if (slackChannels.length === 0) {
-      slackChannels.push(null);
-    }
   }
 
 }

--- a/packages/app/src/server/views/widget/page_content.html
+++ b/packages/app/src/server/views/widget/page_content.html
@@ -16,7 +16,6 @@
   data-page-is-deletable="{% if isDeletablePage() %}true{% else %}false{% endif %}"
   data-page-is-not-creatable="false"
   data-page-is-able-to-delete-completely="{% if pageService.canDeleteCompletely(page.creator._id, user) %}true{% else %}false{% endif %}"
-  data-slack-channels="{% if page %}{{ page.slackChannels }}{% endif %}"
   data-page-created-at="{{ page.createdAt|datetz('Y/m/d H:i:s') }}"
   data-page-creator="{% if page && page.creator %}{{ page.creator|json }}{% endif %}"
   data-page-last-update-username="{% if page && page.lastUpdateUser %}{{ page.lastUpdateUser.name }}{% endif %}"
@@ -32,7 +31,6 @@
 <div id="content-main" class="content-main d-flex"
   data-path="{{ encodeURI(path) }}"
   data-current-user="{% if user %}{{ user._id.toString() }}{% endif %}"
-  data-slack-channels="{% if page %}{{ page.slackChannels }}{% endif %}"
   data-page-is-deleted="{% if page.isDeleted() %}true{% else %}false{% endif %}"
   data-page-has-children="{% if pages.length > 0 %}true{% else %}false{% endif %}"
   >

--- a/packages/app/src/stores/context.tsx
+++ b/packages/app/src/stores/context.tsx
@@ -118,9 +118,6 @@ export const useRevisionAuthor = (initialData?: Nullable<any>): SWRResponse<Null
   return useStaticSWR<Nullable<any>, Error>('revisionAuthor', initialData ?? null);
 };
 
-export const useSlackChannels = (initialData?: Nullable<any>): SWRResponse<Nullable<any>, Error> => {
-  return useStaticSWR<Nullable<any>, Error>('slackChannels', initialData ?? null);
-};
 
 /** **********************************************************
  *                     Computed contexts

--- a/packages/app/src/stores/editor.tsx
+++ b/packages/app/src/stores/editor.tsx
@@ -1,9 +1,26 @@
-import { SWRResponse } from 'swr';
+import useSWR, { SWRResponse } from 'swr';
 import { useStaticSWR } from './use-static-swr';
+import { Nullable } from '~/interfaces/common';
+import { apiGet } from '~/client/util/apiv1-client';
+import { SlackChannels } from '~/interfaces/user-trigger-notification';
+
+
+/*
+* Slack Notification
+*/
 
 export const useIsSlackEnabled = (isEnabled?: boolean): SWRResponse<boolean, Error> => {
   const initialData = false;
   return (
     useStaticSWR('isSlackEnabled', isEnabled || null, { fallbackData: initialData })
+  );
+};
+
+export const useSWRxSlackChannels = (currentPagePath: Nullable<string>): SWRResponse<string[], Error> => {
+  const shouldFetch: boolean = currentPagePath != null;
+  return useSWR(
+    shouldFetch ? ['/pages.updatePost', currentPagePath] : null,
+    (endpoint, path) => apiGet(endpoint, { path }).then((response: SlackChannels) => response.updatePost),
+    { fallbackData: [''] },
   );
 };

--- a/packages/app/test/integration/models/update-post.test.js
+++ b/packages/app/test/integration/models/update-post.test.js
@@ -1,20 +1,6 @@
-const mongoose = require('mongoose');
-
-const { getInstance } = require('../setup-crowi');
+import UpdatePost from '../../../src/server/models/update-post';
 
 describe('UpdatePost', () => {
-  // eslint-disable-next-line no-unused-vars
-  let crowi;
-  let UpdatePost;
-
-  beforeAll(async() => {
-    crowi = await getInstance();
-  });
-
-  beforeEach(async() => {
-    UpdatePost = mongoose.model('UpdatePost');
-  });
-
   describe('.createPrefixesByPathPattern', () => {
     describe('with a path', () => {
       test('should return right patternPrfixes', () => {


### PR DESCRIPTION
## Task
[GROWI][Issue] [bug] User trigger notifacationでデフォルトパターン設定後も記事作成時にInput channelsが自動入力されない
┗[95875](https://redmine.weseek.co.jp/issues/95875) 修正 (4.5.x)

## Description
5系での修正で差分があった以下二つのファイルは、本PRには反映されていません。

- [/SlackNotification.tsx](https://github.com/weseek/growi/pull/5911/files#diff-30d44cac3e4904751761b107333e4a35b58fc86a5add47ef88a5e7299f75ad8e)
┗一行追加されただけ
- [packages/app/src/components/Page/DisplaySwitcher.tsx](https://github.com/weseek/growi/pull/5911/files#diff-dc91afbcf95bb5a5c4fe1e1fe227c15f7966b13ee9bb0d9d3d1093bcfec95160)
┗currentPath -> currentPagePath に変更 (4系では、DisplaySwitcherにcurrentPathが使われていない)

5系での修正は 👉🏻 https://github.com/weseek/growi/pull/5911
