### PR TITLE
feat: Modify swr hook for isEmptyPage & separate pageId and emptyPageId

### DIFF
--- a/packages/app/src/client/services/ContextExtractor.tsx
+++ b/packages/app/src/client/services/ContextExtractor.tsx
@@ -18,7 +18,7 @@ import {
   useShareLinkId, useShareLinksNumber, useTemplateTagData, useCurrentUpdatedAt, useCreator, useRevisionAuthor, useCurrentUser, useTargetAndAncestors,
   useNotFoundTargetPathOrId, useIsSearchPage, useIsForbidden, useIsIdenticalPath, useHasParent,
   useIsAclEnabled, useIsSearchServiceConfigured, useIsSearchServiceReachable, useIsEnabledAttachTitleHeader, useIsNotFoundPermalink,
-  useDefaultIndentSize, useIsIndentSizeForced, useCsrfToken, useIsEmptyPage,
+  useDefaultIndentSize, useIsIndentSizeForced, useCsrfToken, useIsEmptyPage, useEmptyPageId,
 } from '../../stores/context';
 
 const { isTrashPage: _isTrashPage } = pagePathUtils;
@@ -58,7 +58,8 @@ const ContextExtractorOnce: FC = () => {
   const revisionId = mainContent?.getAttribute('data-page-revision-id');
   const path = decodeURI(mainContent?.getAttribute('data-path') || '');
   // assign `null` to avoid returning empty string
-  const pageId = (mainContent?.getAttribute('data-page-id') || notFoundContext?.getAttribute('data-page-id')) || null;
+  const pageId = mainContent?.getAttribute('data-page-id') || null;
+  const emptyPageId = notFoundContext?.getAttribute('data-page-id') || null;
 
   const revisionCreatedAt = +(mainContent?.getAttribute('data-page-revision-created') || '');
 
@@ -138,6 +139,7 @@ const ContextExtractorOnce: FC = () => {
   useIsUserPage(isUserPage);
   useLastUpdateUsername(lastUpdateUsername);
   useCurrentPageId(pageId);
+  useEmptyPageId(emptyPageId);
   usePageIdOnHackmd(pageIdOnHackmd);
   usePageUser(pageUser);
   useCurrentPagePath(path);

--- a/packages/app/src/components/Navbar/GrowiContextualSubNavigation.tsx
+++ b/packages/app/src/components/Navbar/GrowiContextualSubNavigation.tsx
@@ -14,7 +14,7 @@ import {
 import { OnDuplicatedFunction, OnRenamedFunction, OnDeletedFunction } from '~/interfaces/ui';
 import {
   useCurrentCreatedAt, useCurrentUpdatedAt, useCurrentPageId, useRevisionId, useCurrentPagePath,
-  useCreator, useRevisionAuthor, useCurrentUser, useIsGuestUser, useIsSharedUser, useShareLinkId,
+  useCreator, useRevisionAuthor, useCurrentUser, useIsGuestUser, useIsSharedUser, useShareLinkId, useEmptyPageId,
 } from '~/stores/context';
 import {
   usePageAccessoriesModal, PageAccessoriesModalContents, IPageForPageDuplicateModal,
@@ -153,6 +153,7 @@ const GrowiContextualSubNavigation = (props) => {
   const { data: createdAt } = useCurrentCreatedAt();
   const { data: updatedAt } = useCurrentUpdatedAt();
   const { data: pageId } = useCurrentPageId();
+  const { data: emptyPageId } = useEmptyPageId();
   const { data: revisionId } = useRevisionId();
   const { data: path } = useCurrentPagePath();
   const { data: creator } = useCreator();
@@ -247,6 +248,8 @@ const GrowiContextualSubNavigation = (props) => {
 
 
   const ControlComponents = useCallback(() => {
+    const pageIdForSubNavButtons = pageId ?? emptyPageId; // for SubNavButtons
+
     function onPageEditorModeButtonClicked(viewType) {
       mutateEditorMode(viewType);
     }
@@ -266,11 +269,11 @@ const GrowiContextualSubNavigation = (props) => {
     return (
       <>
         <div className="d-flex flex-column align-items-end justify-content-center py-md-2" style={{ gap: `${isCompactMode ? '5px' : '7px'}` }}>
-          { pageId != null && isViewMode && (
+          { pageIdForSubNavButtons != null && isViewMode && (
             <div className="h-50">
               <SubNavButtons
                 isCompactMode={isCompactMode}
-                pageId={pageId}
+                pageId={pageIdForSubNavButtons}
                 shareLinkId={shareLinkId}
                 revisionId={revisionId}
                 path={path}
@@ -302,7 +305,7 @@ const GrowiContextualSubNavigation = (props) => {
       </>
     );
   }, [
-    pageId, revisionId, shareLinkId, editorMode, mutateEditorMode, isCompactMode,
+    pageId, emptyPageId, revisionId, shareLinkId, editorMode, mutateEditorMode, isCompactMode,
     isLinkSharingDisabled, isDeviceSmallerThanMd, isGuestUser, isSharedUser, currentUser,
     isViewMode, isAbleToShowPageEditorModeManager, isAbleToShowPageManagement,
     duplicateItemClickedHandler, renameItemClickedHandler, deleteItemClickedHandler,

--- a/packages/app/src/components/NotFoundPage.tsx
+++ b/packages/app/src/components/NotFoundPage.tsx
@@ -3,7 +3,7 @@ import React, { useMemo, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import urljoin from 'url-join';
 
-import { useCurrentPageId, useCurrentPagePath, useNotFoundTargetPathOrId } from '~/stores/context';
+import { useCurrentPagePath, useIsEmptyPage, useNotFoundTargetPathOrId } from '~/stores/context';
 
 import CustomNavAndContents from './CustomNavigation/CustomNavAndContents';
 import { DescendantsPageListForCurrentPath } from './DescendantsPageList';
@@ -21,7 +21,7 @@ const replaceURLHistory = (path: string) => {
 
 const NotFoundPage = (): JSX.Element => {
   const { t } = useTranslation();
-  const { data: pageId } = useCurrentPageId();
+  const { data: isEmptyPage } = useIsEmptyPage();
   const { data: path } = useCurrentPagePath();
   const { data: notFoundTargetPathOrId } = useNotFoundTargetPathOrId();
 
@@ -30,15 +30,12 @@ const NotFoundPage = (): JSX.Element => {
     if (path == null) {
       return;
     }
-
-    const isEmptyPage = pageId != null; // Todo: should be improved. https://redmine.weseek.co.jp/issues/98152
     const isPermalink = !notFoundTargetPathOrId?.includes('/');
+
     if (isEmptyPage && isPermalink) {
-      // The (as string) below is a workaround for the case. See the link. (Fixed in typescript version 4.4)
-      // https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-4.html#control-flow-analysis-of-aliased-conditions-and-discriminants
-      replaceURLHistory(path as string);
+      replaceURLHistory(path);
     }
-  }, [pageId, path, notFoundTargetPathOrId]);
+  }, [path, isEmptyPage, notFoundTargetPathOrId]);
 
   const navTabMapping = useMemo(() => {
     return {

--- a/packages/app/src/components/NotFoundPage.tsx
+++ b/packages/app/src/components/NotFoundPage.tsx
@@ -31,7 +31,6 @@ const NotFoundPage = (): JSX.Element => {
       return;
     }
     const isPermalink = !notFoundTargetPathOrId?.includes('/');
-
     if (isEmptyPage && isPermalink) {
       replaceURLHistory(path);
     }

--- a/packages/app/src/components/Page/FixPageGrantAlert.tsx
+++ b/packages/app/src/components/Page/FixPageGrantAlert.tsx
@@ -9,9 +9,7 @@ import { toastError, toastSuccess } from '~/client/util/apiNotification';
 import { apiv3Put } from '~/client/util/apiv3-client';
 import { PageGrant, IPageGrantData } from '~/interfaces/page';
 import { IRecordApplicableGrant, IResIsGrantNormalizedGrantData } from '~/interfaces/page-grant';
-import {
-  useCurrentPageId, useCurrentUser, useHasParent,
-} from '~/stores/context';
+import { useCurrentPageId, useCurrentUser, useHasParent } from '~/stores/context';
 import { useSWRxApplicableGrant, useSWRxIsGrantNormalized } from '~/stores/page';
 
 type ModalProps = {

--- a/packages/app/src/stores/context.tsx
+++ b/packages/app/src/stores/context.tsx
@@ -157,7 +157,7 @@ export const useIsEnabledAttachTitleHeader = (initialData?: boolean) : SWRRespon
 };
 
 export const useIsEmptyPage = (initialData?: boolean) : SWRResponse<boolean, Error> => {
-  return useStaticSWR<boolean, Error>('isEmptyPageInNotFoundContext', initialData);
+  return useStaticSWR<boolean, Error>('isEmptyPage', initialData);
 };
 export const useHasParent = (initialData?: boolean) : SWRResponse<boolean, Error> => {
   return useStaticSWR<boolean, Error>('hasParent', initialData);

--- a/packages/app/src/stores/context.tsx
+++ b/packages/app/src/stores/context.tsx
@@ -36,6 +36,10 @@ export const useCurrentPageId = (initialData?: Nullable<string>): SWRResponse<Nu
   return useStaticSWR<Nullable<string>, Error>('currentPageId', initialData);
 };
 
+export const useEmptyPageId = (initialData?: Nullable<string>): SWRResponse<Nullable<string>, Error> => {
+  return useStaticSWR<Nullable<string>, Error>('emptyPageId', initialData);
+};
+
 export const useRevisionCreatedAt = (initialData?: Nullable<any>): SWRResponse<Nullable<any>, Error> => {
   return useStaticSWR<Nullable<any>, Error>('revisionCreatedAt', initialData);
 };

--- a/packages/app/src/stores/page.tsx
+++ b/packages/app/src/stores/page.tsx
@@ -34,8 +34,8 @@ export const useSWRxPageByPath = (path?: string): SWRResponse<IPageHasId, Error>
 export const useSWRxCurrentPage = (shareLinkId?: string): SWRResponse<IPageHasId, Error> => {
   const { data: currentPageId } = useCurrentPageId();
   const { data: isEmptyPage } = useIsEmptyPage();
-  const isPageIdExist = !isEmptyPage && currentPageId != null; // False if the page is empty
-  return useSWRxPage(isPageIdExist ? currentPageId : undefined, shareLinkId);
+  const isNonEmptyPageId = currentPageId != null && !isEmptyPage; // False if the page is empty
+  return useSWRxPage(isNonEmptyPageId ? currentPageId : undefined, shareLinkId);
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/app/src/stores/page.tsx
+++ b/packages/app/src/stores/page.tsx
@@ -13,7 +13,7 @@ import { IPagingResult } from '~/interfaces/paging-result';
 import { apiGet } from '../client/util/apiv1-client';
 import { IPageTagsInfo } from '../interfaces/pageTagsInfo';
 
-import { useCurrentPageId, useCurrentPagePath } from './context';
+import { useCurrentPageId, useCurrentPagePath, useIsEmptyPage } from './context';
 import { ITermNumberManagerUtil, useTermNumberManager } from './use-static-swr';
 
 
@@ -33,8 +33,9 @@ export const useSWRxPageByPath = (path?: string): SWRResponse<IPageHasId, Error>
 
 export const useSWRxCurrentPage = (shareLinkId?: string): SWRResponse<IPageHasId, Error> => {
   const { data: currentPageId } = useCurrentPageId();
-
-  return useSWRxPage(currentPageId ?? undefined, shareLinkId);
+  const { data: isEmptyPage } = useIsEmptyPage();
+  const isPageIdExist = !isEmptyPage && currentPageId != null; // False if the page is empty
+  return useSWRxPage(isPageIdExist ? currentPageId : undefined, shareLinkId);
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/app/src/stores/page.tsx
+++ b/packages/app/src/stores/page.tsx
@@ -33,6 +33,7 @@ export const useSWRxPageByPath = (path?: string): SWRResponse<IPageHasId, Error>
 
 export const useSWRxCurrentPage = (shareLinkId?: string): SWRResponse<IPageHasId, Error> => {
   const { data: currentPageId } = useCurrentPageId();
+
   return useSWRxPage(currentPageId ?? undefined, shareLinkId);
 };
 

--- a/packages/app/src/stores/page.tsx
+++ b/packages/app/src/stores/page.tsx
@@ -13,7 +13,7 @@ import { IPagingResult } from '~/interfaces/paging-result';
 import { apiGet } from '../client/util/apiv1-client';
 import { IPageTagsInfo } from '../interfaces/pageTagsInfo';
 
-import { useCurrentPageId, useCurrentPagePath, useIsEmptyPage } from './context';
+import { useCurrentPageId, useCurrentPagePath } from './context';
 import { ITermNumberManagerUtil, useTermNumberManager } from './use-static-swr';
 
 
@@ -32,10 +32,8 @@ export const useSWRxPageByPath = (path?: string): SWRResponse<IPageHasId, Error>
 };
 
 export const useSWRxCurrentPage = (shareLinkId?: string): SWRResponse<IPageHasId, Error> => {
-  const { data: _currentPageId } = useCurrentPageId();
-  const { data: isEmptyPage } = useIsEmptyPage();
-  const currentPageId = (isEmptyPage || _currentPageId == null) ? undefined : _currentPageId; // undefined if page is empty
-  return useSWRxPage(currentPageId, shareLinkId);
+  const { data: currentPageId } = useCurrentPageId();
+  return useSWRxPage(currentPageId ?? undefined, shareLinkId);
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/app/src/stores/page.tsx
+++ b/packages/app/src/stores/page.tsx
@@ -32,10 +32,10 @@ export const useSWRxPageByPath = (path?: string): SWRResponse<IPageHasId, Error>
 };
 
 export const useSWRxCurrentPage = (shareLinkId?: string): SWRResponse<IPageHasId, Error> => {
-  const { data: currentPageId } = useCurrentPageId();
+  const { data: _currentPageId } = useCurrentPageId();
   const { data: isEmptyPage } = useIsEmptyPage();
-  const isNonEmptyPageId = currentPageId != null && !isEmptyPage; // False if the page is empty
-  return useSWRxPage(isNonEmptyPageId ? currentPageId : undefined, shareLinkId);
+  const currentPageId = (isEmptyPage || _currentPageId == null) ? undefined : _currentPageId; // undefined if page is empty
+  return useSWRxPage(currentPageId, shareLinkId);
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/app/src/stores/ui.tsx
+++ b/packages/app/src/stores/ui.tsx
@@ -395,7 +395,7 @@ export const useIsAbleToShowPageAuthors = (): SWRResponse<boolean, Error> => {
   const isPageExist = currentPageId != null;
 
   return useSWRImmutable(
-    (includesUndefined) ? null : key,
+    includesUndefined ? null : key,
     () => isPageExist && !isUserPage,
   );
 };

--- a/packages/app/src/stores/ui.tsx
+++ b/packages/app/src/stores/ui.tsx
@@ -388,13 +388,13 @@ export const useIsAbleToShowPageAuthors = (): SWRResponse<boolean, Error> => {
   const key = 'isAbleToShowPageAuthors';
   const { data: currentPageId } = useCurrentPageId();
   const { data: isUserPage } = useIsUserPage();
-  const { data: isEmptyPageInNotFoundContext } = useIsEmptyPage();
+  const { data: isEmptyPage } = useIsEmptyPage();
 
   const includesUndefined = [currentPageId, isUserPage].some(v => v === undefined);
   const isPageExist = currentPageId != null;
 
   return useSWRImmutable(
-    (includesUndefined || isEmptyPageInNotFoundContext) ? null : key,
+    (includesUndefined || isEmptyPage) ? null : key,
     () => isPageExist && !isUserPage,
   );
 };

--- a/packages/app/src/stores/ui.tsx
+++ b/packages/app/src/stores/ui.tsx
@@ -341,7 +341,6 @@ export const useIsAbleToShowPageManagement = (): SWRResponse<boolean, Error> => 
   const { data: isSharedUser } = useIsSharedUser();
 
   const pageId = currentPageId ?? emptyPageId;
-
   const includesUndefined = [pageId, isTrashPage, isSharedUser].some(v => v === undefined);
   const isPageExist = pageId != null;
 

--- a/packages/app/src/stores/ui.tsx
+++ b/packages/app/src/stores/ui.tsx
@@ -16,7 +16,7 @@ import { UpdateDescCountData } from '~/interfaces/websocket';
 import loggerFactory from '~/utils/logger';
 
 import {
-  useCurrentPageId, useCurrentPagePath, useIsEditable, useIsTrashPage, useIsUserPage, useIsGuestUser, useIsEmptyPage,
+  useCurrentPageId, useCurrentPagePath, useIsEditable, useIsTrashPage, useIsUserPage, useIsGuestUser, useIsEmptyPage, useEmptyPageId,
   useIsNotCreatable, useIsSharedUser, useNotFoundTargetPathOrId, useIsForbidden, useIsIdenticalPath, useIsNotFoundPermalink, useCurrentUser, useIsDeleted,
 } from './context';
 import { localStorageMiddleware } from './middlewares/sync-to-storage';
@@ -336,11 +336,14 @@ export const useIsAbleToShowTrashPageManagementButtons = (): SWRResponse<boolean
 export const useIsAbleToShowPageManagement = (): SWRResponse<boolean, Error> => {
   const key = 'isAbleToShowPageManagement';
   const { data: currentPageId } = useCurrentPageId();
+  const { data: emptyPageId } = useEmptyPageId();
   const { data: isTrashPage } = useIsTrashPage();
   const { data: isSharedUser } = useIsSharedUser();
 
-  const includesUndefined = [currentPageId, isTrashPage, isSharedUser].some(v => v === undefined);
-  const isPageExist = currentPageId != null;
+  const pageId = currentPageId ?? emptyPageId;
+
+  const includesUndefined = [pageId, isTrashPage, isSharedUser].some(v => v === undefined);
+  const isPageExist = pageId != null;
 
   return useSWRImmutable(
     includesUndefined ? null : key,

--- a/packages/app/src/stores/ui.tsx
+++ b/packages/app/src/stores/ui.tsx
@@ -16,7 +16,7 @@ import { UpdateDescCountData } from '~/interfaces/websocket';
 import loggerFactory from '~/utils/logger';
 
 import {
-  useCurrentPageId, useCurrentPagePath, useIsEditable, useIsTrashPage, useIsUserPage, useIsGuestUser, useIsEmptyPage, useEmptyPageId,
+  useCurrentPageId, useCurrentPagePath, useIsEditable, useIsTrashPage, useIsUserPage, useIsGuestUser, useEmptyPageId,
   useIsNotCreatable, useIsSharedUser, useNotFoundTargetPathOrId, useIsForbidden, useIsIdenticalPath, useIsNotFoundPermalink, useCurrentUser, useIsDeleted,
 } from './context';
 import { localStorageMiddleware } from './middlewares/sync-to-storage';

--- a/packages/app/src/stores/ui.tsx
+++ b/packages/app/src/stores/ui.tsx
@@ -390,13 +390,12 @@ export const useIsAbleToShowPageAuthors = (): SWRResponse<boolean, Error> => {
   const key = 'isAbleToShowPageAuthors';
   const { data: currentPageId } = useCurrentPageId();
   const { data: isUserPage } = useIsUserPage();
-  const { data: isEmptyPage } = useIsEmptyPage();
 
   const includesUndefined = [currentPageId, isUserPage].some(v => v === undefined);
   const isPageExist = currentPageId != null;
 
   return useSWRImmutable(
-    (includesUndefined || isEmptyPage) ? null : key,
+    (includesUndefined) ? null : key,
     () => isPageExist && !isUserPage,
   );
 };


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/98424

-  swr: `useIsEmptyPage` の命名等を修正
- replace 箇所のrefactor
- contextExtractor 内で `pageId` と `emptyPageId` に分離 およびそれに伴う修正