### PR TITLE
imprv: Implement i18n to /me page

### DIFF
--- a/packages/app/src/pages/me.page.tsx
+++ b/packages/app/src/pages/me.page.tsx
@@ -8,6 +8,7 @@ import {
   NextPage, GetServerSideProps, GetServerSidePropsContext,
 } from 'next';
 import { useTranslation } from 'next-i18next';
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
 
@@ -131,10 +132,10 @@ async function injectServerConfigurations(context: GetServerSidePropsContext, pr
 //  * @param props
 //  * @param namespacesRequired
 //  */
-// async function injectNextI18NextConfigurations(context: GetServerSidePropsContext, props: Props, namespacesRequired?: string[] | undefined): Promise<void> {
-//   const nextI18NextConfig = await getNextI18NextConfig(serverSideTranslations, context, namespacesRequired);
-//   props._nextI18Next = nextI18NextConfig._nextI18Next;
-// }
+async function injectNextI18NextConfigurations(context: GetServerSidePropsContext, props: Props, namespacesRequired?: string[] | undefined): Promise<void> {
+  const nextI18NextConfig = await getNextI18NextConfig(serverSideTranslations, context, namespacesRequired);
+  props._nextI18Next = nextI18NextConfig._nextI18Next;
+}
 
 export const getServerSideProps: GetServerSideProps = async(context: GetServerSidePropsContext) => {
   const req = context.req as CrowiRequest<IUserHasId & any>;
@@ -157,6 +158,7 @@ export const getServerSideProps: GetServerSideProps = async(context: GetServerSi
 
   await injectUserUISettings(context, props);
   await injectServerConfigurations(context, props);
+  await injectNextI18NextConfigurations(context, props, ['translation']);
 
   return {
     props,


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/102194
<img width="1914" alt="me_page_styled" src="https://user-images.githubusercontent.com/65263895/183419796-ab042520-a215-4da9-b843-6356cb4ca783.PNG">

- スタイルを実装するタスクですが、/meページのモジュール化すべきスタイルシートがなかったので、i18nの実装だけしました。
- admin関係のi18nは未実装ですが、スコープ外だと思うのでスルーしています
