### PR TITLE
feat: Show incomplete sidebar

### DIFF
--- a/packages/app/src/components/BasicLayout.tsx
+++ b/packages/app/src/components/BasicLayout.tsx
@@ -15,7 +15,7 @@ type Props = {
 
 export const BasicLayout = ({ children, title, className }: Props): JSX.Element => {
 
-  // const Sidebar = dynamic(() => import('../client/js/components/Sidebar'), { ssr: false });
+  const Sidebar = dynamic(() => import('./Sidebar'), { ssr: false });
   // const HotkeysManager = dynamic(() => import('../client/js/components/Hotkeys/HotkeysManager'), { ssr: false });
   // const PageCreateModal = dynamic(() => import('../client/js/components/PageCreateModal'), { ssr: false });
   const ShortcutsModal = dynamic(() => import('./ShortcutsModal'), { ssr: false });
@@ -28,8 +28,7 @@ export const BasicLayout = ({ children, title, className }: Props): JSX.Element 
 
         <div className="page-wrapper d-flex d-print-block">
           <div className="grw-sidebar-wrapper">
-            {/* <Sidebar /> */}
-            Sidebar
+            <Sidebar />
           </div>
 
           <div className="flex-fill mw-0">

--- a/packages/app/src/components/Sidebar/SidebarContents.tsx
+++ b/packages/app/src/components/Sidebar/SidebarContents.tsx
@@ -3,10 +3,12 @@ import React from 'react';
 import { SidebarContentsType } from '~/interfaces/ui';
 import { useCurrentSidebarContents } from '~/stores/ui';
 
-import CustomSidebar from './CustomSidebar';
-import PageTree from './PageTree';
+// import CustomSidebar from './CustomSidebar';
+// import PageTree from './PageTree';
 import RecentChanges from './RecentChanges';
 import Tag from './Tag';
+
+const DummyComponent = (): JSX.Element => <></>; // Todo: remove this later when it is able to render other Contents.
 
 const SidebarContents = (): JSX.Element => {
   const { data: currentSidebarContents } = useCurrentSidebarContents();
@@ -17,13 +19,15 @@ const SidebarContents = (): JSX.Element => {
       Contents = RecentChanges;
       break;
     case SidebarContentsType.CUSTOM:
-      Contents = CustomSidebar;
+      // Contents = CustomSidebar;
+      Contents = DummyComponent;
       break;
     case SidebarContentsType.TAG:
       Contents = Tag;
       break;
     default:
-      Contents = PageTree;
+      // Contents = PageTree;
+      Contents = DummyComponent;
   }
 
   return (


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/99333

開発チームの利便性のためサイドバーを表示
- ページツリーとカスタムサイドバーは利用不可
- `update`(Recent Changes) から下の機能が利用可能
<img width="610" alt="image" src="https://user-images.githubusercontent.com/35527421/176640006-b8b85e2f-6b92-4b56-befd-ed90e0725547.png">
