### PR TITLE
fix: 104818 reload private legacy with path

### DIFF
--- a/packages/app/src/components/PrivateLegacyPages.tsx
+++ b/packages/app/src/components/PrivateLegacyPages.tsx
@@ -452,6 +452,7 @@ const PrivateLegacyPages = (): JSX.Element => {
             });
             toastSuccess(t('private_legacy_pages.by_path_modal.success'));
             setOpenConvertModal(false);
+            mutate();
           }
           catch (errs) {
             if (errs.length === 1) {


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/104818

PrivateLegacyPageの動作確認を自分でしているときに、パスでページを変換した後に古いページのリストが更新されていないことに気が付いたのでそれを修正しました。