### PR TITLE
remove markdown at comment

### DIFF
--- a/packages/app/src/client/services/CommentContainer.js
+++ b/packages/app/src/client/services/CommentContainer.js
@@ -99,7 +99,7 @@ export default class CommentContainer extends Container {
   /**
    * Load data of comments and rerender <PageComments />
    */
-  postComment(comment, isMarkdown, replyTo, isSlackEnabled, slackChannels) {
+  postComment(comment, replyTo, isSlackEnabled, slackChannels) {
     const { pageId, revisionId } = this.getPageContainer().state;
 
     return apiPost('/comments.add', {
@@ -107,7 +107,6 @@ export default class CommentContainer extends Container {
         comment,
         page_id: pageId,
         revision_id: revisionId,
-        is_markdown: isMarkdown,
         replyTo,
       },
       slackNotificationForm: {
@@ -125,13 +124,12 @@ export default class CommentContainer extends Container {
   /**
    * Load data of comments and rerender <PageComments />
    */
-  putComment(comment, isMarkdown, commentId, author) {
+  putComment(comment, commentId, author) {
     const { pageId, revisionId } = this.getPageContainer().state;
 
     return apiPost('/comments.update', {
       commentForm: {
         comment,
-        is_markdown: isMarkdown,
         revision_id: revisionId,
         comment_id: commentId,
       },

--- a/packages/app/src/components/PageComment/CommentEditor.tsx
+++ b/packages/app/src/components/PageComment/CommentEditor.tsx
@@ -59,7 +59,6 @@ type PropsType = {
 }
 
 type EditorRef = {
-  setGfmMode: (value: boolean) => void,
   setValue: (value: string) => void,
   insertText: (text: string) => void,
   terminateUploadingState: () => void,
@@ -85,21 +84,12 @@ const CommentEditor = (props: PropsType): JSX.Element => {
 
   const [isReadyToUse, setIsReadyToUse] = useState(!isForNewComment);
   const [comment, setComment] = useState(commentBody ?? '');
-  const [isMarkdown, setIsMarkdown] = useState(false);
   const [html, setHtml] = useState('');
   const [activeTab, setActiveTab] = useState('comment_editor');
   const [error, setError] = useState();
   const [slackChannels, setSlackChannels] = useState(slackChannelsData?.toString());
 
   const editorRef = useRef<EditorRef>(null);
-
-  const updateStateCheckbox = useCallback((event) => {
-    if (editorRef.current == null) { return }
-    const value = event.target.checked;
-    setIsMarkdown(value);
-    // changeMode
-    editorRef.current.setGfmMode(value);
-  }, []);
 
   const renderHtml = useCallback((markdown: string) => {
     const context = {
@@ -143,7 +133,6 @@ const CommentEditor = (props: PropsType): JSX.Element => {
 
   const initializeEditor = useCallback(() => {
     setComment('');
-    setIsMarkdown(true);
     setHtml('');
     setActiveTab('comment_editor');
     setError(undefined);
@@ -169,7 +158,6 @@ const CommentEditor = (props: PropsType): JSX.Element => {
       if (currentCommentId != null) {
         await commentContainer.putComment(
           comment,
-          isMarkdown,
           currentCommentId,
           commentCreator,
         );
@@ -177,7 +165,6 @@ const CommentEditor = (props: PropsType): JSX.Element => {
       else {
         await commentContainer.postComment(
           comment,
-          isMarkdown,
           replyTo,
           isSlackEnabled,
           slackChannels,
@@ -195,7 +182,7 @@ const CommentEditor = (props: PropsType): JSX.Element => {
     }
   }, [
     comment, commentContainer, currentCommentId, commentCreator, initializeEditor,
-    isMarkdown, isSlackEnabled, onCommentButtonClicked, replyTo, slackChannels,
+    isSlackEnabled, onCommentButtonClicked, replyTo, slackChannels,
   ]);
 
   const ctrlEnterHandler = useCallback((event) => {
@@ -275,7 +262,7 @@ const CommentEditor = (props: PropsType): JSX.Element => {
 
   const renderReady = () => {
 
-    const commentPreview = isMarkdown ? getCommentHtml() : null;
+    const commentPreview = getCommentHtml();
 
     const errorMessage = <span className="text-danger text-right mr-2">{error}</span>;
     const cancelButton = (
@@ -306,7 +293,6 @@ const CommentEditor = (props: PropsType): JSX.Element => {
               <AnyEditor
                 ref={editorRef}
                 value={comment}
-                isGfmMode={isMarkdown}
                 lineNumbers={false}
                 isMobile={isMobile}
                 isUploadable={isUploadable}
@@ -331,27 +317,6 @@ const CommentEditor = (props: PropsType): JSX.Element => {
 
         <div className="comment-submit">
           <div className="d-flex">
-            <label className="mr-2">
-              {activeTab === 'comment_editor' && (
-                <span className="custom-control custom-checkbox">
-                  <input
-                    type="checkbox"
-                    className="custom-control-input"
-                    id="comment-form-is-markdown"
-                    name="isMarkdown"
-                    checked={isMarkdown}
-                    value="1"
-                    onChange={updateStateCheckbox}
-                  />
-                  <label
-                    className="ml-2 custom-control-label"
-                    htmlFor="comment-form-is-markdown"
-                  >
-                    Markdown
-                  </label>
-                </span>
-              ) }
-            </label>
             <span className="flex-grow-1" />
             <span className="d-none d-sm-inline">{ errorMessage && errorMessage }</span>
 

--- a/packages/app/src/server/routes/comment.js
+++ b/packages/app/src/server/routes/comment.js
@@ -229,7 +229,7 @@ module.exports = function(crowi, app) {
     const revisionId = commentForm.revision_id;
     const comment = commentForm.comment;
     const position = commentForm.comment_position || -1;
-    const isMarkdown = false; // comment is always not markdown (https://github.com/weseek/growi/pull/6096)
+    const isMarkdown = commentForm.is_markdown ?? true; // comment is always markdown (https://github.com/weseek/growi/pull/6096)
     const replyTo = commentForm.replyTo;
     const commentEvent = crowi.event('comment');
 
@@ -343,7 +343,7 @@ module.exports = function(crowi, app) {
     const { commentForm } = req.body;
 
     const commentStr = commentForm.comment;
-    const isMarkdown = false; // comment is always not markdown (https://github.com/weseek/growi/pull/6096)
+    const isMarkdown = commentForm.is_markdown ?? true; // comment is always markdown (https://github.com/weseek/growi/pull/6096)
     const commentId = commentForm.comment_id;
     const revision = commentForm.revision_id;
 

--- a/packages/app/src/server/routes/comment.js
+++ b/packages/app/src/server/routes/comment.js
@@ -229,7 +229,7 @@ module.exports = function(crowi, app) {
     const revisionId = commentForm.revision_id;
     const comment = commentForm.comment;
     const position = commentForm.comment_position || -1;
-    const isMarkdown = commentForm.is_markdown;
+    const isMarkdown = false;
     const replyTo = commentForm.replyTo;
     const commentEvent = crowi.event('comment');
 
@@ -343,7 +343,7 @@ module.exports = function(crowi, app) {
     const { commentForm } = req.body;
 
     const commentStr = commentForm.comment;
-    const isMarkdown = commentForm.is_markdown;
+    const isMarkdown = false;
     const commentId = commentForm.comment_id;
     const revision = commentForm.revision_id;
 

--- a/packages/app/src/server/routes/comment.js
+++ b/packages/app/src/server/routes/comment.js
@@ -229,7 +229,7 @@ module.exports = function(crowi, app) {
     const revisionId = commentForm.revision_id;
     const comment = commentForm.comment;
     const position = commentForm.comment_position || -1;
-    const isMarkdown = false;
+    const isMarkdown = false; // comment is always not markdown (https://github.com/weseek/growi/pull/6096)
     const replyTo = commentForm.replyTo;
     const commentEvent = crowi.event('comment');
 
@@ -343,7 +343,7 @@ module.exports = function(crowi, app) {
     const { commentForm } = req.body;
 
     const commentStr = commentForm.comment;
-    const isMarkdown = false;
+    const isMarkdown = false; // comment is always not markdown (https://github.com/weseek/growi/pull/6096)
     const commentId = commentForm.comment_id;
     const revision = commentForm.revision_id;
 


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/98296

- コメントでMarkdown形式を選択できる機能を削除
- apiでは常にisMarkdown = trueを送信するように仕様変更