### PR TITLE
fix Change IActivity user type from string to user ref

### DIFF
--- a/packages/app/src/interfaces/activity.ts
+++ b/packages/app/src/interfaces/activity.ts
@@ -1,3 +1,4 @@
+import { Ref } from './common';
 import { HasObjectId } from './has-object-id';
 import { IUser } from './user';
 
@@ -107,7 +108,7 @@ export type SupportedActionType = typeof SUPPORTED_ACTION_TYPE[keyof typeof SUPP
 export type ISnapshot = Partial<Pick<IUser, 'username'>>
 
 export type IActivity = {
-  user?: string
+  user?: Ref<IUser>
   ip?: string
   endpoint?: string
   targetModel?: SupportedTargetModelType

--- a/packages/app/src/server/service/activity.ts
+++ b/packages/app/src/server/service/activity.ts
@@ -11,7 +11,7 @@ import Crowi from '../crowi';
 
 const logger = loggerFactory('growi:service:ActivityService');
 
-type ParameterType = Omit<IActivity, 'createdAt'>
+type UpdateActivityParameterType = Omit<IActivity, 'user' | 'createdAt' | 'ip' | 'endpoint'>
 
 class ActivityService {
 
@@ -29,7 +29,7 @@ class ActivityService {
   }
 
   initActivityEventListeners(): void {
-    this.activityEvent.on('update', async(activityId: string, parameters: ParameterType, target?: IPage) => {
+    this.activityEvent.on('update', async(activityId: string, parameters: UpdateActivityParameterType, target?: IPage) => {
 
       // update activity
       let activity: IActivity;
@@ -85,7 +85,7 @@ class ActivityService {
     return Activity.create(parameters);
   };
 
-  updateByParameters = async function(activityId: string, parameters: ParameterType): Promise<IActivity> {
+  updateByParameters = async function(activityId: string, parameters: UpdateActivityParameterType): Promise<IActivity> {
     const activity = await Activity.findOneAndUpdate({ _id: activityId }, parameters, { new: true }) as unknown as IActivity;
 
     return activity;


### PR DESCRIPTION
## Task
[#96531](https://redmine.weseek.co.jp/issues/96531) [GROWI] [AuditLog] ログイン / ログアウト / アカウント作成 / コメント削除 /  ページ閲覧時 に activity ドキュメントを作成できる
└ [#97267](https://redmine.weseek.co.jp/issues/97267) activity.user の型を string -> user ref に変更する