### PR TITLE
imprv: 102017 refactor tag labels author info skelton

### DIFF
--- a/packages/app/src/components/Navbar/AuthorInfo.module.scss
+++ b/packages/app/src/components/Navbar/AuthorInfo.module.scss
@@ -1,13 +1,16 @@
 @use '~/styles/bootstrap/init' as bs;
 
+$author-font-size: 12px;
+$date-font-size: 11px;
+
 .grw-author-info :global {
   li {
-    font-size: 12px;
+    font-size: $author-font-size;
     list-style: none;
   }
 
   .text-date {
-    font-size: 11px;
+    font-size: $date-font-size;
   }
 
   .picture {
@@ -24,5 +27,5 @@
 
 .grw-author-info-skelton :global {
   width: 139px;
-  height: 32.84px;
+  height: calc((#{$author-font-size} + #{$date-font-size}) * #{bs.$line-height-base});
 }

--- a/packages/app/src/components/Navbar/AuthorInfo.module.scss
+++ b/packages/app/src/components/Navbar/AuthorInfo.module.scss
@@ -1,5 +1,28 @@
+@use '~/styles/bootstrap/init' as bs;
 
-.grw-author-info-skelton {
+.grw-author-info :global {
+  li {
+    font-size: 12px;
+    list-style: none;
+  }
+
+  .text-date {
+    font-size: 11px;
+  }
+
+  .picture {
+    width: 22px;
+    height: 22px;
+    border: 1px solid bs.$gray-300;
+
+    &.picture-xs {
+      width: 14px;
+      height: 14px;
+    }
+  }
+}
+
+.grw-author-info-skelton :global {
   width: 139px;
   height: 32.84px;
 }

--- a/packages/app/src/components/Navbar/GrowiSubNavigation.module.scss
+++ b/packages/app/src/components/Navbar/GrowiSubNavigation.module.scss
@@ -88,42 +88,20 @@
       font-size: 16px;
     }
 
-    ul.authors {
-      li {
-        font-size: 12px;
-        list-style: none;
-      }
+    .user-list-popover {
+      max-width: 200px;
 
-      .text-date {
-        font-size: 11px;
-      }
+      .user-list-content {
+        direction: rtl;
 
-      .picture {
-        width: 22px;
-        height: 22px;
-        border: 1px solid bs.$gray-300;
-
-        &.picture-xs {
-          width: 14px;
-          height: 14px;
+        .liker-user-count,
+        .seen-user-count {
+          font-size: 12px;
+          font-weight: bolder;
         }
       }
-
-      .user-list-popover {
-        max-width: 200px;
-
-        .user-list-content {
-          direction: rtl;
-
-          .liker-user-count,
-          .seen-user-count {
-            font-size: 12px;
-            font-weight: bolder;
-          }
-        }
-        .cls-1 {
-          isolation: isolate;
-        }
+      .cls-1 {
+        isolation: isolate;
       }
     }
   }

--- a/packages/app/src/components/Navbar/GrowiSubNavigation.tsx
+++ b/packages/app/src/components/Navbar/GrowiSubNavigation.tsx
@@ -103,7 +103,7 @@ export const GrowiSubNavigation = (props: Props): JSX.Element => {
 
         {/* Page Authors */}
         { (showPageAuthors && !isCompactMode) && (
-          <ul className="authors text-nowrap border-left d-none d-lg-block d-edit-none py-2 pl-4 mb-0 ml-3">
+          <ul className={`${AuthorInfoStyles['grw-author-info']} text-nowrap border-left d-none d-lg-block d-edit-none py-2 pl-4 mb-0 ml-3`}>
             <li className="pb-1">
               <AuthorInfo user={creator as IUser} date={createdAt} locate="subnav" />
             </li>

--- a/packages/app/src/components/Navbar/GrowiSubNavigation.tsx
+++ b/packages/app/src/components/Navbar/GrowiSubNavigation.tsx
@@ -89,7 +89,8 @@ export const GrowiSubNavigation = (props: Props): JSX.Element => {
         <div className="grw-path-nav-container">
           { showTagLabel && !isCompactMode && (
             <div className="grw-taglabels-container">
-              <TagLabels tags={tags} isGuestUser={isGuestUser ?? false} tagsUpdateInvoked={tagsUpdatedHandler} />
+              {/* <TagLabels tags={tags} isGuestUser={isGuestUser ?? false} tagsUpdateInvoked={tagsUpdatedHandler} /> */}
+              <Skelton additionalClass={`${TagLabelsStyles['grw-tag-labels-skelton']} py-1`} />
             </div>
           ) }
           <PagePathNav pageId={pageId} pagePath={path} isSingleLineMode={isEditorMode} isCompactMode={isCompactMode} />

--- a/packages/app/src/components/Navbar/GrowiSubNavigation.tsx
+++ b/packages/app/src/components/Navbar/GrowiSubNavigation.tsx
@@ -89,8 +89,7 @@ export const GrowiSubNavigation = (props: Props): JSX.Element => {
         <div className="grw-path-nav-container">
           { showTagLabel && !isCompactMode && (
             <div className="grw-taglabels-container">
-              {/* <TagLabels tags={tags} isGuestUser={isGuestUser ?? false} tagsUpdateInvoked={tagsUpdatedHandler} /> */}
-              <Skelton additionalClass={`${TagLabelsStyles['grw-tag-labels-skelton']} py-1`} />
+              <TagLabels tags={tags} isGuestUser={isGuestUser ?? false} tagsUpdateInvoked={tagsUpdatedHandler} />
             </div>
           ) }
           <PagePathNav pageId={pageId} pagePath={path} isSingleLineMode={isEditorMode} isCompactMode={isCompactMode} />

--- a/packages/app/src/components/Page/RenderTagLabels.tsx
+++ b/packages/app/src/components/Page/RenderTagLabels.tsx
@@ -35,7 +35,7 @@ const RenderTagLabels = React.memo((props: RenderTagLabelsProps) => {
 
       <div id="edit-tags-btn-wrapper-for-tooltip">
         <a
-          className={`btn btn-link btn-edit-tags p-0 text-muted ${isTagsEmpty ? 'no-tags' : ''} ${isGuestUser ? 'disabled' : ''}`}
+          className={`btn btn-link btn-edit-tags p-0 text-muted d-flex ${isTagsEmpty ? 'no-tags' : ''} ${isGuestUser ? 'disabled' : ''}`}
           onClick={openEditorHandler}
         >
           { isTagsEmpty && <>{ t('Add tags for this page') }</>}

--- a/packages/app/src/components/Page/TagLabels.module.scss
+++ b/packages/app/src/components/Page/TagLabels.module.scss
@@ -1,8 +1,10 @@
 @use '~/styles/bootstrap/init' as bs;
 
+$grw-tag-label-font-size: 12px;
+
 .grw-tag-labels :global {
   .grw-tag-label {
-    font-size: 12px;
+    font-size: $grw-tag-label-font-size;
     font-weight: normal;
     border-radius: bs.$border-radius;
   }
@@ -11,5 +13,6 @@
 
 .grw-tag-labels-skelton :global {
   width: 137px;
-  height: 21.99px;
+  height: calc(#{$grw-tag-label-font-size} + #{bs.$badge-padding-y} * 2);
+  font-size: $grw-tag-label-font-size; // set font-size to use the same em value in bs.$badge-padding-y
 }

--- a/packages/app/src/components/Page/TagLabels.module.scss
+++ b/packages/app/src/components/Page/TagLabels.module.scss
@@ -14,5 +14,5 @@ $grw-tag-label-font-size: 12px;
 .grw-tag-labels-skelton :global {
   width: 137px;
   height: calc(#{$grw-tag-label-font-size} + #{bs.$badge-padding-y} * 2);
-  font-size: $grw-tag-label-font-size; // set font-size to use the same em value in bs.$badge-padding-y
+  font-size: $grw-tag-label-font-size; // set font-size to use the same em value in bs.$badge-padding-y(https://getbootstrap.jp/docs/5.0/components/badge/#variables)
 }

--- a/packages/app/src/components/Page/TagLabels.tsx
+++ b/packages/app/src/components/Page/TagLabels.tsx
@@ -27,7 +27,7 @@ const TagLabels:FC<Props> = (props: Props) => {
 
   return (
     <>
-      <form className={`${styles['grw-tag-labels']} grw-tag-labels form-inline`}>
+      <div className={`${styles['grw-tag-labels']} grw-tag-labels d-flex align-items-center`}>
         <i className="tag-icon icon-tag mr-2"></i>
         { tags == null
           ? (
@@ -41,7 +41,7 @@ const TagLabels:FC<Props> = (props: Props) => {
             />
           )
         }
-      </form>
+      </div>
 
       <TagEditModal
         tags={tags}


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/102017

before

<img width="205" alt="TagLabels_before" src="https://user-images.githubusercontent.com/65263895/182609697-50b3097c-eadb-434d-ace7-40f044601c1e.PNG">

after
<img width="257" alt="TagLabels_after" src="https://user-images.githubusercontent.com/65263895/182609717-0de60987-eb75-4019-8074-f97b8e58017e.PNG">

- TagLabelsのデザインが少しずれていたのを修正（プラスボタンがめちゃめちゃ少し上にずれていた）
- TagLabelsとAuthoInfoのスケルトンの高さをハードコーディングではなく、本物のコンポーネントの情報から計算するように実装
