### PR TITLE
fix: Ensure backword compatibility for ES6 when using max_analyzed_offset

### DIFF
--- a/packages/app/src/server/service/search-delegator/elasticsearch.ts
+++ b/packages/app/src/server/service/search-delegator/elasticsearch.ts
@@ -943,7 +943,6 @@ class ElasticsearchDelegator implements SearchDelegator<Data, ESTermsKey, ESQuer
 
   appendHighlight(query) {
     query.body.highlight = {
-      max_analyzed_offset: 1000000 - 1, // Set the query parameter [max_analyzed_offset] to a value less than index setting [1000000] and this will tolerate long field values by truncating them.
       fields: {
         '*': {
           fragment_size: 40,
@@ -953,6 +952,10 @@ class ElasticsearchDelegator implements SearchDelegator<Data, ESTermsKey, ESQuer
         },
       },
     };
+
+    if (!this.isElasticsearchV6) {
+      query.body.highlight.max_analyzed_offset = 1000000 - 1; // Set the query parameter [max_analyzed_offset] to a value less than index setting [1000000] and this will tolerate long field values by truncating them.
+    }
   }
 
   async search(data: SearchableData<ESQueryTerms>, user, userGroups, option): Promise<ISearchResult<unknown>> {


### PR DESCRIPTION
Redmine: なし

ES6 が highlight.query.max_analyzed_offset に対応していないので、ES6 でない時のみ max_analyzed_offset をつけるようにしました。

ES6 の人が index.highlight.max_analyzed_offset の設定値以上の文字列を highlight クエリにかけるには ES7 に上げる以外の方法は今の所 GROWI にはない状態ですが、そもそもサポートを外していく予定なのでこれで OK だと判断しました