### PR TITLE
Imprv/101020 refactor sub nav skelton design

### DIFF
--- a/packages/app/src/components/Navbar/GrowiContextualSubNavigation.tsx
+++ b/packages/app/src/components/Navbar/GrowiContextualSubNavigation.tsx
@@ -155,11 +155,11 @@ const GrowiContextualSubNavigation = (props: GrowiContextualSubNavigationProps):
 
   const PageEditorModeManager = dynamic(
     () => import('./PageEditorModeManager'),
-    { ssr: false, loading: () => <Skelton width={213} height={35} componentHeight={33.99} /> },
+    { ssr: false, loading: () => <Skelton width={213} height={33.99} /> },
   );
   const SubNavButtons = dynamic<SubNavButtonsProps>(
     () => import('./SubNavButtons').then(mod => mod.SubNavButtons),
-    { ssr: false, loading: () => <Skelton width={245} height={16} componentHeight={40} /> },
+    { ssr: false, loading: () => <Skelton width={245} additionalClass='btn-skelton py-2' /> },
   );
 
   const { data: currentPage, mutate: mutateCurrentPage } = useSWRxCurrentPage();

--- a/packages/app/src/components/Navbar/GrowiContextualSubNavigation.tsx
+++ b/packages/app/src/components/Navbar/GrowiContextualSubNavigation.tsx
@@ -159,7 +159,7 @@ const GrowiContextualSubNavigation = (props: GrowiContextualSubNavigationProps):
   );
   const SubNavButtons = dynamic<SubNavButtonsProps>(
     () => import('./SubNavButtons').then(mod => mod.SubNavButtons),
-    { ssr: false, loading: () => <Skelton width={245} additionalClass='btn-skelton py-2' /> },
+    { ssr: false, loading: () => <Skelton additionalClass='btn-skelton py-2' /> },
   );
 
   const { data: currentPage, mutate: mutateCurrentPage } = useSWRxCurrentPage();
