### PR TITLE
Imprv/101815 Security settings  /  UserManagement  / UserGroupManagement  contents

### DIFF
--- a/packages/app/src/components/Admin/Security/SecurityManagementContents.jsx
+++ b/packages/app/src/components/Admin/Security/SecurityManagementContents.jsx
@@ -82,12 +82,12 @@ const SecurityManagementContents = () => {
   return (
     <div data-testid="admin-security">
       <div className="mb-5">
-        {/* <SecuritySetting /> */}
+        <SecuritySetting />
       </div>
 
       {/* Shared Link List */}
       <div className="mb-5">
-        {/* <ShareLinkSetting /> */}
+        <ShareLinkSetting />
       </div>
 
 

--- a/packages/app/src/components/Admin/UserManagement.jsx
+++ b/packages/app/src/components/Admin/UserManagement.jsx
@@ -10,7 +10,7 @@ import PaginationWrapper from '../PaginationWrapper';
 import { withUnstatedContainers } from '../UnstatedUtils';
 
 
-// import InviteUserControl from './Users/InviteUserControl';
+import InviteUserControl from './Users/InviteUserControl';
 import PasswordResetModal from './Users/PasswordResetModal';
 import UserTable from './Users/UserTable';
 
@@ -150,8 +150,7 @@ class UserManagement extends React.Component {
           />
         )}
         <p>
-          {/* show  */}
-          {/* <InviteUserControl /> */}
+          <InviteUserControl />
           <a className="btn btn-outline-secondary ml-2" href="/admin/users/external-accounts" role="button">
             <i className="icon-user-follow" aria-hidden="true"></i>
             {t('admin:user_management.external_account')}

--- a/packages/app/src/components/Admin/Users/UserInviteModal.jsx
+++ b/packages/app/src/components/Admin/Users/UserInviteModal.jsx
@@ -112,7 +112,7 @@ class UserInviteModal extends React.Component {
             className="custom-control-input"
             name="sendEmail"
             defaultChecked={this.state.sendEmail}
-            disabled={isMailerSetup === true}
+            disabled={isMailerSetup === false}
           />
           <label className="custom-control-label" htmlFor="sendEmail">
             {t('admin:user_management.invite_modal.invite_thru_email')}

--- a/packages/app/src/components/Admin/Users/UserInviteModal.jsx
+++ b/packages/app/src/components/Admin/Users/UserInviteModal.jsx
@@ -8,9 +8,10 @@ import {
   Modal, ModalHeader, ModalBody, ModalFooter,
 } from 'reactstrap';
 
+
 import AdminUsersContainer from '~/client/services/AdminUsersContainer';
-import AppContainer from '~/client/services/AppContainer';
 import { toastSuccess, toastError, toastWarning } from '~/client/util/apiNotification';
+import { useIsMailerSetup } from '~/stores/context';
 
 import { withUnstatedContainers } from '../../UnstatedUtils';
 
@@ -99,9 +100,9 @@ class UserInviteModal extends React.Component {
   }
 
   renderModalFooter() {
-    const { t, appContainer } = this.props;
+    const { t, isMailerSetup } = this.props;
     const { isCreateUserButtonPushed } = this.state;
-    const { isMailerSetup } = appContainer.config;
+    // const { isMailerSetup } = appContainer.config;
 
     return (
       <>
@@ -112,7 +113,7 @@ class UserInviteModal extends React.Component {
             className="custom-control-input"
             name="sendEmail"
             defaultChecked={this.state.sendEmail}
-            disabled={!isMailerSetup}
+            disabled={isMailerSetup === true}
           />
           <label className="custom-control-label" htmlFor="sendEmail">
             {t('admin:user_management.invite_modal.invite_thru_email')}
@@ -282,18 +283,18 @@ class UserInviteModal extends React.Component {
 
 const UserInviteModalWrapperFC = (props) => {
   const { t } = useTranslation();
-  return <UserInviteModal t={t} {...props} />;
+  const { data: isMailerSetup } = useIsMailerSetup();
+  return <UserInviteModal t={t} isMailerSetup={isMailerSetup ?? false} {...props} />;
 };
 
 /**
  * Wrapper component for using unstated
  */
-const UserInviteModalWrapper = withUnstatedContainers(UserInviteModalWrapperFC, [AppContainer, AdminUsersContainer]);
+const UserInviteModalWrapper = withUnstatedContainers(UserInviteModalWrapperFC, [AdminUsersContainer]);
 
 
 UserInviteModal.propTypes = {
   t: PropTypes.func.isRequired, // i18next
-  appContainer: PropTypes.instanceOf(AppContainer).isRequired,
   adminUsersContainer: PropTypes.instanceOf(AdminUsersContainer).isRequired,
 };
 

--- a/packages/app/src/components/Admin/Users/UserInviteModal.jsx
+++ b/packages/app/src/components/Admin/Users/UserInviteModal.jsx
@@ -102,7 +102,6 @@ class UserInviteModal extends React.Component {
   renderModalFooter() {
     const { t, isMailerSetup } = this.props;
     const { isCreateUserButtonPushed } = this.state;
-    // const { isMailerSetup } = appContainer.config;
 
     return (
       <>

--- a/packages/app/src/components/Admin/Users/UserInviteModal.jsx
+++ b/packages/app/src/components/Admin/Users/UserInviteModal.jsx
@@ -112,7 +112,7 @@ class UserInviteModal extends React.Component {
             className="custom-control-input"
             name="sendEmail"
             defaultChecked={this.state.sendEmail}
-            disabled={isMailerSetup === false}
+            disabled={!isMailerSetup}
           />
           <label className="custom-control-label" htmlFor="sendEmail">
             {t('admin:user_management.invite_modal.invite_thru_email')}

--- a/packages/app/src/pages/admin/[[...path]].page.tsx
+++ b/packages/app/src/pages/admin/[[...path]].page.tsx
@@ -13,7 +13,7 @@ import { CrowiRequest } from '~/interfaces/crowi-request';
 import PluginUtils from '~/server/plugins/plugin-utils';
 import ConfigLoader from '~/server/service/config-loader';
 import {
-  useCurrentUser, /* useSearchServiceConfigured, */ useIsMailerSetup, useIsSearchServiceReachable, useSiteUrl,
+  useCurrentUser, /* useSearchServiceConfigured, */ useIsAclEnabled, useIsMailerSetup, useIsSearchServiceReachable, useSiteUrl,
 } from '~/stores/context';
 
 import {
@@ -51,7 +51,7 @@ type Props = CommonProps & {
   yarnVersion: string,
   installedPlugins: any,
   envVars: any,
-
+  isAclEnabled: boolean,
   isSearchServiceConfigured: boolean,
   isSearchServiceReachable: boolean,
   isMailerSetup: boolean,
@@ -144,6 +144,8 @@ const AdminMarkdownSettingsPage: NextPage<Props> = (props: Props) => {
   // useSearchServiceConfigured(props.isSearchServiceConfigured);
   useIsSearchServiceReachable(props.isSearchServiceReachable);
 
+  console.log('iii', props.isAclEnabled);
+  useIsAclEnabled(props.isAclEnabled);
   useSiteUrl(props.siteUrl);
 
   // useEnvVars(props.envVars);
@@ -195,7 +197,7 @@ export const getServerSideProps: GetServerSideProps = async(context: GetServerSi
   const req: CrowiRequest = context.req as CrowiRequest;
   const { crowi } = req;
   const {
-    appService, searchService,
+    appService, searchService, aclService,
   } = crowi;
 
   const { user } = req;
@@ -221,6 +223,7 @@ export const getServerSideProps: GetServerSideProps = async(context: GetServerSi
   props.yarnVersion = crowi.runtimeVersions.versions.yarn ? crowi.runtimeVersions.versions.yarn.version.version : null;
   props.installedPlugins = pluginUtils.listPlugins();
   props.envVars = await ConfigLoader.getEnvVarsForDisplay(true);
+  props.isAclEnabled = aclService.isAclEnabled();
 
   props.isSearchServiceConfigured = searchService.isConfigured;
   props.isSearchServiceReachable = searchService.isReachable;

--- a/packages/app/src/pages/admin/[[...path]].page.tsx
+++ b/packages/app/src/pages/admin/[[...path]].page.tsx
@@ -144,7 +144,6 @@ const AdminMarkdownSettingsPage: NextPage<Props> = (props: Props) => {
   // useSearchServiceConfigured(props.isSearchServiceConfigured);
   useIsSearchServiceReachable(props.isSearchServiceReachable);
 
-  console.log('iii', props.isAclEnabled);
   useIsAclEnabled(props.isAclEnabled);
   useSiteUrl(props.siteUrl);
 


### PR DESCRIPTION
## Task
[GROWI][Next.js][Admin][Customize以外] 残存の不具合を修正し、全てのページで正常に表示 & 更新ができる
┗ [101815](https://redmine.weseek.co.jp/issues/101815) [Secyrity][UserGroupManagement][UserManagement] 表示されていないコンテンツの表示

## ScreenShots
## Security Settings
![FireShot Capture 027 - security_settings - GROWI - localhost](https://user-images.githubusercontent.com/59536731/182302124-0b268084-367a-4187-87c0-cb40aa120969.png)


## UserManagement

`<InviteUserControl />` を有効化し、`UserInviteModal` を表示

<img width="471" alt="Screen Shot 2022-08-02 at 14 50 31" src="https://user-images.githubusercontent.com/59536731/182301507-d1f26e6d-3aa2-49b2-82a5-f2a46c63cd7f.png">


## UserGroupManagement

https://github.com/weseek/growi/blob/support/apply-nextjs-2/packages/app/src/components/Admin/UserGroup/UserGroupPage.tsx#L147-L159

↑の部分で`isAclEnabled` の値が undefined になっていたので、`ユーザーグループ作成ボタン` が表示されていませんでした。
よって、`isAclEnabled` を server side から取得し、ユーザーグループ作成ボタンを表示 & ユーザーグループをを新規作成できるようにしました。




### Before
<img width="1077" alt="Screen Shot 2022-08-02 at 15 00 22" src="https://user-images.githubusercontent.com/59536731/182302832-e96393f9-23b3-4ccf-91ef-b1b2000988c4.png">

### After

<img width="1075" alt="Screen Shot 2022-08-02 at 15 01 45" src="https://user-images.githubusercontent.com/59536731/182302987-d2bca089-5e92-4b65-9f63-a91bf7ccd141.png">

<img width="481" alt="Screen Shot 2022-08-02 at 15 04 14" src="https://user-images.githubusercontent.com/59536731/182303324-5d44c131-d21c-4fc5-a1f9-661c2ca4a9df.png">


