### PR TITLE
imprv: Update PageContentFooter for present updated data

### DIFF
--- a/packages/app/src/components/PageContentFooter.tsx
+++ b/packages/app/src/components/PageContentFooter.tsx
@@ -14,7 +14,7 @@ const AuthorInfo = dynamic(() => import('./Navbar/AuthorInfo'), {
   loading: () => <Skelton additionalClass={`${styles['page-content-footer-skelton']} mb-3`} />,
 });
 
-type PageContentFooterProps = {
+export type PageContentFooterProps = {
   page: IPage,
 }
 

--- a/packages/app/src/components/PageContentFooter.tsx
+++ b/packages/app/src/components/PageContentFooter.tsx
@@ -1,27 +1,30 @@
-import React, { memo } from 'react';
+import React from 'react';
 
-import { IPage } from '@growi/core';
 import dynamic from 'next/dynamic';
 
 import { IUser } from '~/interfaces/user';
+import { useSWRxCurrentPage } from '~/stores/page';
 
 import { Skelton } from './Skelton';
 
 import styles from './PageContentFooter.module.scss';
 
-const AuthorInfo = dynamic(() => import('./Navbar/AuthorInfo'),
-  { ssr: false, loading: () => <Skelton additionalClass={`${styles['page-content-footer-skelton']} mb-3`} /> });
+const AuthorInfo = dynamic(() => import('./Navbar/AuthorInfo'), {
+  ssr: false,
+  loading: () => <Skelton additionalClass={`${styles['page-content-footer-skelton']} mb-3`} />,
+});
 
-export type PageContentFooterProps = {
-  page: IPage,
-}
+export const PageContentFooter = (): JSX.Element => {
 
-export const PageContentFooter = memo((props: PageContentFooterProps): JSX.Element => {
-  const { page } = props;
+  const { data: currentPage } = useSWRxCurrentPage();
+
+  if (currentPage == null) {
+    return <></>;
+  }
 
   const {
     creator, lastUpdateUser, createdAt, updatedAt,
-  } = page;
+  } = currentPage;
 
   return (
     <div className={`${styles['page-content-footer']} page-content-footer py-4 d-edit-none d-print-none}`}>
@@ -33,6 +36,6 @@ export const PageContentFooter = memo((props: PageContentFooterProps): JSX.Eleme
       </div>
     </div>
   );
-});
+};
 
 PageContentFooter.displayName = 'PageContentFooter';

--- a/packages/app/src/components/PageContentFooter.tsx
+++ b/packages/app/src/components/PageContentFooter.tsx
@@ -38,7 +38,7 @@ export const PageContentFooter = (props: PageContentFooterProps): JSX.Element =>
   );
 };
 
