### PR TITLE
Imprv/101284 show each tab content on authentication mechanism settings

### DIFF
--- a/packages/app/src/client/services/AdminBasicSecurityContainer.js
+++ b/packages/app/src/client/services/AdminBasicSecurityContainer.js
@@ -16,7 +16,9 @@ export default class AdminBasicSecurityContainer extends Container {
   constructor() {
     super();
 
-    this.state = {};
+    this.state = {
+      isSameUsernameTreatedAsIdenticalUser: false,
+    };
   }
 
   /**

--- a/packages/app/src/client/services/AdminBasicSecurityContainer.js
+++ b/packages/app/src/client/services/AdminBasicSecurityContainer.js
@@ -16,15 +16,7 @@ export default class AdminBasicSecurityContainer extends Container {
   constructor() {
     super();
 
-    this.dummyIsSameUsernameTreatedAsIdenticalUser = 0;
-    this.dummyIsSameUsernameTreatedAsIdenticalUserForError = 1;
-
-    this.state = {
-      retrieveError: null,
-      // set dummy value tile for using suspense
-      isSameUsernameTreatedAsIdenticalUser: this.dummyIsSameUsernameTreatedAsIdenticalUser,
-    };
-
+    this.state = {};
   }
 
   /**

--- a/packages/app/src/client/services/AdminGeneralSecurityContainer.js
+++ b/packages/app/src/client/services/AdminGeneralSecurityContainer.js
@@ -18,15 +18,11 @@ export default class AdminGeneralSecurityContainer extends Container {
   constructor(appContainer) {
     super();
 
-    this.dummyCurrentRestrictGuestMode = 0;
-    this.dummyCurrentRestrictGuestModeForError = 1;
-
     this.state = {
       retrieveError: null,
       sessionMaxAge: null,
       wikiMode: '',
-      // set dummy value tile for using suspense
-      currentRestrictGuestMode: this.dummyCurrentRestrictGuestMode,
+      currentRestrictGuestMode: '',
       currentPageDeletionAuthority: PageSingleDeleteConfigValue.AdminOnly,
       currentPageRecursiveDeletionAuthority: PageRecursiveDeleteConfigValue.Inherit,
       currentPageCompleteDeletionAuthority: PageSingleDeleteCompConfigValue.AdminOnly,

--- a/packages/app/src/client/services/AdminGeneralSecurityContainer.js
+++ b/packages/app/src/client/services/AdminGeneralSecurityContainer.js
@@ -33,7 +33,6 @@ export default class AdminGeneralSecurityContainer extends Container {
       expandOtherOptionsForCompleteDeletion: false,
       isShowRestrictedByOwner: false,
       isShowRestrictedByGroup: false,
-      // appSiteUrl: appContainer.config.crowi.url || '',
       isLocalEnabled: false,
       isLdapEnabled: false,
       isSamlEnabled: false,

--- a/packages/app/src/client/services/AdminGeneralSecurityContainer.js
+++ b/packages/app/src/client/services/AdminGeneralSecurityContainer.js
@@ -37,7 +37,7 @@ export default class AdminGeneralSecurityContainer extends Container {
       expandOtherOptionsForCompleteDeletion: false,
       isShowRestrictedByOwner: false,
       isShowRestrictedByGroup: false,
-      appSiteUrl: appContainer.config.crowi.url || '',
+      // appSiteUrl: appContainer.config.crowi.url || '',
       isLocalEnabled: false,
       isLdapEnabled: false,
       isSamlEnabled: false,

--- a/packages/app/src/client/services/AdminGitHubSecurityContainer.js
+++ b/packages/app/src/client/services/AdminGitHubSecurityContainer.js
@@ -23,7 +23,7 @@ export default class AdminGitHubSecurityContainer extends Container {
 
     this.state = {
       retrieveError: null,
-      callbackUrl: urljoin(pathUtils.removeTrailingSlash(appContainer.config.crowi.url), '/passport/github/callback'),
+      // callbackUrl: urljoin(pathUtils.removeTrailingSlash(appContainer.config.crowi.url), '/passport/github/callback'),
       // set dummy value tile for using suspense
       githubClientId: this.dummyGithubClientId,
       githubClientSecret: '',

--- a/packages/app/src/client/services/AdminGitHubSecurityContainer.js
+++ b/packages/app/src/client/services/AdminGitHubSecurityContainer.js
@@ -23,7 +23,6 @@ export default class AdminGitHubSecurityContainer extends Container {
 
     this.state = {
       retrieveError: null,
-      // callbackUrl: urljoin(pathUtils.removeTrailingSlash(appContainer.config.crowi.url), '/passport/github/callback'),
       // set dummy value tile for using suspense
       githubClientId: this.dummyGithubClientId,
       githubClientSecret: '',

--- a/packages/app/src/client/services/AdminGoogleSecurityContainer.js
+++ b/packages/app/src/client/services/AdminGoogleSecurityContainer.js
@@ -23,7 +23,6 @@ export default class AdminGoogleSecurityContainer extends Container {
 
     this.state = {
       retrieveError: null,
-      // callbackUrl: urljoin(pathUtils.removeTrailingSlash(appContainer.config.crowi.url), '/passport/google/callback'),
       // set dummy value tile for using suspense
       googleClientId: this.dummyGoogleClientId,
       googleClientSecret: '',

--- a/packages/app/src/client/services/AdminGoogleSecurityContainer.js
+++ b/packages/app/src/client/services/AdminGoogleSecurityContainer.js
@@ -23,7 +23,7 @@ export default class AdminGoogleSecurityContainer extends Container {
 
     this.state = {
       retrieveError: null,
-      callbackUrl: urljoin(pathUtils.removeTrailingSlash(appContainer.config.crowi.url), '/passport/google/callback'),
+      // callbackUrl: urljoin(pathUtils.removeTrailingSlash(appContainer.config.crowi.url), '/passport/google/callback'),
       // set dummy value tile for using suspense
       googleClientId: this.dummyGoogleClientId,
       googleClientSecret: '',

--- a/packages/app/src/client/services/AdminLdapSecurityContainer.js
+++ b/packages/app/src/client/services/AdminLdapSecurityContainer.js
@@ -17,13 +17,10 @@ export default class AdminLdapSecurityContainer extends Container {
     super();
 
     this.appContainer = appContainer;
-    this.dummyServerUrl = 0;
-    this.dummyServerUrlForError = 1;
 
     this.state = {
       retrieveError: null,
-      // set dummy value tile for using suspense
-      serverUrl: this.dummyServerUrl,
+      serverUrl: '',
       isUserBind: false,
       ldapBindDN: '',
       ldapBindDNPassword: '',

--- a/packages/app/src/client/services/AdminOidcSecurityContainer.js
+++ b/packages/app/src/client/services/AdminOidcSecurityContainer.js
@@ -19,13 +19,10 @@ export default class AdminOidcSecurityContainer extends Container {
     super();
 
     this.appContainer = appContainer;
-    this.dummyOidcProviderName = 0;
-    this.dummyOidcProviderNameForError = 1;
 
     this.state = {
       retrieveError: null,
-      // set dummy value tile for using suspense
-      oidcProviderName: this.dummyOidcProviderName,
+      oidcProviderName: '',
       oidcIssuerHost: '',
       oidcAuthorizationEndpoint: '',
       oidcTokenEndpoint: '',

--- a/packages/app/src/client/services/AdminOidcSecurityContainer.js
+++ b/packages/app/src/client/services/AdminOidcSecurityContainer.js
@@ -24,7 +24,6 @@ export default class AdminOidcSecurityContainer extends Container {
 
     this.state = {
       retrieveError: null,
-      // callbackUrl: urljoin(pathUtils.removeTrailingSlash(appContainer.config.crowi.url), '/passport/oidc/callback'),
       // set dummy value tile for using suspense
       oidcProviderName: this.dummyOidcProviderName,
       oidcIssuerHost: '',

--- a/packages/app/src/client/services/AdminOidcSecurityContainer.js
+++ b/packages/app/src/client/services/AdminOidcSecurityContainer.js
@@ -24,7 +24,7 @@ export default class AdminOidcSecurityContainer extends Container {
 
     this.state = {
       retrieveError: null,
-      callbackUrl: urljoin(pathUtils.removeTrailingSlash(appContainer.config.crowi.url), '/passport/oidc/callback'),
+      // callbackUrl: urljoin(pathUtils.removeTrailingSlash(appContainer.config.crowi.url), '/passport/oidc/callback'),
       // set dummy value tile for using suspense
       oidcProviderName: this.dummyOidcProviderName,
       oidcIssuerHost: '',

--- a/packages/app/src/client/services/AdminSamlSecurityContainer.js
+++ b/packages/app/src/client/services/AdminSamlSecurityContainer.js
@@ -26,7 +26,6 @@ export default class AdminSamlSecurityContainer extends Container {
       retrieveError: null,
       // TODO GW-1324 ABLCRure DB value takes precedence
       useOnlyEnvVars: false,
-      // callbackUrl: urljoin(pathUtils.removeTrailingSlash(appContainer.config.crowi.url), '/passport/saml/callback'),
       missingMandatoryConfigKeys: [],
       // set dummy value tile for using suspense
       samlEntryPoint: this.dummySamlEntryPoint,

--- a/packages/app/src/client/services/AdminSamlSecurityContainer.js
+++ b/packages/app/src/client/services/AdminSamlSecurityContainer.js
@@ -26,7 +26,7 @@ export default class AdminSamlSecurityContainer extends Container {
       retrieveError: null,
       // TODO GW-1324 ABLCRure DB value takes precedence
       useOnlyEnvVars: false,
-      callbackUrl: urljoin(pathUtils.removeTrailingSlash(appContainer.config.crowi.url), '/passport/saml/callback'),
+      // callbackUrl: urljoin(pathUtils.removeTrailingSlash(appContainer.config.crowi.url), '/passport/saml/callback'),
       missingMandatoryConfigKeys: [],
       // set dummy value tile for using suspense
       samlEntryPoint: this.dummySamlEntryPoint,

--- a/packages/app/src/client/services/AdminSamlSecurityContainer.js
+++ b/packages/app/src/client/services/AdminSamlSecurityContainer.js
@@ -19,16 +19,13 @@ export default class AdminSamlSecurityContainer extends Container {
     super();
 
     this.appContainer = appContainer;
-    this.dummySamlEntryPoint = 0;
-    this.dummySamlEntryPointForError = 1;
 
     this.state = {
       retrieveError: null,
       // TODO GW-1324 ABLCRure DB value takes precedence
       useOnlyEnvVars: false,
       missingMandatoryConfigKeys: [],
-      // set dummy value tile for using suspense
-      samlEntryPoint: this.dummySamlEntryPoint,
+      samlEntryPoint: '',
       samlIssuer: '',
       samlCert: '',
       samlAttrMapId: '',

--- a/packages/app/src/client/services/AdminTwitterSecurityContainer.js
+++ b/packages/app/src/client/services/AdminTwitterSecurityContainer.js
@@ -23,7 +23,6 @@ export default class AdminTwitterSecurityContainer extends Container {
     this.dummyTwitterConsumerKeyForError = 1;
 
     this.state = {
-      // callbackUrl: urljoin(pathUtils.removeTrailingSlash(appContainer.config.crowi.url), '/passport/twitter/callback'),
       // set dummy value tile for using suspense
       twitterConsumerKey: this.dummyTwitterConsumerKey,
       twitterConsumerSecret: '',

--- a/packages/app/src/client/services/AdminTwitterSecurityContainer.js
+++ b/packages/app/src/client/services/AdminTwitterSecurityContainer.js
@@ -19,12 +19,9 @@ export default class AdminTwitterSecurityContainer extends Container {
     super();
 
     this.appContainer = appContainer;
-    this.dummyTwitterConsumerKey = 0;
-    this.dummyTwitterConsumerKeyForError = 1;
 
     this.state = {
-      // set dummy value tile for using suspense
-      twitterConsumerKey: this.dummyTwitterConsumerKey,
+      twitterConsumerKey: '',
       twitterConsumerSecret: '',
       isSameUsernameTreatedAsIdenticalUser: false,
     };

--- a/packages/app/src/client/services/AdminTwitterSecurityContainer.js
+++ b/packages/app/src/client/services/AdminTwitterSecurityContainer.js
@@ -23,7 +23,7 @@ export default class AdminTwitterSecurityContainer extends Container {
     this.dummyTwitterConsumerKeyForError = 1;
 
     this.state = {
-      callbackUrl: urljoin(pathUtils.removeTrailingSlash(appContainer.config.crowi.url), '/passport/twitter/callback'),
+      // callbackUrl: urljoin(pathUtils.removeTrailingSlash(appContainer.config.crowi.url), '/passport/twitter/callback'),
       // set dummy value tile for using suspense
       twitterConsumerKey: this.dummyTwitterConsumerKey,
       twitterConsumerSecret: '',

--- a/packages/app/src/components/Admin/Security/BasicSecuritySetting.jsx
+++ b/packages/app/src/components/Admin/Security/BasicSecuritySetting.jsx
@@ -1,5 +1,4 @@
-/* eslint-disable react/no-danger */
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import PropTypes from 'prop-types';
 
@@ -11,31 +10,24 @@ import { withUnstatedContainers } from '../../UnstatedUtils';
 
 import BasicSecurityManagementContents from './BasicSecuritySettingContents';
 
-let retrieveErrors = null;
-function BasicSecurityManagement(props) {
-  const { adminBasicSecurityContainer } = props;
-  // if (adminBasicSecurityContainer.state.isSameUsernameTreatedAsIdenticalUser === adminBasicSecurityContainer.dummyIsSameUsernameTreatedAsIdenticalUser) {
-  //   throw (async() => {
-  //     try {
-  //       await adminBasicSecurityContainer.retrieveSecurityData();
-  //     }
-  //     catch (err) {
-  //       const errs = toArrayIfNot(err);
-  //       toastError(errs);
-  //       retrieveErrors = errs;
-  //       adminBasicSecurityContainer.setState({
-  //         isSameUsernameTreatedAsIdenticalUser: adminBasicSecurityContainer.dummyIsSameUsernameTreatedAsIdenticalUser,
-  //       });
+const BasicSecurityManagement = (props) => {
+  const { adminBasicSecurityContainer } = props
 
-  //     }
-  //   })();
-  // }
+  useEffect(() => {
+    const fetchBasicSecuritySettingsData = async() => {
+      await adminBasicSecurityContainer.retrieveSecurityData();
+    };
 
-  // if (
-  //   adminBasicSecurityContainer.state.isSameUsernameTreatedAsIdenticalUser === adminBasicSecurityContainer.dummyIsSameUsernameTreatedAsIdenticalUserForError
-  // ) {
-  //   throw new Error(`${retrieveErrors.length} errors occured`);
-  // }
+    try {
+      fetchBasicSecuritySettingsData();
+    }
+    catch (err) {
+      const errs = toArrayIfNot(err);
+      toastError(errs);
+      logger.error(errs);
+    }
+  }, [adminBasicSecurityContainer]);
+
 
   return <BasicSecurityManagementContents />;
 }

--- a/packages/app/src/components/Admin/Security/BasicSecuritySetting.jsx
+++ b/packages/app/src/components/Admin/Security/BasicSecuritySetting.jsx
@@ -24,7 +24,6 @@ const BasicSecurityManagement = (props) => {
     catch (err) {
       const errs = toArrayIfNot(err);
       toastError(errs);
-      logger.error(errs);
     }
   }, [adminBasicSecurityContainer]);
 

--- a/packages/app/src/components/Admin/Security/BasicSecuritySetting.jsx
+++ b/packages/app/src/components/Admin/Security/BasicSecuritySetting.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useCallback } from 'react';
 
 import PropTypes from 'prop-types';
 
