### PR TITLE
fix: 102041 refactor use sw rx page info

### DIFF
--- a/packages/app/src/stores/page.tsx
+++ b/packages/app/src/stores/page.tsx
@@ -81,11 +81,18 @@ export const useSWRxPageInfo = (
   // assign null if shareLinkId is undefined in order to identify SWR key only by pageId
   const fixedShareLinkId = shareLinkId ?? null;
 
-  return useSWRImmutable<IPageInfo | IPageInfoForOperation, Error>(
+  const swrResult = useSWRImmutable<IPageInfo | IPageInfoForOperation, Error>(
     pageId != null ? ['/page/info', pageId, fixedShareLinkId] : null,
     (endpoint, pageId, shareLinkId) => apiv3Get(endpoint, { pageId, shareLinkId }).then(response => response.data),
     { fallbackData: initialData },
   );
+
+  // use mutate because fallbackData does not work
+  if (initialData != null) {
+    swrResult.mutate(initialData);
+  }
+
+  return swrResult;
 };
 
 export const useSWRxPageRevisions = (


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/102041

## 原因
[[...page]]の中で
```
useSWRxPageInfo(pageId, undefined, pageWithMeta?.meta); // store initial data
```
このようにして、initial dataを入れているが、swrのfallbackDataが機能しておらず、キャッシュにデータが保存できていない

## 解決策
useSWRxPageInfoの中で明示的にmutateをする