### PR TITLE
fix: Default markdown linker with relative path does not respect the current page path (v5.1.0)

### DIFF
--- a/packages/app/src/services/renderer/markdown-it/link-by-relative-path.ts
+++ b/packages/app/src/services/renderer/markdown-it/link-by-relative-path.ts
@@ -5,14 +5,16 @@ const PATTERN_RELATIVE_PATH = new RegExp(/^(\.{1,2})(\/.*)?$/);
 
 export default class LinkerByRelativePathConfigurer {
 
-  pagePath: string
+  pagePath: string;
 
   constructor(pagePath: string) {
     this.pagePath = pagePath;
   }
 
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-  configure(md, pagePath: string): void {
+  configure(md): void {
+    const pagePath = this.pagePath;
+
     // Remember old renderer, if overridden, or proxy to default renderer
     const defaultRender = md.renderer.rules.link_open || function(tokens, idx, options, env, self) {
       return self.renderToken(tokens, idx, options);


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/101748

## Note

- Related issue: https://github.com/weseek/growi/pull/5788
- Produced by https://github.com/weseek/growi/pull/6223
