### PR TITLE
imprv: 94754-each-theme-sidebar-color-fix

### DIFF
--- a/packages/app/src/styles/theme/_apply-colors-light.scss
+++ b/packages/app/src/styles/theme/_apply-colors-light.scss
@@ -178,7 +178,10 @@ $dropdown-link-active-bg: $bgcolor-dropdown-link-active;
 .grw-sidebar {
   // List
   @include override-list-group-item($color-list, $bgcolor-sidebar-list-group, $color-list-hover, $bgcolor-list-hover, $color-list-active, $bgcolor-list-active);
-
+  // sidebar-centent-bg
+  .grw-navigation-wrap {
+    box-shadow: 0px 0px 3px rgba(black, 0.24);
+  }
   // Pagetree
   .grw-pagetree {
     @include override-list-group-item-for-pagetree(

--- a/packages/app/src/styles/theme/_apply-colors-light.scss
+++ b/packages/app/src/styles/theme/_apply-colors-light.scss
@@ -180,6 +180,7 @@ $dropdown-link-active-bg: $bgcolor-dropdown-link-active;
   @include override-list-group-item($color-list, $bgcolor-sidebar-list-group, $color-list-hover, $bgcolor-list-hover, $color-list-active, $bgcolor-list-active);
   // sidebar-centent-bg
   .grw-navigation-wrap {
+    // Drop a shadow on the light theme. The dark theme makes '$ bgcolor-sidebar-context' brighter than the body.
     box-shadow: 0px 0px 3px rgba(black, 0.24);
   }
   // Pagetree

--- a/packages/app/src/styles/theme/blackboard.scss
+++ b/packages/app/src/styles/theme/blackboard.scss
@@ -60,7 +60,7 @@ html[dark] {
   $color-resize-button-hover: $color-global;
   $bgcolor-resize-button-hover: darken($bgcolor-resize-button, 5%);
   // Sidebar contents
-  $bgcolor-sidebar-context: $subthemecolor;
+  $bgcolor-sidebar-context: lighten($subthemecolor, 8%);
   $color-sidebar-context: $color-global;
   // Sidebar list group
   // $bgcolor-sidebar-list-group: #; // optional

--- a/packages/app/src/styles/theme/christmas.scss
+++ b/packages/app/src/styles/theme/christmas.scss
@@ -85,7 +85,7 @@ html[dark] {
   $color-resize-button-hover: $color-reversal;
   $bgcolor-resize-button-hover: lighten($bgcolor-resize-button, 5%);
   $color-sidebar-context: $linktext;
-  $bgcolor-sidebar-context: #f4f6fc;
+  $bgcolor-sidebar-context: #f4fcf6;
   // Sidebar list group
   $bgcolor-sidebar-list-group: #fafbff; // optional
 

--- a/packages/app/src/styles/theme/fire-red.scss
+++ b/packages/app/src/styles/theme/fire-red.scss
@@ -56,7 +56,7 @@ html[light] {
   $bgcolor-resize-button-hover: lighten($bgcolor-resize-button, 5%);
   // Sidebar contents
   $color-sidebar-context: $color-global;
-  $bgcolor-sidebar-context: #ebebeb;
+  $bgcolor-sidebar-context: #ececec;
   // Sidebar list group
   // $bgcolor-sidebar-list-group: #; // optional
 
@@ -152,7 +152,7 @@ html[dark] {
   $color-resize-button-hover: $color-global;
   $bgcolor-resize-button-hover: darken($bgcolor-resize-button, 5%);
   // Sidebar contents
-  $bgcolor-sidebar-context: #2e2e2e;
+  $bgcolor-sidebar-context: #413f3f;
   $color-sidebar-context: $color-global;
   // Sidebar list group
   // $bgcolor-sidebar-list-group: #; // optional

--- a/packages/app/src/styles/theme/future.scss
+++ b/packages/app/src/styles/theme/future.scss
@@ -55,7 +55,7 @@ html[dark] {
   $text-shadow-sidebar-nav-item-active: 0px 0px 10px #969494; // optional
 
   // Sidebar contents
-  $color-sidebar-context: #00c2c4;
+  $color-sidebar-context: #2cfbff;
   $bgcolor-sidebar-context: #184040;
 
   // Sidebar list group

--- a/packages/app/src/styles/theme/future.scss
+++ b/packages/app/src/styles/theme/future.scss
@@ -56,7 +56,7 @@ html[dark] {
 
   // Sidebar contents
   $color-sidebar-context: #00c2c4;
-  $bgcolor-sidebar-context: #020b0b;
+  $bgcolor-sidebar-context: #184040;
 
   // Sidebar list group
   $bgcolor-sidebar-list-group: #162126; // optional

--- a/packages/app/src/styles/theme/halloween.scss
+++ b/packages/app/src/styles/theme/halloween.scss
@@ -80,7 +80,7 @@ html[dark] {
 
   // Sidebar contents
   $color-sidebar-context: #aa97cb;
-  $bgcolor-sidebar-context: #1d2126;
+  $bgcolor-sidebar-context: #302b3c;
 
   // Sidebar list group
   $bgcolor-sidebar-list-group: #2c2926; // optional

--- a/packages/app/src/styles/theme/hufflepuff.scss
+++ b/packages/app/src/styles/theme/hufflepuff.scss
@@ -216,7 +216,7 @@ html[dark] {
   $bgcolor-resize-button-hover: darken($bgcolor-resize-button, 7%);
   // Sidebar contents
   $color-sidebar-context: $color-global;
-  $bgcolor-sidebar-context: $subthemecolor;
+  $bgcolor-sidebar-context: lighten($themedark, 5%);
   // Sidebar list group
   $bgcolor-sidebar-list-group: lighten($subthemecolor, 5%);
 

--- a/packages/app/src/styles/theme/jade-green.scss
+++ b/packages/app/src/styles/theme/jade-green.scss
@@ -152,7 +152,7 @@ html[dark] {
   $color-resize-button-hover: $color-global;
   $bgcolor-resize-button-hover: darken($bgcolor-resize-button, 5%);
   // Sidebar contents
-  $bgcolor-sidebar-context: #2e2e2e;
+  $bgcolor-sidebar-context: #3c403c;
   $color-sidebar-context: $color-global;
   // Sidebar list group
   // $bgcolor-sidebar-list-group: #; // optional

--- a/packages/app/src/styles/theme/nature.scss
+++ b/packages/app/src/styles/theme/nature.scss
@@ -72,7 +72,7 @@ html[dark] {
   $bgcolor-sidebar: #188f64;
   // Sidebar contents
   $color-sidebar-context: #7e0044;
-  $bgcolor-sidebar-context: #f7f9e9;
+  $bgcolor-sidebar-context: #f4f5ec;
   // Sidebar resize button
   $color-resize-button: white;
   $bgcolor-resize-button: $themecolor;

--- a/packages/app/src/styles/theme/spring.scss
+++ b/packages/app/src/styles/theme/spring.scss
@@ -73,7 +73,7 @@ html[dark] {
   $bgcolor-resize-button-hover: lighten($bgcolor-resize-button, 5%);
   // Sidebar contents
   $color-sidebar-context: $subthemecolor;
-  $bgcolor-sidebar-context: #fff7ff;
+  $bgcolor-sidebar-context: #fdfffe;
   // Sidebar list group
   $bgcolor-sidebar-list-group: #fafbff; // optional
 

--- a/packages/app/src/styles/theme/spring.scss
+++ b/packages/app/src/styles/theme/spring.scss
@@ -73,7 +73,7 @@ html[dark] {
   $bgcolor-resize-button-hover: lighten($bgcolor-resize-button, 5%);
   // Sidebar contents
   $color-sidebar-context: $subthemecolor;
-  $bgcolor-sidebar-context: #f4f6fc;
+  $bgcolor-sidebar-context: #fff7ff;
   // Sidebar list group
   $bgcolor-sidebar-list-group: #fafbff; // optional
 

--- a/packages/app/src/styles/theme/wood.scss
+++ b/packages/app/src/styles/theme/wood.scss
@@ -91,7 +91,7 @@ html[dark] {
   $bgcolor-sidebar: $themecolor;
   // Sidebar contents
   $color-sidebar-context: #9d7406;
-  $bgcolor-sidebar-context: lighten($themecolor, 32%);
+  $bgcolor-sidebar-context: lighten($themecolor, 38%);
   // Sidebar list group
   $bgcolor-sidebar-list-group: rgba(#f7f5f1, 0.5);
   // Sidebar resize button


### PR DESCRIPTION
# タスク
- https://redmine.weseek.co.jp/issues/94754

# やったこと
- 各色の変更
- ついでにLightテーマ系については影をつけました（Light系は影ついてるのが正しいので）

## 色を確定する際の考え方
- [こちら](https://kudakurage.hatenadiary.com/entry/2019/07/29/083000)の「[高さに応じてLightではshadowが、Darkでは明るさが変わる](https://kudakurage.hatenadiary.com/entry/2019/07/29/083000#:~:text=%E9%AB%98%E3%81%95%E3%81%AB%E5%BF%9C%E3%81%98%E3%81%A6Light%E3%81%A7%E3%81%AFshadow%E3%81%8C%E3%80%81Dark%E3%81%A7%E3%81%AF%E6%98%8E%E3%82%8B%E3%81%95%E3%81%8C%E5%A4%89%E3%82%8F%E3%82%8B)」の部分のセオリーを採用し、Darkでは基本的にサイドバーの色のほうがBodyの色よりも明るくするようにしました
- 周囲との色との整合性を取るように主に色相を調整しました
## 影がついた事がわかるスクショ↓
![image](https://user-images.githubusercontent.com/20252919/172581090-5a984aa8-c3d0-4cb8-b603-1f408ad42387.png)


# 変更したテーマのスクショ
## blackboard
![image](https://user-images.githubusercontent.com/20252919/172582652-e9b3bb22-904f-4905-8cf9-25740c6de2e7.png)

## christmas
![image](https://user-images.githubusercontent.com/20252919/172582772-87408b87-fa39-4dbd-8aaf-266bc5ee8e3f.png)

## fire-red(light)
![image](https://user-images.githubusercontent.com/20252919/172582906-eb4e3669-083a-4f5c-ba52-c37face62780.png)

## fire-red(dark)
![image](https://user-images.githubusercontent.com/20252919/172582980-3298a271-0859-44d7-9301-7400cc5f52a7.png)

## future
![image](https://user-images.githubusercontent.com/20252919/172585077-94fe73ee-fee7-4b97-bf48-4b3575b39132.png)

## halloween
![image](https://user-images.githubusercontent.com/20252919/172585224-0955c44b-7bb7-4567-b05c-fb21be50dfda.png)

## hufflepuff
![image](https://user-images.githubusercontent.com/20252919/172585321-b98d7fbd-a2ca-4cbb-862a-b0576e634c1a.png)

## jade-green(dark)
![image](https://user-images.githubusercontent.com/20252919/172585450-a0a2ab94-3dad-4231-9bab-3dc60d54afbc.png)

## nature
![image](https://user-images.githubusercontent.com/20252919/172585549-2a5ae916-fd4b-46b6-b39e-390ddda81936.png)

## spring
![image](https://user-images.githubusercontent.com/20252919/172587062-2544fce4-cd30-4149-bab2-11faeafd1784.png)

## wood
![image](https://user-images.githubusercontent.com/20252919/172587168-b8694420-5606-4eae-963b-a8f7be1293cf.png)