-export const PageContentFooterWrapper = (): JSX.Element => {
+export const CurrentPageContentFooter = (): JSX.Element => {
   const { data: currentPage } = useSWRxCurrentPage();
 
   if (currentPage == null) {

--- a/packages/app/src/components/PageContentFooter.tsx
+++ b/packages/app/src/components/PageContentFooter.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
+import { IPage, IUser } from '@growi/core';
 import dynamic from 'next/dynamic';
 
-import { IUser } from '~/interfaces/user';
 import { useSWRxCurrentPage } from '~/stores/page';
 
 import { Skelton } from './Skelton';
@@ -14,17 +14,17 @@ const AuthorInfo = dynamic(() => import('./Navbar/AuthorInfo'), {
   loading: () => <Skelton additionalClass={`${styles['page-content-footer-skelton']} mb-3`} />,
 });
 
-export const PageContentFooter = (): JSX.Element => {
+type PageContentFooterProps = {
+  page: IPage,
+}
 
-  const { data: currentPage } = useSWRxCurrentPage();
+export const PageContentFooter = (props: PageContentFooterProps): JSX.Element => {
 
-  if (currentPage == null) {
-    return <></>;
-  }
+  const { page } = props;
 
   const {
     creator, lastUpdateUser, createdAt, updatedAt,
-  } = currentPage;
+  } = page;
 
   return (
     <div className={`${styles['page-content-footer']} page-content-footer py-4 d-edit-none d-print-none}`}>
@@ -38,4 +38,12 @@ export const PageContentFooter = (): JSX.Element => {
   );
 };
 
-PageContentFooter.displayName = 'PageContentFooter';
+export const PageContentFooterWrapper = (): JSX.Element => {
+  const { data: currentPage } = useSWRxCurrentPage();
+
+  if (currentPage == null) {
+    return <></>;
+  }
+
+  return <PageContentFooter page={currentPage} />;
+};

--- a/packages/app/src/components/SearchPage/SearchResultContent.tsx
+++ b/packages/app/src/components/SearchPage/SearchResultContent.tsx
@@ -25,12 +25,13 @@ import { AdditionalMenuItemsRendererProps, ForceHideMenuItems } from '../Common/
 import { GrowiSubNavigationProps } from '../Navbar/GrowiSubNavigation';
 import { SubNavButtonsProps } from '../Navbar/SubNavButtons';
 import { PageCommentProps } from '../PageComment';
+import { PageContentFooterProps } from '../PageContentFooter';
 
 const GrowiSubNavigation = dynamic<GrowiSubNavigationProps>(() => import('../Navbar/GrowiSubNavigation').then(mod => mod.GrowiSubNavigation), { ssr: false });
 const SubNavButtons = dynamic<SubNavButtonsProps>(() => import('../Navbar/SubNavButtons').then(mod => mod.SubNavButtons), { ssr: false });
 const RevisionLoader = dynamic(() => import('../Page/RevisionLoader'), { ssr: false });
 const PageComment = dynamic<PageCommentProps>(() => import('../PageComment').then(mod => mod.PageComment), { ssr: false });
-const PageContentFooter = dynamic(() => import('../PageContentFooter').then(mod => mod.PageContentFooter), { ssr: false });
+const PageContentFooter = dynamic<PageContentFooterProps>(() => import('../PageContentFooter').then(mod => mod.PageContentFooter), { ssr: false });
 
 type AdditionalMenuItemsProps = AdditionalMenuItemsRendererProps & {
   pageId: string,

--- a/packages/app/src/components/SearchPage/SearchResultContent.tsx
+++ b/packages/app/src/components/SearchPage/SearchResultContent.tsx
@@ -25,13 +25,12 @@ import { AdditionalMenuItemsRendererProps, ForceHideMenuItems } from '../Common/
 import { GrowiSubNavigationProps } from '../Navbar/GrowiSubNavigation';
 import { SubNavButtonsProps } from '../Navbar/SubNavButtons';
 import { PageCommentProps } from '../PageComment';
-import { PageContentFooterProps } from '../PageContentFooter';
 
 const GrowiSubNavigation = dynamic<GrowiSubNavigationProps>(() => import('../Navbar/GrowiSubNavigation').then(mod => mod.GrowiSubNavigation), { ssr: false });
 const SubNavButtons = dynamic<SubNavButtonsProps>(() => import('../Navbar/SubNavButtons').then(mod => mod.SubNavButtons), { ssr: false });
 const RevisionLoader = dynamic(() => import('../Page/RevisionLoader'), { ssr: false });
 const PageComment = dynamic<PageCommentProps>(() => import('../PageComment').then(mod => mod.PageComment), { ssr: false });
-const PageContentFooter = dynamic<PageContentFooterProps>(() => import('../PageContentFooter').then(mod => mod.PageContentFooter), { ssr: false });
+const PageContentFooter = dynamic(() => import('../PageContentFooter').then(mod => mod.PageContentFooter), { ssr: false });
 
 type AdditionalMenuItemsProps = AdditionalMenuItemsRendererProps & {
   pageId: string,
@@ -224,9 +223,7 @@ export const SearchResultContent: FC<Props> = (props: Props) => {
           isReadOnly
           hideIfEmpty
         />
-        <PageContentFooter
-          page={page}
-        />
+        <PageContentFooter />
       </div>
     </div>
   );

--- a/packages/app/src/components/SearchPage/SearchResultContent.tsx
+++ b/packages/app/src/components/SearchPage/SearchResultContent.tsx
@@ -223,7 +223,9 @@ export const SearchResultContent: FC<Props> = (props: Props) => {
           isReadOnly
           hideIfEmpty
         />
-        <PageContentFooter />
+        <PageContentFooter
+          page={page}
+        />
       </div>
     </div>
   );

--- a/packages/app/src/pages/[[...path]].page.tsx
+++ b/packages/app/src/pages/[[...path]].page.tsx
@@ -331,7 +331,7 @@ const GrowiPage: NextPage<Props> = (props: Props) => {
               { (pageWithMeta != null && isUsersHomePage(pageWithMeta.data.path)) && (
                 <UsersHomePageFooter creatorId={pageWithMeta.data.creator._id}/>
               ) }
-              <PageContentFooter page={pageWithMeta?.data} />
+              <PageContentFooter />
             </footer>
           )}
 

--- a/packages/app/src/pages/[[...path]].page.tsx
+++ b/packages/app/src/pages/[[...path]].page.tsx
@@ -20,7 +20,7 @@ import superjson from 'superjson';
 import { Comments } from '~/components/Comments';
 import { PageAlerts } from '~/components/PageAlert/PageAlerts';
 // import { useTranslation } from '~/i18n';
-import { PageContentFooter } from '~/components/PageContentFooter';
+import { PageContentFooterWrapper } from '~/components/PageContentFooter';
 import { UsersHomePageFooterProps } from '~/components/UsersHomePageFooter';
 import { CrowiRequest } from '~/interfaces/crowi-request';
 // import { renderScriptTagByName, renderHighlightJsStyleTag } from '~/service/cdn-resources-loader';
@@ -331,7 +331,7 @@ const GrowiPage: NextPage<Props> = (props: Props) => {
               { (pageWithMeta != null && isUsersHomePage(pageWithMeta.data.path)) && (
                 <UsersHomePageFooter creatorId={pageWithMeta.data.creator._id}/>
               ) }
-              <PageContentFooter />
+              <PageContentFooterWrapper />
             </footer>
           )}
 

--- a/packages/app/src/pages/[[...path]].page.tsx
+++ b/packages/app/src/pages/[[...path]].page.tsx
@@ -20,7 +20,7 @@ import superjson from 'superjson';
 import { Comments } from '~/components/Comments';
 import { PageAlerts } from '~/components/PageAlert/PageAlerts';
 // import { useTranslation } from '~/i18n';
-import { PageContentFooterWrapper } from '~/components/PageContentFooter';
+import { CurrentPageContentFooter } from '~/components/PageContentFooter';
 import { UsersHomePageFooterProps } from '~/components/UsersHomePageFooter';
 import { CrowiRequest } from '~/interfaces/crowi-request';
 // import { renderScriptTagByName, renderHighlightJsStyleTag } from '~/service/cdn-resources-loader';
@@ -331,7 +331,7 @@ const GrowiPage: NextPage<Props> = (props: Props) => {
               { (pageWithMeta != null && isUsersHomePage(pageWithMeta.data.path)) && (
                 <UsersHomePageFooter creatorId={pageWithMeta.data.creator._id}/>
               ) }
-              <PageContentFooterWrapper />
+              <CurrentPageContentFooter />
             </footer>
           )}
 


### PR DESCRIPTION
task: [104310](https://redmine.weseek.co.jp/issues/104310)

- EditページのUpdate後にViewに自動遷移しても PageContentFooter の `Last revision posted at` が更新されない の修正