### PR TITLE
Imprv/100056 show app settings

### DIFF
--- a/packages/app/public/static/locales/en_US/translation.json
+++ b/packages/app/public/static/locales/en_US/translation.json
@@ -1125,5 +1125,10 @@
   "page_operation":{
     "paths_recovered": "Paths recovered successfully",
     "path_recovery_failed":"Path recovery failed"
+  },
+  "i18n": {
+    "en_US": "English",
+    "ja_JP": "Japanese",
+    "zh_CN": "Chinese"
   }
 }

--- a/packages/app/public/static/locales/en_US/translation.json
+++ b/packages/app/public/static/locales/en_US/translation.json
@@ -1,4 +1,7 @@
 {
+  "meta": {
+    "display_name": "English"
+  },
   "Help": "Help",
   "view": "View",
   "Edit": "Edit",
@@ -1125,10 +1128,5 @@
   "page_operation":{
     "paths_recovered": "Paths recovered successfully",
     "path_recovery_failed":"Path recovery failed"
-  },
-  "i18n": {
-    "en_US": "English",
-    "ja_JP": "Japanese",
-    "zh_CN": "Chinese"
   }
 }

--- a/packages/app/public/static/locales/ja_JP/translation.json
+++ b/packages/app/public/static/locales/ja_JP/translation.json
@@ -1118,5 +1118,10 @@
   "page_operation":{
     "paths_recovered": "パスを修復しました",
     "path_recovery_failed":"パスを修復できませんでした"
+  },
+  "i18n": {
+    "en_US": "英語",
+    "ja_JP": "日本語",
+    "zh_CN": "中国語"
   }
 }

--- a/packages/app/public/static/locales/ja_JP/translation.json
+++ b/packages/app/public/static/locales/ja_JP/translation.json
@@ -1,4 +1,7 @@
 {
+  "meta": {
+    "display_name": "日本語"
+  },
   "Help": "ヘルプ",
   "view": "View",
   "Edit": "編集",
@@ -1118,10 +1121,5 @@
   "page_operation":{
     "paths_recovered": "パスを修復しました",
     "path_recovery_failed":"パスを修復できませんでした"
-  },
-  "i18n": {
-    "en_US": "英語",
-    "ja_JP": "日本語",
-    "zh_CN": "中国語"
   }
 }

--- a/packages/app/public/static/locales/zh_CN/translation.json
+++ b/packages/app/public/static/locales/zh_CN/translation.json
@@ -1,4 +1,7 @@
 {
+  "meta": {
+    "display_name": "简体中文"
+  },
   "Help": "帮助",
   "view": "View",
 	"Edit": "编辑",
@@ -1128,10 +1131,5 @@
   "page_operation":{
     "paths_recovered": "成功恢复了页面路径",
     "path_recovery_failed":"路径恢复失败"
-  },
-  "i18n": {
-    "en_US": "英语",
-    "ja_JP": "日文",
-    "zh_CN": "中文"
   }
 }

--- a/packages/app/public/static/locales/zh_CN/translation.json
+++ b/packages/app/public/static/locales/zh_CN/translation.json
@@ -1128,5 +1128,10 @@
   "page_operation":{
     "paths_recovered": "成功恢复了页面路径",
     "path_recovery_failed":"路径恢复失败"
+  },
+  "i18n": {
+    "en_US": "英语",
+    "ja_JP": "日文",
+    "zh_CN": "中文"
   }
 }

--- a/packages/app/src/client/util/i18n.js
+++ b/packages/app/src/client/util/i18n.js
@@ -1,3 +1,4 @@
+
 /* eslint-disable */
 import i18n from 'i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
@@ -15,6 +16,9 @@ Object.values(locales).forEach((locale) => {
   });
 });
 
+/*
+* Note: This file will be deleted. use "~/next-i18next.config" instead
+*/
 // extract metadata list from 'public/static/locales/${locale}/meta.json'
 export const localeMetadatas = Object.values(locales).map(locale => locale.meta);
 

--- a/packages/app/src/components/Admin/App/AppSetting.jsx
+++ b/packages/app/src/components/Admin/App/AppSetting.jsx
@@ -1,11 +1,11 @@
 import React, { useCallback } from 'react';
 
-import { useTranslation } from 'next-i18next';
+import { useTranslation, i18n } from 'next-i18next';
 import PropTypes from 'prop-types';
 
 import AdminAppContainer from '~/client/services/AdminAppContainer';
 import { toastSuccess, toastError } from '~/client/util/apiNotification';
-import { i18n } from '~/next-i18next.config';
+import { i18n as i18nConfig } from '~/next-i18next.config';
 import loggerFactory from '~/utils/logger';
 
 
