### PR TITLE
fix: Unable to check the option to send an email when inviting users

### DIFF
--- a/packages/app/src/pages/admin/[[...path]].page.tsx
+++ b/packages/app/src/pages/admin/[[...path]].page.tsx
@@ -188,7 +188,7 @@ const AdminMarkdownSettingsPage: NextPage<Props> = (props: Props) => {
   const targetPage = getTargetPageToRender(adminPagesMap, pagePathKeys);
 
   useCurrentUser(props.currentUser != null ? JSON.parse(props.currentUser) : null);
-  // useIsMailerSetup(props.isMailerSetup);
+  useIsMailerSetup(props.isMailerSetup);
 
   // useSearchServiceConfigured(props.isSearchServiceConfigured);
   useIsSearchServiceReachable(props.isSearchServiceReachable);

--- a/packages/app/src/pages/admin/[[...path]].page.tsx
+++ b/packages/app/src/pages/admin/[[...path]].page.tsx
@@ -271,7 +271,7 @@ const AdminMarkdownSettingsPage: NextPage<Props> = (props: Props) => {
 };
 
 
-async function injectServerConfigurations(context: GetServerSidePropsContext, props: Props): void {
+async function injectServerConfigurations(context: GetServerSidePropsContext, props: Props): Promise<void> {
   const req: CrowiRequest = context.req as CrowiRequest;
   const { crowi } = req;
   const {


### PR DESCRIPTION
## Task
[#101095](https://redmine.weseek.co.jp/issues/101095) [GROWI][Next.js][Admin][Customize以外] 残存の不具合を修正し、全てのページで正常に表示 & 更新ができる 
└ [#103137](https://redmine.weseek.co.jp/issues/103137) メーラーのセットアップが済んでいる状態でユーザーを招待をする際に Email を送るオプションにチェックをつけられない問題の修正