### PR TITLE
feat: Rendering Fab component

### DIFF
--- a/packages/app/src/components/Fab.jsx
+++ b/packages/app/src/components/Fab.jsx
@@ -13,6 +13,8 @@ import loggerFactory from '~/utils/logger';
 import CreatePageIcon from './Icons/CreatePageIcon';
 import ReturnTopIcon from './Icons/ReturnTopIcon';
 
+import styles from './Fab.module.scss';
+
 const logger = loggerFactory('growi:cli:Fab');
 
 const Fab = () => {
@@ -31,7 +33,7 @@ const Fab = () => {
   const stickyChangeHandler = useCallback((event) => {
     logger.debug('StickyEvents.CHANGE detected');
 
-    const newAnimateClasses = event.detail.isSticky ? 'animated fadeInUp faster' : 'animated fadeOut faster';
+    const newAnimateClasses = event.detail.isSticky ? 'animated fadeinup faster' : 'animated fadeout faster';
     const newButtonClasses = event.detail.isSticky ? '' : 'disabled grw-pointer-events-none';
 
     setAnimateClasses(newAnimateClasses);
@@ -71,9 +73,9 @@ const Fab = () => {
   }
 
   return (
-    <div className="grw-fab d-none d-md-block d-edit-none" data-testid="grw-fab">
+    <div className={`${styles['grw-fab']} grw-fab d-none d-md-block d-edit-none`} data-testid="grw-fab">
       {currentUser != null && renderPageCreateButton()}
-      <div data-testid="grw-fab-return-to-top" className={`rounded-circle position-absolute ${animateClasses}`} style={{ bottom: 0, right: 0 }}>
+      <div className={`rounded-circle position-absolute ${animateClasses}`} style={{ bottom: 0, right: 0 }} data-testid="grw-fab-return-to-top">
         <button
           type="button"
           className={`btn btn-light btn-scroll-to-top rounded-circle p-0 ${buttonClasses}`}

--- a/packages/app/src/components/Fab.jsx
+++ b/packages/app/src/components/Fab.jsx
@@ -33,7 +33,7 @@ const Fab = () => {
   const stickyChangeHandler = useCallback((event) => {
     logger.debug('StickyEvents.CHANGE detected');
 
-    const newAnimateClasses = event.detail.isSticky ? 'animated fadeinup faster' : 'animated fadeout faster';
+    const newAnimateClasses = event.detail.isSticky ? 'animated fadeInUp faster' : 'animated fadeOut faster';
     const newButtonClasses = event.detail.isSticky ? '' : 'disabled grw-pointer-events-none';
 
     setAnimateClasses(newAnimateClasses);

--- a/packages/app/src/components/Fab.module.scss
+++ b/packages/app/src/components/Fab.module.scss
@@ -1,16 +1,31 @@
-
 .grw-fab :global {
+  // workaround
+  // https://stackoverflow.com/a/57667536
   .fadeInUp {
-
+    & :local {
+      animation: fab-fadeinup 1s ease 0s;
+    }
   }
-
   .fadeOut {
-
+    & :local {
+      animation: fab-fadeout 0.5s ease 0s forwards;
+    }
   }
 }
 
-// @keyframes fadeout {
-//   100% {
-//     opacity: 0;
-//   }
-// }
+@keyframes fab-fadeinup {
+  0% {
+    opacity: 0;
+    transform: translateY(100px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0px);
+  }
+}
+
+@keyframes fab-fadeout {
+  100% {
+    opacity: 0
+  }
+}

--- a/packages/app/src/components/Fab.module.scss
+++ b/packages/app/src/components/Fab.module.scss
@@ -1,0 +1,16 @@
+
+.grw-fab :global {
+  .fadeInUp {
+
+  }
+
+  .fadeOut {
+
+  }
+}
+
+// @keyframes fadeout {
+//   100% {
+//     opacity: 0;
+//   }
+// }

--- a/packages/app/src/components/Layout/BasicLayout.tsx
+++ b/packages/app/src/components/Layout/BasicLayout.tsx
@@ -19,6 +19,8 @@ const PageDeleteModal = dynamic(() => import('../PageDeleteModal'), { ssr: false
 const PageRenameModal = dynamic(() => import('../PageRenameModal'), { ssr: false });
 const PagePresentationModal = dynamic(() => import('../PagePresentationModal'), { ssr: false });
 const PageAccessoriesModal = dynamic(() => import('../PageAccessoriesModal'), { ssr: false });
+// Fab
+const Fab = dynamic(() => import('../Fab'), { ssr: false });
 
 
 type Props = {
@@ -57,6 +59,8 @@ export const BasicLayout = ({
       <PagePresentationModal />
       <PageAccessoriesModal />
       {/* <HotkeysManager /> */}
+
+      <Fab />
 
       <ShortcutsModal />
       <SystemVersion showShortcutsButton />


### PR DESCRIPTION
タスク: [103755](https://redmine.weseek.co.jp/issues/103755)

- ページ右下 Fab のレンダリング
- フェードアニメーションの実装
- ボタンの background-color や color は　`.btn-primary` のテーマ等が原因
  theme-default 関連のため,　theme修正後に修正見込み
  
## After
![fab_log2](https://user-images.githubusercontent.com/68407388/187841552-47ed47d3-b1bd-416b-aed5-2e49a8205c71.gif)
