### PR TITLE
support: Upgrade typescript to ^4.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "ts-jest": "^27.0.4",
     "ts-node": "^9.1.1",
     "tsconfig-paths": "^3.9.0",
-    "typescript": "^4.6.0",
+    "typescript": "~4.6",
     "yargs": "^17.3.1"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "ts-jest": "^27.0.4",
     "ts-node": "^9.1.1",
     "tsconfig-paths": "^3.9.0",
-    "typescript": "^4.2.3",
+    "typescript": "^4.6.0",
     "yargs": "^17.3.1"
   },
   "engines": {

--- a/packages/app/src/components/UncontrolledCodeMirror.tsx
+++ b/packages/app/src/components/UncontrolledCodeMirror.tsx
@@ -21,7 +21,7 @@ interface UncontrolledCodeMirrorCoreProps extends UncontrolledCodeMirrorProps {
 
 class UncontrolledCodeMirrorCore extends AbstractEditor<UncontrolledCodeMirrorCoreProps> {
 
-  render(): ReactNode {
+  override render(): ReactNode {
 
     const {
       value, isGfmMode, lineNumbers, options, forwardedRef,

--- a/packages/app/src/server/service/s2s-messaging/nchan.ts
+++ b/packages/app/src/server/service/s2s-messaging/nchan.ts
@@ -1,11 +1,13 @@
 import path from 'path';
-import WebSocket from 'ws';
+
 import ReconnectingWebSocket from 'reconnecting-websocket';
+import WebSocket from 'ws';
 
 import axios from '~/utils/axios';
 import loggerFactory from '~/utils/logger';
 
 import S2sMessage from '../../models/vo/s2s-message';
+
 import { AbstractS2sMessagingService } from './base';
 
 const logger = loggerFactory('growi:service:s2s-messaging:nchan');
@@ -56,7 +58,7 @@ class NchanDelegator extends AbstractS2sMessagingService {
   /**
    * @inheritdoc
    */
-  async publish(s2sMessage: S2sMessage): Promise<void> {
+  override async publish(s2sMessage: S2sMessage): Promise<void> {
     await super.publish(s2sMessage);
 
     const url = this.constructUrl(this.publishPath).toString();
@@ -69,7 +71,7 @@ class NchanDelegator extends AbstractS2sMessagingService {
   /**
    * @inheritdoc
    */
-  addMessageHandler(handlable) {
+  override addMessageHandler(handlable) {
     if (this.socket == null) {
       logger.error('socket has not initialized yet.');
       return;
@@ -82,7 +84,7 @@ class NchanDelegator extends AbstractS2sMessagingService {
   /**
    * @inheritdoc
    */
-  removeMessageHandler(handlable) {
+  override removeMessageHandler(handlable) {
     if (this.socket == null) {
       logger.error('socket has not initialized yet.');
       return;

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -15,6 +15,7 @@
     // "strict": true,
     "strictNullChecks": true,
     "noImplicitAny": false,
+    "noImplicitOverride": true,
 
     /* Additional Checks */
     "noUnusedLocals": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -21445,10 +21445,10 @@ typeorm@^0.2.31:
     yargs "^16.2.0"
     zen-observable-ts "^1.0.0"
 
-typescript@^4.2.3:
-  version "4.2.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.4.tgz#8610b59747de028fda898a8aef0e103f156d0961"
-  integrity sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==
+typescript@^4.6.0:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 typpy@2.3.11:
   version "2.3.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -21445,10 +21445,10 @@ typeorm@^0.2.31:
     yargs "^16.2.0"
     zen-observable-ts "^1.0.0"
 
-typescript@^4.6.0:
-  version "4.7.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
-  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
+typescript@~4.6:
+  version "4.6.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.4.tgz#caa78bbc3a59e6a5c510d35703f6a09877ce45e9"
+  integrity sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==
 
 typpy@2.3.11:
   version "2.3.11"


### PR DESCRIPTION
Redmine: https://redmine.weseek.co.jp/issues/98216

Typescript のバージョンを `~4.6` に指定しました。yarn.lock 上では `4.2.4` => `4.6.4`

# その他
- `noImplicitOverride` を使うように tsconfig を改善