@@ -313,7 +313,7 @@ const GrowiContextualSubNavigation = (props: GrowiContextualSubNavigationProps):
         <div className="d-flex flex-column align-items-end justify-content-center py-md-2" style={{ gap: `${isCompactMode ? '5px' : '7px'}` }}>
 
           { isViewMode && (
-            <div className="h-50">
+            <div className="h-50 w-100">
               <SubNavButtons
                 isCompactMode={isCompactMode}
                 pageId={pageId}

--- a/packages/app/src/components/Navbar/GrowiContextualSubNavigation.tsx
+++ b/packages/app/src/components/Navbar/GrowiContextualSubNavigation.tsx
@@ -37,7 +37,7 @@ import ShareLinkIcon from '../Icons/ShareLinkIcon';
 import { Skelton } from '../Skelton';
 
 import { GrowiSubNavigation } from './GrowiSubNavigation';
-import { SubNavButtons } from './SubNavButtons';
+import { SubNavButtonsProps } from './SubNavButtons';
 
 
 type AdditionalMenuItemsProps = {
@@ -153,7 +153,14 @@ type GrowiContextualSubNavigationProps = {
 
 const GrowiContextualSubNavigation = (props: GrowiContextualSubNavigationProps): JSX.Element => {
 
-  const PageEditorModeManager = dynamic(() => import('./PageEditorModeManager'), { ssr: false, loading: () => <Skelton width={208} height={32.49} /> });
+  const PageEditorModeManager = dynamic(
+    () => import('./PageEditorModeManager'),
+    { ssr: false, loading: () => <Skelton width={213} height={35} componentHeight={33.99} /> },
+  );
+  const SubNavButtons = dynamic<SubNavButtonsProps>(
+    () => import('./SubNavButtons').then(mod => mod.SubNavButtons),
+    { ssr: false, loading: () => <Skelton width={245} height={16} componentHeight={40} /> },
+  );
 
   const { data: currentPage, mutate: mutateCurrentPage } = useSWRxCurrentPage();
   const path = currentPage?.path;

--- a/packages/app/src/components/Navbar/GrowiSubNavigation.module.scss
+++ b/packages/app/src/components/Navbar/GrowiSubNavigation.module.scss
@@ -6,6 +6,10 @@
   height: 40px;
 }
 
+%compact-subnav-buttons-height {
+  height: 32px;
+}
+
 // https://github.com/css-modules/css-modules/issues/295#issuecomment-404873976
 // workaround to use '&' in global scope
 .grw-subnav {
@@ -42,6 +46,7 @@
 
     .btn-skelton {
       @extend %subnav-buttons-height;
+      width: 100%;
     }
 
     .btn-subscribe {
@@ -143,17 +148,22 @@
         min-height: 90px;
       }
 
+      .btn-skelton {
+        @extend %compact-subnav-buttons-height;
+        width: 100%;
+      }
+
       .btn-like,
       .btn-bookmark,
       .btn-subscribe {
         width: 32px;
-        height: 32px;
+        @extend %compact-subnav-buttons-height;
         padding: 4px;
         font-size: 16px;
       }
       .btn-seen-user {
         width: 48px;
-        height: 32px;
+        @extend %compact-subnav-buttons-height;
         padding: 4px;
         font-size: 16px;
 
@@ -164,7 +174,7 @@
       }
       .btn-page-item-control {
         width: 32px;
-        height: 32px;
+        @extend %compact-subnav-buttons-height;
         font-size: 12px;
       }
     }

--- a/packages/app/src/components/Navbar/GrowiSubNavigation.module.scss
+++ b/packages/app/src/components/Navbar/GrowiSubNavigation.module.scss
@@ -2,6 +2,10 @@
 @use '~/styles/bootstrap/init' as bs;
 @use '~/styles/mixins';
 
+%subnav-buttons-height {
+  height: 40px;
+}
+
 // https://github.com/css-modules/css-modules/issues/295#issuecomment-404873976
 // workaround to use '&' in global scope
 .grw-subnav {
@@ -36,15 +40,19 @@
       }
     }
 
+    .btn-skelton {
+      @extend %subnav-buttons-height;
+    }
+
     .btn-subscribe {
-      height: 40px;
+      @extend %subnav-buttons-height;
       font-size: 20px;
     }
 
     .btn-like,
     .btn-bookmark,
     .btn-seen-user {
-      height: 40px;
+      @extend %subnav-buttons-height;
       padding-right: 6px;
       padding-left: 8px;
       font-size: 20px;

--- a/packages/app/src/components/Navbar/GrowiSubNavigation.tsx
+++ b/packages/app/src/components/Navbar/GrowiSubNavigation.tsx
@@ -38,8 +38,8 @@ type Props = {
 
 export const GrowiSubNavigation = (props: Props): JSX.Element => {
 
-  const TagLabels = dynamic(() => import('../Page/TagLabels'), { ssr: false, loading: () => <Skelton width={124.5} height={21.99} /> });
-  const AuthorInfo = dynamic(() => import('./AuthorInfo'), { ssr: false, loading: () => <Skelton width={148.32} height={32.84} /> });
+  const TagLabels = dynamic(() => import('../Page/TagLabels'), { ssr: false, loading: () => <Skelton width={137} height={16} componentHeight={21.99} /> });
+  const AuthorInfo = dynamic(() => import('./AuthorInfo'), { ssr: false, loading: () => <Skelton width={139} height={27} componentHeight={32.84} /> });
 
   const { data: editorMode } = useEditorMode();
 

--- a/packages/app/src/components/Navbar/GrowiSubNavigation.tsx
+++ b/packages/app/src/components/Navbar/GrowiSubNavigation.tsx
@@ -11,7 +11,6 @@ import {
 import PagePathNav from '../PagePathNav';
 import { Skelton } from '../Skelton';
 
-import AuthorInfo from './AuthorInfo';
 import DrawerToggler from './DrawerToggler';
 
 

--- a/packages/app/src/components/Navbar/GrowiSubNavigation.tsx
+++ b/packages/app/src/components/Navbar/GrowiSubNavigation.tsx
@@ -37,8 +37,8 @@ type Props = {
 
 export const GrowiSubNavigation = (props: Props): JSX.Element => {
 
-  const TagLabels = dynamic(() => import('../Page/TagLabels'), { ssr: false, loading: () => <Skelton width={137} height={16} componentHeight={21.99} /> });
-  const AuthorInfo = dynamic(() => import('./AuthorInfo'), { ssr: false, loading: () => <Skelton width={139} height={27} componentHeight={32.84} /> });
+  const TagLabels = dynamic(() => import('../Page/TagLabels'), { ssr: false, loading: () => <Skelton width={137} height={21.99} additionalClass='py-1' /> });
+  const AuthorInfo = dynamic(() => import('./AuthorInfo'), { ssr: false, loading: () => <Skelton width={139} height={32.84} additionalClass='py-1' /> });
 
   const { data: editorMode } = useEditorMode();
 

--- a/packages/app/src/components/Navbar/SubNavButtons.tsx
+++ b/packages/app/src/components/Navbar/SubNavButtons.tsx
@@ -12,10 +12,14 @@ import { IPageForPageDuplicateModal } from '~/stores/modal';
 import { useSWRBookmarkInfo } from '../../stores/bookmark';
 import { useSWRxPageInfo } from '../../stores/page';
 import { useSWRxUsersList } from '../../stores/user';
+import BookmarkButtons from '../BookmarkButtons';
 import {
-  AdditionalMenuItemsRendererProps, ForceHideMenuItems, MenuItemType, PageItemControlProps,
+  AdditionalMenuItemsRendererProps, ForceHideMenuItems, MenuItemType,
+  PageItemControl,
 } from '../Common/Dropdown/PageItemControl';
-import { Skelton } from '../Skelton';
+import LikeButtons from '../LikeButtons';
+import SubscribeButton from '../SubscribeButton';
+import SeenUserInfo from '../User/SeenUserInfo';
 
 
 type CommonProps = {
@@ -50,20 +54,6 @@ const SubNavButtonsSubstance = (props: SubNavButtonsSubstanceProps): JSX.Element
   const { mutate: mutatePageInfo } = useSWRxPageInfo(pageId, shareLinkId);
 
   const { data: bookmarkInfo, mutate: mutateBookmarkInfo } = useSWRBookmarkInfo(pageId);
-
-  // dynamic import for show skelton
-  const SubscribeButton = dynamic(() => import('../SubscribeButton'), { ssr: false, loading: () => <Skelton width={37} additionalClass='btn-subscribe'/> });
-  const LikeButtons = dynamic(() => import('../LikeButtons'), { ssr: false, loading: () => <Skelton width={57.48} additionalClass='btn-like'/> });
-  const BookmarkButtons = dynamic(() => import('../BookmarkButtons'), {
-    ssr: false,
-    loading: () => <Skelton width={53.48} additionalClass='total-bookmarks'/>,
-  });
-  const SeenUserInfo = dynamic(() => import('../User/SeenUserInfo'), { ssr: false, loading: () => <Skelton width={58.98} additionalClass='btn-seen-user'/> });
-  const PageItemControl = dynamic<PageItemControlProps>(() => import('../Common/Dropdown/PageItemControl').then(mod => mod.PageItemControl), {
-    ssr: false,
-    loading: () => <Skelton width={37} additionalClass='btn-page-item-control'/>,
-  });
-
 
   const likerIds = isIPageInfoForEntity(pageInfo) ? (pageInfo.likerIds ?? []).slice(0, 15) : [];
   const seenUserIds = isIPageInfoForEntity(pageInfo) ? (pageInfo.seenUserIds ?? []).slice(0, 15) : [];
@@ -215,7 +205,7 @@ const SubNavButtonsSubstance = (props: SubNavButtonsSubstanceProps): JSX.Element
   );
 };
 
-type SubNavButtonsProps= CommonProps & {
+export type SubNavButtonsProps = CommonProps & {
   pageId: string,
   shareLinkId?: string | null,
   revisionId?: string | null,

--- a/packages/app/src/components/Skelton.tsx
+++ b/packages/app/src/components/Skelton.tsx
@@ -3,19 +3,28 @@ import React from 'react';
 type SkeltonProps = {
   width?: number,
   height?: number,
-  additionalClass?: string,
+  componentClass?: string,
+  componentHeight?: number,
   roundedPill?: boolean,
 }
 
 export const Skelton = (props: SkeltonProps): JSX.Element => {
   const {
-    width, height, additionalClass, roundedPill,
+    width, height, componentHeight, componentClass, roundedPill,
   } = props;
 
-  const style = {
+  const componentStyle = {
+    height: componentHeight,
+  };
+
+  const skeltonStyle = {
     width,
     height,
   };
 
-  return <div style={style} className={`grw-skelton ${additionalClass} ${roundedPill ? 'rounded-pill' : ''}`}></div>;
+  return (
+    <div style={componentStyle} className={`d-flex align-items-center ${componentClass}`}>
+      <div style={skeltonStyle} className={`grw-skelton ${roundedPill ? 'rounded-pill' : ''}`}></div>
+    </div>
+  );
 };

--- a/packages/app/src/components/Skelton.tsx
+++ b/packages/app/src/components/Skelton.tsx
@@ -3,19 +3,14 @@ import React from 'react';
 type SkeltonProps = {
   width?: number,
   height?: number,
-  componentClass?: string,
-  componentHeight?: number,
+  additionalClass?: string,
   roundedPill?: boolean,
 }
 
 export const Skelton = (props: SkeltonProps): JSX.Element => {
   const {
-    width, height, componentHeight, componentClass, roundedPill,
+    width, height, additionalClass, roundedPill,
   } = props;
-
-  const componentStyle = {
-    height: componentHeight,
-  };
 
   const skeltonStyle = {
     width,
@@ -23,8 +18,8 @@ export const Skelton = (props: SkeltonProps): JSX.Element => {
   };
 
   return (
-    <div style={componentStyle} className={`d-flex align-items-center ${componentClass}`}>
-      <div style={skeltonStyle} className={`grw-skelton ${roundedPill ? 'rounded-pill' : ''}`}></div>
+    <div style={skeltonStyle} className={`${additionalClass}`}>
+      <div className={`grw-skelton h-100 w-100 ${roundedPill ? 'rounded-pill' : ''}`}></div>
     </div>
   );
 };

--- a/packages/app/src/styles/theme/_apply-colors-dark.scss
+++ b/packages/app/src/styles/theme/_apply-colors-dark.scss
@@ -518,5 +518,5 @@ ul.pagination {
  * skelton
  */
 .grw-skelton {
-  background-color: lighten($bgcolor-subnav, 20%);
+  background-color: lighten($bgcolor-subnav, 15%);
 }

--- a/packages/app/src/styles/theme/_apply-colors-light.scss
+++ b/packages/app/src/styles/theme/_apply-colors-light.scss
@@ -410,5 +410,5 @@ $dropdown-link-active-bg: $bgcolor-dropdown-link-active;
  * skelton
  */
 .grw-skelton {
-  background-color: $gray-200;
+  background-color: darken($bgcolor-subnav, 10%);
 }


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/101020

修正前
<img width="911" alt="スケルトン_修正前" src="https://user-images.githubusercontent.com/65263895/181425977-55546689-67c4-431a-b686-694df1c38689.PNG">

修正後
<img width="923" alt="スケルトン_修正版" src="https://user-images.githubusercontent.com/65263895/181424968-d84ee5f7-6ce8-40ca-b7f9-0d83f4862f2d.PNG">

FB対応後
<img width="774" alt="スケルトンFB後" src="https://user-images.githubusercontent.com/65263895/182071889-34a4e5e4-7be7-4a78-ae18-8e3defc2a01c.PNG">



mosさんの[デザイン](https://xd.adobe.com/view/cd3cb2f8-625d-4a6b-b6e4-917f75c675c5-986f/screen/9eb054d4-99e1-4bbb-8e2d-3f98f04be5b1/)
を参考にGrowiContextualSubNavigationのスケルトンのデザインを修正
