### PR TITLE
imprv: Disable add-activity middleware if used in GET requests

### DIFF
--- a/packages/app/src/server/middlewares/add-activity.ts
+++ b/packages/app/src/server/middlewares/add-activity.ts
@@ -13,6 +13,11 @@ interface AuthorizedRequest extends Request {
 }
 
 export const generateAddActivityMiddleware = crowi => async(req: AuthorizedRequest, res: Response, next: NextFunction): Promise<void> => {
+  if (req.method === 'GET') {
+    logger.error('This middleware is not available for GET requests');
+    return next();
+  }
+
   const parameter = {
     ip:  req.ip,
     endpoint: req.originalUrl,

--- a/packages/app/src/server/routes/index.js
+++ b/packages/app/src/server/routes/index.js
@@ -73,7 +73,7 @@ module.exports = function(crowi, app) {
   // API v3 for auth
   app.use('/_api/v3', apiV3AuthRouter);
 
-  app.get('/'                         , applicationInstalled, unavailableWhenMaintenanceMode, loginRequired, addActivity, autoReconnectToSearch, injectUserUISettings, page.showTopPage);
+  app.get('/'                         , applicationInstalled, unavailableWhenMaintenanceMode, loginRequired, autoReconnectToSearch, injectUserUISettings, page.showTopPage);
 
   app.get('/login/error/:reason'      , applicationInstalled, login.error);
   app.get('/login'                    , applicationInstalled, login.preLogin, login.login);
@@ -245,9 +245,9 @@ module.exports = function(crowi, app) {
 
   app.use('/ogp', express.Router().get('/:pageId([0-9a-z]{0,})', loginRequired, ogp.pageIdRequired, ogp.ogpValidator, ogp.renderOgp));
 
-  app.get('/:id([0-9a-z]{24})'       , loginRequired , addActivity, injectUserUISettings, page.showPage);
+  app.get('/:id([0-9a-z]{24})'       , loginRequired , injectUserUISettings, page.showPage);
 
-  app.get('/*/$'                   , loginRequired , addActivity, injectUserUISettings, page.redirectorWithEndOfSlash);
-  app.get('/*'                     , loginRequired , addActivity, autoReconnectToSearch, injectUserUISettings, page.redirector);
+  app.get('/*/$'                   , loginRequired , injectUserUISettings, page.redirectorWithEndOfSlash);
+  app.get('/*'                     , loginRequired , autoReconnectToSearch, injectUserUISettings, page.redirector);
 
 };

--- a/packages/app/src/server/routes/page.js
+++ b/packages/app/src/server/routes/page.js
@@ -4,6 +4,7 @@ import mongoose from 'mongoose';
 import urljoin from 'url-join';
 
 import { SupportedTargetModel, SupportedAction } from '~/interfaces/activity';
+import Activity from '~/server/models/activity';
 import loggerFactory from '~/utils/logger';
 
 import { PathAlreadyExistsError } from '../models/errors';
@@ -411,8 +412,24 @@ module.exports = function(crowi, app) {
 
     await addRenderVarsForPageTree(renderVars, portalPath, req.user);
 
-    const parameters = { action: SupportedAction.ACTION_PAGE_VIEW };
-    activityEvent.emit('update', res.locals.activity._id, parameters);
+    const shoudCreateActivity = crowi.activityService.shoudUpdateActivity(SupportedAction.ACTION_PAGE_VIEW);
+    if (shoudCreateActivity) {
+      const parameter = {
+        ip:  req.ip,
+        endpoint: req.originalUrl,
+        action: SupportedAction.ACTION_PAGE_VIEW,
+        user: req.user?._id,
+        snapshot: {
+          username: req.user?.username,
+        },
+      };
+      try {
+        await Activity.createByParameters(parameter);
+      }
+      catch (err) {
+        logger.error('Create activity failed', err);
+      }
+    }
 
     return res.render(view, renderVars);
   }
@@ -472,8 +489,24 @@ module.exports = function(crowi, app) {
 
     await addRenderVarsForPageTree(renderVars, path, req.user);
 
-    const parameters = { action: SupportedAction.ACTION_PAGE_VIEW };
-    activityEvent.emit('update', res.locals.activity._id, parameters);
+    const shoudCreateActivity = crowi.activityService.shoudUpdateActivity(SupportedAction.ACTION_PAGE_VIEW);
+    if (shoudCreateActivity) {
+      const parameter = {
+        ip:  req.ip,
+        endpoint: req.originalUrl,
+        action: SupportedAction.ACTION_PAGE_VIEW,
+        user: req.user?._id,
+        snapshot: {
+          username: req.user?.username,
+        },
+      };
+      try {
+        await Activity.createByParameters(parameter);
+      }
+      catch (err) {
+        logger.error('Create activity failed', err);
+      }
+    }
 
     return res.render(view, renderVars);
   }
@@ -655,8 +688,24 @@ module.exports = function(crowi, app) {
   actions.redirector = async function(req, res, next) {
     const path = getPathFromRequest(req);
 
-    const parameters = { action: SupportedAction.ACTION_PAGE_VIEW };
-    activityEvent.emit('update', res.locals.activity._id, parameters);
+    const shoudCreateActivity = crowi.activityService.shoudUpdateActivity(SupportedAction.ACTION_PAGE_VIEW);
+    if (shoudCreateActivity) {
+      const parameter = {
+        ip:  req.ip,
+        endpoint: req.originalUrl,
+        action: SupportedAction.ACTION_PAGE_VIEW,
+        user: req.user?._id,
+        snapshot: {
+          username: req.user?.username,
+        },
+      };
+      try {
+        await Activity.createByParameters(parameter);
+      }
+      catch (err) {
+        logger.error('Create activity failed', err);
+      }
+    }
 
     return redirector(req, res, next, path);
   };
@@ -665,8 +714,24 @@ module.exports = function(crowi, app) {
     const _path = getPathFromRequest(req);
     const path = pathUtils.removeTrailingSlash(_path);
 
-    const parameters = { action: SupportedAction.ACTION_PAGE_VIEW };
-    activityEvent.emit('update', res.locals.activity._id, parameters);
+    const shoudCreateActivity = crowi.activityService.shoudUpdateActivity(SupportedAction.ACTION_PAGE_VIEW);
+    if (shoudCreateActivity) {
+      const parameter = {
+        ip:  req.ip,
+        endpoint: req.originalUrl,
+        action: SupportedAction.ACTION_PAGE_VIEW,
+        user: req.user?._id,
+        snapshot: {
+          username: req.user?.username,
+        },
+      };
+      try {
+        await Activity.createByParameters(parameter);
+      }
+      catch (err) {
+        logger.error('Create activity failed', err);
+      }
+    }
 
     return redirector(req, res, next, path);
   };


### PR DESCRIPTION
## Task
[#98843](https://redmine.weseek.co.jp/issues/98843) [GROWI] [AuditLog] add-middleware を GET リクエスト で’利用する際に、エラーログを出す
└ [#98844](https://redmine.weseek.co.jp/issues/98844) 実装