@@ -13,19 +13,19 @@ import BasicSecurityManagementContents from './BasicSecuritySettingContents';
 const BasicSecurityManagement = (props) => {
   const { adminBasicSecurityContainer } = props;
 
-  useEffect(() => {
-    const fetchBasicSecuritySettingsData = async() => {
-      await adminBasicSecurityContainer.retrieveSecurityData();
-    };
-
+  const fetchBasicSecuritySettingsData = useCallback(async() => {
     try {
-      fetchBasicSecuritySettingsData();
+      await adminBasicSecurityContainer.retrieveSecurityData();
     }
     catch (err) {
       const errs = toArrayIfNot(err);
       toastError(errs);
     }
   }, [adminBasicSecurityContainer]);
+
+  useEffect(() => {
+    fetchBasicSecuritySettingsData();
+  }, [adminBasicSecurityContainer, fetchBasicSecuritySettingsData]);
 
 
   return <BasicSecurityManagementContents />;

--- a/packages/app/src/components/Admin/Security/BasicSecuritySetting.jsx
+++ b/packages/app/src/components/Admin/Security/BasicSecuritySetting.jsx
@@ -11,7 +11,7 @@ import { withUnstatedContainers } from '../../UnstatedUtils';
 import BasicSecurityManagementContents from './BasicSecuritySettingContents';
 
 const BasicSecurityManagement = (props) => {
-  const { adminBasicSecurityContainer } = props
+  const { adminBasicSecurityContainer } = props;
 
   useEffect(() => {
     const fetchBasicSecuritySettingsData = async() => {
@@ -30,7 +30,7 @@ const BasicSecurityManagement = (props) => {
 
 
   return <BasicSecurityManagementContents />;
-}
+};
 
 BasicSecurityManagement.propTypes = {
   adminBasicSecurityContainer: PropTypes.instanceOf(AdminBasicSecurityContainer).isRequired,

--- a/packages/app/src/components/Admin/Security/BasicSecuritySetting.jsx
+++ b/packages/app/src/components/Admin/Security/BasicSecuritySetting.jsx
@@ -14,28 +14,28 @@ import BasicSecurityManagementContents from './BasicSecuritySettingContents';
 let retrieveErrors = null;
 function BasicSecurityManagement(props) {
   const { adminBasicSecurityContainer } = props;
-  if (adminBasicSecurityContainer.state.isSameUsernameTreatedAsIdenticalUser === adminBasicSecurityContainer.dummyIsSameUsernameTreatedAsIdenticalUser) {
-    throw (async() => {
-      try {
-        await adminBasicSecurityContainer.retrieveSecurityData();
-      }
-      catch (err) {
-        const errs = toArrayIfNot(err);
-        toastError(errs);
-        retrieveErrors = errs;
-        adminBasicSecurityContainer.setState({
-          isSameUsernameTreatedAsIdenticalUser: adminBasicSecurityContainer.dummyIsSameUsernameTreatedAsIdenticalUser,
-        });
+  // if (adminBasicSecurityContainer.state.isSameUsernameTreatedAsIdenticalUser === adminBasicSecurityContainer.dummyIsSameUsernameTreatedAsIdenticalUser) {
+  //   throw (async() => {
+  //     try {
+  //       await adminBasicSecurityContainer.retrieveSecurityData();
+  //     }
+  //     catch (err) {
+  //       const errs = toArrayIfNot(err);
+  //       toastError(errs);
+  //       retrieveErrors = errs;
+  //       adminBasicSecurityContainer.setState({
+  //         isSameUsernameTreatedAsIdenticalUser: adminBasicSecurityContainer.dummyIsSameUsernameTreatedAsIdenticalUser,
+  //       });
 
-      }
-    })();
-  }
+  //     }
+  //   })();
+  // }
 
-  if (
-    adminBasicSecurityContainer.state.isSameUsernameTreatedAsIdenticalUser === adminBasicSecurityContainer.dummyIsSameUsernameTreatedAsIdenticalUserForError
-  ) {
-    throw new Error(`${retrieveErrors.length} errors occured`);
-  }
+  // if (
+  //   adminBasicSecurityContainer.state.isSameUsernameTreatedAsIdenticalUser === adminBasicSecurityContainer.dummyIsSameUsernameTreatedAsIdenticalUserForError
+  // ) {
+  //   throw new Error(`${retrieveErrors.length} errors occured`);
+  // }
 
   return <BasicSecurityManagementContents />;
 }

--- a/packages/app/src/components/Admin/Security/FacebookSecuritySetting.jsx
+++ b/packages/app/src/components/Admin/Security/FacebookSecuritySetting.jsx
@@ -14,15 +14,13 @@ class FacebookSecurityManagement extends React.Component {
   render() {
     const { t } = this.props;
     return (
-      <React.Fragment>
-
+      <>
         <h2 className="alert-anchor border-bottom">
           Facebook OAuth { t('security_setting.configuration') }
         </h2>
 
         <p className="well">(TBD)</p>
-
-      </React.Fragment>
+      </>
     );
   }
 

--- a/packages/app/src/components/Admin/Security/FacebookSecuritySetting.jsx
+++ b/packages/app/src/components/Admin/Security/FacebookSecuritySetting.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-danger */
 import React from 'react';
 
 import { withTranslation } from 'next-i18next';

--- a/packages/app/src/components/Admin/Security/GitHubSecuritySetting.jsx
+++ b/packages/app/src/components/Admin/Security/GitHubSecuritySetting.jsx
@@ -25,7 +25,6 @@ function GitHubSecurityManagement(props) {
     catch (err) {
       const errs = toArrayIfNot(err);
       toastError(errs);
-      logger.error(errs);
     }
   }, [adminGitHubSecurityContainer]);
 

--- a/packages/app/src/components/Admin/Security/GitHubSecuritySetting.jsx
+++ b/packages/app/src/components/Admin/Security/GitHubSecuritySetting.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useCallback } from 'react';
 
 import PropTypes from 'prop-types';
 
@@ -11,16 +11,12 @@ import { withUnstatedContainers } from '../../UnstatedUtils';
 
 import GitHubSecuritySettingContents from './GitHubSecuritySettingContents';
 
-function GitHubSecurityManagement(props) {
+const GitHubSecurityManagement = (props) => {
   const { adminGitHubSecurityContainer } = props;
 
-  useEffect(() => {
-    const fetchGitHubSecuritySettingsData = async() => {
-      await adminGitHubSecurityContainer.retrieveSecurityData();
-    };
-
+  const fetchGitHubSecuritySettingsData = useCallback(async() => {
     try {
-      fetchGitHubSecuritySettingsData();
+      await adminGitHubSecurityContainer.retrieveSecurityData();
     }
     catch (err) {
       const errs = toArrayIfNot(err);
@@ -28,8 +24,12 @@ function GitHubSecurityManagement(props) {
     }
   }, [adminGitHubSecurityContainer]);
 
+  useEffect(() => {
+    fetchGitHubSecuritySettingsData();
+  }, [adminGitHubSecurityContainer, fetchGitHubSecuritySettingsData]);
+
   return <GitHubSecuritySettingContents />;
-}
+};
 
 
 GitHubSecurityManagement.propTypes = {

--- a/packages/app/src/components/Admin/Security/GitHubSecuritySetting.jsx
+++ b/packages/app/src/components/Admin/Security/GitHubSecuritySetting.jsx
@@ -1,5 +1,4 @@
-/* eslint-disable react/no-danger */
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import PropTypes from 'prop-types';
 
@@ -15,23 +14,21 @@ import GitHubSecuritySettingContents from './GitHubSecuritySettingContents';
 let retrieveErrors = null;
 function GitHubSecurityManagement(props) {
   const { adminGitHubSecurityContainer } = props;
-  // if (adminGitHubSecurityContainer.state.githubClientId === adminGitHubSecurityContainer.dummyGithubClientId) {
-  //   throw (async() => {
-  //     try {
-  //       await adminGitHubSecurityContainer.retrieveSecurityData();
-  //     }
-  //     catch (err) {
-  //       const errs = toArrayIfNot(err);
-  //       toastError(errs);
-  //       retrieveErrors = errs;
-  //       adminGitHubSecurityContainer.setState({ githubClientId: adminGitHubSecurityContainer.dummyGithubClientIdForError });
-  //     }
-  //   })();
-  // }
 
-  // if (adminGitHubSecurityContainer.state.githubClientId === adminGitHubSecurityContainer.dummyGithubClientIdForError) {
-  //   throw new Error(`${retrieveErrors.length} errors occured`);
-  // }
+  useEffect(() => {
+    const fetchGitHubSecuritySettingsData = async() => {
+      await adminGitHubSecurityContainer.retrieveSecurityData();
+    };
+
+    try {
+      fetchGitHubSecuritySettingsData();
+    }
+    catch (err) {
+      const errs = toArrayIfNot(err);
+      toastError(errs);
+      logger.error(errs);
+    }
+  }, [adminGitHubSecurityContainer]);
 
   return <GitHubSecuritySettingContents />;
 }

--- a/packages/app/src/components/Admin/Security/GitHubSecuritySetting.jsx
+++ b/packages/app/src/components/Admin/Security/GitHubSecuritySetting.jsx
@@ -15,23 +15,23 @@ import GitHubSecuritySettingContents from './GitHubSecuritySettingContents';
 let retrieveErrors = null;
 function GitHubSecurityManagement(props) {
   const { adminGitHubSecurityContainer } = props;
-  if (adminGitHubSecurityContainer.state.githubClientId === adminGitHubSecurityContainer.dummyGithubClientId) {
-    throw (async() => {
-      try {
-        await adminGitHubSecurityContainer.retrieveSecurityData();
-      }
-      catch (err) {
-        const errs = toArrayIfNot(err);
-        toastError(errs);
-        retrieveErrors = errs;
-        adminGitHubSecurityContainer.setState({ githubClientId: adminGitHubSecurityContainer.dummyGithubClientIdForError });
-      }
-    })();
-  }
+  // if (adminGitHubSecurityContainer.state.githubClientId === adminGitHubSecurityContainer.dummyGithubClientId) {
+  //   throw (async() => {
+  //     try {
+  //       await adminGitHubSecurityContainer.retrieveSecurityData();
+  //     }
+  //     catch (err) {
+  //       const errs = toArrayIfNot(err);
+  //       toastError(errs);
+  //       retrieveErrors = errs;
+  //       adminGitHubSecurityContainer.setState({ githubClientId: adminGitHubSecurityContainer.dummyGithubClientIdForError });
+  //     }
+  //   })();
+  // }
 
-  if (adminGitHubSecurityContainer.state.githubClientId === adminGitHubSecurityContainer.dummyGithubClientIdForError) {
-    throw new Error(`${retrieveErrors.length} errors occured`);
-  }
+  // if (adminGitHubSecurityContainer.state.githubClientId === adminGitHubSecurityContainer.dummyGithubClientIdForError) {
+  //   throw new Error(`${retrieveErrors.length} errors occured`);
+  // }
 
   return <GitHubSecuritySettingContents />;
 }

--- a/packages/app/src/components/Admin/Security/GitHubSecuritySetting.jsx
+++ b/packages/app/src/components/Admin/Security/GitHubSecuritySetting.jsx
@@ -11,7 +11,6 @@ import { withUnstatedContainers } from '../../UnstatedUtils';
 
 import GitHubSecuritySettingContents from './GitHubSecuritySettingContents';
 
-let retrieveErrors = null;
 function GitHubSecurityManagement(props) {
   const { adminGitHubSecurityContainer } = props;
 

--- a/packages/app/src/components/Admin/Security/GitHubSecuritySettingContents.jsx
+++ b/packages/app/src/components/Admin/Security/GitHubSecuritySettingContents.jsx
@@ -85,14 +85,14 @@ class GitHubSecurityManagementContents extends React.Component {
               readOnly
             />
             <p className="form-text text-muted small">{t('security_setting.desc_of_callback_URL', { AuthName: 'OAuth' })}</p>
-            {siteUrl == null || siteUrl === ''(
+            {(siteUrl == null || siteUrl === '') && (
               <div className="alert alert-danger">
                 <i
                   className="icon-exclamation"
                   // eslint-disable-next-line max-len
                   dangerouslySetInnerHTML={{ __html: t('security_setting.alert_siteUrl_is_not_set', { link: `<a href="/admin/app">${t('App Settings')}<i class="icon-login"></i></a>` }) }}
                 />
-              </div>,
+              </div>
             )}
           </div>
         </div>

--- a/packages/app/src/components/Admin/Security/GitHubSecuritySettingContents.jsx
+++ b/packages/app/src/components/Admin/Security/GitHubSecuritySettingContents.jsx
@@ -4,6 +4,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useTranslation } from 'next-i18next';
 
+import urljoin from 'url-join';
+import { pathUtils } from '@growi/core';
+
+import { useSiteUrl } from '~/stores/context';
 
 import AdminGeneralSecurityContainer from '~/client/services/AdminGeneralSecurityContainer';
 import AdminGitHubSecurityContainer from '~/client/services/AdminGitHubSecurityContainer';
@@ -33,8 +37,9 @@ class GitHubSecurityManagementContents extends React.Component {
   }
 
   render() {
-    const { t, adminGeneralSecurityContainer, adminGitHubSecurityContainer } = this.props;
+    const { t, adminGeneralSecurityContainer, adminGitHubSecurityContainer, siteUrl } = this.props;
     const { isGitHubEnabled } = adminGeneralSecurityContainer.state;
+    const gitHubCallBackUrl = urljoin(pathUtils.removeTrailingSlash(siteUrl), '/passport/github/callback')
 
     return (
 
@@ -75,11 +80,11 @@ class GitHubSecurityManagementContents extends React.Component {
             <input
               className="form-control"
               type="text"
-              value={adminGitHubSecurityContainer.state.appSiteUrl}
+              value={gitHubCallBackUrl}
               readOnly
             />
             <p className="form-text text-muted small">{t('security_setting.desc_of_callback_URL', { AuthName: 'OAuth' })}</p>
-            {!adminGeneralSecurityContainer.state.appSiteUrl && (
+            {!siteUrl && (
               <div className="alert alert-danger">
                 <i
                   className="icon-exclamation"
@@ -172,7 +177,7 @@ class GitHubSecurityManagementContents extends React.Component {
           <ol id="collapseHelpForGitHubOauth" className="collapse">
             {/* eslint-disable-next-line max-len */}
             <li dangerouslySetInnerHTML={{ __html: t('security_setting.OAuth.GitHub.register_1', { link: '<a href="https://github.com/settings/developers" target=_blank>GitHub Developer Settings</a>' }) }} />
-            <li dangerouslySetInnerHTML={{ __html: t('security_setting.OAuth.GitHub.register_2', { url: adminGitHubSecurityContainer.state.callbackUrl }) }} />
+            <li dangerouslySetInnerHTML={{ __html: t('security_setting.OAuth.GitHub.register_2', { url: gitHubCallBackUrl }) }} />
             <li dangerouslySetInnerHTML={{ __html: t('security_setting.OAuth.GitHub.register_3') }} />
           </ol>
         </div>
@@ -187,7 +192,8 @@ class GitHubSecurityManagementContents extends React.Component {
 
 const GitHubSecurityManagementContentsFC = (props) => {
   const { t } = useTranslation();
-  return <GitHubSecurityManagementContents t={t} {...props} />;
+  const { data: siteUrl } = useSiteUrl();
+  return <GitHubSecurityManagementContents t={t} siteUrl={siteUrl} {...props} />;
 };
 
 /**

--- a/packages/app/src/components/Admin/Security/GitHubSecuritySettingContents.jsx
+++ b/packages/app/src/components/Admin/Security/GitHubSecuritySettingContents.jsx
@@ -39,7 +39,7 @@ class GitHubSecurityManagementContents extends React.Component {
   render() {
     const { t, adminGeneralSecurityContainer, adminGitHubSecurityContainer, siteUrl } = this.props;
     const { isGitHubEnabled } = adminGeneralSecurityContainer.state;
-    const gitHubCallBackUrl = urljoin(pathUtils.removeTrailingSlash(siteUrl), '/passport/github/callback')
+    const gitHubCallBackUrl = urljoin(pathUtils.removeTrailingSlash(siteUrl), '/passport/github/callback');
 
     return (
 

--- a/packages/app/src/components/Admin/Security/GitHubSecuritySettingContents.jsx
+++ b/packages/app/src/components/Admin/Security/GitHubSecuritySettingContents.jsx
@@ -85,7 +85,7 @@ class GitHubSecurityManagementContents extends React.Component {
               readOnly
             />
             <p className="form-text text-muted small">{t('security_setting.desc_of_callback_URL', { AuthName: 'OAuth' })}</p>
-            {siteUrl != null && (
+            {siteUrl != null && siteUrl !== '' && (
               <div className="alert alert-danger">
                 <i
                   className="icon-exclamation"

--- a/packages/app/src/components/Admin/Security/GitHubSecuritySettingContents.jsx
+++ b/packages/app/src/components/Admin/Security/GitHubSecuritySettingContents.jsx
@@ -40,7 +40,7 @@ class GitHubSecurityManagementContents extends React.Component {
       t, adminGeneralSecurityContainer, adminGitHubSecurityContainer, siteUrl,
     } = this.props;
     const { isGitHubEnabled } = adminGeneralSecurityContainer.state;
-    const gitHubCallBackUrl = urljoin(pathUtils.removeTrailingSlash(siteUrl), '/passport/github/callback');
+    const gitHubCallbackUrl = urljoin(pathUtils.removeTrailingSlash(siteUrl), '/passport/github/callback');
 
     return (
 
@@ -81,7 +81,7 @@ class GitHubSecurityManagementContents extends React.Component {
             <input
               className="form-control"
               type="text"
-              value={gitHubCallBackUrl}
+              value={gitHubCallbackUrl}
               readOnly
             />
             <p className="form-text text-muted small">{t('security_setting.desc_of_callback_URL', { AuthName: 'OAuth' })}</p>
@@ -178,7 +178,7 @@ class GitHubSecurityManagementContents extends React.Component {
           <ol id="collapseHelpForGitHubOauth" className="collapse">
             {/* eslint-disable-next-line max-len */}
             <li dangerouslySetInnerHTML={{ __html: t('security_setting.OAuth.GitHub.register_1', { link: '<a href="https://github.com/settings/developers" target=_blank>GitHub Developer Settings</a>' }) }} />
-            <li dangerouslySetInnerHTML={{ __html: t('security_setting.OAuth.GitHub.register_2', { url: gitHubCallBackUrl }) }} />
+            <li dangerouslySetInnerHTML={{ __html: t('security_setting.OAuth.GitHub.register_2', { url: gitHubCallbackUrl }) }} />
             <li dangerouslySetInnerHTML={{ __html: t('security_setting.OAuth.GitHub.register_3') }} />
           </ol>
         </div>

--- a/packages/app/src/components/Admin/Security/GitHubSecuritySettingContents.jsx
+++ b/packages/app/src/components/Admin/Security/GitHubSecuritySettingContents.jsx
@@ -85,7 +85,7 @@ class GitHubSecurityManagementContents extends React.Component {
               readOnly
             />
             <p className="form-text text-muted small">{t('security_setting.desc_of_callback_URL', { AuthName: 'OAuth' })}</p>
-            {!siteUrl && (
+            {siteUrl != null && (
               <div className="alert alert-danger">
                 <i
                   className="icon-exclamation"

--- a/packages/app/src/components/Admin/Security/GitHubSecuritySettingContents.jsx
+++ b/packages/app/src/components/Admin/Security/GitHubSecuritySettingContents.jsx
@@ -85,14 +85,14 @@ class GitHubSecurityManagementContents extends React.Component {
               readOnly
             />
             <p className="form-text text-muted small">{t('security_setting.desc_of_callback_URL', { AuthName: 'OAuth' })}</p>
-            {siteUrl != null && siteUrl !== '' && (
+            {siteUrl == null || siteUrl === ''(
               <div className="alert alert-danger">
                 <i
                   className="icon-exclamation"
                   // eslint-disable-next-line max-len
                   dangerouslySetInnerHTML={{ __html: t('security_setting.alert_siteUrl_is_not_set', { link: `<a href="/admin/app">${t('App Settings')}<i class="icon-login"></i></a>` }) }}
                 />
-              </div>
+              </div>,
             )}
           </div>
         </div>

--- a/packages/app/src/components/Admin/Security/GitHubSecuritySettingContents.jsx
+++ b/packages/app/src/components/Admin/Security/GitHubSecuritySettingContents.jsx
@@ -1,17 +1,16 @@
 /* eslint-disable react/no-danger */
 import React from 'react';
 
-import PropTypes from 'prop-types';
-import { useTranslation } from 'next-i18next';
-
-import urljoin from 'url-join';
 import { pathUtils } from '@growi/core';
+import { useTranslation } from 'next-i18next';
+import PropTypes from 'prop-types';
+import urljoin from 'url-join';
 
-import { useSiteUrl } from '~/stores/context';
 
 import AdminGeneralSecurityContainer from '~/client/services/AdminGeneralSecurityContainer';
 import AdminGitHubSecurityContainer from '~/client/services/AdminGitHubSecurityContainer';
 import { toastSuccess, toastError } from '~/client/util/apiNotification';
+import { useSiteUrl } from '~/stores/context';
 
 import { withUnstatedContainers } from '../../UnstatedUtils';
 
@@ -37,7 +36,9 @@ class GitHubSecurityManagementContents extends React.Component {
   }
 
   render() {
-    const { t, adminGeneralSecurityContainer, adminGitHubSecurityContainer, siteUrl } = this.props;
+    const {
+      t, adminGeneralSecurityContainer, adminGitHubSecurityContainer, siteUrl,
+    } = this.props;
     const { isGitHubEnabled } = adminGeneralSecurityContainer.state;
     const gitHubCallBackUrl = urljoin(pathUtils.removeTrailingSlash(siteUrl), '/passport/github/callback');
 

--- a/packages/app/src/components/Admin/Security/GoogleSecuritySetting.jsx
+++ b/packages/app/src/components/Admin/Security/GoogleSecuritySetting.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useCallback } from 'react';
 
 import PropTypes from 'prop-types';
 
@@ -10,16 +10,12 @@ import { withUnstatedContainers } from '../../UnstatedUtils';
 
 import GoogleSecurityManagementContents from './GoogleSecuritySettingContents';
 
-function GoogleSecurityManagement(props) {
+const GoogleSecurityManagement = (props) => {
   const { adminGoogleSecurityContainer } = props;
 
-  useEffect(() => {
-    const fetchGoogleSecuritySettingsData = async() => {
-      await adminGoogleSecurityContainer.retrieveSecurityData();
-    };
-
+  const fetchGoogleSecuritySettingsData = useCallback(async() => {
     try {
-      fetchGoogleSecuritySettingsData();
+      await adminGoogleSecurityContainer.retrieveSecurityData();
     }
     catch (err) {
       const errs = toArrayIfNot(err);
@@ -27,8 +23,13 @@ function GoogleSecurityManagement(props) {
     }
   }, [adminGoogleSecurityContainer]);
 
+
+  useEffect(() => {
+    fetchGoogleSecuritySettingsData();
+  }, [adminGoogleSecurityContainer, fetchGoogleSecuritySettingsData]);
+
   return <GoogleSecurityManagementContents />;
-}
+};
 
 
 GoogleSecurityManagement.propTypes = {

--- a/packages/app/src/components/Admin/Security/GoogleSecuritySetting.jsx
+++ b/packages/app/src/components/Admin/Security/GoogleSecuritySetting.jsx
@@ -24,7 +24,6 @@ function GoogleSecurityManagement(props) {
     catch (err) {
       const errs = toArrayIfNot(err);
       toastError(errs);
-      logger.error(errs);
     }
   }, [adminGoogleSecurityContainer]);
 

--- a/packages/app/src/components/Admin/Security/GoogleSecuritySetting.jsx
+++ b/packages/app/src/components/Admin/Security/GoogleSecuritySetting.jsx
@@ -10,7 +10,6 @@ import { withUnstatedContainers } from '../../UnstatedUtils';
 
 import GoogleSecurityManagementContents from './GoogleSecuritySettingContents';
 
-let retrieveErrors = null;
 function GoogleSecurityManagement(props) {
   const { adminGoogleSecurityContainer } = props;
 

--- a/packages/app/src/components/Admin/Security/GoogleSecuritySetting.jsx
+++ b/packages/app/src/components/Admin/Security/GoogleSecuritySetting.jsx
@@ -1,5 +1,4 @@
-/* eslint-disable react/no-danger */
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import PropTypes from 'prop-types';
 
@@ -14,23 +13,21 @@ import GoogleSecurityManagementContents from './GoogleSecuritySettingContents';
 let retrieveErrors = null;
 function GoogleSecurityManagement(props) {
   const { adminGoogleSecurityContainer } = props;
-  // if (adminGoogleSecurityContainer.state.googleClientId === adminGoogleSecurityContainer.dummyGoogleClientId) {
-  //   throw (async() => {
-  //     try {
-  //       await adminGoogleSecurityContainer.retrieveSecurityData();
-  //     }
-  //     catch (err) {
-  //       const errs = toArrayIfNot(err);
-  //       toastError(errs);
-  //       retrieveErrors = errs;
-  //       adminGoogleSecurityContainer.setState({ googleClientId: adminGoogleSecurityContainer.dummyGoogleClientIdForError });
-  //     }
-  //   })();
-  // }
 
-  // if (adminGoogleSecurityContainer.state.googleClientId === adminGoogleSecurityContainer.dummyGoogleClientIdForError) {
-  //   throw new Error(`${retrieveErrors.length} errors occured`);
-  // }
+  useEffect(() => {
+    const fetchGoogleSecuritySettingsData = async() => {
+      await adminGoogleSecurityContainer.retrieveSecurityData();
+    };
+
+    try {
+      fetchGoogleSecuritySettingsData();
+    }
+    catch (err) {
+      const errs = toArrayIfNot(err);
+      toastError(errs);
+      logger.error(errs);
+    }
+  }, [adminGoogleSecurityContainer]);
 
   return <GoogleSecurityManagementContents />;
 }

--- a/packages/app/src/components/Admin/Security/GoogleSecuritySetting.jsx
+++ b/packages/app/src/components/Admin/Security/GoogleSecuritySetting.jsx
@@ -14,23 +14,23 @@ import GoogleSecurityManagementContents from './GoogleSecuritySettingContents';
 let retrieveErrors = null;
 function GoogleSecurityManagement(props) {
   const { adminGoogleSecurityContainer } = props;
-  if (adminGoogleSecurityContainer.state.googleClientId === adminGoogleSecurityContainer.dummyGoogleClientId) {
-    throw (async() => {
-      try {
-        await adminGoogleSecurityContainer.retrieveSecurityData();
-      }
-      catch (err) {
-        const errs = toArrayIfNot(err);
-        toastError(errs);
-        retrieveErrors = errs;
-        adminGoogleSecurityContainer.setState({ googleClientId: adminGoogleSecurityContainer.dummyGoogleClientIdForError });
-      }
-    })();
-  }
+  // if (adminGoogleSecurityContainer.state.googleClientId === adminGoogleSecurityContainer.dummyGoogleClientId) {
+  //   throw (async() => {
+  //     try {
+  //       await adminGoogleSecurityContainer.retrieveSecurityData();
+  //     }
+  //     catch (err) {
+  //       const errs = toArrayIfNot(err);
+  //       toastError(errs);
+  //       retrieveErrors = errs;
+  //       adminGoogleSecurityContainer.setState({ googleClientId: adminGoogleSecurityContainer.dummyGoogleClientIdForError });
+  //     }
+  //   })();
+  // }
 
-  if (adminGoogleSecurityContainer.state.googleClientId === adminGoogleSecurityContainer.dummyGoogleClientIdForError) {
-    throw new Error(`${retrieveErrors.length} errors occured`);
-  }
+  // if (adminGoogleSecurityContainer.state.googleClientId === adminGoogleSecurityContainer.dummyGoogleClientIdForError) {
+  //   throw new Error(`${retrieveErrors.length} errors occured`);
+  // }
 
   return <GoogleSecurityManagementContents />;
 }

--- a/packages/app/src/components/Admin/Security/GoogleSecuritySettingContents.jsx
+++ b/packages/app/src/components/Admin/Security/GoogleSecuritySettingContents.jsx
@@ -4,6 +4,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useTranslation } from 'next-i18next';
 
+import urljoin from 'url-join';
+import { pathUtils } from '@growi/core';
+import { useSiteUrl } from '~/stores/context';
 
 import AdminGeneralSecurityContainer from '~/client/services/AdminGeneralSecurityContainer';
 import AdminGoogleSecurityContainer from '~/client/services/AdminGoogleSecurityContainer';
@@ -33,8 +36,9 @@ class GoogleSecurityManagementContents extends React.Component {
   }
 
   render() {
-    const { t, adminGeneralSecurityContainer, adminGoogleSecurityContainer } = this.props;
+    const { t, adminGeneralSecurityContainer, adminGoogleSecurityContainer, siteUrl } = this.props;
     const { isGoogleEnabled } = adminGeneralSecurityContainer.state;
+    const googleCallbackUrl = urljoin(pathUtils.removeTrailingSlash(siteUrl), '/passport/google/callback')
 
     return (
 
@@ -75,11 +79,11 @@ class GoogleSecurityManagementContents extends React.Component {
             <input
               className="form-control"
               type="text"
-              value={adminGoogleSecurityContainer.state.callbackUrl}
+              value={googleCallbackUrl}
               readOnly
             />
             <p className="form-text text-muted small">{t('security_setting.desc_of_callback_URL', { AuthName: 'OAuth' })}</p>
-            {!adminGeneralSecurityContainer.state.appSiteUrl && (
+            {!siteUrl && (
               <div className="alert alert-danger">
                 <i
                   className="icon-exclamation"
@@ -179,7 +183,7 @@ class GoogleSecurityManagementContents extends React.Component {
             <li dangerouslySetInnerHTML={{ __html: t('security_setting.OAuth.Google.register_1', { link: '<a href="https://console.cloud.google.com/apis/credentials" target=_blank>Google Cloud Platform API Manager</a>' }) }} />
             <li dangerouslySetInnerHTML={{ __html: t('security_setting.OAuth.Google.register_2') }} />
             <li dangerouslySetInnerHTML={{ __html: t('security_setting.OAuth.Google.register_3') }} />
-            <li dangerouslySetInnerHTML={{ __html: t('security_setting.OAuth.Google.register_4', { url: adminGoogleSecurityContainer.state.callbackUrl }) }} />
+            <li dangerouslySetInnerHTML={{ __html: t('security_setting.OAuth.Google.register_4', { url: googleCallbackUrl}) }} />
             <li dangerouslySetInnerHTML={{ __html: t('security_setting.OAuth.Google.register_5') }} />
           </ol>
         </div>
@@ -194,7 +198,8 @@ class GoogleSecurityManagementContents extends React.Component {
 
 const GoogleSecurityManagementContentsFc = (props) => {
   const { t } = useTranslation();
-  return <GoogleSecurityManagementContents t={t} {...props} />;
+  const { data: siteUrl } = useSiteUrl();
+  return <GoogleSecurityManagementContents t={t} siteUrl={siteUrl} {...props} />;
 };
 
 
@@ -202,6 +207,7 @@ GoogleSecurityManagementContents.propTypes = {
   t: PropTypes.func.isRequired, // i18next
   adminGeneralSecurityContainer: PropTypes.instanceOf(AdminGeneralSecurityContainer).isRequired,
   adminGoogleSecurityContainer: PropTypes.instanceOf(AdminGoogleSecurityContainer).isRequired,
+  siteUrl: PropTypes.string,
 };
 
 const GoogleSecurityManagementContentsWrapper = withUnstatedContainers(GoogleSecurityManagementContentsFc, [

--- a/packages/app/src/components/Admin/Security/GoogleSecuritySettingContents.jsx
+++ b/packages/app/src/components/Admin/Security/GoogleSecuritySettingContents.jsx
@@ -83,7 +83,7 @@ class GoogleSecurityManagementContents extends React.Component {
               readOnly
             />
             <p className="form-text text-muted small">{t('security_setting.desc_of_callback_URL', { AuthName: 'OAuth' })}</p>
-            {!siteUrl && (
+            {siteUrl != null && (
               <div className="alert alert-danger">
                 <i
                   className="icon-exclamation"

--- a/packages/app/src/components/Admin/Security/GoogleSecuritySettingContents.jsx
+++ b/packages/app/src/components/Admin/Security/GoogleSecuritySettingContents.jsx
@@ -83,14 +83,14 @@ class GoogleSecurityManagementContents extends React.Component {
               readOnly
             />
             <p className="form-text text-muted small">{t('security_setting.desc_of_callback_URL', { AuthName: 'OAuth' })}</p>
-            {siteUrl != null && siteUrl !== '' && (
+            {siteUrl == null || siteUrl === ''(
               <div className="alert alert-danger">
                 <i
                   className="icon-exclamation"
                   // eslint-disable-next-line max-len
                   dangerouslySetInnerHTML={{ __html: t('security_setting.alert_siteUrl_is_not_set', { link: `<a href="/admin/app">${t('App Settings')}<i class="icon-login"></i></a>` }) }}
                 />
-              </div>
+              </div>,
             )}
           </div>
         </div>

--- a/packages/app/src/components/Admin/Security/GoogleSecuritySettingContents.jsx
+++ b/packages/app/src/components/Admin/Security/GoogleSecuritySettingContents.jsx
@@ -1,16 +1,14 @@
-/* eslint-disable react/no-danger */
 import React from 'react';
 
-import PropTypes from 'prop-types';
-import { useTranslation } from 'next-i18next';
-
-import urljoin from 'url-join';
 import { pathUtils } from '@growi/core';
-import { useSiteUrl } from '~/stores/context';
+import { useTranslation } from 'next-i18next';
+import PropTypes from 'prop-types';
+import urljoin from 'url-join';
 
 import AdminGeneralSecurityContainer from '~/client/services/AdminGeneralSecurityContainer';
 import AdminGoogleSecurityContainer from '~/client/services/AdminGoogleSecurityContainer';
 import { toastSuccess, toastError } from '~/client/util/apiNotification';
+import { useSiteUrl } from '~/stores/context';
 
 import { withUnstatedContainers } from '../../UnstatedUtils';
 
@@ -36,9 +34,11 @@ class GoogleSecurityManagementContents extends React.Component {
   }
 
   render() {
-    const { t, adminGeneralSecurityContainer, adminGoogleSecurityContainer, siteUrl } = this.props;
+    const {
+      t, adminGeneralSecurityContainer, adminGoogleSecurityContainer, siteUrl,
+    } = this.props;
     const { isGoogleEnabled } = adminGeneralSecurityContainer.state;
-    const googleCallbackUrl = urljoin(pathUtils.removeTrailingSlash(siteUrl), '/passport/google/callback')
+    const googleCallbackUrl = urljoin(pathUtils.removeTrailingSlash(siteUrl), '/passport/google/callback');
 
     return (
 
@@ -183,7 +183,7 @@ class GoogleSecurityManagementContents extends React.Component {
             <li dangerouslySetInnerHTML={{ __html: t('security_setting.OAuth.Google.register_1', { link: '<a href="https://console.cloud.google.com/apis/credentials" target=_blank>Google Cloud Platform API Manager</a>' }) }} />
             <li dangerouslySetInnerHTML={{ __html: t('security_setting.OAuth.Google.register_2') }} />
             <li dangerouslySetInnerHTML={{ __html: t('security_setting.OAuth.Google.register_3') }} />
-            <li dangerouslySetInnerHTML={{ __html: t('security_setting.OAuth.Google.register_4', { url: googleCallbackUrl}) }} />
+            <li dangerouslySetInnerHTML={{ __html: t('security_setting.OAuth.Google.register_4', { url: googleCallbackUrl }) }} />
             <li dangerouslySetInnerHTML={{ __html: t('security_setting.OAuth.Google.register_5') }} />
           </ol>
         </div>

--- a/packages/app/src/components/Admin/Security/GoogleSecuritySettingContents.jsx
+++ b/packages/app/src/components/Admin/Security/GoogleSecuritySettingContents.jsx
@@ -83,14 +83,14 @@ class GoogleSecurityManagementContents extends React.Component {
               readOnly
             />
             <p className="form-text text-muted small">{t('security_setting.desc_of_callback_URL', { AuthName: 'OAuth' })}</p>
-            {siteUrl == null || siteUrl === ''(
+            {(siteUrl == null || siteUrl === '') && (
               <div className="alert alert-danger">
                 <i
                   className="icon-exclamation"
                   // eslint-disable-next-line max-len
                   dangerouslySetInnerHTML={{ __html: t('security_setting.alert_siteUrl_is_not_set', { link: `<a href="/admin/app">${t('App Settings')}<i class="icon-login"></i></a>` }) }}
                 />
-              </div>,
+              </div>
             )}
           </div>
         </div>

--- a/packages/app/src/components/Admin/Security/GoogleSecuritySettingContents.jsx
+++ b/packages/app/src/components/Admin/Security/GoogleSecuritySettingContents.jsx
@@ -83,7 +83,7 @@ class GoogleSecurityManagementContents extends React.Component {
               readOnly
             />
             <p className="form-text text-muted small">{t('security_setting.desc_of_callback_URL', { AuthName: 'OAuth' })}</p>
-            {siteUrl != null && (
+            {siteUrl != null && siteUrl !== '' && (
               <div className="alert alert-danger">
                 <i
                   className="icon-exclamation"

--- a/packages/app/src/components/Admin/Security/LdapSecuritySetting.jsx
+++ b/packages/app/src/components/Admin/Security/LdapSecuritySetting.jsx
@@ -13,23 +13,23 @@ import LdapSecuritySettingContents from './LdapSecuritySettingContents';
 let retrieveErrors = null;
 function LdapSecuritySetting(props) {
   const { adminLdapSecurityContainer } = props;
-  if (adminLdapSecurityContainer.state.serverUrl === adminLdapSecurityContainer.dummyServerUrl) {
-    throw (async() => {
-      try {
-        await adminLdapSecurityContainer.retrieveSecurityData();
-      }
-      catch (err) {
-        const errs = toArrayIfNot(err);
-        toastError(errs);
-        retrieveErrors = errs;
-        adminLdapSecurityContainer.setState({ serverUrl: adminLdapSecurityContainer.dummyServerUrlForError });
-      }
-    })();
-  }
+  // if (adminLdapSecurityContainer.state.serverUrl === adminLdapSecurityContainer.dummyServerUrl) {
+  //   throw (async() => {
+  //     try {
+  //       await adminLdapSecurityContainer.retrieveSecurityData();
+  //     }
+  //     catch (err) {
+  //       const errs = toArrayIfNot(err);
+  //       toastError(errs);
+  //       retrieveErrors = errs;
+  //       adminLdapSecurityContainer.setState({ serverUrl: adminLdapSecurityContainer.dummyServerUrlForError });
+  //     }
+  //   })();
+  // }
 
-  if (adminLdapSecurityContainer.state.serverUrl === adminLdapSecurityContainer.dummyServerUrlForError) {
-    throw new Error(`${retrieveErrors.length} errors occured`);
-  }
+  // if (adminLdapSecurityContainer.state.serverUrl === adminLdapSecurityContainer.dummyServerUrlForError) {
+  //   throw new Error(`${retrieveErrors.length} errors occured`);
+  // }
 
   return <LdapSecuritySettingContents />;
 }

--- a/packages/app/src/components/Admin/Security/LdapSecuritySetting.jsx
+++ b/packages/app/src/components/Admin/Security/LdapSecuritySetting.jsx
@@ -24,7 +24,6 @@ function LdapSecuritySetting(props) {
     catch (err) {
       const errs = toArrayIfNot(err);
       toastError(errs);
-      logger.error(errs);
     }
   }, [adminLdapSecurityContainer]);
 

--- a/packages/app/src/components/Admin/Security/LdapSecuritySetting.jsx
+++ b/packages/app/src/components/Admin/Security/LdapSecuritySetting.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import PropTypes from 'prop-types';
 
@@ -13,23 +13,21 @@ import LdapSecuritySettingContents from './LdapSecuritySettingContents';
 let retrieveErrors = null;
 function LdapSecuritySetting(props) {
   const { adminLdapSecurityContainer } = props;
-  // if (adminLdapSecurityContainer.state.serverUrl === adminLdapSecurityContainer.dummyServerUrl) {
-  //   throw (async() => {
-  //     try {
-  //       await adminLdapSecurityContainer.retrieveSecurityData();
-  //     }
-  //     catch (err) {
-  //       const errs = toArrayIfNot(err);
-  //       toastError(errs);
-  //       retrieveErrors = errs;
-  //       adminLdapSecurityContainer.setState({ serverUrl: adminLdapSecurityContainer.dummyServerUrlForError });
-  //     }
-  //   })();
-  // }
 
-  // if (adminLdapSecurityContainer.state.serverUrl === adminLdapSecurityContainer.dummyServerUrlForError) {
-  //   throw new Error(`${retrieveErrors.length} errors occured`);
-  // }
+  useEffect(() => {
+    const fetchLdapSecuritySettingsData = async() => {
+      await adminLdapSecurityContainer.retrieveSecurityData();
+    };
+
+    try {
+      fetchLdapSecuritySettingsData();
+    }
+    catch (err) {
+      const errs = toArrayIfNot(err);
+      toastError(errs);
+      logger.error(errs);
+    }
+  }, [adminLdapSecurityContainer]);
 
   return <LdapSecuritySettingContents />;
 }

--- a/packages/app/src/components/Admin/Security/LdapSecuritySetting.jsx
+++ b/packages/app/src/components/Admin/Security/LdapSecuritySetting.jsx
@@ -10,7 +10,6 @@ import { withUnstatedContainers } from '../../UnstatedUtils';
 
 import LdapSecuritySettingContents from './LdapSecuritySettingContents';
 
-let retrieveErrors = null;
 function LdapSecuritySetting(props) {
   const { adminLdapSecurityContainer } = props;
 

--- a/packages/app/src/components/Admin/Security/LdapSecuritySetting.jsx
+++ b/packages/app/src/components/Admin/Security/LdapSecuritySetting.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useCallback } from 'react';
 
 import PropTypes from 'prop-types';
 
@@ -10,16 +10,12 @@ import { withUnstatedContainers } from '../../UnstatedUtils';
 
 import LdapSecuritySettingContents from './LdapSecuritySettingContents';
 
-function LdapSecuritySetting(props) {
+const LdapSecuritySetting = (props) => {
   const { adminLdapSecurityContainer } = props;
 
-  useEffect(() => {
-    const fetchLdapSecuritySettingsData = async() => {
-      await adminLdapSecurityContainer.retrieveSecurityData();
-    };
-
+  const fetchLdapSecuritySettingsData = useCallback(async() => {
     try {
-      fetchLdapSecuritySettingsData();
+      await adminLdapSecurityContainer.retrieveSecurityData();
     }
     catch (err) {
       const errs = toArrayIfNot(err);
@@ -27,8 +23,12 @@ function LdapSecuritySetting(props) {
     }
   }, [adminLdapSecurityContainer]);
 
+  useEffect(() => {
+    fetchLdapSecuritySettingsData();
+  }, [adminLdapSecurityContainer, fetchLdapSecuritySettingsData]);
+
   return <LdapSecuritySettingContents />;
-}
+};
 
 LdapSecuritySetting.propTypes = {
   adminLdapSecurityContainer: PropTypes.instanceOf(AdminLdapSecurityContainer).isRequired,

--- a/packages/app/src/components/Admin/Security/LocalSecuritySetting.jsx
+++ b/packages/app/src/components/Admin/Security/LocalSecuritySetting.jsx
@@ -14,19 +14,19 @@ import LocalSecuritySettingContents from './LocalSecuritySettingContents';
 let retrieveErrors = null;
 function LocalSecuritySetting(props) {
   const { adminLocalSecurityContainer } = props;
-  if (adminLocalSecurityContainer.state.registrationMode === adminLocalSecurityContainer.dummyRegistrationMode) {
-    throw (async() => {
-      try {
-        await adminLocalSecurityContainer.retrieveSecurityData();
-      }
-      catch (err) {
-        const errs = toArrayIfNot(err);
-        toastError(errs);
-        retrieveErrors = errs;
-        adminLocalSecurityContainer.setState({ registrationMode: adminLocalSecurityContainer.dummyRegistrationModeForError });
-      }
-    })();
-  }
+  // if (adminLocalSecurityContainer.state.registrationMode === adminLocalSecurityContainer.dummyRegistrationMode) {
+  //   throw (async() => {
+  //     try {
+  //       await adminLocalSecurityContainer.retrieveSecurityData();
+  //     }
+  //     catch (err) {
+  //       const errs = toArrayIfNot(err);
+  //       toastError(errs);
+  //       retrieveErrors = errs;
+  //       adminLocalSecurityContainer.setState({ registrationMode: adminLocalSecurityContainer.dummyRegistrationModeForError });
+  //     }
+  //   })();
+  // }
 
   if (adminLocalSecurityContainer.state.registrationMode === adminLocalSecurityContainer.dummyRegistrationModeForError) {
     throw new Error(`${retrieveErrors.length} errors occured`);

--- a/packages/app/src/components/Admin/Security/LocalSecuritySetting.jsx
+++ b/packages/app/src/components/Admin/Security/LocalSecuritySetting.jsx
@@ -1,5 +1,4 @@
-/* eslint-disable react/no-danger */
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import PropTypes from 'prop-types';
 
@@ -14,23 +13,21 @@ import LocalSecuritySettingContents from './LocalSecuritySettingContents';
 let retrieveErrors = null;
 function LocalSecuritySetting(props) {
   const { adminLocalSecurityContainer } = props;
-  // if (adminLocalSecurityContainer.state.registrationMode === adminLocalSecurityContainer.dummyRegistrationMode) {
-  //   throw (async() => {
-  //     try {
-  //       await adminLocalSecurityContainer.retrieveSecurityData();
-  //     }
-  //     catch (err) {
-  //       const errs = toArrayIfNot(err);
-  //       toastError(errs);
-  //       retrieveErrors = errs;
-  //       adminLocalSecurityContainer.setState({ registrationMode: adminLocalSecurityContainer.dummyRegistrationModeForError });
-  //     }
-  //   })();
-  // }
 
-  if (adminLocalSecurityContainer.state.registrationMode === adminLocalSecurityContainer.dummyRegistrationModeForError) {
-    throw new Error(`${retrieveErrors.length} errors occured`);
-  }
+  useEffect(() => {
+    const fetchLocalSecuritySettingsData = async() => {
+      await adminLocalSecurityContainer.retrieveSecurityData();
+    };
+
+    try {
+      fetchLocalSecuritySettingsData();
+    }
+    catch (err) {
+      const errs = toArrayIfNot(err);
+      toastError(errs);
+      logger.error(errs);
+    }
+  }, [adminLocalSecurityContainer]);
 
   return <LocalSecuritySettingContents />;
 }

--- a/packages/app/src/components/Admin/Security/LocalSecuritySetting.jsx
+++ b/packages/app/src/components/Admin/Security/LocalSecuritySetting.jsx
@@ -10,7 +10,6 @@ import { withUnstatedContainers } from '../../UnstatedUtils';
 
 import LocalSecuritySettingContents from './LocalSecuritySettingContents';
 
-let retrieveErrors = null;
 function LocalSecuritySetting(props) {
   const { adminLocalSecurityContainer } = props;
 

--- a/packages/app/src/components/Admin/Security/LocalSecuritySetting.jsx
+++ b/packages/app/src/components/Admin/Security/LocalSecuritySetting.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useCallback } from 'react';
 
 import PropTypes from 'prop-types';
 
@@ -10,16 +10,12 @@ import { withUnstatedContainers } from '../../UnstatedUtils';
 
 import LocalSecuritySettingContents from './LocalSecuritySettingContents';
 
-function LocalSecuritySetting(props) {
+const LocalSecuritySetting = (props) => {
   const { adminLocalSecurityContainer } = props;
 
-  useEffect(() => {
-    const fetchLocalSecuritySettingsData = async() => {
-      await adminLocalSecurityContainer.retrieveSecurityData();
-    };
-
+  const fetchLocalSecuritySettingsData = useCallback(async() => {
     try {
-      fetchLocalSecuritySettingsData();
+      await adminLocalSecurityContainer.retrieveSecurityData();
     }
     catch (err) {
       const errs = toArrayIfNot(err);
@@ -27,8 +23,13 @@ function LocalSecuritySetting(props) {
     }
   }, [adminLocalSecurityContainer]);
 
+
+  useEffect(() => {
+    fetchLocalSecuritySettingsData();
+  }, [adminLocalSecurityContainer, fetchLocalSecuritySettingsData]);
+
   return <LocalSecuritySettingContents />;
-}
+};
 
 LocalSecuritySetting.propTypes = {
   adminLocalSecurityContainer: PropTypes.instanceOf(AdminLocalSecurityContainer).isRequired,

--- a/packages/app/src/components/Admin/Security/LocalSecuritySetting.jsx
+++ b/packages/app/src/components/Admin/Security/LocalSecuritySetting.jsx
@@ -24,7 +24,6 @@ function LocalSecuritySetting(props) {
     catch (err) {
       const errs = toArrayIfNot(err);
       toastError(errs);
-      logger.error(errs);
     }
   }, [adminLocalSecurityContainer]);
 

--- a/packages/app/src/components/Admin/Security/LocalSecuritySettingContents.jsx
+++ b/packages/app/src/components/Admin/Security/LocalSecuritySettingContents.jsx
@@ -4,10 +4,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useTranslation } from 'next-i18next';
 
+import { useIsMailerSetup } from '~/stores/context';
+
 
 import AdminGeneralSecurityContainer from '~/client/services/AdminGeneralSecurityContainer';
 import AdminLocalSecurityContainer from '~/client/services/AdminLocalSecurityContainer';
-import AppContainer from '~/client/services/AppContainer';
 import { toastSuccess, toastError } from '~/client/util/apiNotification';
 
 import { withUnstatedContainers } from '../../UnstatedUtils';
@@ -37,14 +38,13 @@ class LocalSecuritySettingContents extends React.Component {
       t,
       adminGeneralSecurityContainer,
       adminLocalSecurityContainer,
-      appContainer,
+      isMailerSetup
     } = this.props;
     const { registrationMode, isPasswordResetEnabled, isEmailAuthenticationEnabled } = adminLocalSecurityContainer.state;
     const { isLocalEnabled } = adminGeneralSecurityContainer.state;
-    const { isMailerSetup } = appContainer.config;
 
     return (
-      <React.Fragment>
+      <>
         {adminLocalSecurityContainer.state.retrieveError != null && (
           <div className="alert alert-danger">
             <p>
@@ -97,7 +97,7 @@ class LocalSecuritySettingContents extends React.Component {
         </div>
 
         {isLocalEnabled && (
-          <React.Fragment>
+          <>
             <h3 className="border-bottom">{t('security_setting.configuration')}</h3>
 
             <div className="row">
@@ -236,9 +236,9 @@ class LocalSecuritySettingContents extends React.Component {
                 </button>
               </div>
             </div>
-          </React.Fragment>
+          </>
         )}
-      </React.Fragment>
+      </>
     );
   }
 
@@ -246,18 +246,17 @@ class LocalSecuritySettingContents extends React.Component {
 
 LocalSecuritySettingContents.propTypes = {
   t: PropTypes.func.isRequired, // i18next
-  appContainer: PropTypes.instanceOf(AppContainer).isRequired,
   adminGeneralSecurityContainer: PropTypes.instanceOf(AdminGeneralSecurityContainer).isRequired,
   adminLocalSecurityContainer: PropTypes.instanceOf(AdminLocalSecurityContainer).isRequired,
 };
 
 const LocalSecuritySettingContentsWrapperFC = (props) => {
   const { t } = useTranslation();
-  return <LocalSecuritySettingContents t={t} {...props} />;
+  const { data: isMailerSetup } = useIsMailerSetup();
+  return <LocalSecuritySettingContents t={t} {...props} isMailerSetup={isMailerSetup ?? false} />;
 };
 
 const LocalSecuritySettingContentsWrapper = withUnstatedContainers(LocalSecuritySettingContentsWrapperFC, [
-  AppContainer,
   AdminGeneralSecurityContainer,
   AdminLocalSecurityContainer,
 ]);

--- a/packages/app/src/components/Admin/Security/LocalSecuritySettingContents.jsx
+++ b/packages/app/src/components/Admin/Security/LocalSecuritySettingContents.jsx
@@ -1,15 +1,13 @@
-/* eslint-disable react/no-danger */
 import React from 'react';
 
-import PropTypes from 'prop-types';
 import { useTranslation } from 'next-i18next';
-
-import { useIsMailerSetup } from '~/stores/context';
+import PropTypes from 'prop-types';
 
 
 import AdminGeneralSecurityContainer from '~/client/services/AdminGeneralSecurityContainer';
 import AdminLocalSecurityContainer from '~/client/services/AdminLocalSecurityContainer';
 import { toastSuccess, toastError } from '~/client/util/apiNotification';
+import { useIsMailerSetup } from '~/stores/context';
 
 import { withUnstatedContainers } from '../../UnstatedUtils';
 
@@ -38,7 +36,7 @@ class LocalSecuritySettingContents extends React.Component {
       t,
       adminGeneralSecurityContainer,
       adminLocalSecurityContainer,
-      isMailerSetup
+      isMailerSetup,
     } = this.props;
     const { registrationMode, isPasswordResetEnabled, isEmailAuthenticationEnabled } = adminLocalSecurityContainer.state;
     const { isLocalEnabled } = adminGeneralSecurityContainer.state;

--- a/packages/app/src/components/Admin/Security/OidcSecuritySetting.jsx
+++ b/packages/app/src/components/Admin/Security/OidcSecuritySetting.jsx
@@ -13,23 +13,6 @@ import OidcSecurityManagementContents from './OidcSecuritySettingContents';
 let retrieveErrors = null;
 function OidcSecurityManagement(props) {
   const { adminOidcSecurityContainer } = props;
-  // if (adminOidcSecurityContainer.state.oidcProviderName === adminOidcSecurityContainer.dummyOidcProviderName) {
-  //   throw (async() => {
-  //     try {
-  //       await adminOidcSecurityContainer.retrieveSecurityData();
-  //     }
-  //     catch (err) {
-  //       const errs = toArrayIfNot(err);
-  //       toastError(errs);
-  //       retrieveErrors = errs;
-  //       adminOidcSecurityContainer.setState({ oidcProviderName: adminOidcSecurityContainer.dummyOidcProviderNameForError });
-  //     }
-  //   })();
-  // }
-
-  // if (adminOidcSecurityContainer.state.oidcProviderName === adminOidcSecurityContainer.dummyOidcProviderNameForError) {
-  //   throw new Error(`${retrieveErrors.length} errors occured`);
-  // }
 
   useEffect(() => {
     const fetchOidcSecuritySettingsData = async() => {

--- a/packages/app/src/components/Admin/Security/OidcSecuritySetting.jsx
+++ b/packages/app/src/components/Admin/Security/OidcSecuritySetting.jsx
@@ -1,5 +1,4 @@
-/* eslint-disable react/no-danger */
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import PropTypes from 'prop-types';
 
@@ -31,6 +30,21 @@ function OidcSecurityManagement(props) {
   // if (adminOidcSecurityContainer.state.oidcProviderName === adminOidcSecurityContainer.dummyOidcProviderNameForError) {
   //   throw new Error(`${retrieveErrors.length} errors occured`);
   // }
+
+  useEffect(() => {
+    const fetchOidcSecuritySettingsData = async() => {
+      await adminOidcSecurityContainer.retrieveSecurityData();
+    };
+
+    try {
+      fetchOidcSecuritySettingsData();
+    }
+    catch (err) {
+      const errs = toArrayIfNot(err);
+      toastError(errs);
+      logger.error(errs);
+    }
+  }, [adminOidcSecurityContainer]);
 
   return <OidcSecurityManagementContents />;
 }

--- a/packages/app/src/components/Admin/Security/OidcSecuritySetting.jsx
+++ b/packages/app/src/components/Admin/Security/OidcSecuritySetting.jsx
@@ -14,23 +14,23 @@ import OidcSecurityManagementContents from './OidcSecuritySettingContents';
 let retrieveErrors = null;
 function OidcSecurityManagement(props) {
   const { adminOidcSecurityContainer } = props;
-  if (adminOidcSecurityContainer.state.oidcProviderName === adminOidcSecurityContainer.dummyOidcProviderName) {
-    throw (async() => {
-      try {
-        await adminOidcSecurityContainer.retrieveSecurityData();
-      }
-      catch (err) {
-        const errs = toArrayIfNot(err);
-        toastError(errs);
-        retrieveErrors = errs;
-        adminOidcSecurityContainer.setState({ oidcProviderName: adminOidcSecurityContainer.dummyOidcProviderNameForError });
-      }
-    })();
-  }
+  // if (adminOidcSecurityContainer.state.oidcProviderName === adminOidcSecurityContainer.dummyOidcProviderName) {
+  //   throw (async() => {
+  //     try {
+  //       await adminOidcSecurityContainer.retrieveSecurityData();
+  //     }
+  //     catch (err) {
+  //       const errs = toArrayIfNot(err);
+  //       toastError(errs);
+  //       retrieveErrors = errs;
+  //       adminOidcSecurityContainer.setState({ oidcProviderName: adminOidcSecurityContainer.dummyOidcProviderNameForError });
+  //     }
+  //   })();
+  // }
 
-  if (adminOidcSecurityContainer.state.oidcProviderName === adminOidcSecurityContainer.dummyOidcProviderNameForError) {
-    throw new Error(`${retrieveErrors.length} errors occured`);
-  }
+  // if (adminOidcSecurityContainer.state.oidcProviderName === adminOidcSecurityContainer.dummyOidcProviderNameForError) {
+  //   throw new Error(`${retrieveErrors.length} errors occured`);
+  // }
 
   return <OidcSecurityManagementContents />;
 }

--- a/packages/app/src/components/Admin/Security/OidcSecuritySetting.jsx
+++ b/packages/app/src/components/Admin/Security/OidcSecuritySetting.jsx
@@ -24,7 +24,6 @@ function OidcSecurityManagement(props) {
     catch (err) {
       const errs = toArrayIfNot(err);
       toastError(errs);
-      logger.error(errs);
     }
   }, [adminOidcSecurityContainer]);
 

--- a/packages/app/src/components/Admin/Security/OidcSecuritySetting.jsx
+++ b/packages/app/src/components/Admin/Security/OidcSecuritySetting.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useCallback } from 'react';
 
 import PropTypes from 'prop-types';
 
@@ -10,16 +10,12 @@ import { withUnstatedContainers } from '../../UnstatedUtils';
 
 import OidcSecurityManagementContents from './OidcSecuritySettingContents';
 
-function OidcSecurityManagement(props) {
+const OidcSecurityManagement = (props) => {
   const { adminOidcSecurityContainer } = props;
 
-  useEffect(() => {
-    const fetchOidcSecuritySettingsData = async() => {
-      await adminOidcSecurityContainer.retrieveSecurityData();
-    };
-
+  const fetchOidcSecuritySettingsData = useCallback(async() => {
     try {
-      fetchOidcSecuritySettingsData();
+      await adminOidcSecurityContainer.retrieveSecurityData();
     }
     catch (err) {
       const errs = toArrayIfNot(err);
@@ -27,8 +23,12 @@ function OidcSecurityManagement(props) {
     }
   }, [adminOidcSecurityContainer]);
 
+  useEffect(() => {
+    fetchOidcSecuritySettingsData();
+  }, [adminOidcSecurityContainer, fetchOidcSecuritySettingsData]);
+
   return <OidcSecurityManagementContents />;
-}
+};
 
 OidcSecurityManagement.propTypes = {
   adminOidcSecurityContainer: PropTypes.instanceOf(AdminOidcSecurityContainer).isRequired,

--- a/packages/app/src/components/Admin/Security/OidcSecuritySetting.jsx
+++ b/packages/app/src/components/Admin/Security/OidcSecuritySetting.jsx
@@ -10,7 +10,6 @@ import { withUnstatedContainers } from '../../UnstatedUtils';
 
 import OidcSecurityManagementContents from './OidcSecuritySettingContents';
 
-let retrieveErrors = null;
 function OidcSecurityManagement(props) {
   const { adminOidcSecurityContainer } = props;
 

--- a/packages/app/src/components/Admin/Security/OidcSecuritySettingContents.jsx
+++ b/packages/app/src/components/Admin/Security/OidcSecuritySettingContents.jsx
@@ -77,7 +77,7 @@ class OidcSecurityManagementContents extends React.Component {
               readOnly
             />
             <p className="form-text text-muted small">{t('security_setting.desc_of_callback_URL', { AuthName: 'OAuth' })}</p>
-            {!siteUrl && (
+            {siteUrl != null && (
               <div className="alert alert-danger">
                 <i
                   className="icon-exclamation"
@@ -373,7 +373,7 @@ class OidcSecurityManagementContents extends React.Component {
                   readOnly
                 />
                 <p className="form-text text-muted small">{t('security_setting.desc_of_callback_URL', { AuthName: 'OAuth' })}</p>
-                {!siteUrl && (
+                {siteUrl != null && (
                   <div className="alert alert-danger">
                     <i
                       className="icon-exclamation"

--- a/packages/app/src/components/Admin/Security/OidcSecuritySettingContents.jsx
+++ b/packages/app/src/components/Admin/Security/OidcSecuritySettingContents.jsx
@@ -4,6 +4,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useTranslation } from 'next-i18next';
 
+import urljoin from 'url-join';
+import { pathUtils } from '@growi/core';
+
+import { useSiteUrl } from '~/stores/context';
+
 
 import AdminGeneralSecurityContainer from '~/client/services/AdminGeneralSecurityContainer';
 import AdminOidcSecurityContainer from '~/client/services/AdminOidcSecurityContainer';
@@ -33,8 +38,9 @@ class OidcSecurityManagementContents extends React.Component {
   }
 
   render() {
-    const { t, adminGeneralSecurityContainer, adminOidcSecurityContainer } = this.props;
+    const { t, adminGeneralSecurityContainer, adminOidcSecurityContainer, siteUrl } = this.props;
     const { isOidcEnabled } = adminGeneralSecurityContainer.state;
+    const  oidcCallbackUrl = urljoin(pathUtils.removeTrailingSlash(siteUrl), '/passport/oidc/callback')
 
     return (
 
@@ -69,11 +75,11 @@ class OidcSecurityManagementContents extends React.Component {
             <input
               className="form-control"
               type="text"
-              value={adminOidcSecurityContainer.state.callbackUrl}
+              value={oidcCallbackUrl}
               readOnly
             />
             <p className="form-text text-muted small">{t('security_setting.desc_of_callback_URL', { AuthName: 'OAuth' })}</p>
-            {!adminGeneralSecurityContainer.state.appSiteUrl && (
+            {!siteUrl && (
               <div className="alert alert-danger">
                 <i
                   className="icon-exclamation"
@@ -365,11 +371,11 @@ class OidcSecurityManagementContents extends React.Component {
                 <input
                   className="form-control"
                   type="text"
-                  defaultValue={adminOidcSecurityContainer.state.callbackUrl || ''}
+                  defaultValue={oidcCallbackUrl}
                   readOnly
                 />
                 <p className="form-text text-muted small">{t('security_setting.desc_of_callback_URL', { AuthName: 'OAuth' })}</p>
-                {!adminGeneralSecurityContainer.state.appSiteUrl && (
+                {!siteUrl && (
                   <div className="alert alert-danger">
                     <i
                       className="icon-exclamation"
@@ -465,11 +471,13 @@ OidcSecurityManagementContents.propTypes = {
   t: PropTypes.func.isRequired, // i18next
   adminGeneralSecurityContainer: PropTypes.instanceOf(AdminGeneralSecurityContainer).isRequired,
   adminOidcSecurityContainer: PropTypes.instanceOf(AdminOidcSecurityContainer).isRequired,
+  siteUrl: PropTypes.string,
 };
 
 const OidcSecurityManagementContentsWrapperFC = (props) => {
   const { t } = useTranslation();
-  return <OidcSecurityManagementContents t={t} {...props} />;
+  const { data: siteUrl } = useSiteUrl();
+  return <OidcSecurityManagementContents t={t} {...props} siteUrl={siteUrl} />;
 };
 
 const OidcSecurityManagementContentsWrapper = withUnstatedContainers(OidcSecurityManagementContentsWrapperFC, [

--- a/packages/app/src/components/Admin/Security/OidcSecuritySettingContents.jsx
+++ b/packages/app/src/components/Admin/Security/OidcSecuritySettingContents.jsx
@@ -44,8 +44,7 @@ class OidcSecurityManagementContents extends React.Component {
 
     return (
 
-      <React.Fragment>
-
+      <>
         <h2 className="alert-anchor border-bottom">
           {t('security_setting.OAuth.OIDC.name')}
         </h2>
@@ -92,7 +91,7 @@ class OidcSecurityManagementContents extends React.Component {
         </div>
 
         {isOidcEnabled && (
-          <React.Fragment>
+          <>
 
             <h3 className="border-bottom">{t('security_setting.configuration')}</h3>
 
@@ -443,7 +442,7 @@ class OidcSecurityManagementContents extends React.Component {
                 </button>
               </div>
             </div>
-          </React.Fragment>
+          </>
         )}
 
 
@@ -461,7 +460,7 @@ class OidcSecurityManagementContents extends React.Component {
           </ol>
         </div>
 
-      </React.Fragment>
+      </>
     );
   }
 

--- a/packages/app/src/components/Admin/Security/OidcSecuritySettingContents.jsx
+++ b/packages/app/src/components/Admin/Security/OidcSecuritySettingContents.jsx
@@ -1,18 +1,15 @@
-/* eslint-disable react/no-danger */
 import React from 'react';
 
-import PropTypes from 'prop-types';
-import { useTranslation } from 'next-i18next';
-
-import urljoin from 'url-join';
 import { pathUtils } from '@growi/core';
-
-import { useSiteUrl } from '~/stores/context';
+import { useTranslation } from 'next-i18next';
+import PropTypes from 'prop-types';
+import urljoin from 'url-join';
 
 
 import AdminGeneralSecurityContainer from '~/client/services/AdminGeneralSecurityContainer';
 import AdminOidcSecurityContainer from '~/client/services/AdminOidcSecurityContainer';
 import { toastSuccess, toastError } from '~/client/util/apiNotification';
+import { useSiteUrl } from '~/stores/context';
 
 import { withUnstatedContainers } from '../../UnstatedUtils';
 
@@ -38,9 +35,11 @@ class OidcSecurityManagementContents extends React.Component {
   }
 
   render() {
-    const { t, adminGeneralSecurityContainer, adminOidcSecurityContainer, siteUrl } = this.props;
+    const {
+      t, adminGeneralSecurityContainer, adminOidcSecurityContainer, siteUrl,
+    } = this.props;
     const { isOidcEnabled } = adminGeneralSecurityContainer.state;
-    const  oidcCallbackUrl = urljoin(pathUtils.removeTrailingSlash(siteUrl), '/passport/oidc/callback')
+    const oidcCallbackUrl = urljoin(pathUtils.removeTrailingSlash(siteUrl), '/passport/oidc/callback');
 
     return (
 

--- a/packages/app/src/components/Admin/Security/OidcSecuritySettingContents.jsx
+++ b/packages/app/src/components/Admin/Security/OidcSecuritySettingContents.jsx
@@ -77,7 +77,7 @@ class OidcSecurityManagementContents extends React.Component {
               readOnly
             />
             <p className="form-text text-muted small">{t('security_setting.desc_of_callback_URL', { AuthName: 'OAuth' })}</p>
-            {siteUrl != null && (
+            {siteUrl != null && siteUrl !== '' && (
               <div className="alert alert-danger">
                 <i
                   className="icon-exclamation"
@@ -373,7 +373,7 @@ class OidcSecurityManagementContents extends React.Component {
                   readOnly
                 />
                 <p className="form-text text-muted small">{t('security_setting.desc_of_callback_URL', { AuthName: 'OAuth' })}</p>
-                {siteUrl != null && (
+                {siteUrl != null && siteUrl !== '' && (
                   <div className="alert alert-danger">
                     <i
                       className="icon-exclamation"

--- a/packages/app/src/components/Admin/Security/OidcSecuritySettingContents.jsx
+++ b/packages/app/src/components/Admin/Security/OidcSecuritySettingContents.jsx
@@ -77,14 +77,14 @@ class OidcSecurityManagementContents extends React.Component {
               readOnly
             />
             <p className="form-text text-muted small">{t('security_setting.desc_of_callback_URL', { AuthName: 'OAuth' })}</p>
-            {siteUrl == null || siteUrl === ''(
+            {(siteUrl == null || siteUrl === '') && (
               <div className="alert alert-danger">
                 <i
                   className="icon-exclamation"
                   // eslint-disable-next-line max-len
                   dangerouslySetInnerHTML={{ __html: t('security_setting.alert_siteUrl_is_not_set', { link: `<a href="/admin/app">${t('App Settings')}<i class="icon-login"></i></a>` }) }}
                 />
-              </div>,
+              </div>
             )}
           </div>
         </div>
@@ -373,14 +373,14 @@ class OidcSecurityManagementContents extends React.Component {
                   readOnly
                 />
                 <p className="form-text text-muted small">{t('security_setting.desc_of_callback_URL', { AuthName: 'OAuth' })}</p>
-                {siteUrl == null || siteUrl === ''(
+                {(siteUrl == null || siteUrl === '') && (
                   <div className="alert alert-danger">
                     <i
                       className="icon-exclamation"
                       // eslint-disable-next-line max-len
                       dangerouslySetInnerHTML={{ __html: t('security_setting.alert_siteUrl_is_not_set', { link: `<a href="/admin/app">${t('App Settings')}<i class="icon-login"></i></a>` }) }}
                     />
-                  </div>,
+                  </div>
                 )}
               </div>
             </div>

--- a/packages/app/src/components/Admin/Security/OidcSecuritySettingContents.jsx
+++ b/packages/app/src/components/Admin/Security/OidcSecuritySettingContents.jsx
@@ -77,14 +77,14 @@ class OidcSecurityManagementContents extends React.Component {
               readOnly
             />
             <p className="form-text text-muted small">{t('security_setting.desc_of_callback_URL', { AuthName: 'OAuth' })}</p>
-            {siteUrl != null && siteUrl !== '' && (
+            {siteUrl == null || siteUrl === ''(
               <div className="alert alert-danger">
                 <i
                   className="icon-exclamation"
                   // eslint-disable-next-line max-len
                   dangerouslySetInnerHTML={{ __html: t('security_setting.alert_siteUrl_is_not_set', { link: `<a href="/admin/app">${t('App Settings')}<i class="icon-login"></i></a>` }) }}
                 />
-              </div>
+              </div>,
             )}
           </div>
         </div>
@@ -373,14 +373,14 @@ class OidcSecurityManagementContents extends React.Component {
                   readOnly
                 />
                 <p className="form-text text-muted small">{t('security_setting.desc_of_callback_URL', { AuthName: 'OAuth' })}</p>
-                {siteUrl != null && siteUrl !== '' && (
+                {siteUrl == null || siteUrl === ''(
                   <div className="alert alert-danger">
                     <i
                       className="icon-exclamation"
                       // eslint-disable-next-line max-len
                       dangerouslySetInnerHTML={{ __html: t('security_setting.alert_siteUrl_is_not_set', { link: `<a href="/admin/app">${t('App Settings')}<i class="icon-login"></i></a>` }) }}
                     />
-                  </div>
+                  </div>,
                 )}
               </div>
             </div>

--- a/packages/app/src/components/Admin/Security/SamlSecuritySetting.jsx
+++ b/packages/app/src/components/Admin/Security/SamlSecuritySetting.jsx
@@ -14,23 +14,23 @@ import SamlSecuritySettingContents from './SamlSecuritySettingContents';
 let retrieveErrors = null;
 function SamlSecurityManagement(props) {
   const { adminSamlSecurityContainer } = props;
-  if (adminSamlSecurityContainer.state.samlEntryPoint === adminSamlSecurityContainer.dummySamlEntryPoint) {
-    throw (async() => {
-      try {
-        await adminSamlSecurityContainer.retrieveSecurityData();
-      }
-      catch (err) {
-        const errs = toArrayIfNot(err);
-        toastError(errs);
-        retrieveErrors = errs;
-        adminSamlSecurityContainer.setState({ samlEntryPoint: adminSamlSecurityContainer.dummySamlEntryPointForError });
-      }
-    })();
-  }
+  // if (adminSamlSecurityContainer.state.samlEntryPoint === adminSamlSecurityContainer.dummySamlEntryPoint) {
+  //   throw (async() => {
+  //     try {
+  //       await adminSamlSecurityContainer.retrieveSecurityData();
+  //     }
+  //     catch (err) {
+  //       const errs = toArrayIfNot(err);
+  //       toastError(errs);
+  //       retrieveErrors = errs;
+  //       adminSamlSecurityContainer.setState({ samlEntryPoint: adminSamlSecurityContainer.dummySamlEntryPointForError });
+  //     }
+  //   })();
+  // }
 
-  if (adminSamlSecurityContainer.state.samlEntryPoint === adminSamlSecurityContainer.dummySamlEntryPointForError) {
-    throw new Error(`${retrieveErrors.length} errors occured`);
-  }
+  // if (adminSamlSecurityContainer.state.samlEntryPoint === adminSamlSecurityContainer.dummySamlEntryPointForError) {
+  //   throw new Error(`${retrieveErrors.length} errors occured`);
+  // }
 
   return <SamlSecuritySettingContents />;
 }

--- a/packages/app/src/components/Admin/Security/SamlSecuritySetting.jsx
+++ b/packages/app/src/components/Admin/Security/SamlSecuritySetting.jsx
@@ -24,7 +24,6 @@ function SamlSecurityManagement(props) {
     catch (err) {
       const errs = toArrayIfNot(err);
       toastError(errs);
-      logger.error(errs);
     }
   }, [adminSamlSecurityContainer]);
 

--- a/packages/app/src/components/Admin/Security/SamlSecuritySetting.jsx
+++ b/packages/app/src/components/Admin/Security/SamlSecuritySetting.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useCallback } from 'react';
 
 import PropTypes from 'prop-types';
 
@@ -10,16 +10,12 @@ import { withUnstatedContainers } from '../../UnstatedUtils';
 
 import SamlSecuritySettingContents from './SamlSecuritySettingContents';
 
-function SamlSecurityManagement(props) {
+const SamlSecurityManagement = (props) => {
   const { adminSamlSecurityContainer } = props;
 
-  useEffect(() => {
-    const fetchSamlSecuritySettingsData = async() => {
-      await adminSamlSecurityContainer.retrieveSecurityData();
-    };
-
+  const fetchSamlSecuritySettingsData = useCallback(async() => {
     try {
-      fetchSamlSecuritySettingsData();
+      await adminSamlSecurityContainer.retrieveSecurityData();
     }
     catch (err) {
       const errs = toArrayIfNot(err);
@@ -27,8 +23,12 @@ function SamlSecurityManagement(props) {
     }
   }, [adminSamlSecurityContainer]);
 
+  useEffect(() => {
+    fetchSamlSecuritySettingsData();
+  }, [adminSamlSecurityContainer, fetchSamlSecuritySettingsData]);
+
   return <SamlSecuritySettingContents />;
-}
+};
 
 SamlSecurityManagement.propTypes = {
   adminSamlSecurityContainer: PropTypes.instanceOf(AdminSamlSecurityContainer).isRequired,

--- a/packages/app/src/components/Admin/Security/SamlSecuritySetting.jsx
+++ b/packages/app/src/components/Admin/Security/SamlSecuritySetting.jsx
@@ -1,5 +1,4 @@
-/* eslint-disable react/no-danger */
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import PropTypes from 'prop-types';
 
@@ -14,23 +13,21 @@ import SamlSecuritySettingContents from './SamlSecuritySettingContents';
 let retrieveErrors = null;
 function SamlSecurityManagement(props) {
   const { adminSamlSecurityContainer } = props;
-  // if (adminSamlSecurityContainer.state.samlEntryPoint === adminSamlSecurityContainer.dummySamlEntryPoint) {
-  //   throw (async() => {
-  //     try {
-  //       await adminSamlSecurityContainer.retrieveSecurityData();
-  //     }
-  //     catch (err) {
-  //       const errs = toArrayIfNot(err);
-  //       toastError(errs);
-  //       retrieveErrors = errs;
-  //       adminSamlSecurityContainer.setState({ samlEntryPoint: adminSamlSecurityContainer.dummySamlEntryPointForError });
-  //     }
-  //   })();
-  // }
 
-  // if (adminSamlSecurityContainer.state.samlEntryPoint === adminSamlSecurityContainer.dummySamlEntryPointForError) {
-  //   throw new Error(`${retrieveErrors.length} errors occured`);
-  // }
+  useEffect(() => {
+    const fetchSamlSecuritySettingsData = async() => {
+      await adminSamlSecurityContainer.retrieveSecurityData();
+    };
+
+    try {
+      fetchSamlSecuritySettingsData();
+    }
+    catch (err) {
+      const errs = toArrayIfNot(err);
+      toastError(errs);
+      logger.error(errs);
+    }
+  }, [adminSamlSecurityContainer]);
 
   return <SamlSecuritySettingContents />;
 }

--- a/packages/app/src/components/Admin/Security/SamlSecuritySetting.jsx
+++ b/packages/app/src/components/Admin/Security/SamlSecuritySetting.jsx
@@ -10,7 +10,6 @@ import { withUnstatedContainers } from '../../UnstatedUtils';
 
 import SamlSecuritySettingContents from './SamlSecuritySettingContents';
 
-let retrieveErrors = null;
 function SamlSecurityManagement(props) {
   const { adminSamlSecurityContainer } = props;
 

--- a/packages/app/src/components/Admin/Security/SamlSecuritySettingContents.jsx
+++ b/packages/app/src/components/Admin/Security/SamlSecuritySettingContents.jsx
@@ -94,7 +94,7 @@ class SamlSecurityManagementContents extends React.Component {
               readOnly
             />
             <p className="form-text text-muted small">{t('security_setting.desc_of_callback_URL', { AuthName: 'SAML Identity' })}</p>
-            {!siteUrl && (
+            {siteUrl != null && (
               <div className="alert alert-danger">
                 <i
                   className="icon-exclamation"

--- a/packages/app/src/components/Admin/Security/SamlSecuritySettingContents.jsx
+++ b/packages/app/src/components/Admin/Security/SamlSecuritySettingContents.jsx
@@ -94,14 +94,14 @@ class SamlSecurityManagementContents extends React.Component {
               readOnly
             />
             <p className="form-text text-muted small">{t('security_setting.desc_of_callback_URL', { AuthName: 'SAML Identity' })}</p>
-            {siteUrl != null && siteUrl !== '' && (
+            {siteUrl == null || siteUrl === ''(
               <div className="alert alert-danger">
                 <i
                   className="icon-exclamation"
                   // eslint-disable-next-line max-len
                   dangerouslySetInnerHTML={{ __html: t('security_setting.alert_siteUrl_is_not_set', { link: `<a href="/admin/app">${t('App Settings')}<i class="icon-login"></i></a>` }) }}
                 />
-              </div>
+              </div>,
             )}
           </div>
         </div>

--- a/packages/app/src/components/Admin/Security/SamlSecuritySettingContents.jsx
+++ b/packages/app/src/components/Admin/Security/SamlSecuritySettingContents.jsx
@@ -94,14 +94,14 @@ class SamlSecurityManagementContents extends React.Component {
               readOnly
             />
             <p className="form-text text-muted small">{t('security_setting.desc_of_callback_URL', { AuthName: 'SAML Identity' })}</p>
-            {siteUrl == null || siteUrl === ''(
+            {(siteUrl == null || siteUrl === '') && (
               <div className="alert alert-danger">
                 <i
                   className="icon-exclamation"
                   // eslint-disable-next-line max-len
                   dangerouslySetInnerHTML={{ __html: t('security_setting.alert_siteUrl_is_not_set', { link: `<a href="/admin/app">${t('App Settings')}<i class="icon-login"></i></a>` }) }}
                 />
-              </div>,
+              </div>
             )}
           </div>
         </div>

--- a/packages/app/src/components/Admin/Security/SamlSecuritySettingContents.jsx
+++ b/packages/app/src/components/Admin/Security/SamlSecuritySettingContents.jsx
@@ -48,7 +48,7 @@ class SamlSecurityManagementContents extends React.Component {
     const { useOnlyEnvVars } = adminSamlSecurityContainer.state;
     const { isSamlEnabled } = adminGeneralSecurityContainer.state;
 
-    const samlCallBackUrl = urljoin(pathUtils.removeTrailingSlash(siteUrl), '/passport/saml/callback');
+    const samlCallbackUrl = urljoin(pathUtils.removeTrailingSlash(siteUrl), '/passport/saml/callback');
 
     return (
       <React.Fragment>
@@ -90,7 +90,7 @@ class SamlSecurityManagementContents extends React.Component {
             <input
               className="form-control"
               type="text"
-              defaultValue={samlCallBackUrl}
+              defaultValue={samlCallbackUrl}
               readOnly
             />
             <p className="form-text text-muted small">{t('security_setting.desc_of_callback_URL', { AuthName: 'SAML Identity' })}</p>

--- a/packages/app/src/components/Admin/Security/SamlSecuritySettingContents.jsx
+++ b/packages/app/src/components/Admin/Security/SamlSecuritySettingContents.jsx
@@ -4,6 +4,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useTranslation } from 'next-i18next';
 import { Collapse } from 'reactstrap';
+import urljoin from 'url-join';
+import { pathUtils } from '@growi/core';
 
 
 import AdminGeneralSecurityContainer from '~/client/services/AdminGeneralSecurityContainer';
@@ -11,6 +13,8 @@ import AdminSamlSecurityContainer from '~/client/services/AdminSamlSecurityConta
 import { toastSuccess, toastError } from '~/client/util/apiNotification';
 
 import { withUnstatedContainers } from '../../UnstatedUtils';
+
+import { useSiteUrl } from '~/stores/context';
 
 class SamlSecurityManagementContents extends React.Component {
 
@@ -38,9 +42,11 @@ class SamlSecurityManagementContents extends React.Component {
   }
 
   render() {
-    const { t, adminGeneralSecurityContainer, adminSamlSecurityContainer } = this.props;
+    const { t, adminGeneralSecurityContainer, adminSamlSecurityContainer, siteUrl } = this.props;
     const { useOnlyEnvVars } = adminSamlSecurityContainer.state;
     const { isSamlEnabled } = adminGeneralSecurityContainer.state;
+
+    const samlCallBackUrl = urljoin(pathUtils.removeTrailingSlash(siteUrl), '/passport/saml/callback')
 
     return (
       <React.Fragment>
@@ -82,11 +88,11 @@ class SamlSecurityManagementContents extends React.Component {
             <input
               className="form-control"
               type="text"
-              defaultValue={adminSamlSecurityContainer.state.callbackUrl}
+              defaultValue={samlCallBackUrl}
               readOnly
             />
             <p className="form-text text-muted small">{t('security_setting.desc_of_callback_URL', { AuthName: 'SAML Identity' })}</p>
-            {!adminGeneralSecurityContainer.state.appSiteUrl && (
+            {!siteUrl && (
               <div className="alert alert-danger">
                 <i
                   className="icon-exclamation"
@@ -534,11 +540,13 @@ SamlSecurityManagementContents.propTypes = {
   t: PropTypes.func.isRequired, // i18next
   adminGeneralSecurityContainer: PropTypes.instanceOf(AdminGeneralSecurityContainer).isRequired,
   adminSamlSecurityContainer: PropTypes.instanceOf(AdminSamlSecurityContainer).isRequired,
+  siteUrl: PropTypes.string,
 };
 
 const SamlSecurityManagementContentsWrapperFC = (props) => {
   const { t } = useTranslation();
-  return <SamlSecurityManagementContents t={t} {...props} />;
+  const { data: siteUrl } = useSiteUrl();
+  return <SamlSecurityManagementContents t={t} siteUrl={siteUrl} {...props} />;
 };
 
 const SamlSecurityManagementContentsWrapper = withUnstatedContainers(SamlSecurityManagementContentsWrapperFC, [

--- a/packages/app/src/components/Admin/Security/SamlSecuritySettingContents.jsx
+++ b/packages/app/src/components/Admin/Security/SamlSecuritySettingContents.jsx
@@ -94,7 +94,7 @@ class SamlSecurityManagementContents extends React.Component {
               readOnly
             />
             <p className="form-text text-muted small">{t('security_setting.desc_of_callback_URL', { AuthName: 'SAML Identity' })}</p>
-            {siteUrl != null && (
+            {siteUrl != null && siteUrl !== '' && (
               <div className="alert alert-danger">
                 <i
                   className="icon-exclamation"

--- a/packages/app/src/components/Admin/Security/SamlSecuritySettingContents.jsx
+++ b/packages/app/src/components/Admin/Security/SamlSecuritySettingContents.jsx
@@ -1,20 +1,20 @@
 /* eslint-disable react/no-danger */
 import React from 'react';
 
-import PropTypes from 'prop-types';
+import { pathUtils } from '@growi/core';
 import { useTranslation } from 'next-i18next';
+import PropTypes from 'prop-types';
 import { Collapse } from 'reactstrap';
 import urljoin from 'url-join';
-import { pathUtils } from '@growi/core';
 
 
 import AdminGeneralSecurityContainer from '~/client/services/AdminGeneralSecurityContainer';
 import AdminSamlSecurityContainer from '~/client/services/AdminSamlSecurityContainer';
 import { toastSuccess, toastError } from '~/client/util/apiNotification';
+import { useSiteUrl } from '~/stores/context';
 
 import { withUnstatedContainers } from '../../UnstatedUtils';
 
-import { useSiteUrl } from '~/stores/context';
 
 class SamlSecurityManagementContents extends React.Component {
 
@@ -42,11 +42,13 @@ class SamlSecurityManagementContents extends React.Component {
   }
 
   render() {
-    const { t, adminGeneralSecurityContainer, adminSamlSecurityContainer, siteUrl } = this.props;
+    const {
+      t, adminGeneralSecurityContainer, adminSamlSecurityContainer, siteUrl,
+    } = this.props;
     const { useOnlyEnvVars } = adminSamlSecurityContainer.state;
     const { isSamlEnabled } = adminGeneralSecurityContainer.state;
 
-    const samlCallBackUrl = urljoin(pathUtils.removeTrailingSlash(siteUrl), '/passport/saml/callback')
+    const samlCallBackUrl = urljoin(pathUtils.removeTrailingSlash(siteUrl), '/passport/saml/callback');
 
     return (
       <React.Fragment>

--- a/packages/app/src/components/Admin/Security/SecurityManagement.jsx
+++ b/packages/app/src/components/Admin/Security/SecurityManagement.jsx
@@ -24,7 +24,6 @@ function SecurityManagement(props) {
     catch (err) {
       const errs = toArrayIfNot(err);
       toastError(errs);
-      logger.error(errs);
     }
   }, [adminGeneralSecurityContainer]);
 

--- a/packages/app/src/components/Admin/Security/SecurityManagement.jsx
+++ b/packages/app/src/components/Admin/Security/SecurityManagement.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useCallback } from 'react';
 
 import PropTypes from 'prop-types';
 
@@ -13,19 +13,19 @@ import SecurityManagementContents from './SecurityManagementContents';
 function SecurityManagement(props) {
   const { adminGeneralSecurityContainer } = props;
 
-  useEffect(() => {
-    const fetchGeneralSecuritySettingsData = async() => {
-      await adminGeneralSecurityContainer.retrieveSecurityData();
-    };
-
+  const fetchGeneralSecuritySettingsData = useCallback(async() => {
     try {
-      fetchGeneralSecuritySettingsData();
+      await adminGeneralSecurityContainer.retrieveSecurityData();
     }
     catch (err) {
       const errs = toArrayIfNot(err);
       toastError(errs);
     }
   }, [adminGeneralSecurityContainer]);
+
+  useEffect(() => {
+    fetchGeneralSecuritySettingsData();
+  }, [adminGeneralSecurityContainer, fetchGeneralSecuritySettingsData]);
 
   return <SecurityManagementContents />;
 }

--- a/packages/app/src/components/Admin/Security/SecurityManagement.jsx
+++ b/packages/app/src/components/Admin/Security/SecurityManagement.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import PropTypes from 'prop-types';
 
@@ -10,29 +10,23 @@ import { withUnstatedContainers } from '../../UnstatedUtils';
 
 import SecurityManagementContents from './SecurityManagementContents';
 
-let retrieveErrors = null;
 function SecurityManagement(props) {
   const { adminGeneralSecurityContainer } = props;
 
-  if (adminGeneralSecurityContainer.state.currentRestrictGuestMode === adminGeneralSecurityContainer.dummyCurrentRestrictGuestMode) {
-    throw (async() => {
-      try {
-        await adminGeneralSecurityContainer.retrieveSecurityData();
-      }
-      catch (err) {
-        const errs = toArrayIfNot(err);
-        toastError(errs);
-        retrieveErrors = errs;
-        adminGeneralSecurityContainer.setState({
-          currentRestrictGuestMode: adminGeneralSecurityContainer.dummyCurrentRestrictGuestModeForError,
-        });
-      }
-    })();
-  }
+  useEffect(() => {
+    const fetchGeneralSecuritySettingsData = async() => {
+      await adminGeneralSecurityContainer.retrieveSecurityData();
+    };
 
-  if (adminGeneralSecurityContainer.state.currentRestrictGuestMode === adminGeneralSecurityContainer.dummyCurrentRestrictGuestModeForError) {
-    throw new Error(`${retrieveErrors.length} errors occured`);
-  }
+    try {
+      fetchGeneralSecuritySettingsData();
+    }
+    catch (err) {
+      const errs = toArrayIfNot(err);
+      toastError(errs);
+      logger.error(errs);
+    }
+  }, [adminGeneralSecurityContainer]);
 
   return <SecurityManagementContents />;
 }

--- a/packages/app/src/components/Admin/Security/SecurityManagementContents.jsx
+++ b/packages/app/src/components/Admin/Security/SecurityManagementContents.jsx
@@ -15,7 +15,7 @@ import OidcSecuritySetting from './OidcSecuritySetting';
 import SamlSecuritySetting from './SamlSecuritySetting';
 import SecuritySetting from './SecuritySetting';
 import ShareLinkSetting from './ShareLinkSetting';
-// import TwitterSecuritySetting from './TwitterSecuritySetting';
+import TwitterSecuritySetting from './TwitterSecuritySetting';
 
 const SecurityManagementContents = () => {
   const { t } = useTranslation();
@@ -133,7 +133,7 @@ const SecurityManagementContents = () => {
             {activeComponents.has('passport_github') && <GitHubSecuritySetting />}
           </TabPane>
           <TabPane tabId="passport_twitter">
-            {/* {activeComponents.has('passport_twitter') && <TwitterSecuritySetting />} */}
+            {activeComponents.has('passport_twitter') && <TwitterSecuritySetting />}
           </TabPane>
           <TabPane tabId="passport_facebook">
             {/* {activeComponents.has('passport_facebook') && <FacebookSecuritySetting />} */}

--- a/packages/app/src/components/Admin/Security/SecurityManagementContents.jsx
+++ b/packages/app/src/components/Admin/Security/SecurityManagementContents.jsx
@@ -10,7 +10,7 @@ import CustomNav from '../../CustomNavigation/CustomNav';
 // import GitHubSecuritySetting from './GitHubSecuritySetting';
 // import GoogleSecuritySetting from './GoogleSecuritySetting';
 // import LdapSecuritySetting from './LdapSecuritySetting';
-// import LocalSecuritySetting from './LocalSecuritySetting';
+import LocalSecuritySetting from './LocalSecuritySetting';
 // import OidcSecuritySetting from './OidcSecuritySetting';
 // import SamlSecuritySetting from './SamlSecuritySetting';
 import SecuritySetting from './SecuritySetting';
@@ -112,7 +112,7 @@ const SecurityManagementContents = () => {
         />
         <TabContent activeTab={activeTab} className="p-5">
           <TabPane tabId="passport_local">
-            {/* {activeComponents.has('passport_local') && <LocalSecuritySetting />} */}
+            {activeComponents.has('passport_local') && <LocalSecuritySetting />}
           </TabPane>
           <TabPane tabId="passport_ldap">
             {/* {activeComponents.has('passport_ldap') && <LdapSecuritySetting />} */}

--- a/packages/app/src/components/Admin/Security/SecurityManagementContents.jsx
+++ b/packages/app/src/components/Admin/Security/SecurityManagementContents.jsx
@@ -12,7 +12,7 @@ import CustomNav from '../../CustomNavigation/CustomNav';
 import LdapSecuritySetting from './LdapSecuritySetting';
 import LocalSecuritySetting from './LocalSecuritySetting';
 // import OidcSecuritySetting from './OidcSecuritySetting';
-// import SamlSecuritySetting from './SamlSecuritySetting';
+import SamlSecuritySetting from './SamlSecuritySetting';
 import SecuritySetting from './SecuritySetting';
 import ShareLinkSetting from './ShareLinkSetting';
 // import TwitterSecuritySetting from './TwitterSecuritySetting';
@@ -118,7 +118,7 @@ const SecurityManagementContents = () => {
             {activeComponents.has('passport_ldap') && <LdapSecuritySetting />}
           </TabPane>
           <TabPane tabId="passport_saml">
-            {/* {activeComponents.has('passport_saml') && <SamlSecuritySetting />} */}
+            {activeComponents.has('passport_saml') && <SamlSecuritySetting />}
           </TabPane>
           <TabPane tabId="passport_oidc">
             {/* {activeComponents.has('passport_oidc') && <OidcSecuritySetting />} */}

--- a/packages/app/src/components/Admin/Security/SecurityManagementContents.jsx
+++ b/packages/app/src/components/Admin/Security/SecurityManagementContents.jsx
@@ -7,7 +7,7 @@ import CustomNav from '../../CustomNavigation/CustomNav';
 
 import BasicSecuritySetting from './BasicSecuritySetting';
 // import FacebookSecuritySetting from './FacebookSecuritySetting';
-// import GitHubSecuritySetting from './GitHubSecuritySetting';
+import GitHubSecuritySetting from './GitHubSecuritySetting';
 import GoogleSecuritySetting from './GoogleSecuritySetting';
 import LdapSecuritySetting from './LdapSecuritySetting';
 import LocalSecuritySetting from './LocalSecuritySetting';
@@ -130,7 +130,7 @@ const SecurityManagementContents = () => {
             {activeComponents.has('passport_google') && <GoogleSecuritySetting />}
           </TabPane>
           <TabPane tabId="passport_github">
-            {/* {activeComponents.has('passport_github') && <GitHubSecuritySetting />} */}
+            {activeComponents.has('passport_github') && <GitHubSecuritySetting />}
           </TabPane>
           <TabPane tabId="passport_twitter">
             {/* {activeComponents.has('passport_twitter') && <TwitterSecuritySetting />} */}

--- a/packages/app/src/components/Admin/Security/SecurityManagementContents.jsx
+++ b/packages/app/src/components/Admin/Security/SecurityManagementContents.jsx
@@ -5,7 +5,7 @@ import { TabContent, TabPane } from 'reactstrap';
 
 import CustomNav from '../../CustomNavigation/CustomNav';
 
-// import BasicSecuritySetting from './BasicSecuritySetting';
+import BasicSecuritySetting from './BasicSecuritySetting';
 // import FacebookSecuritySetting from './FacebookSecuritySetting';
 // import GitHubSecuritySetting from './GitHubSecuritySetting';
 // import GoogleSecuritySetting from './GoogleSecuritySetting';
@@ -124,7 +124,7 @@ const SecurityManagementContents = () => {
             {activeComponents.has('passport_oidc') && <OidcSecuritySetting />}
           </TabPane>
           <TabPane tabId="passport_basic">
-            {/* {activeComponents.has('passport_basic') && <BasicSecuritySetting />} */}
+            {activeComponents.has('passport_basic') && <BasicSecuritySetting />}
           </TabPane>
           <TabPane tabId="passport_google">
             {/* {activeComponents.has('passport_google') && <GoogleSecuritySetting />} */}

--- a/packages/app/src/components/Admin/Security/SecurityManagementContents.jsx
+++ b/packages/app/src/components/Admin/Security/SecurityManagementContents.jsx
@@ -11,7 +11,7 @@ import CustomNav from '../../CustomNavigation/CustomNav';
 // import GoogleSecuritySetting from './GoogleSecuritySetting';
 import LdapSecuritySetting from './LdapSecuritySetting';
 import LocalSecuritySetting from './LocalSecuritySetting';
-// import OidcSecuritySetting from './OidcSecuritySetting';
+import OidcSecuritySetting from './OidcSecuritySetting';
 import SamlSecuritySetting from './SamlSecuritySetting';
 import SecuritySetting from './SecuritySetting';
 import ShareLinkSetting from './ShareLinkSetting';
@@ -121,7 +121,7 @@ const SecurityManagementContents = () => {
             {activeComponents.has('passport_saml') && <SamlSecuritySetting />}
           </TabPane>
           <TabPane tabId="passport_oidc">
-            {/* {activeComponents.has('passport_oidc') && <OidcSecuritySetting />} */}
+            {activeComponents.has('passport_oidc') && <OidcSecuritySetting />}
           </TabPane>
           <TabPane tabId="passport_basic">
             {/* {activeComponents.has('passport_basic') && <BasicSecuritySetting />} */}

--- a/packages/app/src/components/Admin/Security/SecurityManagementContents.jsx
+++ b/packages/app/src/components/Admin/Security/SecurityManagementContents.jsx
@@ -8,7 +8,7 @@ import CustomNav from '../../CustomNavigation/CustomNav';
 import BasicSecuritySetting from './BasicSecuritySetting';
 // import FacebookSecuritySetting from './FacebookSecuritySetting';
 // import GitHubSecuritySetting from './GitHubSecuritySetting';
-// import GoogleSecuritySetting from './GoogleSecuritySetting';
+import GoogleSecuritySetting from './GoogleSecuritySetting';
 import LdapSecuritySetting from './LdapSecuritySetting';
 import LocalSecuritySetting from './LocalSecuritySetting';
 import OidcSecuritySetting from './OidcSecuritySetting';
@@ -127,7 +127,7 @@ const SecurityManagementContents = () => {
             {activeComponents.has('passport_basic') && <BasicSecuritySetting />}
           </TabPane>
           <TabPane tabId="passport_google">
-            {/* {activeComponents.has('passport_google') && <GoogleSecuritySetting />} */}
+            {activeComponents.has('passport_google') && <GoogleSecuritySetting />}
           </TabPane>
           <TabPane tabId="passport_github">
             {/* {activeComponents.has('passport_github') && <GitHubSecuritySetting />} */}

--- a/packages/app/src/components/Admin/Security/SecurityManagementContents.jsx
+++ b/packages/app/src/components/Admin/Security/SecurityManagementContents.jsx
@@ -6,7 +6,7 @@ import { TabContent, TabPane } from 'reactstrap';
 import CustomNav from '../../CustomNavigation/CustomNav';
 
 import BasicSecuritySetting from './BasicSecuritySetting';
-// import FacebookSecuritySetting from './FacebookSecuritySetting';
+import FacebookSecuritySetting from './FacebookSecuritySetting';
 import GitHubSecuritySetting from './GitHubSecuritySetting';
 import GoogleSecuritySetting from './GoogleSecuritySetting';
 import LdapSecuritySetting from './LdapSecuritySetting';
@@ -136,7 +136,7 @@ const SecurityManagementContents = () => {
             {activeComponents.has('passport_twitter') && <TwitterSecuritySetting />}
           </TabPane>
           <TabPane tabId="passport_facebook">
-            {/* {activeComponents.has('passport_facebook') && <FacebookSecuritySetting />} */}
+            {activeComponents.has('passport_facebook') && <FacebookSecuritySetting />}
           </TabPane>
         </TabContent>
       </div>

--- a/packages/app/src/components/Admin/Security/SecurityManagementContents.jsx
+++ b/packages/app/src/components/Admin/Security/SecurityManagementContents.jsx
@@ -9,7 +9,7 @@ import CustomNav from '../../CustomNavigation/CustomNav';
 // import FacebookSecuritySetting from './FacebookSecuritySetting';
 // import GitHubSecuritySetting from './GitHubSecuritySetting';
 // import GoogleSecuritySetting from './GoogleSecuritySetting';
-// import LdapSecuritySetting from './LdapSecuritySetting';
+import LdapSecuritySetting from './LdapSecuritySetting';
 import LocalSecuritySetting from './LocalSecuritySetting';
 // import OidcSecuritySetting from './OidcSecuritySetting';
 // import SamlSecuritySetting from './SamlSecuritySetting';
@@ -115,7 +115,7 @@ const SecurityManagementContents = () => {
             {activeComponents.has('passport_local') && <LocalSecuritySetting />}
           </TabPane>
           <TabPane tabId="passport_ldap">
-            {/* {activeComponents.has('passport_ldap') && <LdapSecuritySetting />} */}
+            {activeComponents.has('passport_ldap') && <LdapSecuritySetting />}
           </TabPane>
           <TabPane tabId="passport_saml">
             {/* {activeComponents.has('passport_saml') && <SamlSecuritySetting />} */}

--- a/packages/app/src/components/Admin/Security/TwitterSecuritySetting.jsx
+++ b/packages/app/src/components/Admin/Security/TwitterSecuritySetting.jsx
@@ -1,5 +1,4 @@
-/* eslint-disable react/no-danger */
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import PropTypes from 'prop-types';
 
@@ -9,31 +8,25 @@ import { toArrayIfNot } from '~/utils/array-utils';
 
 import { withUnstatedContainers } from '../../UnstatedUtils';
 
-
 import TwitterSecuritySettingContents from './TwitterSecuritySettingContents';
 
-let retrieveErrors = null;
 function TwitterSecurityManagement(props) {
   const { adminTwitterSecurityContainer } = props;
-  // if (adminTwitterSecurityContainer.state.twitterConsumerKey === adminTwitterSecurityContainer.dummyTwitterConsumerKey) {
-  //   throw (async() => {
-  //     try {
-  //       await adminTwitterSecurityContainer.retrieveSecurityData();
-  //     }
-  //     catch (err) {
-  //       const errs = toArrayIfNot(err);
-  //       toastError(errs);
-  //       retrieveErrors = errs;
-  //       adminTwitterSecurityContainer.setState({
-  //         twitterConsumerKey: adminTwitterSecurityContainer.dummyTwitterConsumerKeyForError,
-  //       });
-  //     }
-  //   })();
-  // }
 
-  // if (adminTwitterSecurityContainer.state.twitterConsumerKey === adminTwitterSecurityContainer.dummyTwitterConsumerKeyForError) {
-  //   throw new Error(`${retrieveErrors.length} errors occured`);
-  // }
+  useEffect(() => {
+    const fetchTwitterSecuritySettingsData = async() => {
+      await adminTwitterSecurityContainer.retrieveSecurityData();
+    };
+
+    try {
+      fetchTwitterSecuritySettingsData();
+    }
+    catch (err) {
+      const errs = toArrayIfNot(err);
+      toastError(errs);
+      logger.error(errs);
+    }
+  }, [adminTwitterSecurityContainer]);
 
   return <TwitterSecuritySettingContents />;
 }

--- a/packages/app/src/components/Admin/Security/TwitterSecuritySetting.jsx
+++ b/packages/app/src/components/Admin/Security/TwitterSecuritySetting.jsx
@@ -24,7 +24,6 @@ function TwitterSecurityManagement(props) {
     catch (err) {
       const errs = toArrayIfNot(err);
       toastError(errs);
-      logger.error(errs);
     }
   }, [adminTwitterSecurityContainer]);
 

--- a/packages/app/src/components/Admin/Security/TwitterSecuritySetting.jsx
+++ b/packages/app/src/components/Admin/Security/TwitterSecuritySetting.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useCallback } from 'react';
 
 import PropTypes from 'prop-types';
 
@@ -10,16 +10,12 @@ import { withUnstatedContainers } from '../../UnstatedUtils';
 
 import TwitterSecuritySettingContents from './TwitterSecuritySettingContents';
 
-function TwitterSecurityManagement(props) {
+const TwitterSecurityManagement = (props) => {
   const { adminTwitterSecurityContainer } = props;
 
-  useEffect(() => {
-    const fetchTwitterSecuritySettingsData = async() => {
-      await adminTwitterSecurityContainer.retrieveSecurityData();
-    };
-
+  const fetchTwitterSecuritySettingsData = useCallback(async() => {
     try {
-      fetchTwitterSecuritySettingsData();
+      await adminTwitterSecurityContainer.retrieveSecurityData();
     }
     catch (err) {
       const errs = toArrayIfNot(err);
@@ -27,8 +23,12 @@ function TwitterSecurityManagement(props) {
     }
   }, [adminTwitterSecurityContainer]);
 
+  useEffect(() => {
+    fetchTwitterSecuritySettingsData();
+  }, [adminTwitterSecurityContainer, fetchTwitterSecuritySettingsData]);
+
   return <TwitterSecuritySettingContents />;
-}
+};
 
 TwitterSecurityManagement.propTypes = {
   adminTwitterSecurityContainer: PropTypes.instanceOf(AdminTwitterSecurityContainer).isRequired,

--- a/packages/app/src/components/Admin/Security/TwitterSecuritySetting.jsx
+++ b/packages/app/src/components/Admin/Security/TwitterSecuritySetting.jsx
@@ -15,25 +15,25 @@ import TwitterSecuritySettingContents from './TwitterSecuritySettingContents';
 let retrieveErrors = null;
 function TwitterSecurityManagement(props) {
   const { adminTwitterSecurityContainer } = props;
-  if (adminTwitterSecurityContainer.state.twitterConsumerKey === adminTwitterSecurityContainer.dummyTwitterConsumerKey) {
-    throw (async() => {
-      try {
-        await adminTwitterSecurityContainer.retrieveSecurityData();
-      }
-      catch (err) {
-        const errs = toArrayIfNot(err);
-        toastError(errs);
-        retrieveErrors = errs;
-        adminTwitterSecurityContainer.setState({
-          twitterConsumerKey: adminTwitterSecurityContainer.dummyTwitterConsumerKeyForError,
-        });
-      }
-    })();
-  }
+  // if (adminTwitterSecurityContainer.state.twitterConsumerKey === adminTwitterSecurityContainer.dummyTwitterConsumerKey) {
+  //   throw (async() => {
+  //     try {
+  //       await adminTwitterSecurityContainer.retrieveSecurityData();
+  //     }
+  //     catch (err) {
+  //       const errs = toArrayIfNot(err);
+  //       toastError(errs);
+  //       retrieveErrors = errs;
+  //       adminTwitterSecurityContainer.setState({
+  //         twitterConsumerKey: adminTwitterSecurityContainer.dummyTwitterConsumerKeyForError,
+  //       });
+  //     }
+  //   })();
+  // }
 
-  if (adminTwitterSecurityContainer.state.twitterConsumerKey === adminTwitterSecurityContainer.dummyTwitterConsumerKeyForError) {
-    throw new Error(`${retrieveErrors.length} errors occured`);
-  }
+  // if (adminTwitterSecurityContainer.state.twitterConsumerKey === adminTwitterSecurityContainer.dummyTwitterConsumerKeyForError) {
+  //   throw new Error(`${retrieveErrors.length} errors occured`);
+  // }
 
   return <TwitterSecuritySettingContents />;
 }

--- a/packages/app/src/components/Admin/Security/TwitterSecuritySettingContents.jsx
+++ b/packages/app/src/components/Admin/Security/TwitterSecuritySettingContents.jsx
@@ -85,14 +85,14 @@ class TwitterSecuritySettingContents extends React.Component {
               readOnly
             />
             <p className="form-text text-muted small">{t('security_setting.desc_of_callback_URL', { AuthName: 'OAuth' })}</p>
-            {siteUrl == null || siteUrl === ''(
+            {(siteUrl == null || siteUrl === '') && (
               <div className="alert alert-danger">
                 <i
                   className="icon-exclamation"
                   // eslint-disable-next-line max-len
                   dangerouslySetInnerHTML={{ __html: t('security_setting.alert_siteUrl_is_not_set', { link: `<a href="/admin/app">${t('App Settings')}<i class="icon-login"></i></a>` }) }}
                 />
-              </div>,
+              </div>
             )}
           </div>
         </div>

--- a/packages/app/src/components/Admin/Security/TwitterSecuritySettingContents.jsx
+++ b/packages/app/src/components/Admin/Security/TwitterSecuritySettingContents.jsx
@@ -5,6 +5,12 @@ import PropTypes from 'prop-types';
 import { useTranslation } from 'next-i18next';
 
 
+import urljoin from 'url-join';
+import { pathUtils } from '@growi/core';
+
+import { useSiteUrl } from '~/stores/context';
+
+
 import AdminGeneralSecurityContainer from '~/client/services/AdminGeneralSecurityContainer';
 import AdminTwitterSecurityContainer from '~/client/services/AdminTwitterSecurityContainer';
 import { toastSuccess, toastError } from '~/client/util/apiNotification';
@@ -33,8 +39,9 @@ class TwitterSecuritySettingContents extends React.Component {
   }
 
   render() {
-    const { t, adminGeneralSecurityContainer, adminTwitterSecurityContainer } = this.props;
+    const { t, adminGeneralSecurityContainer, adminTwitterSecurityContainer, siteUrl } = this.props;
     const { isTwitterEnabled } = adminGeneralSecurityContainer.state;
+    const twitterCallBackUrl = urljoin(pathUtils.removeTrailingSlash(siteUrl), '/passport/twitter/callback')
 
     return (
 
@@ -75,11 +82,11 @@ class TwitterSecuritySettingContents extends React.Component {
             <input
               className="form-control"
               type="text"
-              value={adminTwitterSecurityContainer.state.callbackUrl}
+              value={twitterCallBackUrl}
               readOnly
             />
             <p className="form-text text-muted small">{t('security_setting.desc_of_callback_URL', { AuthName: 'OAuth' })}</p>
-            {!adminGeneralSecurityContainer.state.appSiteUrl && (
+            {!siteUrl && (
               <div className="alert alert-danger">
                 <i
                   className="icon-exclamation"
@@ -197,11 +204,13 @@ TwitterSecuritySettingContents.propTypes = {
   t: PropTypes.func.isRequired, // i18next
   adminGeneralSecurityContainer: PropTypes.instanceOf(AdminGeneralSecurityContainer).isRequired,
   adminTwitterSecurityContainer: PropTypes.instanceOf(AdminTwitterSecurityContainer).isRequired,
+  siteUrl: PropTypes.string,
 };
 
 const TwitterSecuritySettingContentsWrapperFC = (props) => {
   const { t } = useTranslation();
-  return <TwitterSecuritySettingContents t={t} {...props} />;
+  const { data: siteUrl } = useSiteUrl();
+  return <TwitterSecuritySettingContents t={t} siteUrl={siteUrl} {...props} />;
 };
 
 /**

--- a/packages/app/src/components/Admin/Security/TwitterSecuritySettingContents.jsx
+++ b/packages/app/src/components/Admin/Security/TwitterSecuritySettingContents.jsx
@@ -40,7 +40,7 @@ class TwitterSecuritySettingContents extends React.Component {
       t, adminGeneralSecurityContainer, adminTwitterSecurityContainer, siteUrl,
     } = this.props;
     const { isTwitterEnabled } = adminGeneralSecurityContainer.state;
-    const twitterCallBackUrl = urljoin(pathUtils.removeTrailingSlash(siteUrl), '/passport/twitter/callback');
+    const twitterCallbackUrl = urljoin(pathUtils.removeTrailingSlash(siteUrl), '/passport/twitter/callback');
 
     return (
 
@@ -81,7 +81,7 @@ class TwitterSecuritySettingContents extends React.Component {
             <input
               className="form-control"
               type="text"
-              value={twitterCallBackUrl}
+              value={twitterCallbackUrl}
               readOnly
             />
             <p className="form-text text-muted small">{t('security_setting.desc_of_callback_URL', { AuthName: 'OAuth' })}</p>

--- a/packages/app/src/components/Admin/Security/TwitterSecuritySettingContents.jsx
+++ b/packages/app/src/components/Admin/Security/TwitterSecuritySettingContents.jsx
@@ -1,19 +1,16 @@
 /* eslint-disable react/no-danger */
 import React from 'react';
 
-import PropTypes from 'prop-types';
-import { useTranslation } from 'next-i18next';
-
-
-import urljoin from 'url-join';
 import { pathUtils } from '@growi/core';
-
-import { useSiteUrl } from '~/stores/context';
+import { useTranslation } from 'next-i18next';
+import PropTypes from 'prop-types';
+import urljoin from 'url-join';
 
 
 import AdminGeneralSecurityContainer from '~/client/services/AdminGeneralSecurityContainer';
 import AdminTwitterSecurityContainer from '~/client/services/AdminTwitterSecurityContainer';
 import { toastSuccess, toastError } from '~/client/util/apiNotification';
+import { useSiteUrl } from '~/stores/context';
 
 import { withUnstatedContainers } from '../../UnstatedUtils';
 
@@ -39,9 +36,11 @@ class TwitterSecuritySettingContents extends React.Component {
   }
 
   render() {
-    const { t, adminGeneralSecurityContainer, adminTwitterSecurityContainer, siteUrl } = this.props;
+    const {
+      t, adminGeneralSecurityContainer, adminTwitterSecurityContainer, siteUrl,
+    } = this.props;
     const { isTwitterEnabled } = adminGeneralSecurityContainer.state;
-    const twitterCallBackUrl = urljoin(pathUtils.removeTrailingSlash(siteUrl), '/passport/twitter/callback')
+    const twitterCallBackUrl = urljoin(pathUtils.removeTrailingSlash(siteUrl), '/passport/twitter/callback');
 
     return (
 

--- a/packages/app/src/components/Admin/Security/TwitterSecuritySettingContents.jsx
+++ b/packages/app/src/components/Admin/Security/TwitterSecuritySettingContents.jsx
@@ -85,7 +85,7 @@ class TwitterSecuritySettingContents extends React.Component {
               readOnly
             />
             <p className="form-text text-muted small">{t('security_setting.desc_of_callback_URL', { AuthName: 'OAuth' })}</p>
-            {siteUrl != null && (
+            {siteUrl != null && siteUrl !== '' && (
               <div className="alert alert-danger">
                 <i
                   className="icon-exclamation"

--- a/packages/app/src/components/Admin/Security/TwitterSecuritySettingContents.jsx
+++ b/packages/app/src/components/Admin/Security/TwitterSecuritySettingContents.jsx
@@ -85,7 +85,7 @@ class TwitterSecuritySettingContents extends React.Component {
               readOnly
             />
             <p className="form-text text-muted small">{t('security_setting.desc_of_callback_URL', { AuthName: 'OAuth' })}</p>
-            {!siteUrl && (
+            {siteUrl != null && (
               <div className="alert alert-danger">
                 <i
                   className="icon-exclamation"

--- a/packages/app/src/components/Admin/Security/TwitterSecuritySettingContents.jsx
+++ b/packages/app/src/components/Admin/Security/TwitterSecuritySettingContents.jsx
@@ -85,14 +85,14 @@ class TwitterSecuritySettingContents extends React.Component {
               readOnly
             />
             <p className="form-text text-muted small">{t('security_setting.desc_of_callback_URL', { AuthName: 'OAuth' })}</p>
-            {siteUrl != null && siteUrl !== '' && (
+            {siteUrl == null || siteUrl === ''(
               <div className="alert alert-danger">
                 <i
                   className="icon-exclamation"
                   // eslint-disable-next-line max-len
                   dangerouslySetInnerHTML={{ __html: t('security_setting.alert_siteUrl_is_not_set', { link: `<a href="/admin/app">${t('App Settings')}<i class="icon-login"></i></a>` }) }}
                 />
-              </div>
+              </div>,
             )}
           </div>
         </div>

--- a/packages/app/src/pages/admin/[[...path]].page.tsx
+++ b/packages/app/src/pages/admin/[[...path]].page.tsx
@@ -193,7 +193,7 @@ export const getServerSideProps: GetServerSideProps = async(context: GetServerSi
     props.currentUser = JSON.stringify(user);
   }
 
-  injectServerConfigurations(context, props)
+  injectServerConfigurations(context, props);
   injectNextI18NextConfigurations(context, props, ['admin']);
 
   props.siteUrl = appService.getSiteUrl();

--- a/packages/app/src/pages/admin/[[...path]].page.tsx
+++ b/packages/app/src/pages/admin/[[...path]].page.tsx
@@ -12,7 +12,7 @@ import { CrowiRequest } from '~/interfaces/crowi-request';
 import PluginUtils from '~/server/plugins/plugin-utils';
 import ConfigLoader from '~/server/service/config-loader';
 import {
-  useCurrentUser, /* useSearchServiceConfigured, */ useIsSearchServiceReachable, useSiteUrl,
+  useCurrentUser, /* useSearchServiceConfigured, */ useIsMailerSetup, useIsSearchServiceReachable, useSiteUrl,
 } from '~/stores/context';
 
 import {
@@ -51,6 +51,7 @@ type Props = CommonProps & {
 
   isSearchServiceConfigured: boolean,
   isSearchServiceReachable: boolean,
+  isMailerSetup: boolean,
 
   siteUrl: string,
 };
@@ -135,6 +136,7 @@ const AdminMarkdownSettingsPage: NextPage<Props> = (props: Props) => {
   const title = content.title;
 
   useCurrentUser(props.currentUser != null ? JSON.parse(props.currentUser) : null);
+  useIsMailerSetup(props.isMailerSetup);
 
   // useSearchServiceConfigured(props.isSearchServiceConfigured);
   useIsSearchServiceReachable(props.isSearchServiceReachable);
@@ -149,6 +151,15 @@ const AdminMarkdownSettingsPage: NextPage<Props> = (props: Props) => {
     </AdminLayout>
   );
 };
+
+
+function injectServerConfigurations(context: GetServerSidePropsContext, props: Props): void {
+  const req: CrowiRequest = context.req as CrowiRequest;
+  const { crowi } = req;
+  const { mailService } = crowi;
+
+  props.isMailerSetup = mailService.isMailerSetup;
+}
 
 /**
  * for Server Side Translations
@@ -182,6 +193,7 @@ export const getServerSideProps: GetServerSideProps = async(context: GetServerSi
     props.currentUser = JSON.stringify(user);
   }
 
+  injectServerConfigurations(context, props)
   injectNextI18NextConfigurations(context, props, ['admin']);
 
   props.siteUrl = appService.getSiteUrl();

--- a/packages/app/src/stores/context.tsx
+++ b/packages/app/src/stores/context.tsx
@@ -172,6 +172,10 @@ export const useIsSearchServiceReachable = (initialData?: boolean) : SWRResponse
   return useStaticSWR<boolean, Error>('isSearchServiceReachable', initialData);
 };
 
+export const useIsMailerSetup = (initialData?: boolean): SWRResponse<boolean, any> => {
+  return useStaticSWR('isMailerSetup', initialData);
+};
+
 export const useIsSearchScopeChildrenAsDefault = (initialData?: boolean) : SWRResponse<boolean, Error> => {
   return useStaticSWR<boolean, Error>('isSearchScopeChildrenAsDefault', initialData);
 };


### PR DESCRIPTION
## Task
- [101284](https://redmine.weseek.co.jp/issues/101284) [Security] TabPane の各コンテンツを表示する

## Description
- `AdminSecurityHogeContainer` で定義されている state `callbackUrl` はそれぞれ一箇所でしか使われていなかったので、コンポーネント側で定義するようにしました。
- HogeSettings のData fetch
┗ 不要になった dummyHoge, dummyHogeError の削除
- `getServerSideProps` にて injectServerConfigurationsをし、`isMailerSetup` を注入


## ScreenShots
## ID/Pass
<img width="1304" alt="Screen Shot 2022-07-26 at 22 29 47" src="https://user-images.githubusercontent.com/59536731/181018862-f2576a29-327e-4020-90b6-dc4837f0a3a8.png">

## LDAP
![ldap](https://user-images.githubusercontent.com/59536731/181019119-adb2f390-f98d-4ce8-a8cd-99b847191799.png)

## SAML
![saml](https://user-images.githubusercontent.com/59536731/181019136-9df4b781-b7b5-4ddc-adf6-9fda5c3dbddd.png)

## OIDC
![oidc](https://user-images.githubusercontent.com/59536731/181019152-cc373a38-938a-400b-8a3b-338397e3a888.png)

## BASIC
<img width="1011" alt="Screen Shot 2022-07-26 at 22 31 27" src="https://user-images.githubusercontent.com/59536731/181018829-361e4967-5333-4066-b68e-44da1cd2bb91.png">

## Google
<img width="1067" alt="Screen Shot 2022-07-26 at 22 31 34" src="https://user-images.githubusercontent.com/59536731/181018803-7af8eda6-c8ab-4642-9f07-277c88ba5ddb.png">

## GiitHub
<img width="1039" alt="Screen Shot 2022-07-26 at 22 31 43" src="https://user-images.githubusercontent.com/59536731/181018764-6538e799-b239-43be-a34f-3dd9988f8693.png">

## Twitter
<img width="1036" alt="Screen Shot 2022-07-26 at 22 31 52" src="https://user-images.githubusercontent.com/59536731/181018747-925f36d0-7c47-4cf1-8e86-9ce237272e39.png">

## Facebook
<img width="946" alt="Screen Shot 2022-07-26 at 22 31 56" src="https://user-images.githubusercontent.com/59536731/181018720-964180c7-b342-4673-896d-f5c8ad003632.png">

