### PR TITLE
feat: AuditLog Settings

### DIFF
--- a/packages/app/resource/locales/en_US/translation.json
+++ b/packages/app/resource/locales/en_US/translation.json
@@ -126,6 +126,7 @@
   "ChildUserGroup": "ChildUserGroup",
   "UserGroup Management": "UserGroup Management",
   "AuditLog": "AuditLog",
+  "AudtitLog Settings": "AuditLog Settings",
   "Full Text Search Management": "Full Text Search Management",
   "Import Data": "Import Data",
   "Export Archive Data": "Export Archive Data",

--- a/packages/app/resource/locales/en_US/translation.json
+++ b/packages/app/resource/locales/en_US/translation.json
@@ -126,7 +126,7 @@
   "ChildUserGroup": "ChildUserGroup",
   "UserGroup Management": "UserGroup Management",
   "AuditLog": "AuditLog",
-  "AudtitLog Settings": "AuditLog Settings",
+  "AuditLog Settings": "AuditLog Settings",
   "Full Text Search Management": "Full Text Search Management",
   "Import Data": "Import Data",
   "Export Archive Data": "Export Archive Data",

--- a/packages/app/resource/locales/ja_JP/translation.json
+++ b/packages/app/resource/locales/ja_JP/translation.json
@@ -126,6 +126,7 @@
   "ChildUserGroup": "子グループ",
   "UserGroup Management": "グループ管理",
   "AuditLog": "監査ログ",
+  "AudtitLog Settings": "監査ログ設定",
   "Full Text Search Management": "全文検索管理",
   "Import Data": "データインポート",
   "Export Archive Data": "データアーカイブ",

--- a/packages/app/resource/locales/ja_JP/translation.json
+++ b/packages/app/resource/locales/ja_JP/translation.json
@@ -126,7 +126,7 @@
   "ChildUserGroup": "子グループ",
   "UserGroup Management": "グループ管理",
   "AuditLog": "監査ログ",
-  "AudtitLog Settings": "監査ログ設定",
+  "AuditLog Settings": "監査ログ設定",
   "Full Text Search Management": "全文検索管理",
   "Import Data": "データインポート",
   "Export Archive Data": "データアーカイブ",

--- a/packages/app/resource/locales/zh_CN/translation.json
+++ b/packages/app/resource/locales/zh_CN/translation.json
@@ -134,6 +134,7 @@
   "ChildUserGroup": "儿童用户组",
 	"UserGroup Management": "用户组管理",
   "AuditLog": "审计日志",
+  "AudtitLog Settings": "审计日志设置",
 	"Full Text Search Management": "全文搜索管理",
 	"Import Data": "导入数据",
 	"Export Archive Data": "导出主题数据",

--- a/packages/app/resource/locales/zh_CN/translation.json
+++ b/packages/app/resource/locales/zh_CN/translation.json
@@ -134,7 +134,7 @@
   "ChildUserGroup": "儿童用户组",
 	"UserGroup Management": "用户组管理",
   "AuditLog": "审计日志",
-  "AudtitLog Settings": "审计日志设置",
+  "AuditLog Settings": "审计日志设置",
 	"Full Text Search Management": "全文搜索管理",
 	"Import Data": "导入数据",
 	"Export Archive Data": "导出主题数据",

--- a/packages/app/src/client/admin.jsx
+++ b/packages/app/src/client/admin.jsx
@@ -32,6 +32,7 @@ import { swrGlobalConfiguration } from '~/utils/swr-utils';
 import AdminHome from '../components/Admin/AdminHome/AdminHome';
 import AppSettingsPage from '../components/Admin/App/AppSettingsPage';
 import { AuditLogManagement } from '../components/Admin/AuditLogManagement';
+import { AuditLogSettings } from '../components/Admin/AuditLogSettings';
 import AdminNavigation from '../components/Admin/Common/AdminNavigation';
 import Customize from '../components/Admin/Customize/Customize';
 import ExportArchiveDataPage from '../components/Admin/ExportArchiveDataPage';
@@ -110,6 +111,7 @@ Object.assign(componentMappings, {
   'admin-full-text-search-management': <FullTextSearchManagement />,
   'admin-user-group-page': <UserGroupPage />,
   'admin-audit-log': <AuditLogManagement />,
+  'admin-audit-log-settings': <AuditLogSettings />,
   'admin-navigation': <AdminNavigation />,
 });
 

