### PR TITLE
feat: Apply background image and navbar image for themes

### DIFF
--- a/packages/app/src/components/Layout/AdminLayout.tsx
+++ b/packages/app/src/components/Layout/AdminLayout.tsx
@@ -32,7 +32,7 @@ const AdminLayout = ({
     <RawLayout title={title} className={`admin-page ${styles['admin-page']}`}>
       <GrowiNavbar />
 
-      <header className="py-0">
+      <header className="py-0 position-relative">
         <h1 className="title">{title}</h1>
       </header>
       <div id="main" className="main">

--- a/packages/app/src/components/Layout/RawLayout.tsx
+++ b/packages/app/src/components/Layout/RawLayout.tsx
@@ -30,16 +30,14 @@ export const RawLayout = ({ children, title, className }: Props): JSX.Element =>
 
   const [colorScheme, setColorScheme] = useState<Themes|undefined>(undefined);
   const [backgroundImageSrc, setBackgroundImageSrc] = useState<string | undefined>(undefined);
+
   // set colorScheme in CSR
   useEffect(() => {
     setColorScheme(resolvedTheme as Themes);
   }, [resolvedTheme]);
 
+  // set background image
   useEffect(() => {
-    if (growiTheme == null || colorScheme == null) {
-      setBackgroundImageSrc(undefined);
-      return;
-    }
     const imgSrc = getBackgroundImageSrc(growiTheme, colorScheme);
     setBackgroundImageSrc(imgSrc);
   }, [growiTheme, colorScheme]);

--- a/packages/app/src/components/Layout/RawLayout.tsx
+++ b/packages/app/src/components/Layout/RawLayout.tsx
@@ -53,8 +53,8 @@ export const RawLayout = ({ children, title, className }: Props): JSX.Element =>
       </Head>
       <ThemeProvider theme={growiTheme}>
         <div className={classNames.join(' ')} data-color-scheme={colorScheme}>
-          {backgroundImageSrc != null && <div className="bg-image-wrapper">
-            <Image className='bg-image' alt='background-image' src={backgroundImageSrc} layout='fill' quality="100" />
+          {backgroundImageSrc != null && <div className="grw-bg-image-wrapper">
+            <Image className='grw-bg-image' alt='background-image' src={backgroundImageSrc} layout='fill' quality="100" />
           </div>}
           {children}
         </div>

--- a/packages/app/src/components/Layout/RawLayout.tsx
+++ b/packages/app/src/components/Layout/RawLayout.tsx
@@ -54,7 +54,7 @@ export const RawLayout = ({ children, title, className }: Props): JSX.Element =>
       <ThemeProvider theme={growiTheme}>
         <div className={classNames.join(' ')} data-color-scheme={colorScheme}>
           {backgroundImageSrc != null && <div className="bg-image-wrapper">
-            <Image className='bg-image' alt='background-image' src={backgroundImageSrc} layout='fill' />
+            <Image className='bg-image' alt='background-image' src={backgroundImageSrc} layout='fill' quality="100" />
           </div>}
           {children}
         </div>

--- a/packages/app/src/components/Layout/RawLayout.tsx
+++ b/packages/app/src/components/Layout/RawLayout.tsx
@@ -1,10 +1,14 @@
-import React, { ReactNode, useEffect, useState } from 'react';
+import React, {
+  ReactNode, useCallback, useEffect, useState,
+} from 'react';
 
 import Head from 'next/head';
+import Image from 'next/image';
 
 import { useGrowiTheme } from '~/stores/context';
 import { Themes, useNextThemes } from '~/stores/use-next-themes';
 
+import { getBackgroundImageSrc } from '../Theme/utils/ThemeImageProvider';
 import { ThemeProvider } from '../Theme/utils/ThemeProvider';
 
 type Props = {
@@ -25,11 +29,20 @@ export const RawLayout = ({ children, title, className }: Props): JSX.Element =>
   const { resolvedTheme } = useNextThemes();
 
   const [colorScheme, setColorScheme] = useState<Themes|undefined>(undefined);
-
+  const [backgroundImageSrc, setBackgroundImageSrc] = useState<string | undefined>(undefined);
   // set colorScheme in CSR
   useEffect(() => {
     setColorScheme(resolvedTheme as Themes);
   }, [resolvedTheme]);
+
+  useEffect(() => {
+    if (growiTheme == null || colorScheme == null) {
+      setBackgroundImageSrc(undefined);
+      return;
+    }
+    const imgSrc = getBackgroundImageSrc(growiTheme, colorScheme);
+    setBackgroundImageSrc(imgSrc);
+  }, [growiTheme, colorScheme]);
 
   return (
     <>
@@ -40,6 +53,9 @@ export const RawLayout = ({ children, title, className }: Props): JSX.Element =>
       </Head>
       <ThemeProvider theme={growiTheme}>
         <div className={classNames.join(' ')} data-color-scheme={colorScheme}>
+          {backgroundImageSrc != null && <div className="bg-image-wrapper">
+            <Image className='bg-image' alt='background-image' src={backgroundImageSrc} layout='fill' />
+          </div>}
           {children}
         </div>
       </ThemeProvider>

--- a/packages/app/src/components/Theme/ThemeAntarctic.module.scss
+++ b/packages/app/src/components/Theme/ThemeAntarctic.module.scss
@@ -34,6 +34,18 @@
   }
 }
 
+.theme :global {
+  .bg-image-wrapper {
+    position: fixed;
+    width: 100%;
+    height: 100%;
+  }
+
+  .bg-image {
+    object-fit: cover;
+  }
+}
+
 $themecolor: #000080;
 $themelight: #f0f8ff;
 $accentcolor: #ffd700;

--- a/packages/app/src/components/Theme/ThemeAntarctic.module.scss
+++ b/packages/app/src/components/Theme/ThemeAntarctic.module.scss
@@ -34,13 +34,13 @@
 }
 
 .theme :global {
-  .bg-image-wrapper {
+  .grw-bg-image-wrapper {
     position: fixed;
     width: 100%;
     height: 100%;
   }
 
-  .bg-image {
+  .grw-bg-image {
     object-fit: cover;
   }
 }

--- a/packages/app/src/components/Theme/ThemeAntarctic.module.scss
+++ b/packages/app/src/components/Theme/ThemeAntarctic.module.scss
@@ -16,7 +16,6 @@
 
 .growi:not(.login-page) {
   // add background-image
-  #page-wrapper,
   .page-editor-preview-container {
     background-image: url('/images/themes/antarctic/bg.svg');
     background-attachment: fixed;

--- a/packages/app/src/components/Theme/ThemeAntarctic.tsx
+++ b/packages/app/src/components/Theme/ThemeAntarctic.tsx
@@ -1,6 +1,15 @@
+import { Themes } from '~/stores/use-next-themes';
+
 import { ThemeInjector } from './utils/ThemeInjector';
 
 import styles from './ThemeAntarctic.module.scss';
+
+export const getBackgroundImageSrc = (colorScheme: Themes): string => {
+  switch (colorScheme) {
+    default:
+      return '/images/themes/antarctic/bg.svg';
+  }
+};
 
 const ThemeAntarctic = ({ children }: { children: JSX.Element }): JSX.Element => {
   return <ThemeInjector className={styles.theme}>{children}</ThemeInjector>;

--- a/packages/app/src/components/Theme/ThemeChristmas.module.scss
+++ b/packages/app/src/components/Theme/ThemeChristmas.module.scss
@@ -36,13 +36,13 @@ $color-link-wiki-hover: lighten($color-link-wiki, 15%);
 }
 
 .theme :global {
-  .bg-image-wrapper {
+  .grw-bg-image-wrapper {
     position: fixed;
     width: 100%;
     height: 100%;
   }
 
-  .bg-image {
+  .grw-bg-image {
     object-fit: cover;
   }
 }

--- a/packages/app/src/components/Theme/ThemeChristmas.module.scss
+++ b/packages/app/src/components/Theme/ThemeChristmas.module.scss
@@ -27,12 +27,23 @@ $color-link-wiki-hover: lighten($color-link-wiki, 15%);
 
 .growi:not(.login-page) {
   // add background-image
-  #page-wrapper,
   .page-editor-preview-container {
     background-image: url('/images/themes/christmas/christmas.jpg');
     background-attachment: fixed;
     background-position: center center;
     background-size: cover;
+  }
+}
+
+.theme :global {
+  .bg-image-wrapper {
+    position: fixed;
+    width: 100%;
+    height: 100%;
+  }
+
+  .bg-image {
+    object-fit: cover;
   }
 }
 

--- a/packages/app/src/components/Theme/ThemeChristmas.tsx
+++ b/packages/app/src/components/Theme/ThemeChristmas.tsx
@@ -1,6 +1,15 @@
+import { Themes } from '~/stores/use-next-themes';
+
 import { ThemeInjector } from './utils/ThemeInjector';
 
 import styles from './ThemeChristmas.module.scss';
+
+export const getBackgroundImageSrc = (colorScheme: Themes): string => {
+  switch (colorScheme) {
+    default:
+      return '/images/themes/christmas/christmas.jpg';
+  }
+};
 
 const ThemeChristmas = ({ children }: { children: JSX.Element }): JSX.Element => {
   return <ThemeInjector className={styles.theme}>{children}</ThemeInjector>;

--- a/packages/app/src/components/Theme/ThemeHalloween.module.scss
+++ b/packages/app/src/components/Theme/ThemeHalloween.module.scss
@@ -26,9 +26,16 @@ $light: lighten($secondary, 10%);
   }
 
   // add background-image
-  #page-wrapper,
   .page-editor-preview-container {
     background-image: url('/images/themes/halloween/halloween.jpg');
+  }
+}
+
+.theme :global {
+  .bg-image-wrapper {
+    position: fixed;
+    width: 100%;
+    height: 100%;
   }
 }
 

--- a/packages/app/src/components/Theme/ThemeHalloween.module.scss
+++ b/packages/app/src/components/Theme/ThemeHalloween.module.scss
@@ -28,7 +28,7 @@ $light: lighten($secondary, 10%);
 }
 
 .theme :global {
-  .bg-image-wrapper {
+  .grw-bg-image-wrapper {
     position: fixed;
     width: 100%;
     height: 100%;

--- a/packages/app/src/components/Theme/ThemeHalloween.module.scss
+++ b/packages/app/src/components/Theme/ThemeHalloween.module.scss
@@ -21,10 +21,6 @@ $light: lighten($secondary, 10%);
 // $dark: #;
 
 .growi:not(.login-page) {
-  #wrapper > .navbar {
-    background-image: url(/images/themes/halloween/halloween-navbar.jpg);
-  }
-
   // add background-image
   .page-editor-preview-container {
     background-image: url('/images/themes/halloween/halloween.jpg');
@@ -36,6 +32,10 @@ $light: lighten($secondary, 10%);
     position: fixed;
     width: 100%;
     height: 100%;
+  }
+
+  .grw-navbar {
+    background-image: url('/images/themes/halloween/halloween-navbar.jpg') !important;
   }
 }
 

--- a/packages/app/src/components/Theme/ThemeHalloween.tsx
+++ b/packages/app/src/components/Theme/ThemeHalloween.tsx
@@ -1,6 +1,15 @@
+import { Themes } from '~/stores/use-next-themes';
+
 import { ThemeInjector } from './utils/ThemeInjector';
 
 import styles from './ThemeHalloween.module.scss';
+
+export const getBackgroundImageSrc = (colorScheme: Themes): string => {
+  switch (colorScheme) {
+    default:
+      return '/images/themes/halloween/halloween-navbar.jpg';
+  }
+};
 
 const ThemeHalloween = ({ children }: { children: JSX.Element }): JSX.Element => {
   return <ThemeInjector className={styles.theme}>{children}</ThemeInjector>;

--- a/packages/app/src/components/Theme/ThemeHalloween.tsx
+++ b/packages/app/src/components/Theme/ThemeHalloween.tsx
@@ -7,7 +7,7 @@ import styles from './ThemeHalloween.module.scss';
 export const getBackgroundImageSrc = (colorScheme: Themes): string => {
   switch (colorScheme) {
     default:
-      return '/images/themes/halloween/halloween-navbar.jpg';
+      return '/images/themes/halloween/halloween.jpg';
   }
 };
 

--- a/packages/app/src/components/Theme/ThemeHufflepuff.module.scss
+++ b/packages/app/src/components/Theme/ThemeHufflepuff.module.scss
@@ -122,6 +122,16 @@
     }
   }
 
+  .growi:not(.login-page) {
+    // add background-image
+    .page-editor-preview-container {
+      background-image: url('/images/themes/hufflepuff/badger-light3.png');
+      background-attachment: fixed;
+      background-position: bottom;
+      background-size: cover;
+    }
+  }
+
   // login and register
   .nologin {
     #page-wrapper {
@@ -277,6 +287,16 @@
 
   .card-timeline > .card-header {
     background-color: $accentcolor;
+  }
+
+  .growi:not(.login-page) {
+    // add background-image
+    .page-editor-preview-container {
+      background-image: url('/images/themes/hufflepuff/badger-dark.jpg');
+      background-attachment: fixed;
+      background-position: bottom;
+      background-size: cover;
+    }
   }
 
   // login and register

--- a/packages/app/src/components/Theme/ThemeHufflepuff.module.scss
+++ b/packages/app/src/components/Theme/ThemeHufflepuff.module.scss
@@ -19,10 +19,6 @@
 // }
 
 .theme :global {
-  .wrapper {
-    position: relative;
-  }
-
   .bg-image-wrapper {
     position: fixed;
     width: 100%;

--- a/packages/app/src/components/Theme/ThemeHufflepuff.module.scss
+++ b/packages/app/src/components/Theme/ThemeHufflepuff.module.scss
@@ -18,6 +18,23 @@
 //   border-bottom: $accentcolor 4px solid;
 // }
 
+.theme :global {
+  .wrapper {
+    position: relative;
+  }
+
+  .bg-image-wrapper {
+    position: fixed;
+    width: 100%;
+    height: 100%;
+  }
+
+  .bg-image {
+    object-fit: cover;
+    object-position: bottom;
+  }
+}
+
 //== Light Mode
 //
 .theme[data-color-scheme='light'] :global {
@@ -102,17 +119,6 @@
   .btn-group.grw-page-editor-mode-manager {
     .btn.btn-outline-primary {
       @include page-editor-mode-manager.btn-page-editor-mode-manager(darken($primary, 70%), lighten($primary, 5%), lighten($primary, 20%));
-    }
-  }
-
-  .growi:not(.login-page) {
-    // add background-image
-    #page-wrapper,
-    .page-editor-preview-container {
-      background-image: url('/images/themes/hufflepuff/badger-light3.png');
-      background-attachment: fixed;
-      background-position: bottom;
-      background-size: cover;
     }
   }
 
@@ -271,17 +277,6 @@
 
   .card-timeline > .card-header {
     background-color: $accentcolor;
-  }
-
-  .growi:not(.login-page) {
-    // add background-image
-    #page-wrapper,
-    .page-editor-preview-container {
-      background-image: url('/images/themes/hufflepuff/badger-dark.jpg');
-      background-attachment: fixed;
-      background-position: bottom;
-      background-size: cover;
-    }
   }
 
   // login and register

--- a/packages/app/src/components/Theme/ThemeHufflepuff.module.scss
+++ b/packages/app/src/components/Theme/ThemeHufflepuff.module.scss
@@ -19,13 +19,13 @@
 // }
 
 .theme :global {
-  .bg-image-wrapper {
+  .grw-bg-image-wrapper {
     position: fixed;
     width: 100%;
     height: 100%;
   }
 
-  .bg-image {
+  .grw-bg-image {
     object-fit: cover;
     object-position: bottom;
   }

--- a/packages/app/src/components/Theme/ThemeHufflepuff.tsx
+++ b/packages/app/src/components/Theme/ThemeHufflepuff.tsx
@@ -1,6 +1,19 @@
+import { Themes } from '~/stores/use-next-themes';
+
 import { ThemeInjector } from './utils/ThemeInjector';
 
 import styles from './ThemeHufflepuff.module.scss';
+
+export const getBackgroundImageSrc = (colorScheme: Themes): string => {
+  switch (colorScheme) {
+    case Themes.light:
+      return '/images/themes/hufflepuff/badger-light3.png';
+    case Themes.dark:
+      return '/images/themes/hufflepuff/badger-dark.jpg';
+    default:
+      return '/images/themes/hufflepuff/badger-light3.png';
+  }
+};
 
 const ThemeHufflepuff = ({ children }: { children: JSX.Element }): JSX.Element => {
   return <ThemeInjector className={styles.theme}>{children}</ThemeInjector>;

--- a/packages/app/src/components/Theme/ThemeIsland.module.scss
+++ b/packages/app/src/components/Theme/ThemeIsland.module.scss
@@ -7,7 +7,7 @@ $color-primary: #97cbc3;
 $color-themelight: rgba(183, 226, 219, 1);
 
 .theme :global {
-  .bg-image-wrapper {
+  .grw-bg-image-wrapper {
     position: fixed;
     width: 100%;
     height: 100%;

--- a/packages/app/src/components/Theme/ThemeIsland.module.scss
+++ b/packages/app/src/components/Theme/ThemeIsland.module.scss
@@ -97,7 +97,6 @@ $color-themelight: rgba(183, 226, 219, 1);
     background: lighten($color-themelight, 5%);
   }
 
-  #wrapper > #page-wrapper,
   .page-editor-preview-container {
     background-image: url('/images/themes/island/island.png');
     background-attachment: fixed;

--- a/packages/app/src/components/Theme/ThemeIsland.module.scss
+++ b/packages/app/src/components/Theme/ThemeIsland.module.scss
@@ -7,6 +7,14 @@ $color-primary: #97cbc3;
 $color-themelight: rgba(183, 226, 219, 1);
 
 .theme :global {
+  .bg-image-wrapper {
+    position: fixed;
+    width: 100%;
+    height: 100%;
+  }
+}
+
+.theme :global {
   $primary: $color-primary;
   // Background colors
   $bgcolor-card: $gray-50;

--- a/packages/app/src/components/Theme/ThemeIsland.tsx
+++ b/packages/app/src/components/Theme/ThemeIsland.tsx
@@ -1,6 +1,15 @@
+import { Themes } from '~/stores/use-next-themes';
+
 import { ThemeInjector } from './utils/ThemeInjector';
 
 import styles from './ThemeIsland.module.scss';
+
+export const getBackgroundImageSrc = (colorScheme: Themes): string => {
+  switch (colorScheme) {
+    default:
+      return '/images/themes/island/island.png';
+  }
+};
 
 const ThemeIsland = ({ children }: { children: JSX.Element }): JSX.Element => {
   return <ThemeInjector className={styles.theme}>{children}</ThemeInjector>;

--- a/packages/app/src/components/Theme/ThemeSpring.module.scss
+++ b/packages/app/src/components/Theme/ThemeSpring.module.scss
@@ -26,13 +26,13 @@ $accentcolor: #e08dbc;
 }
 
 .theme :global {
-  .bg-image-wrapper {
+  .grw-bg-image-wrapper {
     position: fixed;
     width: 100%;
     height: 100%;
   }
 
-  .bg-image {
+  .grw-bg-image {
     object-fit: cover;
     object-position: bottom;
   }

--- a/packages/app/src/components/Theme/ThemeSpring.module.scss
+++ b/packages/app/src/components/Theme/ThemeSpring.module.scss
@@ -25,6 +25,19 @@ $accentcolor: #e08dbc;
   border-bottom: $accentcolor 4px solid;
 }
 
+.theme :global {
+  .bg-image-wrapper {
+    position: fixed;
+    width: 100%;
+    height: 100%;
+  }
+
+  .bg-image {
+    object-fit: cover;
+    object-position: bottom;
+  }
+}
+
 //== Light Mode
 //
 .theme :global {
@@ -107,7 +120,6 @@ $accentcolor: #e08dbc;
 
   .growi:not(.login-page) {
     // add background-image
-    #page-wrapper,
     .page-editor-preview-container {
       background-image: url('/images/themes/spring/spring02.svg');
       background-attachment: fixed;

--- a/packages/app/src/components/Theme/ThemeSpring.tsx
+++ b/packages/app/src/components/Theme/ThemeSpring.tsx
@@ -1,6 +1,15 @@
+import { Themes } from '~/stores/use-next-themes';
+
 import { ThemeInjector } from './utils/ThemeInjector';
 
 import styles from './ThemeSpring.module.scss';
+
+export const getBackgroundImageSrc = (colorScheme: Themes): string => {
+  switch (colorScheme) {
+    default:
+      return '/images/themes/spring/spring02.svg';
+  }
+};
 
 const ThemeSpring = ({ children }: { children: JSX.Element }): JSX.Element => {
   return <ThemeInjector className={styles.theme}>{children}</ThemeInjector>;

--- a/packages/app/src/components/Theme/ThemeWood.module.scss
+++ b/packages/app/src/components/Theme/ThemeWood.module.scss
@@ -35,10 +35,6 @@ $themecolor: #b9b177;
 $themelight: #f5f3ee;
 
 .theme :global {
-  .wrapper {
-    position: relative;
-  }
-
   .bg-image-wrapper {
     position: fixed;
     width: 100%;

--- a/packages/app/src/components/Theme/ThemeWood.module.scss
+++ b/packages/app/src/components/Theme/ThemeWood.module.scss
@@ -14,7 +14,6 @@
 
 .growi:not(.login-page) {
   // add background-image
-  #page-wrapper,
   .page-editor-preview-container {
     background-image: url('/images/themes/wood/wood.jpg');
     background-attachment: fixed;
@@ -34,6 +33,23 @@
 
 $themecolor: #b9b177;
 $themelight: #f5f3ee;
+
+.theme :global {
+  .wrapper {
+    position: relative;
+  }
+
+  .bg-image-wrapper {
+    position: fixed;
+    width: 100%;
+    height: 100%;
+  }
+
+  .bg-image {
+    object-fit: cover;
+    object-position: center center;
+  }
+}
 
 //== Light Mode
 //

--- a/packages/app/src/components/Theme/ThemeWood.module.scss
+++ b/packages/app/src/components/Theme/ThemeWood.module.scss
@@ -35,13 +35,13 @@ $themecolor: #b9b177;
 $themelight: #f5f3ee;
 
 .theme :global {
-  .bg-image-wrapper {
+  .grw-bg-image-wrapper {
     position: fixed;
     width: 100%;
     height: 100%;
   }
 
-  .bg-image {
+  .grw-bg-image {
     object-fit: cover;
     object-position: center center;
   }

--- a/packages/app/src/components/Theme/ThemeWood.tsx
+++ b/packages/app/src/components/Theme/ThemeWood.tsx
@@ -1,6 +1,15 @@
+import { Themes } from '~/stores/use-next-themes';
+
 import { ThemeInjector } from './utils/ThemeInjector';
 
 import styles from './ThemeWood.module.scss';
+
+export const getBackgroundImageSrc = (colorScheme: Themes): string => {
+  switch (colorScheme) {
+    default:
+      return '/images/themes/wood/wood.jpg';
+  }
+};
 
 const ThemeWood = ({ children }: { children: JSX.Element }): JSX.Element => {
   return <ThemeInjector className={styles.theme}>{children}</ThemeInjector>;

--- a/packages/app/src/components/Theme/utils/ThemeImageProvider.tsx
+++ b/packages/app/src/components/Theme/utils/ThemeImageProvider.tsx
@@ -9,7 +9,10 @@ import { getBackgroundImageSrc as getIslandBackgroundImageSrc } from '../ThemeIs
 import { getBackgroundImageSrc as getSpringBackgroundImageSrc } from '../ThemeSpring';
 import { getBackgroundImageSrc as getWoodBackgroundImageSrc } from '../ThemeWood';
 
-export const getBackgroundImageSrc = (theme: GrowiThemes, colorScheme: Themes): string | undefined => {
+export const getBackgroundImageSrc = (theme: GrowiThemes | undefined, colorScheme: Themes | undefined): string | undefined => {
+  if (theme == null || colorScheme == null) {
+    return undefined;
+  }
   switch (theme) {
     case GrowiThemes.ANTARCTIC:
       return getAntarcticBackgroundImageSrc(colorScheme);

--- a/packages/app/src/components/Theme/utils/ThemeImageProvider.tsx
+++ b/packages/app/src/components/Theme/utils/ThemeImageProvider.tsx
@@ -1,0 +1,31 @@
+import { GrowiThemes } from '~/interfaces/theme';
+import { Themes } from '~/stores/use-next-themes';
+
+import { getBackgroundImageSrc as getAntarcticBackgroundImageSrc } from '../ThemeAntarctic';
+import { getBackgroundImageSrc as getChristmasBackgroundImageSrc } from '../ThemeChristmas';
+import { getBackgroundImageSrc as getHalloweenBackgroundImageSrc } from '../ThemeHalloween';
+import { getBackgroundImageSrc as getHuffulePuffBackgroundImageSrc } from '../ThemeHufflepuff';
+import { getBackgroundImageSrc as getIslandBackgroundImageSrc } from '../ThemeIsland';
+import { getBackgroundImageSrc as getSpringBackgroundImageSrc } from '../ThemeSpring';
+import { getBackgroundImageSrc as getWoodBackgroundImageSrc } from '../ThemeWood';
+
+export const getBackgroundImageSrc = (theme: GrowiThemes, colorScheme: Themes): string | undefined => {
+  switch (theme) {
+    case GrowiThemes.ANTARCTIC:
+      return getAntarcticBackgroundImageSrc(colorScheme);
+    case GrowiThemes.CHRISTMAS:
+      return getChristmasBackgroundImageSrc(colorScheme);
+    case GrowiThemes.HALLOWEEN:
+      return getHalloweenBackgroundImageSrc(colorScheme);
+    case GrowiThemes.ISLAND:
+      return getIslandBackgroundImageSrc(colorScheme);
+    case GrowiThemes.HUFFLEPUFF:
+      return getHuffulePuffBackgroundImageSrc(colorScheme);
+    case GrowiThemes.SPRING:
+      return getSpringBackgroundImageSrc(colorScheme);
+    case GrowiThemes.WOOD:
+      return getWoodBackgroundImageSrc(colorScheme);
+    default:
+      return undefined;
+  }
+};

--- a/packages/app/src/pages/[[...path]].page.tsx
+++ b/packages/app/src/pages/[[...path]].page.tsx
@@ -283,7 +283,7 @@ const GrowiPage: NextPage<Props> = (props: Props) => {
       </Head>
       {/* <BasicLayout title={useCustomTitle(props, t('GROWI'))} className={classNames.join(' ')}> */}
       <BasicLayout title={useCustomTitle(props, 'GROWI')} className={classNames.join(' ')} expandContainer={props.isContainerFluid}>
-        <header className="py-0">
+        <header className="py-0 position-relative">
           <GrowiContextualSubNavigation isLinkSharingDisabled={props.disableLinkSharing} />
         </header>
         <div className="d-edit-none">


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/101211
https://redmine.weseek.co.jp/issues/102458

# やったこと
- 背景画像の表示
  - ThemeImageProvider を実装
    - ThemeImageProvider の getBackgroundImageSrc に現在のテーマと light/dark mode の値を渡すと、テーマに応じた背景画像のURLを返すようにしている
    - 背景画像のURLは、背景画像を使用するテーマのコンポーネント内に実装した getBackgroundImageSrc を ThemeImageProvider の getBackgroundImageSrc から呼び出すことで取得している
- ナビバー画像の表示
  - こちらは scss で background-image を用いて表示している


HufflePuff / light
<img width="1913" alt="image" src="https://user-images.githubusercontent.com/35527421/183665388-35c3c2b7-6293-48cc-b23a-4640ac30920f.png">

HufflePuff / dark
<img width="1916" alt="image" src="https://user-images.githubusercontent.com/35527421/183665451-9eae96fd-d3a5-4d19-9c2d-74e631a2ecd9.png">

ここから下は light/dark による画像の違いなし

Wood (背景が木目の画像)
<img width="1918" alt="image" src="https://user-images.githubusercontent.com/35527421/183665622-2fdaa0a4-dd5f-4dd6-af67-e91aa1038fc7.png">

Island(背景がグラデーションの画像)
<img width="1916" alt="image" src="https://user-images.githubusercontent.com/35527421/183665680-86ad2095-64e6-40de-929a-5a5c7f038bee.png">

Christmas (ナビバーと背景に画像)
![image](https://user-images.githubusercontent.com/35527421/183665947-99c7d78f-15cc-4df4-95ae-b20536f49121.png)

Antarctic
<img width="1919" alt="image" src="https://user-images.githubusercontent.com/35527421/183666058-df4bd65d-4578-4bc0-a0e4-1d5d27d8bbd9.png">

Spring
<img width="1920" alt="image" src="https://user-images.githubusercontent.com/35527421/183666180-b87744f1-16c6-4174-827b-7ebf211371b6.png">

Halloween (ナビバーと背景に画像)
<img width="1913" alt="image" src="https://user-images.githubusercontent.com/35527421/183666319-731bd4b6-163a-461d-9a6e-4b4b814e83e6.png">
