### PR TITLE
fix: Empty trash doesn't work

### DIFF
--- a/packages/app/src/server/routes/apiv3/pages.js
+++ b/packages/app/src/server/routes/apiv3/pages.js
@@ -594,7 +594,7 @@ module.exports = (crowi) => {
   router.delete('/empty-trash', accessTokenParser, loginRequired, csrf, apiV3FormValidator, async(req, res) => {
     const options = {};
 
-    const pagesInTrash = await Page.findChildrenByParentPathOrIdAndViewer('/trash', req.user);
+    const pagesInTrash = await crowi.pageService.findChildrenByParentPathOrIdAndViewer('/trash', req.user);
 
     const deletablePages = crowi.pageService.filterPagesByCanDeleteCompletely(pagesInTrash, req.user, true);
 


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/99106

## バグの原因

- もともとモデル層にあった`findChildrenByParentPathOrIdAndViewer`というメソッドがサービス層に移動されたときに、呼び出しもとが変更されていなかった
