### PR TITLE
feat: Create activity document when initial user is created

### DIFF
--- a/packages/app/src/server/routes/index.js
+++ b/packages/app/src/server/routes/index.js
@@ -91,7 +91,7 @@ module.exports = function(crowi, app) {
   if (!isInstalled) {
     const installer = require('./installer')(crowi);
     app.get('/installer'              , applicationNotInstalled , installer.index);
-    app.post('/installer'             , apiLimiter , applicationNotInstalled , registerFormValidator.registerRules(), registerFormValidator.registerValidation, csrf, installer.install);
+    app.post('/installer'             , apiLimiter , applicationNotInstalled , registerFormValidator.registerRules(), registerFormValidator.registerValidation, csrf, addActivity, installer.install);
     return;
   }
 

--- a/packages/app/src/server/routes/installer.js
+++ b/packages/app/src/server/routes/installer.js
@@ -1,3 +1,4 @@
+import { SUPPORTED_ACTION_TYPE } from '~/interfaces/activity';
 import loggerFactory from '~/utils/logger';
 
 import { InstallerService, FailedToCreateAdminUserError } from '../service/installer';
@@ -7,6 +8,8 @@ const logger = loggerFactory('growi:routes:installer');
 module.exports = function(crowi) {
 
   const actions = {};
+
+  const activityEvent = crowi.event('activity');
 
   actions.index = function(req, res) {
     return res.render('installer');
@@ -55,6 +58,10 @@ module.exports = function(crowi) {
       }
 
       req.flash('successMessage', req.t('message.complete_to_install2'));
+
+      const parameters = { action: SUPPORTED_ACTION_TYPE.ACTION_REGISTRATION_SUCCESS };
+      activityEvent.emit('update', res.locals.activity._id, parameters);
+
       return res.redirect('/');
     });
   };


### PR DESCRIPTION
## Task
[#96531](https://redmine.weseek.co.jp/issues/96531) [GROWI] [AuditLog] ログイン / ログアウト / アカウント作成 / コメント削除 /  ページ閲覧時 に activity ドキュメントを作成できる
└ [#97564](https://redmine.weseek.co.jp/issues/97564) 初回ユーザーを作成した時に Activity ドキュメントを作成できる