### PR TITLE
feat: Disable Fab component

### DIFF
--- a/packages/app/src/components/Fab.module.scss
+++ b/packages/app/src/components/Fab.module.scss
@@ -3,7 +3,7 @@
   // https://stackoverflow.com/a/57667536
   .fadeInUp {
     & :local {
-      animation: fab-fadeinup 1s ease 0s;
+      animation: fab-fadeinup 0.5s ease 0s;
     }
   }
   .fadeOut {

--- a/packages/app/src/components/Layout/BasicLayout.tsx
+++ b/packages/app/src/components/Layout/BasicLayout.tsx
@@ -60,6 +60,10 @@ export const BasicLayout = ({
       <PageAccessoriesModal />
       {/* <HotkeysManager /> */}
 
+      {/*
+      * Comment out to prevent err >>> TypeError: Cannot read properties of null (reading 'bottom')
+      * This err occurs when moving to "grw-fav-sticky-trigger" pages.
+      */ }
       {/* <Fab /> */}
 
       <ShortcutsModal />

--- a/packages/app/src/components/Layout/BasicLayout.tsx
+++ b/packages/app/src/components/Layout/BasicLayout.tsx
@@ -19,8 +19,8 @@ const PageDeleteModal = dynamic(() => import('../PageDeleteModal'), { ssr: false
 const PageRenameModal = dynamic(() => import('../PageRenameModal'), { ssr: false });
 const PagePresentationModal = dynamic(() => import('../PagePresentationModal'), { ssr: false });
 const PageAccessoriesModal = dynamic(() => import('../PageAccessoriesModal'), { ssr: false });
-// Fab
-const Fab = dynamic(() => import('../Fab'), { ssr: false });
+// // Fab
+// const Fab = dynamic(() => import('../Fab'), { ssr: false });
 
 
 type Props = {
@@ -60,7 +60,7 @@ export const BasicLayout = ({
       <PageAccessoriesModal />
       {/* <HotkeysManager /> */}
 
-      <Fab />
+      {/* <Fab /> */}
 
       <ShortcutsModal />
       <SystemVersion showShortcutsButton />


### PR DESCRIPTION
- Fab.jsxの`sticky-events`エラーの回避のため、Fabコンポーネントのコメントアウト