### PR TITLE
fix: Pager is not displayed

### DIFF
--- a/packages/app/src/components/DescendantsPageList.tsx
+++ b/packages/app/src/components/DescendantsPageList.tsx
@@ -103,7 +103,7 @@ export const DescendantsPageListSubstance = (props: SubstanceProps): JSX.Element
     );
   }
 
-  const showPager = pagingResult.items.length > pagingResult.limit;
+  const showPager = pagingResult.totalCount > pagingResult.limit;
 
   return (
     <>


### PR DESCRIPTION
## Task
[#102947](https://redmine.weseek.co.jp/issues/102947) [Bug] ページリストの機能を使って表示するとページの一覧が20件までしか表示されない
└ [#102948](https://redmine.weseek.co.jp/issues/102948) 修正
