### PR TITLE
Imprv/101156 delete unused code related to theme preview and custom bar editor

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -211,7 +211,6 @@
     "handsontable": "=6.2.2",
     "i18next-hmr": "^1.7.7",
     "jquery-slimscroll": "^1.3.8",
-    "jquery-ui": "^1.12.1",
     "jquery.cookie": "~1.4.1",
     "jshint": "^2.13.0",
     "load-css-file": "^1.0.0",

--- a/packages/app/resource/cdn-manifests.js
+++ b/packages/app/resource/cdn-manifests.js
@@ -148,13 +148,6 @@ module.exports = {
       },
     },
     {
-      name: 'jquery-ui',
-      url: 'https://cdn.jsdelivr.net/jquery.ui/1.11.4/jquery-ui.min.css',
-      args: {
-        integrity: '',
-      },
-    },
-    {
       name: 'highlight-theme-github',
       url: 'https://cdn.jsdelivr.net/npm/highlight.js@9.13.0/styles/github.css',
       args: {

--- a/packages/app/src/client/services/AdminCustomizeContainer.js
+++ b/packages/app/src/client/services/AdminCustomizeContainer.js
@@ -75,7 +75,6 @@ export default class AdminCustomizeContainer extends Container {
       const { customizeParams } = response.data;
 
       this.setState({
-        // currentTheme: customizeParams.themeType,
         isEnabledTimeline: customizeParams.isEnabledTimeline,
         isSavedStatesOfTabChanges: customizeParams.isSavedStatesOfTabChanges,
         isEnabledAttachTitleHeader: customizeParams.isEnabledAttachTitleHeader,

--- a/packages/app/src/client/services/AdminCustomizeContainer.js
+++ b/packages/app/src/client/services/AdminCustomizeContainer.js
@@ -111,11 +111,6 @@ export default class AdminCustomizeContainer extends Container {
    */
   switchThemeType(themeName) {
     this.setState({ currentTheme: themeName });
-
-    // preview if production
-    if (process.env.NODE_ENV !== 'development') {
-      this.previewTheme(themeName);
-    }
   }
 
   /**
@@ -234,24 +229,6 @@ export default class AdminCustomizeContainer extends Container {
    */
   changeCustomizeScript(inpuValue) {
     this.setState({ currentCustomizeScript: inpuValue });
-  }
-
-  /**
-   * Preview theme
-   * @param {string} themeName
-   */
-  async previewTheme(themeName) {
-    try {
-      // get theme asset path
-      const response = await apiv3Get('/customize-setting/theme/asset-path', { themeName });
-      const { assetPath } = response.data;
-
-      const themeLink = document.getElementById('grw-theme-link');
-      themeLink.setAttribute('href', assetPath);
-    }
-    catch (err) {
-      toastError(err);
-    }
   }
 
   /**

--- a/packages/app/src/client/services/AdminCustomizeContainer.js
+++ b/packages/app/src/client/services/AdminCustomizeContainer.js
@@ -19,8 +19,6 @@ export default class AdminCustomizeContainer extends Container {
 
     this.state = {
       retrieveError: null,
-      // set dummy value tile for using suspense
-      currentTheme: 'default',
       isEnabledTimeline: false,
       isSavedStatesOfTabChanges: false,
       isEnabledAttachTitleHeader: false,
@@ -77,7 +75,7 @@ export default class AdminCustomizeContainer extends Container {
       const { customizeParams } = response.data;
 
       this.setState({
-        currentTheme: customizeParams.themeType,
+        // currentTheme: customizeParams.themeType,
         isEnabledTimeline: customizeParams.isEnabledTimeline,
         isSavedStatesOfTabChanges: customizeParams.isSavedStatesOfTabChanges,
         isEnabledAttachTitleHeader: customizeParams.isEnabledAttachTitleHeader,
@@ -106,12 +104,6 @@ export default class AdminCustomizeContainer extends Container {
     }
   }
 
-  /**
-   * Switch themeType
-   */
-  switchThemeType(themeName) {
-    this.setState({ currentTheme: themeName });
-  }
 
   /**
    * Switch enabledTimeLine
@@ -242,25 +234,6 @@ export default class AdminCustomizeContainer extends Container {
     styleLInk.href = styleLInk.href.replace(/[^/]+\.css$/, `${styleId}.css`);
   }
 
-  /**
-   * Update theme
-   * @memberOf AdminCustomizeContainer
-   */
-  async updateCustomizeTheme() {
-    try {
-      const response = await apiv3Put('/customize-setting/theme', {
-        themeType: this.state.currentTheme,
-      });
-      const { customizedParams } = response.data;
-      this.setState({
-        themeType: customizedParams.themeType,
-      });
-    }
-    catch (err) {
-      logger.error(err);
-      throw new Error('Failed to update data');
-    }
-  }
 
   /**
    * Update function

--- a/packages/app/src/components/Admin/Customize/Customize.jsx
+++ b/packages/app/src/components/Admin/Customize/Customize.jsx
@@ -1,5 +1,5 @@
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useCallback } from 'react';
 
 import PropTypes from 'prop-types';
 
@@ -26,20 +26,20 @@ const logger = loggerFactory('growi:services:AdminCustomizePage');
 function Customize(props) {
   const { adminCustomizeContainer } = props;
 
-  useEffect(() => {
-    async function fetchCustomizeSettingsData() {
-      await adminCustomizeContainer.retrieveCustomizeData();
-    }
-
+  const fetchCustomizeSettingsData = useCallback(async() =>  {
     try {
-      fetchCustomizeSettingsData();
+      await adminCustomizeContainer.retrieveCustomizeData()
     }
     catch (err) {
       const errs = toArrayIfNot(err);
       toastError(errs);
       logger.error(errs);
     }
-  }, [adminCustomizeContainer]);
+  }, []);
+
+  useEffect(() => {
+    fetchCustomizeSettingsData();
+  }, [fetchCustomizeSettingsData]);
 
 
   return (

--- a/packages/app/src/components/Admin/Customize/Customize.jsx
+++ b/packages/app/src/components/Admin/Customize/Customize.jsx
@@ -26,16 +26,16 @@ const logger = loggerFactory('growi:services:AdminCustomizePage');
 function Customize(props) {
   const { adminCustomizeContainer } = props;
 
-  const fetchCustomizeSettingsData = useCallback(async() =>  {
+  const fetchCustomizeSettingsData = useCallback(async() => {
     try {
-      await adminCustomizeContainer.retrieveCustomizeData()
+      await adminCustomizeContainer.retrieveCustomizeData();
     }
     catch (err) {
       const errs = toArrayIfNot(err);
       toastError(errs);
       logger.error(errs);
     }
-  }, []);
+  }, [adminCustomizeContainer]);
 
   useEffect(() => {
     fetchCustomizeSettingsData();

--- a/packages/app/src/components/Admin/Customize/CustomizeThemeOptions.jsx
+++ b/packages/app/src/components/Admin/Customize/CustomizeThemeOptions.jsx
@@ -57,7 +57,7 @@ const CustomizeThemeOptions = (props) => {
 
   const selectedHandler = useCallback((themeName) => {
     adminCustomizeContainer.switchThemeType(themeName);
-    mutateGrowiTheme(themeName, false);
+    mutateGrowiTheme(themeName);
   }, [adminCustomizeContainer, mutateGrowiTheme]);
 
   return (

--- a/packages/app/src/components/Admin/Customize/CustomizeThemeOptions.jsx
+++ b/packages/app/src/components/Admin/Customize/CustomizeThemeOptions.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 
 import { useTranslation } from 'next-i18next';
 import PropTypes from 'prop-types';
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
 
 import AdminCustomizeContainer from '~/client/services/AdminCustomizeContainer';
 import { GrowiThemes } from '~/interfaces/theme';
-import { useGrowiTheme } from '~/stores/context';
 
 import { withUnstatedContainers } from '../../UnstatedUtils';
 
@@ -50,15 +49,11 @@ const uniqueTheme = [{
 
 const CustomizeThemeOptions = (props) => {
 
-  const { adminCustomizeContainer } = props;
-  const { t } = useTranslation();
-  const { mutate: mutateGrowiTheme } = useGrowiTheme();
-  const { currentLayout, currentTheme } = adminCustomizeContainer.state;
+  const { adminCustomizeContainer, currentTheme } = props;
+  const { currentLayout } = adminCustomizeContainer.state;
 
-  const selectedHandler = useCallback((themeName) => {
-    adminCustomizeContainer.switchThemeType(themeName);
-    mutateGrowiTheme(themeName);
-  }, [adminCustomizeContainer, mutateGrowiTheme]);
+  const { t } = useTranslation();
+
 
   return (
     <div id="themeOptions" className={`${currentLayout === 'kibela' && 'disabled'}`}>
@@ -71,7 +66,7 @@ const CustomizeThemeOptions = (props) => {
               <ThemeColorBox
                 key={theme.name}
                 isSelected={currentTheme === theme.name}
-                onSelected={() => selectedHandler(theme.name)}
+                onSelected={() => props.onSelected(theme.name)}
                 {...theme}
               />
             );
@@ -87,7 +82,7 @@ const CustomizeThemeOptions = (props) => {
               <ThemeColorBox
                 key={theme.name}
                 isSelected={currentTheme === theme.name}
-                onSelected={() => selectedHandler(theme.name)}
+                onSelected={() => props.onSelected(theme.name)}
                 {...theme}
               />
             );
@@ -103,6 +98,8 @@ const CustomizeThemeOptionsWrapper = withUnstatedContainers(CustomizeThemeOption
 
 CustomizeThemeOptions.propTypes = {
   adminCustomizeContainer: PropTypes.instanceOf(AdminCustomizeContainer).isRequired,
+  onSelected: PropTypes.func,
+  currentTheme: PropTypes.string,
 };
 
 export default CustomizeThemeOptionsWrapper;

--- a/packages/app/src/components/Admin/Customize/CustomizeThemeOptions.jsx
+++ b/packages/app/src/components/Admin/Customize/CustomizeThemeOptions.jsx
@@ -55,6 +55,11 @@ const CustomizeThemeOptions = (props) => {
   const { mutate: mutateGrowiTheme } = useGrowiTheme();
   const { currentLayout, currentTheme } = adminCustomizeContainer.state;
 
+  const selectedHandler = (themeName) => {
+    adminCustomizeContainer.switchThemeType(themeName);
+    mutateGrowiTheme(themeName);
+  };
+
   return (
     <div id="themeOptions" className={`${currentLayout === 'kibela' && 'disabled'}`}>
       {/* Light and Dark Themes */}
@@ -66,7 +71,7 @@ const CustomizeThemeOptions = (props) => {
               <ThemeColorBox
                 key={theme.name}
                 isSelected={currentTheme === theme.name}
-                onSelected={() => mutateGrowiTheme(theme.name)}
+                onSelected={() => selectedHandler(theme.name)}
                 {...theme}
               />
             );
@@ -82,7 +87,7 @@ const CustomizeThemeOptions = (props) => {
               <ThemeColorBox
                 key={theme.name}
                 isSelected={currentTheme === theme.name}
-                onSelected={() => mutateGrowiTheme(theme.name)}
+                onSelected={() => selectedHandler(theme.name)}
                 {...theme}
               />
             );

--- a/packages/app/src/components/Admin/Customize/CustomizeThemeOptions.jsx
+++ b/packages/app/src/components/Admin/Customize/CustomizeThemeOptions.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 
 import { useTranslation } from 'next-i18next';
 import PropTypes from 'prop-types';
@@ -55,10 +55,10 @@ const CustomizeThemeOptions = (props) => {
   const { mutate: mutateGrowiTheme } = useGrowiTheme();
   const { currentLayout, currentTheme } = adminCustomizeContainer.state;
 
-  const selectedHandler = (themeName) => {
+  const selectedHandler = useCallback((themeName) => {
     adminCustomizeContainer.switchThemeType(themeName);
-    mutateGrowiTheme(themeName);
-  };
+    mutateGrowiTheme(themeName, false);
+  }, [adminCustomizeContainer, mutateGrowiTheme]);
 
   return (
     <div id="themeOptions" className={`${currentLayout === 'kibela' && 'disabled'}`}>

--- a/packages/app/src/components/Admin/Customize/CustomizeThemeSetting.tsx
+++ b/packages/app/src/components/Admin/Customize/CustomizeThemeSetting.tsx
@@ -30,15 +30,13 @@ const CustomizeThemeSetting = (props: Props): JSX.Element => {
   }, [t, adminCustomizeContainer]);
 
   return (
-    <React.Fragment>
-      <div className="row">
-        <div className="col-12">
-          <h2 className="admin-setting-header">{t('admin:customize_setting.theme')}</h2>
-          <CustomizeThemeOptions />
-          <AdminUpdateButtonRow onClick={submitHandler} disabled={adminCustomizeContainer.state.retrieveError != null} />
-        </div>
+    <div className="row">
+      <div className="col-12">
+        <h2 className="admin-setting-header">{t('admin:customize_setting.theme')}</h2>
+        <CustomizeThemeOptions />
+        <AdminUpdateButtonRow onClick={submitHandler} disabled={adminCustomizeContainer.state.retrieveError != null} />
       </div>
-    </React.Fragment>
+    </div>
   );
 };
 

--- a/packages/app/src/components/Admin/Customize/CustomizeThemeSetting.tsx
+++ b/packages/app/src/components/Admin/Customize/CustomizeThemeSetting.tsx
@@ -20,7 +20,6 @@ const CustomizeThemeSetting = (props: Props): JSX.Element => {
   const { t } = useTranslation();
 
   const submitHandler = useCallback(async() => {
-    console.log('adminCustomizeContainer_currentTheme', adminCustomizeContainer.state.currentTheme);
     try {
       await adminCustomizeContainer.updateCustomizeTheme();
       toastSuccess(t('toaster.update_successed', { target: t('admin:customize_setting.theme') }));

--- a/packages/app/src/components/Admin/Customize/CustomizeThemeSetting.tsx
+++ b/packages/app/src/components/Admin/Customize/CustomizeThemeSetting.tsx
@@ -2,12 +2,11 @@ import React, { useCallback } from 'react';
 
 import { useTranslation } from 'next-i18next';
 
-import { apiv3Put } from '~/client/util/apiv3-client';
-
-import { useGrowiTheme } from '~/stores/context';
-
 import AdminCustomizeContainer from '~/client/services/AdminCustomizeContainer';
 import { toastSuccess, toastError } from '~/client/util/apiNotification';
+import { apiv3Put } from '~/client/util/apiv3-client';
+import { useGrowiTheme } from '~/stores/context';
+
 
 import { withUnstatedContainers } from '../../UnstatedUtils';
 import AdminUpdateButtonRow from '../Common/AdminUpdateButtonRow';
@@ -26,11 +25,11 @@ const CustomizeThemeSetting = (props: Props): JSX.Element => {
 
   const selectedHandler = useCallback((themeName) => {
     mutateGrowiTheme(themeName);
-  }, [adminCustomizeContainer, mutateGrowiTheme]);
+  }, [mutateGrowiTheme]);
 
   const submitHandler = useCallback(async() => {
     try {
-      if(currentTheme != null){
+      if (currentTheme != null) {
         await apiv3Put('/customize-setting/theme', {
           themeType: currentTheme,
         });
@@ -41,7 +40,7 @@ const CustomizeThemeSetting = (props: Props): JSX.Element => {
     catch (err) {
       toastError(err);
     }
-  }, [t, adminCustomizeContainer]);
+  }, [currentTheme, t]);
 
   return (
     <div className="row">

--- a/packages/app/src/components/Admin/Customize/CustomizeThemeSetting.tsx
+++ b/packages/app/src/components/Admin/Customize/CustomizeThemeSetting.tsx
@@ -2,6 +2,10 @@ import React, { useCallback } from 'react';
 
 import { useTranslation } from 'next-i18next';
 
+import { apiv3Put } from '~/client/util/apiv3-client';
+
+import { useGrowiTheme } from '~/stores/context';
+
 import AdminCustomizeContainer from '~/client/services/AdminCustomizeContainer';
 import { toastSuccess, toastError } from '~/client/util/apiNotification';
 
@@ -17,11 +21,21 @@ type Props = {
 const CustomizeThemeSetting = (props: Props): JSX.Element => {
 
   const { adminCustomizeContainer } = props;
+  const { data: currentTheme, mutate: mutateGrowiTheme } = useGrowiTheme();
   const { t } = useTranslation();
+
+  const selectedHandler = useCallback((themeName) => {
+    mutateGrowiTheme(themeName);
+  }, [adminCustomizeContainer, mutateGrowiTheme]);
 
   const submitHandler = useCallback(async() => {
     try {
-      await adminCustomizeContainer.updateCustomizeTheme();
+      if(currentTheme != null){
+        await apiv3Put('/customize-setting/theme', {
+          themeType: currentTheme,
+        });
+      }
+
       toastSuccess(t('toaster.update_successed', { target: t('admin:customize_setting.theme') }));
     }
     catch (err) {
@@ -33,7 +47,7 @@ const CustomizeThemeSetting = (props: Props): JSX.Element => {
     <div className="row">
       <div className="col-12">
         <h2 className="admin-setting-header">{t('admin:customize_setting.theme')}</h2>
-        <CustomizeThemeOptions />
+        <CustomizeThemeOptions onSelected={selectedHandler} currentTheme={currentTheme} />
         <AdminUpdateButtonRow onClick={submitHandler} disabled={adminCustomizeContainer.state.retrieveError != null} />
       </div>
     </div>

--- a/packages/app/src/components/Admin/Customize/CustomizeThemeSetting.tsx
+++ b/packages/app/src/components/Admin/Customize/CustomizeThemeSetting.tsx
@@ -20,6 +20,7 @@ const CustomizeThemeSetting = (props: Props): JSX.Element => {
   const { t } = useTranslation();
 
   const submitHandler = useCallback(async() => {
+    console.log('adminCustomizeContainer_currentTheme', adminCustomizeContainer.state.currentTheme);
     try {
       await adminCustomizeContainer.updateCustomizeTheme();
       toastSuccess(t('toaster.update_successed', { target: t('admin:customize_setting.theme') }));

--- a/packages/app/src/components/Layout/AdminLayout.tsx
+++ b/packages/app/src/components/Layout/AdminLayout.tsx
@@ -46,7 +46,6 @@ const AdminLayout = ({
               <AdminNavigation selected={selectedNavOpt} />
             </div>
             <div className="col-lg-9">
-              {/* TODO: inject Admincontainer (injectableContainers & adminSecurityContainers) by https://redmine.weseek.co.jp/issues/100072 */}
               <Provider inject={injectableContainers}>
                 {children}
               </Provider>

--- a/packages/app/src/components/Layout/AdminLayout.tsx
+++ b/packages/app/src/components/Layout/AdminLayout.tsx
@@ -10,8 +10,6 @@ import { RawLayout } from './RawLayout';
 import styles from './Admin.module.scss';
 
 
-// import { injectableContainers } from '~/client/admin';
-
 type Props = {
   title: string
   /**
@@ -26,7 +24,7 @@ type Props = {
 
 
 const AdminLayout = ({
-  children, title, selectedNavOpt, injectableContainers
+  children, title, selectedNavOpt, injectableContainers,
 }: Props): JSX.Element => {
 
   const AdminNavigation = dynamic(() => import('~/components/Admin/Common/AdminNavigation'), { ssr: false });

--- a/packages/app/src/components/Layout/AdminLayout.tsx
+++ b/packages/app/src/components/Layout/AdminLayout.tsx
@@ -3,6 +3,8 @@ import React, { ReactNode } from 'react';
 import dynamic from 'next/dynamic';
 import { Provider } from 'unstated';
 
+import { AdminInjectableContainers } from '~/interfaces/unstated-container';
+
 import { GrowiNavbar } from '../Navbar/GrowiNavbar';
 
 import { RawLayout } from './RawLayout';
@@ -19,7 +21,7 @@ type Props = {
    */
   selectedNavOpt: string
   children?: ReactNode
-  injectableContainers: any
+  injectableContainers: AdminInjectableContainers
 }
 
 

--- a/packages/app/src/components/Layout/AdminLayout.tsx
+++ b/packages/app/src/components/Layout/AdminLayout.tsx
@@ -21,11 +21,12 @@ type Props = {
    */
   selectedNavOpt: string
   children?: ReactNode
+  injectableContainers: any
 }
 
 
 const AdminLayout = ({
-  children, title, selectedNavOpt,
+  children, title, selectedNavOpt, injectableContainers
 }: Props): JSX.Element => {
 
   const AdminNavigation = dynamic(() => import('~/components/Admin/Common/AdminNavigation'), { ssr: false });
@@ -46,7 +47,7 @@ const AdminLayout = ({
             </div>
             <div className="col-lg-9">
               {/* TODO: inject Admincontainer (injectableContainers & adminSecurityContainers) by https://redmine.weseek.co.jp/issues/100072 */}
-              <Provider>
+              <Provider inject={injectableContainers}>
                 {children}
               </Provider>
             </div>

--- a/packages/app/src/interfaces/unstated-container.ts
+++ b/packages/app/src/interfaces/unstated-container.ts
@@ -18,7 +18,7 @@ import AdminTwitterSecurityContainer from '~/client/services/AdminTwitterSecurit
 import AdminUserGroupDetailContainer from '~/client/services/AdminUserGroupDetailContainer';
 import AdminUsersContainer from '~/client/services/AdminUsersContainer';
 
-export type AdminUnstatedContainers =
+type AdminUnstatedContainers =
   AdminAppContainer | AdminBasicSecurityContainer | AdminCustomizeContainer | AdminExternalAccountsContainer |
   AdminGeneralSecurityContainer | AdminGitHubSecurityContainer | AdminGoogleSecurityContainer | AdminHomeContainer |
   AdminImportContainer | AdminLdapSecurityContainer | AdminLocalSecurityContainer | AdminMarkDownContainer |

--- a/packages/app/src/interfaces/unstated-container.ts
+++ b/packages/app/src/interfaces/unstated-container.ts
@@ -1,0 +1,28 @@
+import AdminAppContainer from '~/client/services/AdminAppContainer';
+import AdminBasicSecurityContainer from '~/client/services/AdminBasicSecurityContainer';
+import AdminCustomizeContainer from '~/client/services/AdminCustomizeContainer';
+import AdminExternalAccountsContainer from '~/client/services/AdminExternalAccountsContainer';
+import AdminGeneralSecurityContainer from '~/client/services/AdminGeneralSecurityContainer';
+import AdminGitHubSecurityContainer from '~/client/services/AdminGitHubSecurityContainer';
+import AdminGoogleSecurityContainer from '~/client/services/AdminGoogleSecurityContainer';
+import AdminHomeContainer from '~/client/services/AdminHomeContainer';
+import AdminImportContainer from '~/client/services/AdminImportContainer';
+import AdminLdapSecurityContainer from '~/client/services/AdminLdapSecurityContainer';
+import AdminLocalSecurityContainer from '~/client/services/AdminLocalSecurityContainer';
+import AdminMarkDownContainer from '~/client/services/AdminMarkDownContainer';
+import AdminNotificationContainer from '~/client/services/AdminNotificationContainer';
+import AdminOidcSecurityContainer from '~/client/services/AdminOidcSecurityContainer';
+import AdminSamlSecurityContainer from '~/client/services/AdminSamlSecurityContainer';
+import AdminSlackIntegrationLegacyContainer from '~/client/services/AdminSlackIntegrationLegacyContainer';
+import AdminTwitterSecurityContainer from '~/client/services/AdminTwitterSecurityContainer';
+import AdminUserGroupDetailContainer from '~/client/services/AdminUserGroupDetailContainer';
+import AdminUsersContainer from '~/client/services/AdminUsersContainer';
+
+export type AdminUnstatedContainers =
+  AdminAppContainer | AdminBasicSecurityContainer | AdminCustomizeContainer | AdminExternalAccountsContainer |
+  AdminGeneralSecurityContainer | AdminGitHubSecurityContainer | AdminGoogleSecurityContainer | AdminHomeContainer |
+  AdminImportContainer | AdminLdapSecurityContainer | AdminLocalSecurityContainer | AdminMarkDownContainer |
+  AdminNotificationContainer | AdminOidcSecurityContainer | AdminSamlSecurityContainer | AdminSlackIntegrationLegacyContainer |
+  AdminTwitterSecurityContainer | AdminUserGroupDetailContainer | AdminUsersContainer;
+
+export type AdminInjectableContainers = AdminUnstatedContainers[];

--- a/packages/app/src/pages/admin/[[...path]].page.tsx
+++ b/packages/app/src/pages/admin/[[...path]].page.tsx
@@ -18,6 +18,9 @@ import {
 import {
   CommonProps, getServerSideCommonProps, useCustomTitle, getNextI18NextConfig,
 } from '../utils/commons';
+
+import AdminCustomizeContainer from '~/client/services/AdminCustomizeContainer';
+
 // import { useEnvVars } from '~/stores/admin-context';
 
 const AdminHome = dynamic(() => import('../../components/Admin/AdminHome/AdminHome'), { ssr: false });
@@ -143,8 +146,27 @@ const AdminMarkdownSettingsPage: NextPage<Props> = (props: Props) => {
 
   // useEnvVars(props.envVars);
 
+
+  const adminCustomizeContainer = new AdminCustomizeContainer();
+
+  const injectableContainers = [
+    // appContainer,
+    // adminAppContainer,
+    // adminImportContainer,
+    // adminSocketIoContainer,
+    // adminHomeContainer,
+    adminCustomizeContainer,
+    // adminUsersContainer,
+    // adminExternalAccountsContainer,
+    // adminNotificationContainer,
+    // adminSlackIntegrationLegacyContainer,
+    // adminMarkDownContainer,
+    // adminUserGroupDetailContainer,
+    // socketIoContainer,
+  ];
+
   return (
-    <AdminLayout title={title} selectedNavOpt={name}>
+    <AdminLayout title={title} selectedNavOpt={name} injectableContainers={injectableContainers}>
       {content.component}
     </AdminLayout>
   );

--- a/packages/app/src/pages/admin/[[...path]].page.tsx
+++ b/packages/app/src/pages/admin/[[...path]].page.tsx
@@ -8,6 +8,7 @@ import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
 
+import AdminCustomizeContainer from '~/client/services/AdminCustomizeContainer';
 import { CrowiRequest } from '~/interfaces/crowi-request';
 import PluginUtils from '~/server/plugins/plugin-utils';
 import ConfigLoader from '~/server/service/config-loader';
@@ -19,7 +20,6 @@ import {
   CommonProps, getServerSideCommonProps, useCustomTitle, getNextI18NextConfig,
 } from '../utils/commons';
 
-import AdminCustomizeContainer from '~/client/services/AdminCustomizeContainer';
 
 // import { useEnvVars } from '~/stores/admin-context';
 
@@ -152,10 +152,8 @@ const AdminMarkdownSettingsPage: NextPage<Props> = (props: Props) => {
   const adminCustomizeContainer = new AdminCustomizeContainer();
 
   const injectableContainers = [
-    // appContainer,
     // adminAppContainer,
     // adminImportContainer,
-    // adminSocketIoContainer,
     // adminHomeContainer,
     adminCustomizeContainer,
     // adminUsersContainer,
@@ -164,7 +162,6 @@ const AdminMarkdownSettingsPage: NextPage<Props> = (props: Props) => {
     // adminSlackIntegrationLegacyContainer,
     // adminMarkDownContainer,
     // adminUserGroupDetailContainer,
-    // socketIoContainer,
   ];
 
   return (

--- a/packages/app/src/server/views/admin/customize.html
+++ b/packages/app/src/server/views/admin/customize.html
@@ -1,16 +1,6 @@
 {% extends '../layout/admin.html' %}
-{% block html_title %}{{ customizeService.generateCustomTitleForFixedPageName(t('Customize')) }}{% endblock %}
 
-{% block html_additional_headers %}
-{% parent %}
-<!-- CodeMirror -->
-{{ cdnStyleTag('jquery-ui') }}
-<style>
-  .CodeMirror {
-    border: 1px solid $gray-100;
-  }
-</style>
-{% endblock %}
+{% block html_title %}{{ customizeService.generateCustomTitleForFixedPageName(t('Customize')) }}{% endblock %}
 
 {% block content_header %}
 <h1 class="title">{{ t('Customize') }}</h1>

--- a/yarn.lock
+++ b/yarn.lock
@@ -12614,18 +12614,11 @@ jquery-slimscroll@^1.3.8:
   dependencies:
     jquery ">= 1.7"
 
-jquery-ui@^1.12.1:
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/jquery-ui/-/jquery-ui-1.13.0.tgz#ab5ac65f37ca093c51b3478c4097f55bbc008f36"
-  integrity sha512-Osf7ECXNTYHtKBkn9xzbIf9kifNrBhfywFEKxOeB/OVctVmLlouV9mfc2qXCp6uyO4Pn72PXKOnj09qXetopCw==
-  dependencies:
-    jquery ">=1.8.0 <4.0.0"
-
 jquery.cookie@~1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jquery.cookie/-/jquery.cookie-1.4.1.tgz#d63dce209eab691fe63316db08ca9e47e0f9385b"
 
-"jquery@>= 1.7", jquery@>=1.12.0, "jquery@>=1.8.0 <4.0.0":
+"jquery@>= 1.7", jquery@>=1.12.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.0.tgz#c72a09f15c1bdce142f49dbf1170bdf8adac2470"
   integrity sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==


### PR DESCRIPTION
## Task
[GROWI][Next.js][Admin][Customize] 各種設定の更新ができる
┗[101156](https://redmine.weseek.co.jp/issues/101156) テーマのプレビュー機能、CustomHogeEditorの削除に伴い不要になったコードを削除 & themeが更新されないbug 修正

## Description
- package "jquery-ui` の削除
- adminCustomizeContainer での theme 関連のstate method を削除
- AdminLayout にて Provider でinject adminContainers

## ScreenRecording (latest)

https://user-images.githubusercontent.com/59536731/182072980-7e2ce721-616b-4e86-a250-74d0f7de322c.mov

## Note
CustomizeContainer 以外の UnstatedContainers の インスタンスの有効化は　https://redmine.weseek.co.jp/issues/101816 のタスクで行います。
