### PR TITLE
fix: Error when trying login with an email that contains plus sign

### DIFF
--- a/packages/app/src/server/middlewares/login-form-validator.ts
+++ b/packages/app/src/server/middlewares/login-form-validator.ts
@@ -47,8 +47,8 @@ export const inviteValidation = (req, res, next) => {
 export const loginRules = () => {
   return [
     body('loginForm.username')
-      .matches(/^[\da-zA-Z\-_.@]+$/)
-      .withMessage('Username has invalid characters')
+      .matches(/^[\da-zA-Z\-_.+@]+$/)
+      .withMessage('Username or E-mail has invalid characters')
       .not()
       .isEmpty()
       .withMessage('Username field is required'),


### PR DESCRIPTION
## Task
[#100067](https://redmine.weseek.co.jp/issues/100067) [Bug] + が含まれている mail でユーザーの仮発行ができるもののログイン時に username has invalid characters と言われてしまうのを修正
└ [#100063](https://redmine.weseek.co.jp/issues/100063) 修正