### PR TITLE
imprv: move uploadAttachment

### DIFF
--- a/packages/app/src/client/services/CommentContainer.js
+++ b/packages/app/src/client/services/CommentContainer.js
@@ -152,16 +152,4 @@ export default class CommentContainer extends Container {
       });
   }
 
-  uploadAttachment(file) {
-    const { pageId, pagePath } = this.getPageContainer().state;
-
-    const endpoint = '/attachments.add';
-    const formData = new FormData();
-    formData.append('file', file);
-    formData.append('path', pagePath);
-    formData.append('page_id', pageId);
-
-    return apiPostForm(endpoint, formData);
-  }
-
 }

--- a/packages/app/src/components/PageComment/CommentEditor.jsx
+++ b/packages/app/src/components/PageComment/CommentEditor.jsx
@@ -213,8 +213,9 @@ class CommentEditor extends React.Component {
     catch (err) {
       this.apiErrorHandler(err);
     }
-
-    this.editor.terminateUploadingState();
+    finally {
+      this.editor.terminateUploadingState();
+    }
   }
 
   apiErrorHandler(error) {


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/95889

- CommentContainerの中にあった`uploadAttachment`メソッドの処理をCommentEditorに移動