### PR TITLE
Imprv/101879 apply border to customize option boxes

### DIFF
--- a/packages/app/src/components/Layout/AdminLayout.tsx
+++ b/packages/app/src/components/Layout/AdminLayout.tsx
@@ -29,26 +29,28 @@ const AdminLayout = ({
   const SystemVersion = dynamic(() => import('../SystemVersion'), { ssr: false });
 
   return (
-    <RawLayout title={title} className={`admin-page ${styles['admin-page']}`}>
-      <GrowiNavbar />
+    <RawLayout title={title}>
+      <div className={`admin-page ${styles['admin-page']}`}>
+        <GrowiNavbar />
 
-      <header className="py-0">
-        <h1 className="title">{title}</h1>
-      </header>
-      <div id="main" className="main">
-        <div className="container-fluid">
-          <div className="row">
-            <div className="col-lg-3">
-              <AdminNavigation selected={selectedNavOpt} />
-            </div>
-            <div className="col-lg-9">
-              {children}
+        <header className="py-0">
+          <h1 className="title">{title}</h1>
+        </header>
+        <div id="main" className="main">
+          <div className="container-fluid">
+            <div className="row">
+              <div className="col-lg-3">
+                <AdminNavigation selected={selectedNavOpt} />
+              </div>
+              <div className="col-lg-9">
+                {children}
+              </div>
             </div>
           </div>
         </div>
-      </div>
 
-      <SystemVersion />
+        <SystemVersion />
+      </div>
     </RawLayout>
   );
 };

--- a/packages/app/src/styles/theme/_apply-colors.scss
+++ b/packages/app/src/styles/theme/_apply-colors.scss
@@ -634,7 +634,7 @@ mark.rbt-highlight-text {
  * GROWI admin page #layoutOptions #themeOptions
  */
 
-// .admin-page {
+.admin-page {
   #layoutOptions {
     .customize-layout-card {
       &.border-active {
@@ -654,7 +654,7 @@ mark.rbt-highlight-text {
       }
     }
   }
-// }
+}
 
 /*
  * HackMd

--- a/packages/app/src/styles/theme/_apply-colors.scss
+++ b/packages/app/src/styles/theme/_apply-colors.scss
@@ -633,7 +633,6 @@ mark.rbt-highlight-text {
 /*
  * GROWI admin page #layoutOptions #themeOptions
  */
-
 .admin-page {
   #layoutOptions {
     .customize-layout-card {

--- a/packages/app/src/styles/theme/_apply-colors.scss
+++ b/packages/app/src/styles/theme/_apply-colors.scss
@@ -633,7 +633,8 @@ mark.rbt-highlight-text {
 /*
  * GROWI admin page #layoutOptions #themeOptions
  */
-.admin-page {
+
+// .admin-page {
   #layoutOptions {
     .customize-layout-card {
       &.border-active {
@@ -653,7 +654,7 @@ mark.rbt-highlight-text {
       }
     }
   }
-}
+// }
 
 /*
  * HackMd


### PR DESCRIPTION
## Task
[GROWI][Next.js][Admin][Customize] 各種設定の更新ができる
┗ [101879](https://redmine.weseek.co.jp/issues/101879) 選択中の要素にボーダーがつかないのを修正

## ScreenShots
### Before
<img width="782" alt="Screen Shot 2022-08-09 at 16 27 52" src="https://user-images.githubusercontent.com/59536731/183590215-df017c10-163e-4e0f-8b9a-30c3e799bd88.png">



### After
<img width="766" alt="Screen Shot 2022-08-09 at 16 27 12" src="https://user-images.githubusercontent.com/59536731/183590088-eff822bf-f103-4c1a-b899-08f15e2f7b45.png">