@@ -77,22 +77,27 @@ const AppSetting = (props) => {
         </label>
         <div className="col-md-6 py-2">
           {
-            i18n.locales.map(locale => (
-              <div key={locale} className="custom-control custom-radio custom-control-inline">
-                <input
-                  type="radio"
-                  id={`radioLang${locale}`}
-                  className="custom-control-input"
-                  name="globalLang"
-                  value={locale}
-                  checked={adminAppContainer.state.globalLang === locale}
-                  onChange={(e) => {
-                    adminAppContainer.changeGlobalLang(e.target.value);
-                  }}
-                />
-                <label className="custom-control-label" htmlFor={`radioLang${locale}`}>{t(`i18n.${locale}`)}</label>
-              </div>
-            ))
+            i18nConfig.locales.map((locale) => {
+              const fixedT = i18n.getFixedT(locale);
+              i18n.loadLanguages(i18nConfig.locales);
+
+              return (
+                <div key={locale} className="custom-control custom-radio custom-control-inline">
+                  <input
+                    type="radio"
+                    id={`radioLang${locale}`}
+                    className="custom-control-input"
+                    name="globalLang"
+                    value={locale}
+                    checked={adminAppContainer.state.globalLang === locale}
+                    onChange={(e) => {
+                      adminAppContainer.changeGlobalLang(e.target.value);
+                    }}
+                  />
+                  <label className="custom-control-label" htmlFor={`radioLang${locale}`}>{fixedT('meta.display_name')}</label>
+                </div>
+              );
+            })
           }
         </div>
       </div>

--- a/packages/app/src/components/Admin/App/AppSetting.jsx
+++ b/packages/app/src/components/Admin/App/AppSetting.jsx
@@ -1,11 +1,11 @@
 import React, { useCallback } from 'react';
 
-import PropTypes from 'prop-types';
 import { useTranslation } from 'next-i18next';
+import PropTypes from 'prop-types';
 
 import AdminAppContainer from '~/client/services/AdminAppContainer';
 import { toastSuccess, toastError } from '~/client/util/apiNotification';
-import { localeMetadatas } from '~/client/util/i18n';
+import { i18n } from '~/next-i18next.config';
 import loggerFactory from '~/utils/logger';
 
 
@@ -77,20 +77,20 @@ const AppSetting = (props) => {
         </label>
         <div className="col-md-6 py-2">
           {
-            localeMetadatas.map(meta => (
-              <div key={meta.id} className="custom-control custom-radio custom-control-inline">
+            i18n.locales.map(locale => (
+              <div key={locale} className="custom-control custom-radio custom-control-inline">
                 <input
                   type="radio"
-                  id={`radioLang${meta.id}`}
+                  id={`radioLang${locale}`}
                   className="custom-control-input"
                   name="globalLang"
-                  value={meta.id}
-                  checked={adminAppContainer.state.globalLang === meta.id}
+                  value={locale}
+                  checked={adminAppContainer.state.globalLang === locale}
                   onChange={(e) => {
                     adminAppContainer.changeGlobalLang(e.target.value);
                   }}
                 />
-                <label className="custom-control-label" htmlFor={`radioLang${meta.id}`}>{meta.displayName}</label>
+                <label className="custom-control-label" htmlFor={`radioLang${locale}`}>{t(`i18n.${locale}`)}</label>
               </div>
             ))
           }

--- a/packages/app/src/components/Admin/App/AppSettingsPageContents.tsx
+++ b/packages/app/src/components/Admin/App/AppSettingsPageContents.tsx
@@ -58,8 +58,7 @@ const AppSettingsPageContents = (props: Props) => {
       <div className="row">
         <div className="col-lg-12">
           <h2 className="admin-setting-header">{t('App Settings')}</h2>
-          {/* TODO: show AppSetting by https://redmine.weseek.co.jp/issues/100056 */}
-          {/* <AppSetting /> */}
+          <AppSetting />
         </div>
       </div>
 


### PR DESCRIPTION
## Task
[Next.js] /admin にて、各ナビでページ遷移できる
┗[100056](https://redmine.weseek.co.jp/issues/100056) [App Settings] App Settings 項目 の表示

## Note
~~マージはしないでください~~
~~マージ可能だが、[#6234](https://github.com/weseek/growi/pull/6234) が太ります~~


## Screen Shot
- ラジオボタンの初期値にチェックが付いていないのは他の部分も同じなので、このタスクではスルーでお願いしたいです。
- 言語設定の部分は、ユーザーの言語設定に関わらず 「English」「日本語」「简体中文」 と表示されるようにしました。
<img width="1200" alt="Screen Shot 2022-07-13 at 17 27 59" src="https://user-images.githubusercontent.com/59536731/178687731-b8b7cac5-4b32-4094-badd-ad471b0377cb.png">


