### PR TITLE
fix: Set max_analyzed_offset to elasticsearch querying options (for 4.5.x)

### DIFF
--- a/packages/app/src/server/service/search-delegator/elasticsearch.ts
+++ b/packages/app/src/server/service/search-delegator/elasticsearch.ts
@@ -951,7 +951,6 @@ class ElasticsearchDelegator implements SearchDelegator<Data> {
 
   appendHighlight(query) {
     query.body.highlight = {
-      max_analyzed_offset: 1000000 - 1, // Set the query parameter [max_analyzed_offset] to a value less than index setting [1000000] and this will tolerate long field values by truncating them.
       fields: {
         '*': {
           fragment_size: 40,
@@ -961,6 +960,10 @@ class ElasticsearchDelegator implements SearchDelegator<Data> {
         },
       },
     };
+
+    if (!this.isElasticsearchV6) {
+      query.body.highlight.max_analyzed_offset = 1000000 - 1; // Set the query parameter [max_analyzed_offset] to a value less than index setting [1000000] and this will tolerate long field values by truncating them.
+    }
   }
 
   async search(data: SearchableData, user, userGroups, option): Promise<Result<Data> & MetaData> {

--- a/packages/app/src/server/service/search-delegator/elasticsearch.ts
+++ b/packages/app/src/server/service/search-delegator/elasticsearch.ts
@@ -951,6 +951,7 @@ class ElasticsearchDelegator implements SearchDelegator<Data> {
 
   appendHighlight(query) {
     query.body.highlight = {
+      max_analyzed_offset: 1000000 - 1, // Set the query parameter [max_analyzed_offset] to a value less than index setting [1000000] and this will tolerate long field values by truncating them.
       fields: {
         '*': {
           fragment_size: 40,


### PR DESCRIPTION
Redmine: なし

https://github.com/weseek/growi/pull/6115 と https://github.com/weseek/growi/pull/6121 の 4.5.x 向け