### PR TITLE
imprv: refactor skelton component

### DIFF
--- a/packages/app/src/components/Navbar/AuthorInfo.module.scss
+++ b/packages/app/src/components/Navbar/AuthorInfo.module.scss
@@ -1,0 +1,5 @@
+
+.grw-author-info-skelton {
+  width: 139px;
+  height: 32.84px;
+}

--- a/packages/app/src/components/Navbar/GrowiContextualSubNavigation.tsx
+++ b/packages/app/src/components/Navbar/GrowiContextualSubNavigation.tsx
@@ -39,6 +39,8 @@ import { Skelton } from '../Skelton';
 import { GrowiSubNavigation } from './GrowiSubNavigation';
 import { SubNavButtonsProps } from './SubNavButtons';
 
+import PageEditorModeManagerStyles from './PageEditorModeManager.module.scss';
+
 
 type AdditionalMenuItemsProps = {
   pageId: string,
@@ -155,7 +157,7 @@ const GrowiContextualSubNavigation = (props: GrowiContextualSubNavigationProps):
 
   const PageEditorModeManager = dynamic(
     () => import('./PageEditorModeManager'),
-    { ssr: false, loading: () => <Skelton width={213} height={33.99} /> },
+    { ssr: false, loading: () => <Skelton additionalClass={`${PageEditorModeManagerStyles['grw-page-editor-mode-manager-skelton']}`} /> },
   );
   const SubNavButtons = dynamic<SubNavButtonsProps>(
     () => import('./SubNavButtons').then(mod => mod.SubNavButtons),

--- a/packages/app/src/components/Navbar/GrowiSubNavigation.tsx
+++ b/packages/app/src/components/Navbar/GrowiSubNavigation.tsx
@@ -14,7 +14,8 @@ import { Skelton } from '../Skelton';
 import DrawerToggler from './DrawerToggler';
 
 
-import TagLabelsStyle from '../Page/TagLabels.module.scss';
+import TagLabelsStyles from '../Page/TagLabels.module.scss';
+import AuthorInfoStyles from './AuthorInfo.module.scss';
 import styles from './GrowiSubNavigation.module.scss';
 
 
@@ -40,9 +41,12 @@ export const GrowiSubNavigation = (props: Props): JSX.Element => {
 
   const TagLabels = dynamic(() => import('../Page/TagLabels'), {
     ssr: false,
-    loading: () => <Skelton additionalClass={`${TagLabelsStyle['grw-tag-labels-skelton']} py-1`} />,
+    loading: () => <Skelton additionalClass={`${TagLabelsStyles['grw-tag-labels-skelton']} py-1`} />,
   });
-  const AuthorInfo = dynamic(() => import('./AuthorInfo'), { ssr: false, loading: () => <Skelton width={139} height={32.84} additionalClass='py-1' /> });
+  const AuthorInfo = dynamic(() => import('./AuthorInfo'), {
+    ssr: false,
+    loading: () => <Skelton additionalClass={`${AuthorInfoStyles['grw-author-info-skelton']} py-1`} />,
+  });
 
   const { data: editorMode } = useEditorMode();
 

--- a/packages/app/src/components/Navbar/GrowiSubNavigation.tsx
+++ b/packages/app/src/components/Navbar/GrowiSubNavigation.tsx
@@ -14,6 +14,7 @@ import { Skelton } from '../Skelton';
 import DrawerToggler from './DrawerToggler';
 
 
+import TagLabelsStyle from '../Page/TagLabels.module.scss';
 import styles from './GrowiSubNavigation.module.scss';
 
 
@@ -37,7 +38,10 @@ type Props = {
 
 export const GrowiSubNavigation = (props: Props): JSX.Element => {
 
-  const TagLabels = dynamic(() => import('../Page/TagLabels'), { ssr: false, loading: () => <Skelton width={137} height={21.99} additionalClass='py-1' /> });
+  const TagLabels = dynamic(() => import('../Page/TagLabels'), {
+    ssr: false,
+    loading: () => <Skelton additionalClass={`${TagLabelsStyle['grw-tag-labels-skelton']} py-1`} />,
+  });
   const AuthorInfo = dynamic(() => import('./AuthorInfo'), { ssr: false, loading: () => <Skelton width={139} height={32.84} additionalClass='py-1' /> });
 
   const { data: editorMode } = useEditorMode();

--- a/packages/app/src/components/Navbar/PageEditorModeManager.module.scss
+++ b/packages/app/src/components/Navbar/PageEditorModeManager.module.scss
@@ -2,6 +2,8 @@
 @use '~/styles/bootstrap/init' as bs;
 @use '~/styles/mixins';
 
+$btn-line-height: 1.2rem;
+
 .grw-page-editor-mode-manager :global {
   .btn {
     width: 70px;
@@ -11,7 +13,7 @@
 
     &.view-button,
     &.edit-button {
-      line-height: 1.2rem;
+      line-height: $btn-line-height;
       .grw-page-editor-mode-manager-icon {
         @include bs.media-breakpoint-down(sm) {
           font-size: 1.2rem;
@@ -19,7 +21,7 @@
       }
     }
     &.hackmd-button {
-      line-height: 1.2rem;
+      line-height: $btn-line-height;
       .grw-page-editor-mode-manager-icon {
         @include bs.media-breakpoint-down(sm) {
           font-size: 1.2rem;
@@ -35,5 +37,5 @@
 
 .grw-page-editor-mode-manager-skelton :global {
   width: 213px;
-  height: 33.99px;
+  height: calc($btn-line-height + bs.$btn-padding-y*2);
 }

--- a/packages/app/src/components/Navbar/PageEditorModeManager.module.scss
+++ b/packages/app/src/components/Navbar/PageEditorModeManager.module.scss
@@ -32,3 +32,8 @@
     }
   }
 }
+
+.grw-page-editor-mode-manager-skelton :global {
+  width: 213px;
+  height: 33.99px;
+}

--- a/packages/app/src/components/Navbar/PageEditorModeManager.module.scss
+++ b/packages/app/src/components/Navbar/PageEditorModeManager.module.scss
@@ -36,6 +36,7 @@ $btn-line-height: 1.2rem;
 }
 
 .grw-page-editor-mode-manager-skelton :global {
+
   width: 213px;
-  height: calc($btn-line-height + bs.$btn-padding-y*2);
+  height: calc($btn-line-height + bs.$btn-padding-y*2 + bs.$btn-border-width*2);
 }

--- a/packages/app/src/components/Page/TagLabels.module.scss
+++ b/packages/app/src/components/Page/TagLabels.module.scss
@@ -1,0 +1,9 @@
+@use '~/styles/bootstrap/init' as bs;
+
+.grw-tag-labels :global {
+  .grw-tag-label {
+    font-size: 12px;
+    font-weight: normal;
+    border-radius: bs.$border-radius;
+  }
+}

--- a/packages/app/src/components/Page/TagLabels.module.scss
+++ b/packages/app/src/components/Page/TagLabels.module.scss
@@ -7,3 +7,9 @@
     border-radius: bs.$border-radius;
   }
 }
+
+
+.grw-tag-labels-skelton :global {
+  width: 137px;
+  height: 21.99px;
+}

--- a/packages/app/src/components/Page/TagLabels.tsx
+++ b/packages/app/src/components/Page/TagLabels.tsx
@@ -3,6 +3,8 @@ import React, { FC, useState } from 'react';
 import RenderTagLabels from './RenderTagLabels';
 import TagEditModal from './TagEditModal';
 
+import styles from './TagLabels.module.scss';
+
 type Props = {
   tags?: string[],
   isGuestUser: boolean,
@@ -25,7 +27,7 @@ const TagLabels:FC<Props> = (props: Props) => {
 
   return (
     <>
-      <form className="grw-tag-labels form-inline">
+      <form className={`${styles['grw-tag-labels']} grw-tag-labels form-inline`}>
         <i className="tag-icon icon-tag mr-2"></i>
         { tags == null
           ? (

--- a/packages/app/src/components/Sidebar/RecentChanges.tsx
+++ b/packages/app/src/components/Sidebar/RecentChanges.tsx
@@ -17,7 +17,9 @@ import FormattedDistanceDate from '../FormattedDistanceDate';
 
 import InfiniteScroll from './InfiniteScroll';
 
+import TagLabelsStyles from '../Page/TagLabels.module.scss';
 import styles from './RecentChanges.module.scss';
+
 
 const logger = loggerFactory('growi:History');
 
@@ -82,7 +84,7 @@ const LargePageItem = memo(({ page }: PageItemProps): JSX.Element => {
             <PagePathHierarchicalLink linkedPagePath={linkedPagePathLatter} basePath={dPagePath.isRoot ? undefined : dPagePath.former} />
             {locked}
           </h5>
-          <div className="grw-tag-labels mt-1 mb-2">
+          <div className={`grw-tag-labels ${TagLabelsStyles['grw-tag-labels']} mt-1 mb-2`}>
             { tagElements }
           </div>
           <PageItemLower page={page} />

--- a/packages/app/src/components/Sidebar/RecentChanges.tsx
+++ b/packages/app/src/components/Sidebar/RecentChanges.tsx
@@ -84,7 +84,7 @@ const LargePageItem = memo(({ page }: PageItemProps): JSX.Element => {
             <PagePathHierarchicalLink linkedPagePath={linkedPagePathLatter} basePath={dPagePath.isRoot ? undefined : dPagePath.former} />
             {locked}
           </h5>
-          <div className={`grw-tag-labels ${TagLabelsStyles['grw-tag-labels']} mt-1 mb-2`}>
+          <div className="grw-tag-labels mt-1 mb-2">
             { tagElements }
           </div>
           <PageItemLower page={page} />

--- a/packages/app/src/components/Skelton.tsx
+++ b/packages/app/src/components/Skelton.tsx
@@ -1,24 +1,17 @@
 import React from 'react';
 
 type SkeltonProps = {
-  width?: number,
-  height?: number,
   additionalClass?: string,
   roundedPill?: boolean,
 }
 
 export const Skelton = (props: SkeltonProps): JSX.Element => {
   const {
-    width, height, additionalClass, roundedPill,
+    additionalClass, roundedPill,
   } = props;
 
-  const skeltonStyle = {
-    width,
-    height,
-  };
-
   return (
-    <div style={skeltonStyle} className={`${additionalClass}`}>
+    <div className={`${additionalClass}`}>
       <div className={`grw-skelton h-100 w-100 ${roundedPill ? 'rounded-pill' : ''}`}></div>
     </div>
   );

--- a/packages/app/src/styles/_tag.scss
+++ b/packages/app/src/styles/_tag.scss
@@ -25,5 +25,7 @@
 .grw-recent-changes {
   .grw-tag-label {
     font-size: 10px;
+    font-weight: normal;
+    border-radius: bs.$border-radius;
   }
 }

--- a/packages/app/src/styles/_tag.scss
+++ b/packages/app/src/styles/_tag.scss
@@ -6,14 +6,6 @@
   }
 }
 
-.grw-tag-labels {
-  .grw-tag-label {
-    font-size: 12px;
-    font-weight: normal;
-    border-radius: bs.$border-radius;
-  }
-}
-
 .grw-popular-tag-labels {
   text-align: left;
 


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/101877

- スケルトンコンポーネントからwidth, heightのpropsを削除、スタイルはcssで当てる実装に変更
- 親コンポーネントでスケルトンのwidth, heightをハードコーディングしていた部分をcssでスタイルを当てるように修正

TagLabelsとAuthorInfoのスケルトンリファクタは既存コンポーネントのスタイルを変更する必要がありそうだったので別タスク(https://redmine.weseek.co.jp/issues/102017)
でやります