### PR TITLE
Enable MathJax on RevisionRenderer

### DIFF
--- a/packages/app/src/components/Page/RevisionRenderer.tsx
+++ b/packages/app/src/components/Page/RevisionRenderer.tsx
@@ -98,6 +98,8 @@ const RevisionRenderer = (props: Props): JSX.Element => {
     growiRenderer, markdown, pagePath, highlightKeywords,
   } = props;
 
+  const isMathJaxEnabled = !!growiRenderer.growiRendererConfig.env.MATHJAX;
+
   const [html, setHtml] = useState('');
 
   const { data: editorSettings } = useEditorSettings();
@@ -158,6 +160,7 @@ const RevisionRenderer = (props: Props): JSX.Element => {
     <RevisionBody
       html={html}
       additionalClassName={props.additionalClassName}
+      isMathJaxEnabled={isMathJaxEnabled}
       renderMathJaxOnInit
     />
   );


### PR DESCRIPTION
`isMathJaxEnabled` is not passed to `RevisionBody` and the MathJax was disabled in the main panel.