### PR TITLE
fix: Remove unnecessary type definition

### DIFF
--- a/packages/app/src/components/Admin/App/AwsSetting.jsx
+++ b/packages/app/src/components/Admin/App/AwsSetting.jsx
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
 
 import AdminAppContainer from '~/client/services/AdminAppContainer';
-import AppContainer from '~/client/services/AppContainer';
 
 import { withUnstatedContainers } from '../../UnstatedUtils';
 
@@ -153,10 +152,9 @@ function AwsSetting(props) {
 /**
  * Wrapper component for using unstated
  */
-const AwsSettingWrapper = withUnstatedContainers(AwsSetting, [AppContainer, AdminAppContainer]);
+const AwsSettingWrapper = withUnstatedContainers(AwsSetting, [AdminAppContainer]);
 
 AwsSetting.propTypes = {
-  appContainer: PropTypes.instanceOf(AppContainer).isRequired,
   adminAppContainer: PropTypes.instanceOf(AdminAppContainer).isRequired,
 };
 

--- a/packages/app/src/components/Admin/App/AwsSetting.jsx
+++ b/packages/app/src/components/Admin/App/AwsSetting.jsx
@@ -156,7 +156,6 @@ function AwsSetting(props) {
 const AwsSettingWrapper = withUnstatedContainers(AwsSetting, [AppContainer, AdminAppContainer]);
 
 AwsSetting.propTypes = {
-  t: PropTypes.func.isRequired, // i18next
   appContainer: PropTypes.instanceOf(AppContainer).isRequired,
   adminAppContainer: PropTypes.instanceOf(AdminAppContainer).isRequired,
 };


### PR DESCRIPTION
[96330](https://redmine.weseek.co.jp/issues/96330) [Omit Unstated] withTranslation を useTranslation に置き換える
┗[97518](https://redmine.weseek.co.jp/issues/97518) 修正

console上にエラーが出てたので修正