### PR TITLE
imprv: No Request / Response when Audit Log is disabled

### DIFF
--- a/packages/app/src/client/services/ContextExtractor.tsx
+++ b/packages/app/src/client/services/ContextExtractor.tsx
@@ -18,8 +18,8 @@ import {
   useShareLinkId, useShareLinksNumber, useTemplateTagData, useCurrentUpdatedAt, useCreator, useRevisionAuthor, useCurrentUser, useTargetAndAncestors,
   useNotFoundTargetPathOrId, useIsSearchPage, useIsForbidden, useIsIdenticalPath, useHasParent,
   useIsAclEnabled, useIsSearchServiceConfigured, useIsSearchServiceReachable, useIsEnabledAttachTitleHeader, useIsNotFoundPermalink,
-  useDefaultIndentSize, useIsIndentSizeForced, useCsrfToken, useIsEmptyPage, useEmptyPageId, useGrowiVersion, useActivityExpirationSeconds,
-  useAuditLogAvailableActions,
+  useDefaultIndentSize, useIsIndentSizeForced, useCsrfToken, useIsEmptyPage, useEmptyPageId, useGrowiVersion, useAuditLogEnabled,
+  useActivityExpirationSeconds, useAuditLogAvailableActions,
 } from '../../stores/context';
 
 const { isTrashPage: _isTrashPage } = pagePathUtils;
@@ -124,6 +124,7 @@ const ContextExtractorOnce: FC = () => {
   useIsEnabledAttachTitleHeader(configByContextHydrate.isEnabledAttachTitleHeader);
   useIsIndentSizeForced(configByContextHydrate.isIndentSizeForced);
   useDefaultIndentSize(configByContextHydrate.adminPreferredIndentSize);
+  useAuditLogEnabled(configByContextHydrate.auditLogEnabled);
   useActivityExpirationSeconds(configByContextHydrate.activityExpirationSeconds);
   useAuditLogAvailableActions(configByContextHydrate.auditLogAvailableActions);
   useGrowiVersion(configByContextHydrate.crowi.version);

--- a/packages/app/src/server/models/config.ts
+++ b/packages/app/src/server/models/config.ts
@@ -245,6 +245,7 @@ schema.statics.getLocalconfig = function(crowi) {
     globalLang: crowi.configManager.getConfig('crowi', 'app:globalLang'),
     pageLimitationL: crowi.configManager.getConfig('crowi', 'customize:showPageLimitationL'),
     pageLimitationXL: crowi.configManager.getConfig('crowi', 'customize:showPageLimitationXL'),
+    auditLogEnabled: crowi.configManager.getConfig('crowi', 'app:auditLogEnabled'),
     activityExpirationSeconds: crowi.configManager.getConfig('crowi', 'app:activityExpirationSeconds'),
     auditLogAvailableActions: crowi.activityService.getAvailableActions(false),
     isSidebarDrawerMode: crowi.configManager.getConfig('crowi', 'customize:isSidebarDrawerMode'),

--- a/packages/app/src/server/routes/apiv3/activity.ts
+++ b/packages/app/src/server/routes/apiv3/activity.ts
@@ -44,7 +44,7 @@ module.exports = (crowi: Crowi): Router => {
     if (!auditLogEnabled) {
       const msg = 'AuditLog is not enabled';
       logger.error(msg);
-      return res.apiv3Err(msg, 406);
+      return res.apiv3Err(msg, 405);
     }
 
     const limit = req.query.limit || await crowi.configManager?.getConfig('crowi', 'customize:showPageLimitationS') || 10;

--- a/packages/app/src/server/routes/apiv3/activity.ts
+++ b/packages/app/src/server/routes/apiv3/activity.ts
@@ -40,6 +40,13 @@ module.exports = (crowi: Crowi): Router => {
 
   // eslint-disable-next-line max-len
   router.get('/', apiLimiter, accessTokenParser, loginRequiredStrictly, adminRequired, validator.list, apiV3FormValidator, async(req: Request, res: ApiV3Response) => {
+    const auditLogEnabled = crowi.configManager?.getConfig('crowi', 'app:auditLogEnabled') || false;
+    if (!auditLogEnabled) {
+      const msg = 'AuditLog is not enabled';
+      logger.error(msg);
+      return res.apiv3Err(msg, 406);
+    }
+
     const limit = req.query.limit || await crowi.configManager?.getConfig('crowi', 'customize:showPageLimitationS') || 10;
     const offset = req.query.offset || 1;
 

--- a/packages/app/src/stores/activity.ts
+++ b/packages/app/src/stores/activity.ts
@@ -1,14 +1,17 @@
 import { SWRResponse } from 'swr';
 import useSWRImmutable from 'swr/immutable';
 
-import { apiv3Get } from '../client/util/apiv3-client';
-import { IActivityHasId, ISearchFilter } from '../interfaces/activity';
-import { PaginateResult } from '../interfaces/mongoose-utils';
+import { apiv3Get } from '~/client/util/apiv3-client';
+import { IActivityHasId, ISearchFilter } from '~/interfaces/activity';
+import { PaginateResult } from '~/interfaces/mongoose-utils';
+import { useAuditLogEnabled } from '~/stores/context';
 
 export const useSWRxActivity = (limit?: number, offset?: number, searchFilter?: ISearchFilter): SWRResponse<PaginateResult<IActivityHasId>, Error> => {
+  const { data: auditLogEnabled } = useAuditLogEnabled();
+
   const stringifiedSearchFilter = JSON.stringify(searchFilter);
   return useSWRImmutable(
-    ['/activity', limit, offset, stringifiedSearchFilter],
+    auditLogEnabled ? ['/activity', limit, offset, stringifiedSearchFilter] : null,
     (endpoint, limit, offset, stringifiedSearchFilter) => apiv3Get(endpoint, { limit, offset, searchFilter: stringifiedSearchFilter })
       .then(result => result.data.paginationResult),
   );

--- a/packages/app/src/stores/context.tsx
+++ b/packages/app/src/stores/context.tsx
@@ -177,6 +177,10 @@ export const useDefaultIndentSize = (initialData?: number) : SWRResponse<number,
   return useStaticSWR<number, Error>('defaultIndentSize', initialData, { fallbackData: 4 });
 };
 
+export const useAuditLogEnabled = (initialData?: boolean): SWRResponse<boolean, Error> => {
+  return useStaticSWR<boolean, Error>('auditLogEnabled', initialData);
+};
+
 export const useActivityExpirationSeconds = (initialData?: number) : SWRResponse<number, Error> => {
   return useStaticSWR<number, Error>('activityExpirationSeconds', initialData);
 };


### PR DESCRIPTION
## Task
[#98233](https://redmine.weseek.co.jp/issues/98233) [GROWI] [AuditLog] AuditLog 機能自体の ON / OFF ができる
└ [#98236](https://redmine.weseek.co.jp/issues/98236) 環境変数を参照し OFF 時に req / res しないようにする