### PR TITLE
imprv: Create redirect when password is not available

### DIFF
--- a/packages/app/src/components/Me/PersonalSettings.jsx
+++ b/packages/app/src/components/Me/PersonalSettings.jsx
@@ -58,10 +58,11 @@ const PersonalSettings = () => {
     };
   }, [t]);
 
+  const isNoPassword = window.location.hash === '#password';
 
   return (
     <div data-testid="grw-personal-settings">
-      <CustomNavAndContents navTabMapping={navTabMapping} navigationMode="both" tabContentClasses={['px-0']} />
+      <CustomNavAndContents defaultTabIndex={isNoPassword && 2} navTabMapping={navTabMapping} navigationMode="both" tabContentClasses={['px-0']} />
     </div>
   );
 


### PR DESCRIPTION
 [97688](https://redmine.weseek.co.jp/issues/97688) ユーザー新規登録後、パスワードがない場合に設定画面にリダイレクトできる
┗ [96009](https://redmine.weseek.co.jp/issues/96009) パスワードがない場合のリダイレクトをつくる。