### PR TITLE
feat: Show user picture in Audit Log

### DIFF
--- a/packages/app/public/static/locales/en_US/admin/admin.json
+++ b/packages/app/public/static/locales/en_US/admin/admin.json
@@ -529,6 +529,7 @@
     }
   },
   "audit_log_management": {
+    "user": "User",
     "username": "Username",
     "date": "Date",
     "action": "Action",

--- a/packages/app/public/static/locales/ja_JP/admin/admin.json
+++ b/packages/app/public/static/locales/ja_JP/admin/admin.json
@@ -528,7 +528,8 @@
     }
   },
   "audit_log_management": {
-    "username": "ユーザー名",
+    "user": "ユーザー",
+    "username": "ユーザ名",
     "date": "日付",
     "action": "アクション",
     "ip": "IPアドレス",

--- a/packages/app/public/static/locales/ja_JP/admin/admin.json
+++ b/packages/app/public/static/locales/ja_JP/admin/admin.json
@@ -529,7 +529,7 @@
   },
   "audit_log_management": {
     "user": "ユーザー",
-    "username": "ユーザ名",
+    "username": "ユーザー名",
     "date": "日付",
     "action": "アクション",
     "ip": "IPアドレス",

--- a/packages/app/public/static/locales/zh_CN/admin/admin.json
+++ b/packages/app/public/static/locales/zh_CN/admin/admin.json
@@ -538,6 +538,7 @@
     }
   },
   "audit_log_management": {
+    "user": "用户",
     "username": "帐号",
     "date": "日期",
     "action": "行动",

--- a/packages/app/src/components/Admin/AuditLog/ActivityTable.tsx
+++ b/packages/app/src/components/Admin/AuditLog/ActivityTable.tsx
@@ -35,7 +35,9 @@ export const ActivityTable : FC<Props> = (props: Props) => {
             return (
               <tr data-testid="activity-table" key={activity._id}>
                 <td>
-                  <UserPicture user={activity.user} className="picture rounded-circle" />
+                  {activity.user != null && (
+                    <UserPicture user={activity.user} className="picture rounded-circle" />
+                  )}
                 </td>
                 <td>{activity.snapshot?.username}</td>
                 <td>{formatDate(activity.createdAt)}</td>

--- a/packages/app/src/components/Admin/AuditLog/ActivityTable.tsx
+++ b/packages/app/src/components/Admin/AuditLog/ActivityTable.tsx
@@ -23,8 +23,7 @@ export const ActivityTable : FC<Props> = (props: Props) => {
       <table className="table table-default table-bordered table-user-list">
         <thead>
           <tr>
-            <th scope="col"></th>
-            <th scope="col">{t('admin:audit_log_management.username')}</th>
+            <th scope="col">{t('admin:audit_log_management.user')}</th>
             <th scope="col">{t('admin:audit_log_management.date')}</th>
             <th scope="col">{t('admin:audit_log_management.action')}</th>
             <th scope="col">{t('admin:audit_log_management.ip')}</th>
@@ -36,16 +35,12 @@ export const ActivityTable : FC<Props> = (props: Props) => {
             return (
               <tr data-testid="activity-table" key={activity._id}>
                 <td>
-                  {activity.user != null && (
-                    <UserPicture user={activity.user} className="picture rounded-circle" />
+                  { activity.user != null && (
+                    <>
+                      <UserPicture user={activity.user} className="picture rounded-circle" />
+                      <a className="ml-2" href={pagePathUtils.userPageRoot(activity.user)}>{activity.snapshot?.username}</a>
+                    </>
                   )}
-                </td>
-                <td>
-                  {
-                    activity.user != null
-                      ? (<a href={pagePathUtils.userPageRoot(activity.user)}>{activity.snapshot?.username}</a>)
-                      : (<>{activity.snapshot?.username}</>)
-                  }
                 </td>
                 <td>{formatDate(activity.createdAt)}</td>
                 <td>{t(`admin:audit_log_action.${activity.action}`)}</td>

--- a/packages/app/src/components/Admin/AuditLog/ActivityTable.tsx
+++ b/packages/app/src/components/Admin/AuditLog/ActivityTable.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react';
 
+import { pagePathUtils } from '@growi/core';
 import { UserPicture } from '@growi/ui';
 import { format } from 'date-fns';
 import { useTranslation } from 'react-i18next';
@@ -39,7 +40,13 @@ export const ActivityTable : FC<Props> = (props: Props) => {
                     <UserPicture user={activity.user} className="picture rounded-circle" />
                   )}
                 </td>
-                <td>{activity.snapshot?.username}</td>
+                <td>
+                  {
+                    activity.user != null
+                      ? (<a href={pagePathUtils.userPageRoot(activity.user)}>{activity.snapshot?.username}</a>)
+                      : (<>{activity.snapshot?.username}</>)
+                  }
+                </td>
                 <td>{formatDate(activity.createdAt)}</td>
                 <td>{t(`admin:audit_log_action.${activity.action}`)}</td>
                 <td>{activity.ip}</td>

--- a/packages/app/src/components/Admin/AuditLog/ActivityTable.tsx
+++ b/packages/app/src/components/Admin/AuditLog/ActivityTable.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react';
 
+import { UserPicture } from '@growi/ui';
 import { format } from 'date-fns';
 import { useTranslation } from 'react-i18next';
 
@@ -21,6 +22,7 @@ export const ActivityTable : FC<Props> = (props: Props) => {
       <table className="table table-default table-bordered table-user-list">
         <thead>
           <tr>
+            <th scope="col"></th>
             <th scope="col">{t('admin:audit_log_management.username')}</th>
             <th scope="col">{t('admin:audit_log_management.date')}</th>
             <th scope="col">{t('admin:audit_log_management.action')}</th>
@@ -32,6 +34,9 @@ export const ActivityTable : FC<Props> = (props: Props) => {
           {props.activityList.map((activity) => {
             return (
               <tr data-testid="activity-table" key={activity._id}>
+                <td>
+                  <UserPicture user={activity.user} className="picture rounded-circle" />
+                </td>
                 <td>{activity.snapshot?.username}</td>
                 <td>{formatDate(activity.createdAt)}</td>
                 <td>{t(`admin:audit_log_action.${activity.action}`)}</td>

--- a/packages/app/src/server/models/activity.ts
+++ b/packages/app/src/server/models/activity.ts
@@ -126,19 +126,6 @@ activitySchema.statics.updateByParameters = async function(activityId: string, p
   return activity;
 };
 
-activitySchema.statics.getPaginatedActivity = async function(limit: number, offset: number, query) {
-  const paginateResult = await this.paginate(
-    query,
-    {
-      limit,
-      offset,
-      sort: { createdAt: -1 },
-      populate: 'user',
-    },
-  );
-  return paginateResult;
-};
-
 activitySchema.statics.findSnapshotUsernamesByUsernameRegexWithTotalCount = async function(
     q: string, option: { sortOpt: number | string, offset: number, limit: number},
 ): Promise<{usernames: string[], totalCount: number}> {

--- a/packages/app/src/server/models/activity.ts
+++ b/packages/app/src/server/models/activity.ts
@@ -133,6 +133,7 @@ activitySchema.statics.getPaginatedActivity = async function(limit: number, offs
       limit,
       offset,
       sort: { createdAt: -1 },
+      populate: 'user',
     },
   );
   return paginateResult;

--- a/packages/app/src/server/routes/apiv3/activity.ts
+++ b/packages/app/src/server/routes/apiv3/activity.ts
@@ -93,10 +93,18 @@ module.exports = (crowi: Crowi): Router => {
     }
 
     try {
-      const paginationResult = await Activity.getPaginatedActivity(limit, offset, query);
+      const paginateResult = await Activity.paginate(
+        query,
+        {
+          limit,
+          offset,
+          sort: { createdAt: -1 },
+          populate: 'user',
+        },
+      );
 
       const User = crowi.model('User');
-      const serializedDocs = paginationResult.docs.map((doc: IActivity) => {
+      const serializedDocs = paginateResult.docs.map((doc: IActivity) => {
         if (doc.user != null && doc.user instanceof User) {
           doc.user = serializeUserSecurely(doc.user);
         }
@@ -104,7 +112,7 @@ module.exports = (crowi: Crowi): Router => {
       });
 
       const serializedPaginationResult = {
-        ...paginationResult,
+        ...paginateResult,
         docs: serializedDocs,
       };
 

--- a/packages/app/src/stores/activity.ts
+++ b/packages/app/src/stores/activity.ts
@@ -13,6 +13,6 @@ export const useSWRxActivity = (limit?: number, offset?: number, searchFilter?: 
   return useSWRImmutable(
     auditLogEnabled ? ['/activity', limit, offset, stringifiedSearchFilter] : null,
     (endpoint, limit, offset, stringifiedSearchFilter) => apiv3Get(endpoint, { limit, offset, searchFilter: stringifiedSearchFilter })
-      .then(result => result.data.paginationResult),
+      .then(result => result.data.serializedPaginationResult),
   );
 };


### PR DESCRIPTION
## Task
[#100580](https://redmine.weseek.co.jp/issues/100580) [AuditLog] テーブルの username 周りの改善
└ [#100596](https://redmine.weseek.co.jp/issues/100596) 実装

## Screenshot
<img width="236" alt="ScreenShot 2022-07-25 22 48 21" src="https://user-images.githubusercontent.com/34241526/180793016-37a914c7-dc09-4a86-af34-10cba1aaf03a.png">

