### PR TITLE
fix: User registration page is not redirected after tmp login on v4.5.x

### DIFF
--- a/packages/app/src/server/middlewares/login-required.js
+++ b/packages/app/src/server/middlewares/login-required.js
@@ -11,19 +11,6 @@ const logger = loggerFactory('growi:middleware:login-required');
 module.exports = (crowi, isGuestAllowed = false, fallback = null) => {
 
   return function(req, res, next) {
-
-    // check the route config and ACL
-    if (isGuestAllowed && crowi.aclService.isGuestAllowedToRead()) {
-      logger.debug('Allowed to read: ', req.path);
-      return next();
-    }
-
-    // check the page is shared
-    if (isGuestAllowed && req.isSharedPage) {
-      logger.debug('Target page is shared page');
-      return next();
-    }
-
     const User = crowi.model('User');
 
     // check the user logged in
@@ -41,6 +28,18 @@ module.exports = (crowi, isGuestAllowed = false, fallback = null) => {
       if (req.user.status === User.STATUS_INVITED) {
         return res.redirect('/login/invited');
       }
+    }
+
+    // check the route config and ACL
+    if (isGuestAllowed && crowi.aclService.isGuestAllowedToRead()) {
+      logger.debug('Allowed to read: ', req.path);
+      return next();
+    }
+
+    // check the page is shared
+    if (isGuestAllowed && req.isSharedPage) {
+      logger.debug('Target page is shared page');
+      return next();
     }
 
     // is api path

--- a/packages/app/src/server/routes/login.js
+++ b/packages/app/src/server/routes/login.js
@@ -215,8 +215,7 @@ module.exports = function(crowi, app) {
       }
     }
     else {
-      return res.render('invited', {
-      });
+      return res.render('invited');
     }
   };
 


### PR DESCRIPTION
## Task
[GROWI][bug][4.5.x] Bug: 「ID&Password」有効状態で管理者が「新規ユーザーの仮発行」を使用したユーザーがログインボタンを押下時にユーザー新規登録画面に遷移しない
┗[100217](https://redmine.weseek.co.jp/issues/100217) 修正


## Note
- 5系での修正PR は 👉🏻 https://github.com/weseek/growi/pull/6197
- 動作確認は終了済み