### PR TITLE
feat: Feat/create notification when parent page are deleted

### DIFF
--- a/packages/app/src/server/service/page.ts
+++ b/packages/app/src/server/service/page.ts
@@ -2257,7 +2257,7 @@ class PageService {
     const activity = await activityService.createByParameters(parameters);
     // Get user to be notified
     let targetUsers = await activity.getNotificationTargetUsers();
-    if (descendantPages !== undefined && descendantPages.length > 0) {
+    if (descendantPages != null && descendantPages.length > 0) {
       const User = this.crowi.model('User');
       const targetDescendantsUsers = await Subscription.getSubscriptions(descendantPages);
       const descendantsUsers = targetDescendantsUsers.filter(item => (item.toString() !== user._id.toString()));

--- a/packages/app/src/server/service/page.ts
+++ b/packages/app/src/server/service/page.ts
@@ -169,7 +169,7 @@ class PageService {
 
     // Change the parameter of the function into the pages
     // rename
-    this.pageEvent.on('rename', async(page, descendantPages, user) => {
+    this.pageEvent.on('rename', async(page, user, descendantPages) => {
       const isRecursively = descendantPages != null;
       const action = isRecursively ? SUPPORTED_ACTION_TYPE.ACTION_PAGE_RECURSIVELY_RENAME : SUPPORTED_ACTION_TYPE.ACTION_PAGE_RENAME;
       try {
@@ -191,7 +191,7 @@ class PageService {
     });
 
     // delete
-    this.pageEvent.on('delete', async(page, descendantPages, user) => {
+    this.pageEvent.on('delete', async(page, user, descendantPages) => {
       const isRecursively = descendantPages != null;
       const action = isRecursively ? SUPPORTED_ACTION_TYPE.ACTION_PAGE_RECURSIVELY_DELETE : SUPPORTED_ACTION_TYPE.ACTION_PAGE_DELETE;
       try {
@@ -543,7 +543,7 @@ class PageService {
       update.updatedAt = new Date();
     }
     const renamedPage = await Page.findByIdAndUpdate(page._id, { $set: update }, { new: true });
-    this.pageEvent.emit('rename', page, null, user);
+    this.pageEvent.emit('rename', page, user, null);
 
     // create page redirect
     if (options.createRedirectPage) {
@@ -689,7 +689,7 @@ class PageService {
       await PageRedirect.create({ fromPath: page.path, toPath: newPagePath });
     }
 
-    this.pageEvent.emit('rename', page, null, user);
+    this.pageEvent.emit('rename', page, user, null);
 
     return renamedPage;
   }
@@ -844,7 +844,7 @@ class PageService {
           await renameDescendants(
             batch, user, options, pathRegExp, newPagePathPrefix, shouldUseV4Process,
           );
-          pageEvent.emit('rename', targetPage, batch, user);
+          pageEvent.emit('rename', targetPage, user, batch);
           logger.debug(`Renaming pages progressing: (count=${count})`);
         }
         catch (err) {
@@ -1420,7 +1420,7 @@ class PageService {
       this.deleteRecursivelyMainOperation(page, user, pageOp._id);
     }
     else {
-      this.pageEvent.emit('delete', page, null, user);
+      this.pageEvent.emit('delete', page, user, null);
     }
 
     return deletedPage;
@@ -1508,7 +1508,7 @@ class PageService {
       }
     }
 
-    this.pageEvent.emit('delete', page, null, user);
+    this.pageEvent.emit('delete', page, user, null);
     this.pageEvent.emit('create', deletedPage, user);
 
     return deletedPage;
@@ -1608,7 +1608,7 @@ class PageService {
         try {
           count += batch.length;
           await deleteDescendants(batch, user);
-          pageEvent.emit('delete', targetPage, batch, user);
+          pageEvent.emit('delete', targetPage, user, batch);
           logger.debug(`Deleting pages progressing: (count=${count})`);
         }
         catch (err) {

--- a/packages/app/src/server/service/page.ts
+++ b/packages/app/src/server/service/page.ts
@@ -169,7 +169,7 @@ class PageService {
 
     // Change the parameter of the function into the pages
     // rename
-    this.pageEvent.on('rename', async(page, user, descendantPages) => {
+    this.pageEvent.on('rename', async(page, user, descendantPages?) => {
       const isRecursively = descendantPages != null;
       const action = isRecursively ? SUPPORTED_ACTION_TYPE.ACTION_PAGE_RECURSIVELY_RENAME : SUPPORTED_ACTION_TYPE.ACTION_PAGE_RENAME;
       try {
@@ -191,7 +191,7 @@ class PageService {
     });
 
     // delete
-    this.pageEvent.on('delete', async(page, user, descendantPages) => {
+    this.pageEvent.on('delete', async(page, user, descendantPages?) => {
       const isRecursively = descendantPages != null;
       const action = isRecursively ? SUPPORTED_ACTION_TYPE.ACTION_PAGE_RECURSIVELY_DELETE : SUPPORTED_ACTION_TYPE.ACTION_PAGE_DELETE;
       try {
@@ -543,7 +543,7 @@ class PageService {
       update.updatedAt = new Date();
     }
     const renamedPage = await Page.findByIdAndUpdate(page._id, { $set: update }, { new: true });
-    this.pageEvent.emit('rename', page, user, null);
+    this.pageEvent.emit('rename', page, user);
 
     // create page redirect
     if (options.createRedirectPage) {
@@ -689,7 +689,7 @@ class PageService {
       await PageRedirect.create({ fromPath: page.path, toPath: newPagePath });
     }
 
-    this.pageEvent.emit('rename', page, user, null);
+    this.pageEvent.emit('rename', page, user);
 
     return renamedPage;
   }
@@ -1420,7 +1420,7 @@ class PageService {
       this.deleteRecursivelyMainOperation(page, user, pageOp._id);
     }
     else {
-      this.pageEvent.emit('delete', page, user, null);
+      this.pageEvent.emit('delete', page, user);
     }
 
     return deletedPage;
@@ -1508,7 +1508,7 @@ class PageService {
       }
     }
 
-    this.pageEvent.emit('delete', page, user, null);
+    this.pageEvent.emit('delete', page, user);
     this.pageEvent.emit('create', deletedPage, user);
 
     return deletedPage;

--- a/packages/app/src/server/service/page.ts
+++ b/packages/app/src/server/service/page.ts
@@ -26,6 +26,7 @@ import { createBatchStream } from '~/server/util/batch-stream';
 import loggerFactory from '~/utils/logger';
 import { prepareDeleteConfigValuesForCalc } from '~/utils/page-delete-config';
 
+import PageEvent from '../events/page';
 import { ObjectIdLike } from '../interfaces/mongoose-utils';
 import { PathAlreadyExistsError } from '../models/errors';
 import PageOperation, { PageActionStage, PageActionType } from '../models/page-operation';
@@ -190,9 +191,11 @@ class PageService {
     });
 
     // delete
-    this.pageEvent.on('delete', async(page, user) => {
+    this.pageEvent.on('delete', async(page, descendantPages, user) => {
+      const isRecursively = descendantPages != null;
+      const action = isRecursively ? SUPPORTED_ACTION_TYPE.ACTION_PAGE_RECURSIVELY_DELETE : SUPPORTED_ACTION_TYPE.ACTION_PAGE_DELETE;
       try {
-        await this.createAndSendNotifications(page, null, user, SUPPORTED_ACTION_TYPE.ACTION_PAGE_DELETE);
+        await this.createAndSendNotifications(page, descendantPages, user, action);
       }
       catch (err) {
         logger.error(err);
@@ -541,6 +544,7 @@ class PageService {
     }
     const renamedPage = await Page.findByIdAndUpdate(page._id, { $set: update }, { new: true });
     this.pageEvent.emit('rename', page, null, user);
+
     // create page redirect
     if (options.createRedirectPage) {
       const PageRedirect = mongoose.model('PageRedirect') as unknown as PageRedirectModel;
@@ -1415,6 +1419,9 @@ class PageService {
        */
       this.deleteRecursivelyMainOperation(page, user, pageOp._id);
     }
+    else {
+      this.pageEvent.emit('delete', page, null, user);
+    }
 
     return deletedPage;
   }
@@ -1440,7 +1447,6 @@ class PageService {
         throw err;
       }
     }
-    this.pageEvent.emit('delete', page, user);
     this.pageEvent.emit('create', deletedPage, user);
 
     return deletedPage;
@@ -1502,7 +1508,7 @@ class PageService {
       }
     }
 
-    this.pageEvent.emit('delete', page, user);
+    this.pageEvent.emit('delete', page, null, user);
     this.pageEvent.emit('create', deletedPage, user);
 
     return deletedPage;
@@ -1592,6 +1598,7 @@ class PageService {
     const deleteDescendants = this.deleteDescendants.bind(this);
     let count = 0;
     let nDeletedNonEmptyPages = 0; // used for updating descendantCount
+    const pageEvent = this.pageEvent;
 
     const writeStream = new Writable({
       objectMode: true,
@@ -1601,6 +1608,7 @@ class PageService {
         try {
           count += batch.length;
           await deleteDescendants(batch, user);
+          pageEvent.emit('delete', targetPage, batch, user);
           logger.debug(`Deleting pages progressing: (count=${count})`);
         }
         catch (err) {
@@ -2248,10 +2256,15 @@ class PageService {
     };
     const activity = await activityService.createByParameters(parameters);
     // Get user to be notified
-    let targetUsers = await activity.getNotificationTargetUsers();
+    const targetUsers = await activity.getNotificationTargetUsers();
     if (descendantPages != null) {
+      const User = this.crowi.model('User');
       const targetDescendantsUsers = await Subscription.getSubscriptions(descendantPages);
-      targetUsers = targetUsers.concat(targetDescendantsUsers.filter(item => (item.toString() !== user._id.toString())));
+      const descendantsUsers = targetDescendantsUsers.filter(item => (item.toString() !== user._id.toString()));
+      targetUsers.concat(await User.find({
+        _id: { $in: descendantsUsers },
+        status: User.STATUS_ACTIVE,
+      }).distinct('_id'));
     }
     // Create and send notifications
     await inAppNotificationService.upsertByActivity(targetUsers, activity, snapshot);

--- a/packages/app/test/integration/service/page.test.js
+++ b/packages/app/test/integration/service/page.test.js
@@ -538,7 +538,7 @@ describe('PageService', () => {
     });
   });
 
-  describe.only('delete page', () => {
+  describe('delete page', () => {
     let getDeletedPageNameSpy;
     let pageEventSpy;
     let deleteDescendantsWithStreamSpy;

--- a/packages/app/test/integration/service/page.test.js
+++ b/packages/app/test/integration/service/page.test.js
@@ -350,7 +350,7 @@ describe('PageService', () => {
 
         expect(xssSpy).toHaveBeenCalled();
 
-        expect(pageEventSpy).toHaveBeenCalledWith('rename', parentForRename1, null, testUser2);
+        expect(pageEventSpy).toHaveBeenCalledWith('rename', parentForRename1, testUser2, null);
 
         expect(resultPage.path).toBe('/renamed1');
         expect(resultPage.updatedAt).toEqual(parentForRename1.updatedAt);
@@ -363,7 +363,7 @@ describe('PageService', () => {
 
         expect(xssSpy).toHaveBeenCalled();
 
-        expect(pageEventSpy).toHaveBeenCalledWith('rename', parentForRename2, null, testUser2);
+        expect(pageEventSpy).toHaveBeenCalledWith('rename', parentForRename2, testUser2, null);
 
         expect(resultPage.path).toBe('/renamed2');
         expect(resultPage.updatedAt).toEqual(dateToUse);
@@ -375,7 +375,7 @@ describe('PageService', () => {
         const resultPage = await crowi.pageService.renamePage(parentForRename3, '/renamed3', testUser2, { createRedirectPage: true });
 
         expect(xssSpy).toHaveBeenCalled();
-        expect(pageEventSpy).toHaveBeenCalledWith('rename', parentForRename3, null, testUser2);
+        expect(pageEventSpy).toHaveBeenCalledWith('rename', parentForRename3, testUser2, null);
 
         expect(resultPage.path).toBe('/renamed3');
         expect(resultPage.updatedAt).toEqual(parentForRename3.updatedAt);
@@ -388,7 +388,7 @@ describe('PageService', () => {
 
         expect(xssSpy).toHaveBeenCalled();
         expect(renameDescendantsWithStreamSpy).toHaveBeenCalled();
-        expect(pageEventSpy).toHaveBeenCalledWith('rename', parentForRename4, null, testUser2);
+        expect(pageEventSpy).toHaveBeenCalledWith('rename', parentForRename4, testUser2, null);
 
         expect(resultPage.path).toBe('/renamed4');
         expect(resultPage.updatedAt).toEqual(parentForRename4.updatedAt);
@@ -538,7 +538,7 @@ describe('PageService', () => {
     });
   });
 
-  describe('delete page', () => {
+  describe.only('delete page', () => {
     let getDeletedPageNameSpy;
     let pageEventSpy;
     let deleteDescendantsWithStreamSpy;
@@ -564,7 +564,7 @@ describe('PageService', () => {
       expect(resultPage.updatedAt).toEqual(parentForDelete1.updatedAt);
       expect(resultPage.lastUpdateUser).toEqual(testUser1._id);
 
-      expect(pageEventSpy).toHaveBeenCalledWith('delete', parentForDelete1, null, testUser2);
+      expect(pageEventSpy).toHaveBeenCalledWith('delete', parentForDelete1, testUser2, null);
       expect(pageEventSpy).toHaveBeenCalledWith('create', resultPage, testUser2);
     });
 
@@ -581,7 +581,7 @@ describe('PageService', () => {
       expect(resultPage.updatedAt).toEqual(parentForDelete2.updatedAt);
       expect(resultPage.lastUpdateUser).toEqual(testUser1._id);
 
-      expect(pageEventSpy).toHaveBeenCalledWith('delete', parentForDelete2, null, testUser2);
+      expect(pageEventSpy).toHaveBeenCalledWith('delete', parentForDelete2, testUser2, null);
       expect(pageEventSpy).toHaveBeenCalledWith('create', resultPage, testUser2);
     });
 

--- a/packages/app/test/integration/service/page.test.js
+++ b/packages/app/test/integration/service/page.test.js
@@ -350,7 +350,7 @@ describe('PageService', () => {
 
         expect(xssSpy).toHaveBeenCalled();
 
-        expect(pageEventSpy).toHaveBeenCalledWith('rename', parentForRename1, testUser2, null);
+        expect(pageEventSpy).toHaveBeenCalledWith('rename', parentForRename1, testUser2);
 
         expect(resultPage.path).toBe('/renamed1');
         expect(resultPage.updatedAt).toEqual(parentForRename1.updatedAt);
@@ -363,7 +363,7 @@ describe('PageService', () => {
 
         expect(xssSpy).toHaveBeenCalled();
 
-        expect(pageEventSpy).toHaveBeenCalledWith('rename', parentForRename2, testUser2, null);
+        expect(pageEventSpy).toHaveBeenCalledWith('rename', parentForRename2, testUser2);
 
         expect(resultPage.path).toBe('/renamed2');
         expect(resultPage.updatedAt).toEqual(dateToUse);
@@ -375,7 +375,7 @@ describe('PageService', () => {
         const resultPage = await crowi.pageService.renamePage(parentForRename3, '/renamed3', testUser2, { createRedirectPage: true });
 
         expect(xssSpy).toHaveBeenCalled();
-        expect(pageEventSpy).toHaveBeenCalledWith('rename', parentForRename3, testUser2, null);
+        expect(pageEventSpy).toHaveBeenCalledWith('rename', parentForRename3, testUser2);
 
         expect(resultPage.path).toBe('/renamed3');
         expect(resultPage.updatedAt).toEqual(parentForRename3.updatedAt);
@@ -388,7 +388,7 @@ describe('PageService', () => {
 
         expect(xssSpy).toHaveBeenCalled();
         expect(renameDescendantsWithStreamSpy).toHaveBeenCalled();
-        expect(pageEventSpy).toHaveBeenCalledWith('rename', parentForRename4, testUser2, null);
+        expect(pageEventSpy).toHaveBeenCalledWith('rename', parentForRename4, testUser2);
 
         expect(resultPage.path).toBe('/renamed4');
         expect(resultPage.updatedAt).toEqual(parentForRename4.updatedAt);
@@ -564,7 +564,7 @@ describe('PageService', () => {
       expect(resultPage.updatedAt).toEqual(parentForDelete1.updatedAt);
       expect(resultPage.lastUpdateUser).toEqual(testUser1._id);
 
-      expect(pageEventSpy).toHaveBeenCalledWith('delete', parentForDelete1, testUser2, null);
+      expect(pageEventSpy).toHaveBeenCalledWith('delete', parentForDelete1, testUser2);
       expect(pageEventSpy).toHaveBeenCalledWith('create', resultPage, testUser2);
     });
 
@@ -581,7 +581,7 @@ describe('PageService', () => {
       expect(resultPage.updatedAt).toEqual(parentForDelete2.updatedAt);
       expect(resultPage.lastUpdateUser).toEqual(testUser1._id);
 
-      expect(pageEventSpy).toHaveBeenCalledWith('delete', parentForDelete2, testUser2, null);
+      expect(pageEventSpy).toHaveBeenCalledWith('delete', parentForDelete2, testUser2);
       expect(pageEventSpy).toHaveBeenCalledWith('create', resultPage, testUser2);
     });
 

--- a/packages/app/test/integration/service/page.test.js
+++ b/packages/app/test/integration/service/page.test.js
@@ -564,7 +564,7 @@ describe('PageService', () => {
       expect(resultPage.updatedAt).toEqual(parentForDelete1.updatedAt);
       expect(resultPage.lastUpdateUser).toEqual(testUser1._id);
 
-      expect(pageEventSpy).toHaveBeenCalledWith('delete', parentForDelete1, testUser2);
+      expect(pageEventSpy).toHaveBeenCalledWith('delete', parentForDelete1, null, testUser2);
       expect(pageEventSpy).toHaveBeenCalledWith('create', resultPage, testUser2);
     });
 
@@ -581,7 +581,7 @@ describe('PageService', () => {
       expect(resultPage.updatedAt).toEqual(parentForDelete2.updatedAt);
       expect(resultPage.lastUpdateUser).toEqual(testUser1._id);
 
-      expect(pageEventSpy).toHaveBeenCalledWith('delete', parentForDelete2, testUser2);
+      expect(pageEventSpy).toHaveBeenCalledWith('delete', parentForDelete2, null, testUser2);
       expect(pageEventSpy).toHaveBeenCalledWith('create', resultPage, testUser2);
     });
 


### PR DESCRIPTION
以下ストーリー参照
https://redmine.weseek.co.jp/issues/84441 

子孫ページを含む親ページが削除されたときに、子孫ページのみをサブスクライブしているユーザーに対して通知を飛ばせるようにする。