### PR TITLE
Imprv/100055 show full text search management and audit log pages

### DIFF
--- a/packages/app/src/components/Admin/ElasticsearchManagement/ElasticsearchManagement.jsx
+++ b/packages/app/src/components/Admin/ElasticsearchManagement/ElasticsearchManagement.jsx
@@ -226,9 +226,9 @@ const ElasticsearchManagementWrapperFC = (props) => {
   const { data: isSearchServiceReachable } = useIsSearchServiceReachable();
   const { data: socket } = useAdminSocket();
 
-  // if (isSearchServiceReachable == null) {
-  //   return <></>;
-  // }
+  if (isSearchServiceReachable == null) {
+    return <></>;
+  }
 
   return <ElasticsearchManagement t={t} isSearchServiceReachable={isSearchServiceReachable} socket={socket} {...props} />;
 };
@@ -236,7 +236,7 @@ const ElasticsearchManagementWrapperFC = (props) => {
 
 ElasticsearchManagement.propTypes = {
   t: PropTypes.func.isRequired, // i18next
-  isSearchServiceReachable: PropTypes.bool,
+  isSearchServiceReachable: PropTypes.bool.isRequired,
   socket: PropTypes.object,
 };
 

--- a/packages/app/src/components/Admin/ElasticsearchManagement/ElasticsearchManagement.jsx
+++ b/packages/app/src/components/Admin/ElasticsearchManagement/ElasticsearchManagement.jsx
@@ -1,7 +1,6 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { useTranslation } from 'next-i18next';
-import PropTypes from 'prop-types';
 
 
 import { toastSuccess, toastError } from '~/client/util/apiNotification';
@@ -14,96 +13,82 @@ import RebuildIndexControls from './RebuildIndexControls';
 import ReconnectControls from './ReconnectControls';
 import StatusTable from './StatusTable';
 
-class ElasticsearchManagement extends React.Component {
+const ElasticsearchManagement = (props) => {
+  const { t } = useTranslation();
+  const { data: isSearchServiceReachable } = useIsSearchServiceReachable();
+  const { data: socket } = useAdminSocket();
 
-  constructor(props) {
-    super(props);
+  const [isInitialized, setIsInitialized] = useState(false);
 
-    this.state = {
-      isInitialized: false,
+  const [isConnected, setIsConnected] = useState(false);
+  const [isConfigured, setIsConfigured] = useState(false);
+  const [isReconnectingProcessing, setIsReconnectingProcessing] = useState(false);
+  const [isRebuildingProcessing, setIsRebuildingProcessing] = useState(false);
+  const [isRebuildingCompleted, setIsRebuildingCompleted] = useState(false);
 
-      isConnected: false,
-      isConfigured: false,
-      isReconnectingProcessing: false,
-      isRebuildingProcessing: false,
-      isRebuildingCompleted: false,
+  const [isNormalized, setIsNormalized] = useState(null);
+  const [indicesData, setIndicesData] = useState(null);
+  const [aliasesData, setAliasesData] = useState(null);
 
-      isNormalized: null,
-      indicesData: null,
-      aliasesData: null,
-    };
 
-    this.reconnect = this.reconnect.bind(this);
-    this.normalizeIndices = this.normalizeIndices.bind(this);
-    this.rebuildIndices = this.rebuildIndices.bind(this);
-  }
-
-  async UNSAFE_UNSAFE_componentWillMount() {
-    this.retrieveIndicesStatus();
-  }
-
-  componentDidMount() {
-    this.initWebSockets();
-  }
-
-  initWebSockets() {
-    const { socket } = this.props;
-
-    if (socket != null) {
-      socket.on('addPageProgress', (data) => {
-        this.setState({
-          isRebuildingProcessing: true,
-        });
-      });
-
-      socket.on('finishAddPage', async(data) => {
-        await this.retrieveIndicesStatus();
-        this.setState({
-          isRebuildingProcessing: false,
-          isRebuildingCompleted: true,
-        });
-      });
-
-      socket.on('rebuildingFailed', (data) => {
-        toastError(new Error(data.error), 'Rebuilding Index has failed.');
-      });
-    }
-
-  }
-
-  async retrieveIndicesStatus() {
+  const retrieveIndicesStatus = async() => {
     try {
       const { data } = await apiv3Get('/search/indices');
       const { info } = data;
 
-      this.setState({
-        isConnected: true,
-        isConfigured: true,
+      setIsConnected(true);
+      setIsConfigured(true);
 
-        indicesData: info.indices,
-        aliasesData: info.aliases,
-        isNormalized: info.isNormalized,
-      });
+      setIndicesData(info.indices);
+      setAliasesData(info.aliases);
+      setIsNormalized(info.isNormalized);
     }
     catch (errors) {
-      this.setState({ isConnected: false });
+      setIsConnected(false);
 
       // evaluate whether configured or not
       for (const error of errors) {
         if (error.code === 'search-service-unconfigured') {
-          this.setState({ isConfigured: false });
+          setIsConfigured(false);
         }
       }
 
       toastError(errors);
     }
     finally {
-      this.setState({ isInitialized: true });
+      setIsInitialized(true);
     }
-  }
+  };
 
-  async reconnect() {
-    this.setState({ isReconnectingProcessing: true });
+
+  useEffect(() => {
+    if (socket == null) {
+      return;
+    }
+    socket.on('addPageProgress', (data) => {
+      setIsRebuildingProcessing(true);
+    });
+
+    socket.on('finishAddPage', async(data) => {
+      await retrieveIndicesStatus();
+      setIsRebuildingProcessing(false);
+      setIsRebuildingCompleted(true);
+    });
+
+    socket.on('rebuildingFailed', (data) => {
+      toastError(new Error(data.error), 'Rebuilding Index has failed.');
+    });
+
+    return () => {
+      socket.off('addPageProgress');
+      socket.off('finishAddPage');
+      socket.off('rebuildingFailed');
+    };
+  }, [socket]);
+
+
+  const reconnect = async() => {
+    setIsReconnectingProcessing(true);
 
     try {
       await apiv3Post('/search/connection');
@@ -115,9 +100,9 @@ class ElasticsearchManagement extends React.Component {
 
     // reload
     window.location.reload();
-  }
+  };
 
-  async normalizeIndices() {
+  const normalizeIndices = async() => {
 
     try {
       await apiv3Put('/search/indices', { operation: 'normalize' });
@@ -126,13 +111,13 @@ class ElasticsearchManagement extends React.Component {
       toastError(e);
     }
 
-    await this.retrieveIndicesStatus();
+    await retrieveIndicesStatus();
 
     toastSuccess('Normalizing has succeeded');
-  }
+  };
 
-  async rebuildIndices() {
-    this.setState({ isRebuildingProcessing: true });
+  const rebuildIndices = async() => {
+    setIsRebuildingProcessing(true);
 
     try {
       await apiv3Put('/search/indices', { operation: 'rebuild' });
@@ -142,102 +127,79 @@ class ElasticsearchManagement extends React.Component {
       toastError(e);
     }
 
-    await this.retrieveIndicesStatus();
-  }
+    await retrieveIndicesStatus();
+  };
 
-  render() {
-    const { t, isSearchServiceReachable } = this.props;
-    const {
-      isInitialized,
-      isConnected, isConfigured, isReconnectingProcessing, isRebuildingProcessing, isRebuildingCompleted,
-      isNormalized, indicesData, aliasesData,
-    } = this.state;
+  const isErrorOccuredOnSearchService = !isSearchServiceReachable;
 
-    const isErrorOccuredOnSearchService = !isSearchServiceReachable;
+  const isReconnectBtnEnabled = !isReconnectingProcessing && (!isInitialized || !isConnected || isErrorOccuredOnSearchService);
 
-    const isReconnectBtnEnabled = !isReconnectingProcessing && (!isInitialized || !isConnected || isErrorOccuredOnSearchService);
-
-    return (
-      <>
-        <div className="row">
-          <div className="col-md-12">
-            <StatusTable
-              isInitialized={isInitialized}
-              isErrorOccuredOnSearchService={isErrorOccuredOnSearchService}
-              isConnected={isConnected}
-              isConfigured={isConfigured}
-              isNormalized={isNormalized}
-              indicesData={indicesData}
-              aliasesData={aliasesData}
-            />
-          </div>
+  return (
+    <>
+      <div className="row">
+        <div className="col-md-12">
+          <StatusTable
+            isInitialized={isInitialized}
+            isErrorOccuredOnSearchService={isErrorOccuredOnSearchService}
+            isConnected={isConnected}
+            isConfigured={isConfigured}
+            isNormalized={isNormalized}
+            indicesData={indicesData}
+            aliasesData={aliasesData}
+          />
         </div>
+      </div>
 
-        <hr />
+      <hr />
 
-        {/* Controls */}
-        <div className="row">
-          <label className="col-md-3 col-form-label text-left text-md-right">{ t('full_text_search_management.reconnect') }</label>
-          <div className="col-md-6">
-            <ReconnectControls
-              isEnabled={isReconnectBtnEnabled}
-              isProcessing={isReconnectingProcessing}
-              onReconnectingRequested={this.reconnect}
-            />
-          </div>
+      {/* Controls */}
+      <div className="row">
+        <label className="col-md-3 col-form-label text-left text-md-right">{ t('full_text_search_management.reconnect') }</label>
+        <div className="col-md-6">
+          <ReconnectControls
+            isEnabled={isReconnectBtnEnabled}
+            isProcessing={isReconnectingProcessing}
+            onReconnectingRequested={reconnect}
+          />
         </div>
+      </div>
 
-        <hr />
+      <hr />
 
-        <div className="row">
-          <label className="col-md-3 col-form-label text-left text-md-right">{ t('full_text_search_management.normalize') }</label>
-          <div className="col-md-6">
-            <NormalizeIndicesControls
-              isRebuildingProcessing={isRebuildingProcessing}
-              isRebuildingCompleted={isRebuildingCompleted}
-              isNormalized={isNormalized}
-              onNormalizingRequested={this.normalizeIndices}
-            />
-          </div>
+      <div className="row">
+        <label className="col-md-3 col-form-label text-left text-md-right">{ t('full_text_search_management.normalize') }</label>
+        <div className="col-md-6">
+          <NormalizeIndicesControls
+            isRebuildingProcessing={isRebuildingProcessing}
+            isRebuildingCompleted={isRebuildingCompleted}
+            isNormalized={isNormalized}
+            onNormalizingRequested={normalizeIndices}
+          />
         </div>
+      </div>
 
-        <hr />
+      <hr />
 
-        <div className="row">
-          <label className="col-md-3 col-form-label text-left text-md-right">{ t('full_text_search_management.rebuild') }</label>
-          <div className="col-md-6">
-            <RebuildIndexControls
-              isRebuildingProcessing={isRebuildingProcessing}
-              isRebuildingCompleted={isRebuildingCompleted}
-              isNormalized={isNormalized}
-              onRebuildingRequested={this.rebuildIndices}
-            />
-          </div>
+      <div className="row">
+        <label className="col-md-3 col-form-label text-left text-md-right">{ t('full_text_search_management.rebuild') }</label>
+        <div className="col-md-6">
+          <RebuildIndexControls
+            isRebuildingProcessing={isRebuildingProcessing}
+            isRebuildingCompleted={isRebuildingCompleted}
+            isNormalized={isNormalized}
+            onRebuildingRequested={rebuildIndices}
+          />
         </div>
+      </div>
 
-      </>
-    );
-  }
+    </>
+  );
 
-}
-
-const ElasticsearchManagementWrapperFC = (props) => {
-  const { t } = useTranslation();
-  const { data: isSearchServiceReachable } = useIsSearchServiceReachable();
-  const { data: socket } = useAdminSocket();
-
-  if (isSearchServiceReachable == null) {
-    return <></>;
-  }
-
-  return <ElasticsearchManagement t={t} isSearchServiceReachable={isSearchServiceReachable} socket={socket} {...props} />;
 };
 
 
 ElasticsearchManagement.propTypes = {
-  t: PropTypes.func.isRequired, // i18next
-  isSearchServiceReachable: PropTypes.bool.isRequired,
-  socket: PropTypes.object,
+
 };
 
-export default ElasticsearchManagementWrapperFC;
+export default ElasticsearchManagement;

--- a/packages/app/src/components/Admin/ElasticsearchManagement/ElasticsearchManagement.tsx
+++ b/packages/app/src/components/Admin/ElasticsearchManagement/ElasticsearchManagement.tsx
@@ -13,7 +13,7 @@ import RebuildIndexControls from './RebuildIndexControls';
 import ReconnectControls from './ReconnectControls';
 import StatusTable from './StatusTable';
 
-const ElasticsearchManagement = (props) => {
+const ElasticsearchManagement = () => {
   const { t } = useTranslation();
   const { data: isSearchServiceReachable } = useIsSearchServiceReachable();
   const { data: socket } = useAdminSocket();
@@ -26,7 +26,7 @@ const ElasticsearchManagement = (props) => {
   const [isRebuildingProcessing, setIsRebuildingProcessing] = useState(false);
   const [isRebuildingCompleted, setIsRebuildingCompleted] = useState(false);
 
-  const [isNormalized, setIsNormalized] = useState(null);
+  const [isNormalized, setIsNormalized] = useState(false);
   const [indicesData, setIndicesData] = useState(null);
   const [aliasesData, setAliasesData] = useState(null);
 
@@ -171,7 +171,6 @@ const ElasticsearchManagement = (props) => {
         <div className="col-md-6">
           <NormalizeIndicesControls
             isRebuildingProcessing={isRebuildingProcessing}
-            isRebuildingCompleted={isRebuildingCompleted}
             isNormalized={isNormalized}
             onNormalizingRequested={normalizeIndices}
           />

--- a/packages/app/src/components/Admin/ElasticsearchManagement/ElasticsearchManagement.tsx
+++ b/packages/app/src/components/Admin/ElasticsearchManagement/ElasticsearchManagement.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 
 import { useTranslation } from 'next-i18next';
 
@@ -32,7 +32,7 @@ const ElasticsearchManagement = () => {
   const [aliasesData, setAliasesData] = useState(null);
 
 
-  const retrieveIndicesStatus = async() => {
+  const retrieveIndicesStatus = useCallback(async() => {
     try {
       const { data } = await apiv3Get('/search/indices');
       const { info } = data;
@@ -59,7 +59,14 @@ const ElasticsearchManagement = () => {
     finally {
       setIsInitialized(true);
     }
-  };
+  }, []);
+
+  useEffect(() => {
+    const fetchIndicesStatusData = async() => {
+      await retrieveIndicesStatus();
+    };
+    fetchIndicesStatusData();
+  }, [retrieveIndicesStatus]);
 
 
   useEffect(() => {

--- a/packages/app/src/components/Admin/ElasticsearchManagement/ElasticsearchManagement.tsx
+++ b/packages/app/src/components/Admin/ElasticsearchManagement/ElasticsearchManagement.tsx
@@ -9,7 +9,6 @@ import { SocketEventName } from '~/interfaces/websocket';
 import { useIsSearchServiceReachable } from '~/stores/context';
 import { useAdminSocket } from '~/stores/socket-io';
 
-
 import NormalizeIndicesControls from './NormalizeIndicesControls';
 import RebuildIndexControls from './RebuildIndexControls';
 import ReconnectControls from './ReconnectControls';

--- a/packages/app/src/components/Admin/ElasticsearchManagement/ElasticsearchManagement.tsx
+++ b/packages/app/src/components/Admin/ElasticsearchManagement/ElasticsearchManagement.tsx
@@ -5,8 +5,10 @@ import { useTranslation } from 'next-i18next';
 
 import { toastSuccess, toastError } from '~/client/util/apiNotification';
 import { apiv3Get, apiv3Post, apiv3Put } from '~/client/util/apiv3-client';
+import { SocketEventName } from '~/interfaces/websocket';
 import { useIsSearchServiceReachable } from '~/stores/context';
 import { useAdminSocket } from '~/stores/socket-io';
+
 
 import NormalizeIndicesControls from './NormalizeIndicesControls';
 import RebuildIndexControls from './RebuildIndexControls';
@@ -65,24 +67,24 @@ const ElasticsearchManagement = () => {
     if (socket == null) {
       return;
     }
-    socket.on('addPageProgress', (data) => {
+    socket.on(SocketEventName.AddPageProgress, (data) => {
       setIsRebuildingProcessing(true);
     });
 
-    socket.on('finishAddPage', async(data) => {
+    socket.on(SocketEventName.FinishAddPage, async(data) => {
       await retrieveIndicesStatus();
       setIsRebuildingProcessing(false);
       setIsRebuildingCompleted(true);
     });
 
-    socket.on('rebuildingFailed', (data) => {
+    socket.on(SocketEventName.RebuildingFailed, (data) => {
       toastError(new Error(data.error), 'Rebuilding Index has failed.');
     });
 
     return () => {
-      socket.off('addPageProgress');
-      socket.off('finishAddPage');
-      socket.off('rebuildingFailed');
+      socket.off(SocketEventName.AddPageProgress);
+      socket.off(SocketEventName.FinishAddPage);
+      socket.off(SocketEventName.RebuildingFailed);
     };
   }, [socket]);
 

--- a/packages/app/src/components/Admin/ElasticsearchManagement/RebuildIndexControls.jsx
+++ b/packages/app/src/components/Admin/ElasticsearchManagement/RebuildIndexControls.jsx
@@ -1,11 +1,10 @@
 import React from 'react';
 
-import PropTypes from 'prop-types';
 import { useTranslation } from 'next-i18next';
+import PropTypes from 'prop-types';
 
-import AdminSocketIoContainer from '~/client/services/AdminSocketIoContainer';
+import { useAdminSocket } from '~/stores/socket-io';
 
-import { withUnstatedContainers } from '../../UnstatedUtils';
 import LabeledProgressBar from '../Common/LabeledProgressBar';
 
 class RebuildIndexControls extends React.Component {
@@ -25,24 +24,25 @@ class RebuildIndexControls extends React.Component {
   }
 
   initWebSockets() {
-    const socket = this.props.adminSocketIoContainer.getSocket();
+    const { socket } = this.props;
 
-    socket.on('addPageProgress', (data) => {
-      this.setState({
-        total: data.totalCount,
-        current: data.count,
-        skip: data.skipped,
+    if (socket != null) {
+      socket.on('addPageProgress', (data) => {
+        this.setState({
+          total: data.totalCount,
+          current: data.count,
+          skip: data.skipped,
+        });
       });
-    });
 
-    socket.on('finishAddPage', (data) => {
-      this.setState({
-        total: data.totalCount,
-        current: data.count,
-        skip: data.skipped,
+      socket.on('finishAddPage', (data) => {
+        this.setState({
+          total: data.totalCount,
+          current: data.count,
+          skip: data.skipped,
+        });
       });
-    });
-
+    }
   }
 
   renderProgressBar() {
@@ -109,24 +109,20 @@ class RebuildIndexControls extends React.Component {
 
 const RebuildIndexControlsFC = (props) => {
   const { t } = useTranslation();
-  return <RebuildIndexControls t={t} {...props} />;
+  const { data: socket } = useAdminSocket();
+  return <RebuildIndexControls t={t} socket={socket} {...props} />;
 };
 
 
-/**
- * Wrapper component for using unstated
- */
-const RebuildIndexControlsWrapper = withUnstatedContainers(RebuildIndexControlsFC, [AdminSocketIoContainer]);
-
 RebuildIndexControls.propTypes = {
   t: PropTypes.func.isRequired, // i18next
-  adminSocketIoContainer: PropTypes.instanceOf(AdminSocketIoContainer).isRequired,
 
   isRebuildingProcessing: PropTypes.bool.isRequired,
   isRebuildingCompleted: PropTypes.bool.isRequired,
 
   isNormalized: PropTypes.bool,
   onRebuildingRequested: PropTypes.func.isRequired,
+  socket: PropTypes.object,
 };
 
-export default RebuildIndexControlsWrapper;
+export default RebuildIndexControlsFC;

--- a/packages/app/src/interfaces/websocket.ts
+++ b/packages/app/src/interfaces/websocket.ts
@@ -11,6 +11,12 @@ export const SocketEventName = {
   // Page migration
   PageMigrationSuccess: 'PageMigrationSuccess',
   PageMigrationError: 'PageMigrationError',
+
+  // Elasticsearch
+  AddPageProgress: 'addPageProgress',
+  FinishAddPage: 'finishAddPage',
+  RebuildingFailed: 'rebuildingFailed',
+
 } as const;
 export type SocketEventName = typeof SocketEventName[keyof typeof SocketEventName];
 

--- a/packages/app/src/pages/admin/[[...path]].page.tsx
+++ b/packages/app/src/pages/admin/[[...path]].page.tsx
@@ -7,6 +7,7 @@ import { useRouter } from 'next/router';
 
 import AdminHome from '~/components/Admin/AdminHome/AdminHome';
 import AppSettingsPageContents from '~/components/Admin/App/AppSettingsPageContents';
+import { AuditLogManagement } from '~/components/Admin/AuditLogManagement';
 import ElasticsearchManagement from '~/components/Admin/ElasticsearchManagement/ElasticsearchManagement';
 import ExportArchiveDataPage from '~/components/Admin/ExportArchiveDataPage';
 import DataImportPageContents from '~/components/Admin/ImportData/ImportDataPageContents';
@@ -108,6 +109,10 @@ const AdminMarkdownSettingsPage: NextPage<Props> = (props: Props) => {
     search: {
       title: useCustomTitle(props, t('Full Text Search Management')),
       component: <ElasticsearchManagement />,
+    },
+    'audit-log': {
+      title: useCustomTitle(props, t('AuditLog')),
+      component: <AuditLogManagement />,
     },
   };
 

--- a/packages/app/src/pages/admin/[[...path]].page.tsx
+++ b/packages/app/src/pages/admin/[[...path]].page.tsx
@@ -23,7 +23,7 @@ import PluginUtils from '~/server/plugins/plugin-utils';
 import ConfigLoader from '~/server/service/config-loader';
 import {
   useCurrentUser,
-  /* useSearchServiceConfigured, useSearchServiceReachable, */ useSiteUrl,
+  /* useSearchServiceConfigured , */ useIsSearchServiceReachable, useSiteUrl,
 } from '~/stores/context';
 // import { useEnvVars } from '~/stores/admin-context';
 
@@ -122,7 +122,7 @@ const AdminMarkdownSettingsPage: NextPage<Props> = (props: Props) => {
   useCurrentUser(props.currentUser != null ? JSON.parse(props.currentUser) : null);
 
   // useSearchServiceConfigured(props.isSearchServiceConfigured);
-  // useSearchServiceReachable(props.isSearchServiceReachable);
+  useIsSearchServiceReachable(props.isSearchServiceReachable);
 
   useSiteUrl(props.siteUrl);
 

--- a/packages/app/src/pages/admin/[[...path]].page.tsx
+++ b/packages/app/src/pages/admin/[[...path]].page.tsx
@@ -7,6 +7,7 @@ import { useRouter } from 'next/router';
 
 import AdminHome from '~/components/Admin/AdminHome/AdminHome';
 import AppSettingsPageContents from '~/components/Admin/App/AppSettingsPageContents';
+import ElasticsearchManagement from '~/components/Admin/ElasticsearchManagement/ElasticsearchManagement';
 import ExportArchiveDataPage from '~/components/Admin/ExportArchiveDataPage';
 import DataImportPageContents from '~/components/Admin/ImportData/ImportDataPageContents';
 import MarkDownSettingContents from '~/components/Admin/MarkdownSetting/MarkDownSettingContents';
@@ -19,8 +20,6 @@ import { CrowiRequest } from '~/interfaces/crowi-request';
 import { CommonProps, getServerSideCommonProps, useCustomTitle } from '~/pages/commons';
 import PluginUtils from '~/server/plugins/plugin-utils';
 import ConfigLoader from '~/server/service/config-loader';
-
-// import ElasticsearchManagement from '~/components/Admin/ElasticsearchManagement/ElasticsearchManagement';
 import {
   useCurrentUser,
   /* useSearchServiceConfigured, useSearchServiceReachable, */ useSiteUrl,
@@ -108,8 +107,7 @@ const AdminMarkdownSettingsPage: NextPage<Props> = (props: Props) => {
     },
     search: {
       title: useCustomTitle(props, t('Full Text Search Management')),
-      // component: <ElasticsearchManagement />,
-      component: <>ElasticsearchManagement</>,
+      component: <ElasticsearchManagement />,
     },
   };
 

--- a/packages/app/src/pages/admin/[[...path]].page.tsx
+++ b/packages/app/src/pages/admin/[[...path]].page.tsx
@@ -22,8 +22,7 @@ import { CommonProps, getServerSideCommonProps, useCustomTitle } from '~/pages/c
 import PluginUtils from '~/server/plugins/plugin-utils';
 import ConfigLoader from '~/server/service/config-loader';
 import {
-  useCurrentUser,
-  /* useSearchServiceConfigured , */ useIsSearchServiceReachable, useSiteUrl,
+  useCurrentUser, /* useSearchServiceConfigured, */ useIsSearchServiceReachable, useSiteUrl,
 } from '~/stores/context';
 // import { useEnvVars } from '~/stores/admin-context';
 


### PR DESCRIPTION
## Task
- [100055](https://redmine.weseek.co.jp/issues/100055) [Full Text Search Management][AuditLog] の表示

## ScreenShots
### Full Text Search Management 
<img width="1091" alt="Screen Shot 2022-07-21 at 22 53 10" src="https://user-images.githubusercontent.com/59536731/180231126-7e784ef2-7738-40d9-b15b-ed23bd462665.png">

## AuditLog
![FireShot Capture 020 - Audit Log - TOKA - localhost](https://user-images.githubusercontent.com/59536731/180171526-974f1822-78a3-4e96-9508-308035108e73.png)

