### PR TITLE
fix: Cannot update user group without parent

### DIFF
--- a/packages/app/src/components/Admin/UserGroupDetail/UpdateParentConfirmModal.tsx
+++ b/packages/app/src/components/Admin/UserGroupDetail/UpdateParentConfirmModal.tsx
@@ -1,4 +1,5 @@
 import React, { FC, useState } from 'react';
+
 import { useTranslation } from 'react-i18next';
 import {
   Modal, ModalHeader, ModalBody, ModalFooter,
@@ -29,7 +30,7 @@ const UpdateParentConfirmModal: FC = () => {
         <i className="icon icon-warning"></i> {t('admin:user_group_management.update_parent_confirm_modal.header')}
       </ModalHeader>
       {
-        targetGroup != null && updateData != null && updateData?.parent !== undefined ? (
+        targetGroup != null && updateData != null ? (
           <>
             <ModalBody>
               <div className="mb-2">

--- a/packages/app/src/components/Admin/UserGroupDetail/UserGroupDetailPage.tsx
+++ b/packages/app/src/components/Admin/UserGroupDetail/UserGroupDetailPage.tsx
@@ -1,32 +1,35 @@
 import React, {
   FC, useState, useCallback,
 } from 'react';
+
 import { useTranslation } from 'react-i18next';
 
-import UserGroupForm from '../UserGroup/UserGroupForm';
-import UserGroupTable from '../UserGroup/UserGroupTable';
-import UserGroupModal from '../UserGroup/UserGroupModal';
-import UserGroupDeleteModal from '../UserGroup/UserGroupDeleteModal';
-import UpdateParentConfirmModal from './UpdateParentConfirmModal';
-import UserGroupDropdown from '../UserGroup/UserGroupDropdown';
-import UserGroupUserTable from './UserGroupUserTable';
-import UserGroupUserModal from './UserGroupUserModal';
-import UserGroupPageList from './UserGroupPageList';
 
+import { toastSuccess, toastError } from '~/client/util/apiNotification';
 import {
   apiv3Get, apiv3Put, apiv3Delete, apiv3Post,
 } from '~/client/util/apiv3-client';
-import { toastSuccess, toastError } from '~/client/util/apiNotification';
 import { IPageHasId } from '~/interfaces/page';
 import {
   IUserGroup, IUserGroupHasId,
 } from '~/interfaces/user';
+import { useIsAclEnabled } from '~/stores/context';
+import { useUpdateUserGroupConfirmModal } from '~/stores/modal';
 import {
   useSWRxUserGroupPages, useSWRxUserGroupRelationList, useSWRxChildUserGroupList,
   useSWRxSelectableParentUserGroups, useSWRxSelectableChildUserGroups, useSWRxAncestorUserGroups,
 } from '~/stores/user-group';
-import { useIsAclEnabled } from '~/stores/context';
-import { useUpdateUserGroupConfirmModal } from '~/stores/modal';
+
+import UserGroupDeleteModal from '../UserGroup/UserGroupDeleteModal';
+import UserGroupDropdown from '../UserGroup/UserGroupDropdown';
+import UserGroupForm from '../UserGroup/UserGroupForm';
+import UserGroupModal from '../UserGroup/UserGroupModal';
+import UserGroupTable from '../UserGroup/UserGroupTable';
+
+import UpdateParentConfirmModal from './UpdateParentConfirmModal';
+import UserGroupPageList from './UserGroupPageList';
+import UserGroupUserModal from './UserGroupUserModal';
+import UserGroupUserTable from './UserGroupUserTable';
 
 const UserGroupDetailPage: FC = () => {
   const { t } = useTranslation();
@@ -85,10 +88,6 @@ const UserGroupDetailPage: FC = () => {
   }, []);
 
   const updateUserGroup = useCallback(async(userGroup: IUserGroupHasId, update: Partial<IUserGroupHasId>, forceUpdateParents: boolean) => {
-    if (update.parent == null) {
-      throw Error('"parent" attr must not be null');
-    }
-
     const parentId = typeof update.parent === 'string' ? update.parent : update.parent?._id;
     const res = await apiv3Put<{ userGroup: IUserGroupHasId }>(`/user-groups/${userGroup._id}`, {
       name: update.name,
@@ -120,7 +119,7 @@ const UserGroupDetailPage: FC = () => {
   );
 
   const onClickSubmitForm = useCallback(async(targetGroup: IUserGroupHasId, userGroupData: Partial<IUserGroupHasId>): Promise<void> => {
-    if (userGroupData?.parent === undefined || typeof userGroupData?.parent === 'string') {
+    if (typeof userGroupData?.parent === 'string') {
       toastError(t('Something went wrong. Please try again.'));
       return;
     }

--- a/packages/app/src/components/Admin/UserGroupDetail/UserGroupDetailPage.tsx
+++ b/packages/app/src/components/Admin/UserGroupDetail/UserGroupDetailPage.tsx
@@ -92,7 +92,7 @@ const UserGroupDetailPage: FC = () => {
     const res = await apiv3Put<{ userGroup: IUserGroupHasId }>(`/user-groups/${userGroup._id}`, {
       name: update.name,
       description: update.description,
-      parentId,
+      parentId: parentId ?? null,
       forceUpdateParents,
     });
     const { userGroup: updatedUserGroup } = res.data;


### PR DESCRIPTION
## Task
[Issue][userGroup][bug] 親を指定せずにUserGroupの概要を更新しようとすると「Error Something went wrong. Please try again.」のエラーが表示され、更新できない
┗[104025](https://redmine.weseek.co.jp/issues/104025)


## Before

https://user-images.githubusercontent.com/59536731/189270967-ca6db315-55b3-4a2e-a65a-fbbc3bc5b22a.mov

## After


https://user-images.githubusercontent.com/59536731/189271435-601d7728-2260-4185-a6fd-8881c73474f5.mov



## Memo
あとこれでいいのかわかっておらず見落としもありそうなので確認お願いします。
(もしかしたら実装者が修正した方が早いかもしれません)

`Something went wrong. Please try again.` エラー内容がわからず改善した方がいいんじゃなかろうか と思っているがどうすればいいかわからず....。そのままでいいとのことであればそのままにします。

https://github.com/weseek/growi/blob/9faad941647406d36348355a0c71ad5a6791490b/packages/app/src/components/Admin/UserGroupDetail/UpdateParentConfirmModal.tsx#L75-L79


## VRT
関係のない部分で差分が出ているのでスルーでOK

