### PR TITLE
fix: Display trash page alert

### DIFF
--- a/packages/app/src/pages/[[...path]].page.tsx
+++ b/packages/app/src/pages/[[...path]].page.tsx
@@ -198,7 +198,6 @@ const GrowiPage: NextPage<Props> = (props: Props) => {
   useIsNotFound(props.isNotFound);
   useIsNotCreatable(props.IsNotCreatable);
   useRedirectFrom(props.redirectFrom);
-  // useIsTrashPage(_isTrashPage(props.currentPagePath));
   // useShared();
   // useShareLinkId(props.shareLinkId);
   useIsSharedUser(false); // this page cann't be routed for '/share'
@@ -247,6 +246,8 @@ const GrowiPage: NextPage<Props> = (props: Props) => {
   useCurrentPagePath(pagePath);
   useCurrentPathname(props.currentPathname);
   useEditingMarkdown(pageWithMeta?.data.revision?.body);
+  useIsTrashPage(_isTrashPage(pagePath));
+
   const { data: grantData } = useSWRxIsGrantNormalized(pageId);
   const { mutate: mutateSelectedGrant } = useSelectedGrant();
 


### PR DESCRIPTION
## Task
[#99801](https://redmine.weseek.co.jp/issues/99801) [Next.js] ゴミ箱ページ（/trash）をnext.jsでレンダリングできる
└ [#104757](https://redmine.weseek.co.jp/issues/104757) /trash 配下にあるページにアラートを表示する