### PR TITLE
Add isContainerFluid to page schema

### DIFF
--- a/packages/app/src/interfaces/page.ts
+++ b/packages/app/src/interfaces/page.ts
@@ -28,6 +28,7 @@ export interface IPage {
   pageIdOnHackmd: string,
   revisionHackmdSynced: Ref<IRevision>,
   hasDraftOnHackmd: boolean,
+  isContainerFluid: boolean,
   deleteUser: Ref<IUser>,
   deletedAt: Date,
 }
@@ -66,6 +67,7 @@ export type IPageInfoForOperation = IPageInfoForEntity & {
   isBookmarked?: boolean,
   isLiked?: boolean,
   subscriptionStatus?: SubscriptionStatusType,
+  isContainerFluid?: boolean,
 }
 
 export type IPageInfoForListing = IPageInfoForEntity & HasRevisionShortbody;
@@ -81,7 +83,7 @@ export const isIPageInfoForEntity = (pageInfo: any | undefined): pageInfo is IPa
 export const isIPageInfoForOperation = (pageInfo: any | undefined): pageInfo is IPageInfoForOperation => {
   return pageInfo != null
     && isIPageInfoForEntity(pageInfo)
-    && ('isBookmarked' in pageInfo || 'isLiked' in pageInfo || 'subscriptionStatus' in pageInfo);
+    && ('isBookmarked' in pageInfo || 'isLiked' in pageInfo || 'subscriptionStatus' in pageInfo || 'isContainerFluid' in pageInfo);
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/app/src/server/models/obsolete-page.js
+++ b/packages/app/src/server/models/obsolete-page.js
@@ -694,6 +694,7 @@ export const getPageSchema = (crowi) => {
     const Revision = crowi.model('Revision');
     const format = options.format || 'markdown';
     const grantUserGroupId = options.grantUserGroupId || null;
+    const isContainerFluid = crowi.configManager.getConfig('crowi', 'customize:isContainerFluid');
 
     // sanitize path
     path = crowi.xss.process(path); // eslint-disable-line no-param-reassign
@@ -715,7 +716,9 @@ export const getPageSchema = (crowi) => {
     page.creator = user;
     page.lastUpdateUser = user;
     page.status = STATUS_PUBLISHED;
-
+    if (isContainerFluid != null) {
+      page.isContainerFluid = isContainerFluid;
+    }
     await validateAppliedScope(user, grant, grantUserGroupId);
     page.applyScope(user, grant, grantUserGroupId);
 

--- a/packages/app/src/server/models/page.ts
+++ b/packages/app/src/server/models/page.ts
@@ -102,6 +102,7 @@ const schema = new Schema<PageDocument, PageModel>({
   pageIdOnHackmd: { type: String },
   revisionHackmdSynced: { type: ObjectId, ref: 'Revision' }, // the revision that is synced to HackMD
   hasDraftOnHackmd: { type: Boolean }, // set true if revision and revisionHackmdSynced are same but HackMD document has modified
+  isContainerFluid: { type: Boolean },
   updatedAt: { type: Date, default: Date.now }, // Do not use timetamps for updatedAt because it breaks 'updateMetadata: false' option
   deleteUser: { type: ObjectId, ref: 'User' },
   deletedAt: { type: Date },

--- a/packages/app/src/server/service/page.ts
+++ b/packages/app/src/server/service/page.ts
@@ -349,6 +349,9 @@ class PageService {
     const isAbleToDeleteCompletely: boolean = this.canDeleteCompletely((page.creator as IUserHasId)?._id, user, false); // use normal delete config
 
     const subscription = await Subscription.findByUserIdAndTargetId(user._id, pageId);
+    const isContainerFluid: boolean = page.isContainerFluid !== undefined
+      ? page.isContainerFluid
+      : this.crowi.configManager.getConfig('crowi', 'customize:isContainerFluid');
 
     return {
       data: page,
@@ -358,6 +361,7 @@ class PageService {
         isBookmarked,
         isLiked,
         subscriptionStatus: subscription?.status,
+        isContainerFluid,
       },
     };
   }

--- a/packages/app/src/server/service/page.ts
+++ b/packages/app/src/server/service/page.ts
@@ -3301,6 +3301,8 @@ class PageService {
   async create(path: string, body: string, user, options: PageCreateOptions = {}): Promise<PageDocument> {
     const Page = mongoose.model('Page') as unknown as PageModel;
 
+    const isContainerFluid = this.crowi.configManager.getConfig('crowi', 'customize:isContainerFluid');
+
     // Switch method
     const isV5Compatible = this.crowi.configManager.getConfig('crowi', 'app:isV5Compatible');
     if (!isV5Compatible) {
@@ -3347,7 +3349,9 @@ class PageService {
       const parent = await this.getParentAndFillAncestorsByUser(user, path);
       page.parent = parent._id;
     }
-
+    if (isContainerFluid != null) {
+      page.isContainerFluid = isContainerFluid;
+    }
     // Save
     let savedPage = await page.save();
 


### PR DESCRIPTION
https://youtrack.weseek.co.jp/issue/GW-7823
- Add isContainerFluid to page schema and interface
- Add isContainerFluid to page metadata
- Set value of isContainerFluid in page metadata by config if attribute not exists in page document