### PR TITLE
feat: create notification when parent page are comletely deleted

### DIFF
--- a/packages/app/src/server/service/page.ts
+++ b/packages/app/src/server/service/page.ts
@@ -26,6 +26,7 @@ import { createBatchStream } from '~/server/util/batch-stream';
 import loggerFactory from '~/utils/logger';
 import { prepareDeleteConfigValuesForCalc } from '~/utils/page-delete-config';
 
+import PageEvent from '../events/page';
 import { ObjectIdLike } from '../interfaces/mongoose-utils';
 import { PathAlreadyExistsError } from '../models/errors';
 import PageOperation, { PageActionStage, PageActionType } from '../models/page-operation';
@@ -190,9 +191,11 @@ class PageService {
     });
 
     // delete
-    this.pageEvent.on('delete', async(page, user) => {
+    this.pageEvent.on('delete', async(page, descendantPages, user) => {
+      const isRecursively = descendantPages != null;
+      const action = isRecursively ? SUPPORTED_ACTION_TYPE.ACTION_PAGE_RECURSIVELY_DELETE : SUPPORTED_ACTION_TYPE.ACTION_PAGE_DELETE;
       try {
-        await this.createAndSendNotifications(page, null, user, SUPPORTED_ACTION_TYPE.ACTION_PAGE_DELETE);
+        await this.createAndSendNotifications(page, descendantPages, user, action);
       }
       catch (err) {
         logger.error(err);
@@ -541,6 +544,7 @@ class PageService {
     }
     const renamedPage = await Page.findByIdAndUpdate(page._id, { $set: update }, { new: true });
     this.pageEvent.emit('rename', page, null, user);
+
     // create page redirect
     if (options.createRedirectPage) {
       const PageRedirect = mongoose.model('PageRedirect') as unknown as PageRedirectModel;
@@ -1415,6 +1419,9 @@ class PageService {
        */
       this.deleteRecursivelyMainOperation(page, user, pageOp._id);
     }
+    else {
+      this.pageEvent.emit('delete', page, null, user);
+    }
 
     return deletedPage;
   }
@@ -1440,7 +1447,6 @@ class PageService {
         throw err;
       }
     }
-    this.pageEvent.emit('delete', page, user);
     this.pageEvent.emit('create', deletedPage, user);
 
     return deletedPage;
@@ -1502,7 +1508,7 @@ class PageService {
       }
     }
 
-    this.pageEvent.emit('delete', page, user);
+    this.pageEvent.emit('delete', page, null, user);
     this.pageEvent.emit('create', deletedPage, user);
 
     return deletedPage;
@@ -1592,6 +1598,7 @@ class PageService {
     const deleteDescendants = this.deleteDescendants.bind(this);
     let count = 0;
     let nDeletedNonEmptyPages = 0; // used for updating descendantCount
+    const pageEvent = this.pageEvent;
 
     const writeStream = new Writable({
       objectMode: true,
@@ -1601,6 +1608,7 @@ class PageService {
         try {
           count += batch.length;
           await deleteDescendants(batch, user);
+          pageEvent.emit('delete', targetPage, batch, user);
           logger.debug(`Deleting pages progressing: (count=${count})`);
         }
         catch (err) {
@@ -2248,10 +2256,15 @@ class PageService {
     };
     const activity = await activityService.createByParameters(parameters);
     // Get user to be notified
-    let targetUsers = await activity.getNotificationTargetUsers();
+    const targetUsers = await activity.getNotificationTargetUsers();
     if (descendantPages != null) {
+      const User = this.crowi.model('User');
       const targetDescendantsUsers = await Subscription.getSubscriptions(descendantPages);
-      targetUsers = targetUsers.concat(targetDescendantsUsers.filter(item => (item.toString() !== user._id.toString())));
+      const descendantsUsers = targetDescendantsUsers.filter(item => (item.toString() !== user._id.toString()));
+      targetUsers.concat(await User.find({
+        _id: { $in: descendantsUsers },
+        status: User.STATUS_ACTIVE,
+      }).distinct('_id'));
     }
     // Create and send notifications
     await inAppNotificationService.upsertByActivity(targetUsers, activity, snapshot);

--- a/packages/app/test/integration/service/page.test.js
+++ b/packages/app/test/integration/service/page.test.js
@@ -564,7 +564,7 @@ describe('PageService', () => {
       expect(resultPage.updatedAt).toEqual(parentForDelete1.updatedAt);
       expect(resultPage.lastUpdateUser).toEqual(testUser1._id);
 
-      expect(pageEventSpy).toHaveBeenCalledWith('delete', parentForDelete1, testUser2);
+      expect(pageEventSpy).toHaveBeenCalledWith('delete', parentForDelete1, null, testUser2);
       expect(pageEventSpy).toHaveBeenCalledWith('create', resultPage, testUser2);
     });
 
@@ -581,7 +581,7 @@ describe('PageService', () => {
       expect(resultPage.updatedAt).toEqual(parentForDelete2.updatedAt);
       expect(resultPage.lastUpdateUser).toEqual(testUser1._id);
 
-      expect(pageEventSpy).toHaveBeenCalledWith('delete', parentForDelete2, testUser2);
+      expect(pageEventSpy).toHaveBeenCalledWith('delete', parentForDelete2, null, testUser2);
       expect(pageEventSpy).toHaveBeenCalledWith('create', resultPage, testUser2);
     });
 

--- a/packages/app/test/integration/service/page.test.js
+++ b/packages/app/test/integration/service/page.test.js
@@ -644,7 +644,7 @@ describe('PageService', () => {
       expect(deleteCompletelyOperationSpy).toHaveBeenCalled();
       expect(deleteCompletelyDescendantsWithStreamSpy).not.toHaveBeenCalled();
 
-      expect(pageEventSpy).toHaveBeenCalledWith('deleteCompletely', parentForDeleteCompletely, testUser2);
+      expect(pageEventSpy).toHaveBeenCalledWith('deleteCompletely', parentForDeleteCompletely, null, testUser2);
     });
 
 
@@ -654,7 +654,7 @@ describe('PageService', () => {
       expect(deleteCompletelyOperationSpy).toHaveBeenCalled();
       expect(deleteCompletelyDescendantsWithStreamSpy).toHaveBeenCalled();
 
-      expect(pageEventSpy).toHaveBeenCalledWith('deleteCompletely', parentForDeleteCompletely, testUser2);
+      expect(pageEventSpy).toHaveBeenCalledWith('deleteCompletely', parentForDeleteCompletely, null, testUser2);
     });
   });
 


### PR DESCRIPTION
以下ストーリー参照
https://redmine.weseek.co.jp/issues/84441

子孫ページを含む親ページが完全削除されたときに、子孫ページのみをサブスクライブしているユーザーに対して通知を飛ばせるようにする。