### PR TITLE
fix/99731 cypress err related to api settings

### DIFF
--- a/packages/app/test/cypress/integration/60-home/home.spec.ts
+++ b/packages/app/test/cypress/integration/60-home/home.spec.ts
@@ -33,14 +33,12 @@ context('Access User settings', () => {
     });
     // collapse sidebar
     cy.collapseSidebar(true);
-  });
-
-  it('Update settings', () => {
     cy.visit('/me');
-
     // hide fab
     cy.getByTestid('grw-fab-container').invoke('attr', 'style', 'display: none');
+  });
 
+  it('Access User information', () => {
     // User information
     cy.getByTestid('grw-user-settings').should('be.visible');
     cy.screenshot(`${ssPrefix}-user-information-1`);
@@ -50,8 +48,9 @@ context('Access User settings', () => {
 
     cy.get('.toast-close-button').click({ multiple: true }); // close toast alert
     cy.get('.toast').should('not.exist');
+  });
 
-    // Access External account
+  it('Access External account', () => {
     cy.getByTestid('grw-personal-settings').find('.nav-title.nav li:eq(1) a').click();
     cy.scrollTo('top');
     cy.screenshot(`${ssPrefix}-external-account-1`);
@@ -67,8 +66,9 @@ context('Access User settings', () => {
     cy.screenshot(`${ssPrefix}-external-account-4`);
 
     cy.get('.toast').should('not.exist');
+  });
 
-    // Access Password setting
+  it('Access Password setting', () => {
     cy.getByTestid('grw-personal-settings').find('.nav-title.nav li:eq(2) a').click();
     cy.scrollTo('top');
     cy.screenshot(`${ssPrefix}-password-settings-1`);
@@ -78,8 +78,9 @@ context('Access User settings', () => {
 
     cy.get('.toast-close-button').click({ multiple: true }); // close toast alert
     cy.get('.toast').should('not.exist');
+  });
 
-    // Access API setting
+  it('Access API setting', () => {
     cy.getByTestid('grw-personal-settings').find('.nav-title.nav li:eq(3) a').click();
     cy.scrollTo('top');
     cy.screenshot(`${ssPrefix}-api-setting-1`);
@@ -90,8 +91,9 @@ context('Access User settings', () => {
 
     cy.get('.toast-close-button').click({ multiple: true }); // close toast alert
     cy.get('.toast').should('not.exist');
+  });
 
-    // Access Editor setting
+  it('Access Editor setting', () => {
     cy.getByTestid('grw-personal-settings').find('.nav-title.nav li:eq(4) a').click();
     cy.scrollTo('top');
     cy.getByTestid('grw-editor-settings').should('be.visible');
@@ -102,8 +104,9 @@ context('Access User settings', () => {
 
     cy.get('.toast-close-button').click({ multiple: true }); // close toast alert
     cy.get('.toast').should('not.exist');
+  });
 
-    // Access In-app notification setting
+  it('Access In-app notification setting', () => {
     cy.getByTestid('grw-personal-settings').find('.nav-title.nav li:eq(5) a').click();
     cy.scrollTo('top');
     cy.screenshot(`${ssPrefix}-in-app-notification-setting-1`);
@@ -111,5 +114,4 @@ context('Access User settings', () => {
     cy.get('.toast').should('be.visible').invoke('attr', 'style', 'opacity: 1');
     cy.screenshot(`${ssPrefix}-in-app-notification-setting-2`);
   });
-
 });


### PR DESCRIPTION
## Task
[Omit Unstated] [SWR化] PersonalContainer
┗[99731](https://redmine.weseek.co.jp/issues/99731) [cypress][data-testid=grw-api-settings-input]`, but never found it. のエラー修正



## Description
https://github.com/weseek/growi/pull/6182 で出力されるcypress エラーの修正をしました。

[CI Cypress err](https://github.com/weseek/growi/runs/7208947340?check_suite_focus=true)
[VRT Screen shot err](https://growi-vrt-snapshots.s3.amazonaws.com/faae68da81d3fdc931366c397a88b3236b8a58f3/index.html?id=new-60-home/home.spec.ts/Access%20User%20settings%20--%20Update%20settings%20(failed).png)
```
  1) Update settings
 1 passing (38s)
  1 failing
  1) Access User settings
       Update settings:
     AssertionError: Timed out retrying after 4000ms: Expected to find element: `[data-testid=grw-api-settings-input]`, but never found it.
      at Context.eval (http://localhost:3000/__cypress/tests?p=test/cypress/integration/60-home/home.spec.ts:165:50)
```


## local環境での再現手順
DBで username `admin` の apiToken を null にして `y
arn cy:run --spec **/60-home/*` を実行すると再現する

### 補足
- `// Access API setting` より前の test (`// Access External account`,` // Access Password setting`) をコメントアウトすると再現しなくなる
- 実際に触ってみても正常動作する(apiTokenがnull の状態で「tokenを更新」ボタンを押すと、tokenが記述されたinputが表示される)
- 実装が原因というより cypress の書き方がよくなかった?と認識


## 解決方法
- `it('Update settings', () => { ~~~` の中に詰め込まれていた各タブでの処理を `it(~~~` 毎に分けたら解決しました。
また、it で分けた方が、デバッグしやすいと判断しました。
(.toast should be visible などの(過去に表示された)エラーはいろんな箇所で使われているのでどこのトースターなのか気付きにくかったので　👉🏻 #6207 )
 <img width="398" alt="Screen Shot 2022-07-06 at 19 03 33" src="https://user-images.githubusercontent.com/59536731/177525835-d5542dca-7942-4a0a-8655-fedd82e2691e.png">
