### PR TITLE
Fix/102704 ignore csrf: api delete

### DIFF
--- a/packages/app/src/server/crowi/express-init.js
+++ b/packages/app/src/server/crowi/express-init.js
@@ -150,7 +150,7 @@ module.exports = function(crowi, app) {
 
   // csurf should be initialized after express-session
   // default methods + PUT. See: https://expressjs.com/en/resources/middleware/csurf.html#ignoremethods
-  app.use(csrf({ ignoreMethods: ['GET', 'HEAD', 'OPTIONS', 'PUT', 'POST'], cookie: false }));
+  app.use(csrf({ ignoreMethods: ['GET', 'HEAD', 'OPTIONS', 'PUT', 'POST', 'DELETE'], cookie: false }));
 
   // passport
   debug('initialize Passport');


### PR DESCRIPTION
## Task
[GROWI][Next.js][Admin][Customize以外] 残存の不具合を修正し、全てのページで正常に表示 & 更新ができる
┗[102704](https://redmine.weseek.co.jp/issues/102704) [UserGroup Management] [external_account_management][Share link]  fix invalid csrf token

## Description
削除ボタンを押したときに、` invalid csrf token` のエラーがブラウザのコンソールに出力され、削除できない問題を修正しました。


以下で正常に動作することを確認しています
- UserGroup Management の delete user
- External Account Management の delete user
- Share link の delete


## Memo
このタスク用の動作確認タスクを新規作成しました。
https://redmine.weseek.co.jp/issues/102623