### PR TITLE
feat: Created the activity inside service/page.ts and gathered descendants users.

### DIFF
--- a/packages/app/src/server/service/activity.ts
+++ b/packages/app/src/server/service/activity.ts
@@ -6,6 +6,7 @@ import {
 } from '~/interfaces/activity';
 import { Ref } from '~/interfaces/common';
 import { IPage } from '~/interfaces/page';
+import { IUser } from '~/interfaces/user';
 import Activity from '~/server/models/activity';
 
 import loggerFactory from '../../utils/logger';
@@ -41,7 +42,7 @@ class ActivityService {
   }
 
   initActivityEventListeners(): void {
-    this.activityEvent.on('update', async(activityId: string, parameters, target?: IPage, descendantPages?: Ref<IPage>[]) => {
+    this.activityEvent.on('update', async(activityId: string, parameters, target?: IPage, descendantsSubscribedUsers?: Ref<IUser>[]) => {
       let activity: IActivity;
       const shoudUpdate = this.shoudUpdateActivity(parameters.action);
 
@@ -54,7 +55,7 @@ class ActivityService {
           return;
         }
 
-        this.activityEvent.emit('updated', activity, target, descendantPages);
+        this.activityEvent.emit('updated', activity, target, descendantsSubscribedUsers);
       }
     });
   }

--- a/packages/app/src/server/service/page.ts
+++ b/packages/app/src/server/service/page.ts
@@ -878,7 +878,6 @@ class PageService {
       .pipe(writeStream);
 
     await streamToPromise(writeStream);
-    console.log('Who are the subscribed users\n', descendantsSubscribedUsers);
     return descendantsSubscribedUsers;
   }
 


### PR DESCRIPTION
AuditLog実装に伴って、再度「親ページに対するアクションが起こされたとき、子孫ページのみをサブスクライブしているユーザーに対して通知を送る」機能実装を、renameから行う。

武井さんと仕様確認した際、現状descendantsPagesを一気に取得する仕様においてコストが高すぎると指摘されたため、ベースは同じにしつつ、以下の変更を加えた。
- activityインスタンスをサービス層で生成するという仕様は変わらず。
- batch処理でメモリーに負担をかけないためdescendant pagesを塊ごとにとってくる処理の最中で、getSubscriptionsメソッドを用いてユーザーを取得。
- よってリネームされたページの配下にあるページをサブスクライブしているユーザー全てを先に取得し、activityEvent.emit('update')を呼ぶ。

以上の仕様に変更したのち、動作確認済み。