### PR TITLE
Imprv/101976 delete debug code related to editor

### DIFF
--- a/packages/app/src/components/PageEditor.tsx
+++ b/packages/app/src/components/PageEditor.tsx
@@ -399,8 +399,6 @@ const PageEditor = (props: Props): JSX.Element => {
     return <></>;
   }
 
-  // const config = props.appContainer.getConfig();
-  // const isUploadable = config.upload.image || config.upload.file;
   const isUploadable = isUploadableImage || isUploadableFile;
 
 

--- a/packages/app/src/components/PageEditor.tsx
+++ b/packages/app/src/components/PageEditor.tsx
@@ -411,8 +411,6 @@ const PageEditor = (props: Props): JSX.Element => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const EditorAny = Editor as any;
 
-  // console.log('EditorAny', markdown);
-
   return (
     <div className="d-flex flex-wrap">
       <div className="page-editor-editor-container flex-grow-1 flex-basis-0 mw-0">

--- a/packages/app/src/components/PageEditor/CodeMirrorEditor.jsx
+++ b/packages/app/src/components/PageEditor/CodeMirrorEditor.jsx
@@ -987,9 +987,6 @@ class CodeMirrorEditor extends AbstractEditor {
       gutters.push('CodeMirror-lint-markers');
     }
 
-    console.log(' this.state.value', this.state.value);
-    console.log(' this.props.value', this.props.value);
-
     return (
       <div className={`grw-codemirror-editor ${styles['grw-codemirror-editor']}`}>
 


### PR DESCRIPTION
## Task
[GROWI][Nextjs] Built-in Editorでeditorとpreviewの表示ができる
┗[101976](https://redmine.weseek.co.jp/issues/101976) デバッグコードの削除

## Description
以下のPRで生まれた不要なコードを削除しました。
https://github.com/weseek/growi/pull/6290/files

## Note
CIで落ちてますが、本PRとは関係ないのでマージ可能です。