--- a/packages/app/src/components/Admin/AuditLogManagement.tsx
+++ b/packages/app/src/components/Admin/AuditLogManagement.tsx
@@ -92,7 +92,14 @@ export const AuditLogManagement: FC = () => {
 
   return (
     <div data-testid="admin-auditlog">
-      <h2 className="admin-setting-header mb-3">{t('AuditLog')}</h2>
+      <h2 className="admin-setting-header mb-3">
+        <span>
+          {t('AuditLog')}
+        </span>
+        <a href="/admin/audit-log/settings" className="btn btn-lg">
+          <i className="icon-settings" />
+        </a>
+      </h2>
 
       <div className="form-inline mb-3">
         <SearchUsernameTypeahead

--- a/packages/app/src/components/Admin/AuditLogSettings.tsx
+++ b/packages/app/src/components/Admin/AuditLogSettings.tsx
@@ -1,11 +1,24 @@
 import React, { FC } from 'react';
 
+import { useTranslation } from 'react-i18next';
+
 export const AuditLogSettings: FC = () => {
+  const { t } = useTranslation();
+
   const adminAuditLogSettingsElm = document.getElementById('admin-audit-log-settings');
   const activityExpirationSeconds = adminAuditLogSettingsElm?.getAttribute('activity-expiration-seconds') || 2592000;
 
-
   return (
-    <>AuditLog Settings</>
+    <div data-testid="admin-auditlog-settings">
+      <h3 className="mb-4">
+        <a href="/admin/audit-log">
+          <i className="icon-arrow-left" />
+          {t('AuditLog')}
+        </a>
+      </h3>
+      <h2 className="admin-setting-header mb-3">
+        {t('AuditLog Settings')}
+      </h2>
+    </div>
   );
 };

--- a/packages/app/src/components/Admin/AuditLogSettings.tsx
+++ b/packages/app/src/components/Admin/AuditLogSettings.tsx
@@ -1,0 +1,7 @@
+import React, { FC } from 'react';
+
+export const AuditLogSettings: FC = () => {
+  return (
+    <>AuditLog Settings</>
+  );
+};

--- a/packages/app/src/components/Admin/AuditLogSettings.tsx
+++ b/packages/app/src/components/Admin/AuditLogSettings.tsx
@@ -1,6 +1,10 @@
 import React, { FC } from 'react';
 
 export const AuditLogSettings: FC = () => {
+  const adminAuditLogSettingsElm = document.getElementById('admin-audit-log-settings');
+  const activityExpirationSeconds = adminAuditLogSettingsElm?.getAttribute('activity-expiration-seconds') || 2592000;
+
+
   return (
     <>AuditLog Settings</>
   );

--- a/packages/app/src/server/routes/admin.js
+++ b/packages/app/src/server/routes/admin.js
@@ -296,7 +296,8 @@ module.exports = function(crowi, app) {
   };
 
   actions.auditLog.settings = (req, res) => {
-    return res.render('admin/audit-log-settings');
+    const activityExpirationSeconds = configManager.getConfig('crowi', 'app:activityExpirationSeconds') || 2592000;
+    return res.render('admin/audit-log-settings', { activityExpirationSeconds });
   };
 
   // Importer management

--- a/packages/app/src/server/routes/admin.js
+++ b/packages/app/src/server/routes/admin.js
@@ -295,6 +295,10 @@ module.exports = function(crowi, app) {
     return res.render('admin/audit-log');
   };
 
+  actions.auditLog.settings = (req, res) => {
+    return res.render('admin/audit-log-settings');
+  };
+
   // Importer management
   actions.importer = {};
   actions.importer.api = api;

--- a/packages/app/src/server/routes/index.js
+++ b/packages/app/src/server/routes/index.js
@@ -141,6 +141,7 @@ module.exports = function(crowi, app) {
 
   // auditLog admin
   app.get('/admin/audit-log'                            , loginRequiredStrictly, adminRequired, admin.auditLog.index);
+  app.get('/admin/audit-log/settings'                   , loginRequiredStrictly, adminRequired, admin.auditLog.settings);
 
   // importer management for admin
   app.get('/admin/importer'                     , loginRequiredStrictly , adminRequired , admin.importer.index);

--- a/packages/app/src/server/service/config-loader.ts
+++ b/packages/app/src/server/service/config-loader.ts
@@ -626,7 +626,7 @@ const ENV_VAR_NAME_TO_CONFIG_INFO = {
     ns: 'crowi',
     key: 'app:activityExpirationSeconds',
     type: ValueType.NUMBER,
-    default: 2592000,
+    default: 2592000, // 30 days
   },
 };
 

--- a/packages/app/src/server/views/admin/audit-log-settings.html
+++ b/packages/app/src/server/views/admin/audit-log-settings.html
@@ -1,0 +1,11 @@
+{% extends '../layout/admin.html' %}
+
+{% block html_title %}{{ customizeService.generateCustomTitleForFixedPageName(t('AudtitLog Settings')) }}{% endblock %}
+
+{% block content_header %}
+<h1 class="title">{{ t('AudtitLog Settings') }}</h1>
+{% endblock %}
+
+{% block content_main %}
+<div id ="admin-audit-log-settings"></div>
+{% endblock content_main %}

--- a/packages/app/src/server/views/admin/audit-log-settings.html
+++ b/packages/app/src/server/views/admin/audit-log-settings.html
@@ -9,7 +9,7 @@
 {% block content_main %}
 <div
   id="admin-audit-log-settings"
-  activityExpirationSeconds="{{ activityExpirationSeconds }}"
+  activity-expiration-seconds="{{ activityExpirationSeconds }}"
 >
 </div>
 {% endblock content_main %}

--- a/packages/app/src/server/views/admin/audit-log-settings.html
+++ b/packages/app/src/server/views/admin/audit-log-settings.html
@@ -1,6 +1,6 @@
 {% extends '../layout/admin.html' %}
 
-{% block html_title %}{{ customizeService.generateCustomTitleForFixedPageName(t('AudtitLog Settings')) }}{% endblock %}
+{% block html_title %}{{ customizeService.generateCustomTitleForFixedPageName(t('AuditLog Settings')) }}{% endblock %}
 
 {% block content_header %}
 <h1 class="title">{{ t('AudtitLog Settings') }}</h1>

--- a/packages/app/src/server/views/admin/audit-log-settings.html
+++ b/packages/app/src/server/views/admin/audit-log-settings.html
@@ -7,5 +7,9 @@
 {% endblock %}
 
 {% block content_main %}
-<div id ="admin-audit-log-settings"></div>
+<div
+  id="admin-audit-log-settings"
+  activityExpirationSeconds="{{ activityExpirationSeconds }}"
+>
+</div>
 {% endblock content_main %}


### PR DESCRIPTION
## Task
[#93968](https://redmine.weseek.co.jp/issues/93968) [GROWI] [AuditLog] 設定画面を作成し保存する Activity の種類を選択できる
└ [#97396](https://redmine.weseek.co.jp/issues/97396) admin/audit-log/settings が表示できる