### PR TITLE
feat: Separate trust proxies by type

### DIFF
--- a/packages/app/src/server/crowi/express-init.js
+++ b/packages/app/src/server/crowi/express-init.js
@@ -71,12 +71,12 @@ module.exports = function(crowi, app) {
 
   try {
     const trustProxy = trustProxyBool ?? trustProxyCsv ?? trustProxyHops;
-    if (trustProxy != null) {
-      app.set('trust proxy', trustProxy);
-    }
     if (isNotSpec) {
       // eslint-disable-next-line max-len
-      logger.warn(`If multiple environment variables TRUST_PROXY_ ~ are set, they are set preferentially in the order of BOOL → CSV → HOPS. Set value: ${app.get('trust proxy')}`);
+      logger.warn(`If multiple environment variables TRUST_PROXY_ ~ are set, they are set preferentially in the order of BOOL → CSV → HOPS. Set value: ${trustProxy}`);
+    }
+    if (trustProxy != null) {
+      app.set('trust proxy', trustProxy);
     }
   }
   catch (err) {

--- a/packages/app/src/server/crowi/express-init.js
+++ b/packages/app/src/server/crowi/express-init.js
@@ -67,21 +67,22 @@ module.exports = function(crowi, app) {
   const trustProxyCsv = configManager.getConfig('crowi', 'security:trustProxyCsv');
   const trustProxyHops = configManager.getConfig('crowi', 'security:trustProxyHops');
 
-  const trustProxies = [trustProxyBool, trustProxyCsv, trustProxyHops];
+  const isNotSpec = [trustProxyBool, trustProxyCsv, trustProxyHops].filter(trustProxy => trustProxy != null).length !== 1;
 
-  const isNotSpec = trustProxies.filter(trustProxy => trustProxy != null).length !== 1;
-
-  for (const trustProxy of trustProxies) {
+  try {
+    const trustProxy = trustProxyBool ?? trustProxyCsv ?? trustProxyHops;
     if (trustProxy != null) {
       app.set('trust proxy', trustProxy);
-      break;
+    }
+    if (isNotSpec) {
+      // eslint-disable-next-line max-len
+      logger.warn(`If multiple environment variables TRUST_PROXY_ ~ are set, they are set preferentially in the order of BOOL → CSV → HOPS. Set value: ${app.get('trust proxy')}`);
     }
   }
-
-  if (isNotSpec) {
-    // eslint-disable-next-line max-len
-    logger.warn(`If multiple environment variables TRUST_PROXY_ ~ are set, they are set preferentially in the order of BOOL → CSV → HOPS. Set value: ${app.get('trust proxy')}`);
+  catch (err) {
+    logger.error(err);
   }
+
 
   app.use(helmet({
     contentSecurityPolicy: false,

--- a/packages/app/src/server/crowi/express-init.js
+++ b/packages/app/src/server/crowi/express-init.js
@@ -67,15 +67,15 @@ module.exports = function(crowi, app) {
   const trustProxyCsv = configManager.getConfig('crowi', 'security:trustProxyCsv');
   const trustProxyHops = configManager.getConfig('crowi', 'security:trustProxyHops');
 
-  const isNotSpec = [trustProxyBool, trustProxyCsv, trustProxyHops].filter(trustProxy => trustProxy != null).length !== 1;
+  const trustProxy = trustProxyBool ?? trustProxyCsv ?? trustProxyHops;
 
   try {
-    const trustProxy = trustProxyBool ?? trustProxyCsv ?? trustProxyHops;
-    if (isNotSpec) {
-      // eslint-disable-next-line max-len
-      logger.warn(`If more than one TRUST_PROXY_ ~ environment variable is set, the values are set in the following order of inequality size (BOOL > CSV > HOPS) first. Set value: ${trustProxy}`);
-    }
     if (trustProxy != null) {
+      const isNotSpec = [trustProxyBool, trustProxyCsv, trustProxyHops].filter(trustProxy => trustProxy != null).length !== 1;
+      if (isNotSpec) {
+        // eslint-disable-next-line max-len
+        logger.warn(`If more than one TRUST_PROXY_ ~ environment variable is set, the values are set in the following order of inequality size (BOOL > CSV > HOPS) first. Set value: ${trustProxy}`);
+      }
       app.set('trust proxy', trustProxy);
     }
   }

--- a/packages/app/src/server/crowi/express-init.js
+++ b/packages/app/src/server/crowi/express-init.js
@@ -73,7 +73,7 @@ module.exports = function(crowi, app) {
     const trustProxy = trustProxyBool ?? trustProxyCsv ?? trustProxyHops;
     if (isNotSpec) {
       // eslint-disable-next-line max-len
-      logger.warn(`If multiple environment variables TRUST_PROXY_ ~ are set, they are set preferentially in the order of BOOL → CSV → HOPS. Set value: ${trustProxy}`);
+      logger.warn(`If more than one TRUST_PROXY_ ~ environment variable is set, the values are set in the following order of inequality size (BOOL > CSV > HOPS) first. Set value: ${trustProxy}`);
     }
     if (trustProxy != null) {
       app.set('trust proxy', trustProxy);

--- a/packages/app/src/server/service/config-loader.ts
+++ b/packages/app/src/server/service/config-loader.ts
@@ -364,10 +364,22 @@ const ENV_VAR_NAME_TO_CONFIG_INFO = {
     type:    ValueType.BOOLEAN,
     default: false,
   },
-  TRUSTED_PROXIES: {
+  TRUST_PROXY_BOOL: {
     ns:      'crowi',
-    key:     'security:trustedProxies',
+    key:     'security:trustProxyBool',
+    type:    ValueType.BOOLEAN,
+    default: null,
+  },
+  TRUST_PROXY_CSV: {
+    ns:      'crowi',
+    key:     'security:trustProxyCsv',
     type:    ValueType.STRING,
+    default: null,
+  },
+  TRUST_PROXY_HOPS: {
+    ns:      'crowi',
+    key:     'security:trustProxyHops',
+    type:    ValueType.NUMBER,
     default: null,
   },
   LOCAL_STRATEGY_ENABLED: {


### PR DESCRIPTION
## Task
[#101027](https://redmine.weseek.co.jp/issues/101027) [AuditLog] 環境変数 Trust Proxy を boolean、string、number の3種類の型で設定できる
└ [#101028](https://redmine.weseek.co.jp/issues/101028) 実装