### PR TITLE
fix: Uploading image using shortcut key(ctrl+v) shows toastError

### DIFF
--- a/packages/app/public/static/locales/en_US/translation.json
+++ b/packages/app/public/static/locales/en_US/translation.json
@@ -538,6 +538,7 @@
     "create_failed": "Failed to create {{target}}",
     "update_successed": "Succeeded to update {{target}}",
     "update_failed": "Failed to update {{target}}",
+    "file_upload_succeeded": "File upload succeeded.",
     "file_upload_failed": "File upload failed.",
     "initialize_successed": "Succeeded to initialize {{target}}",
     "give_user_admin": "Succeeded to give {{username}} admin",

--- a/packages/app/public/static/locales/ja_JP/translation.json
+++ b/packages/app/public/static/locales/ja_JP/translation.json
@@ -538,6 +538,7 @@
     "create_failed": "{{target}}の作成に失敗しました",
     "update_successed": "{{target}}を更新しました",
     "update_failed": "{{target}}の更新に失敗しました",
+    "file_upload_succeeded": "ファイルをアップロードしました",
     "file_upload_failed": "ファイルのアップロードに失敗しました",
     "initialize_successed": "{{target}}を初期化しました",
     "give_user_admin": "{{username}}を管理者に設定しました",

--- a/packages/app/public/static/locales/zh_CN/translation.json
+++ b/packages/app/public/static/locales/zh_CN/translation.json
@@ -516,6 +516,7 @@
     "create_failed": "Failed to create {{target}}",
 		"update_successed": "Succeeded to update {{target}}",
     "update_failed": "Failed to update {{target}}",
+    "file_upload_succeeded": "文件上传成功",
     "file_upload_failed": "文件上传失败",
     "initialize_successed": "Succeeded to initialize {{target}}",
 		"give_user_admin": "Succeeded to give {{username}} admin",

--- a/packages/app/src/components/PageEditor/Editor.tsx
+++ b/packages/app/src/components/PageEditor/Editor.tsx
@@ -8,7 +8,7 @@ import {
   Modal, ModalHeader, ModalBody,
 } from 'reactstrap';
 
-import { toastError } from '~/client/util/apiNotification';
+import { toastError, toastSuccess } from '~/client/util/apiNotification';
 import { useDefaultIndentSize } from '~/stores/context';
 import { useEditorSettings } from '~/stores/editor';
 import { useIsMobile } from '~/stores/ui';
@@ -141,7 +141,7 @@ const Editor = React.forwardRef((props: EditorPropsType, ref): JSX.Element => {
   const pasteFilesHandler = useCallback((event) => {
     const items = event.clipboardData.items || event.clipboardData.files || [];
 
-    toastError(t('toaster.file_upload_failed'));
+    toastSuccess(t('toaster.file_upload_succeeded'));
 
     // abort if length is not 1
     if (items.length < 1) {


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/103018

修正後
![file upload with success toastr](https://user-images.githubusercontent.com/35527421/186092413-8a8c3723-cab2-423c-aa85-c5fe10907125.gif)

画像の添付も確認済み