### PR TITLE
fix/96693 Show toast error

### DIFF
--- a/packages/app/src/components/Me/AssociateModal.tsx
+++ b/packages/app/src/components/Me/AssociateModal.tsx
@@ -8,7 +8,7 @@ import {
   ModalFooter,
 } from 'reactstrap';
 
-import { toastSuccess } from '~/client/util/apiNotification';
+import { toastSuccess, toastError } from '~/client/util/apiNotification';
 import { usePersonalSettings, useSWRxPersonalExternalAccounts } from '~/stores/personal-settings';
 
 import LdapAuthTest from '../Admin/Security/LdapAuthTest';
@@ -35,11 +35,16 @@ const AssociateModal = (props: Props): JSX.Element => {
 
 
   const clickAddLdapAccountHandler = useCallback(async() => {
-    await associateLdapAccount({ username, password });
-    mutatePersonalExternalAccounts();
+    try {
+      await associateLdapAccount({ username, password });
+      mutatePersonalExternalAccounts();
 
-    closeModalHandler();
-    toastSuccess(t('security_setting.updated_general_security_setting'));
+      closeModalHandler();
+      toastSuccess(t('security_setting.updated_general_security_setting'));
+    }
+    catch (err) {
+      toastError(err);
+    }
 
   }, [associateLdapAccount, closeModalHandler, mutatePersonalExternalAccounts, password, t, username]);
 

--- a/packages/app/src/stores/personal-settings.tsx
+++ b/packages/app/src/stores/personal-settings.tsx
@@ -1,11 +1,15 @@
 import useSWR, { SWRResponse } from 'swr';
 
+
 import { IExternalAccount } from '~/interfaces/external-account';
 import { IUser } from '~/interfaces/user';
+import loggerFactory from '~/utils/logger';
 
 import { apiv3Get, apiv3Put } from '../client/util/apiv3-client';
 
 import { useStaticSWR } from './use-static-swr';
+
+const logger = loggerFactory('growi:stores:personal-settings');
 
 
 export const useSWRxPersonalSettings = (): SWRResponse<IUser, Error> => {
@@ -51,16 +55,34 @@ export const usePersonalSettings = (): SWRResponse<IUser, Error> & IPersonalSett
     };
 
     // invoke API
-    await apiv3Put('/personal-setting/', updateData);
+    try {
+      await apiv3Put('/personal-setting/', updateData);
+    }
+    catch (err) {
+      logger.error(err);
+      throw new Error('Failed to update personal data');
+    }
   };
 
 
   const associateLdapAccount = async(account): Promise<void> => {
-    await apiv3Put('/personal-setting/associate-ldap', account);
+    try {
+      await apiv3Put('/personal-setting/associate-ldap', account);
+    }
+    catch (err) {
+      logger.error(err);
+      throw new Error('Failed to associate ldap account');
+    }
   };
 
   const disassociateLdapAccount = async(account): Promise<void> => {
-    await apiv3Put('/personal-setting/disassociate-ldap', account);
+    try {
+      await apiv3Put('/personal-setting/disassociate-ldap', account);
+    }
+    catch (err) {
+      logger.error(err);
+      throw new Error('Failed to disassociate ldap account');
+    }
   };
 
   return {


### PR DESCRIPTION
## Task
[Omit Unstated] [SWR化] PersonalContainer
┗[99693](https://redmine.weseek.co.jp/issues/99693)Cypress のエラー修正

## Discription
[マスターマージPR (Omit Personal Contaiener)](https://github.com/weseek/growi/pull/6182) にて、Cypressのエラーが出ていたので、修正しました。

### エラー内容
```
  1 failing
  1) Access User settings
       Update settings:
     AssertionError: Timed out retrying after 4000ms: Expected to find element: `.toast`, but never found it.
      at Context.eval (http://localhost:3000/__cypress/tests?p=test/cypress/integration/60-home/home.spec.ts:144:26)
```
https://github.com/weseek/growi/runs/7168852916?check_suite_focus=true
