### PR TITLE
feat: Fix CommentEditor button

### DIFF
--- a/packages/app/src/components/PageComment/CommentEditor.tsx
+++ b/packages/app/src/components/PageComment/CommentEditor.tsx
@@ -232,7 +232,13 @@ export const CommentEditor = (props: CommentEditorProps): JSX.Element => {
 
     const errorMessage = <span className="text-danger text-right mr-2">{error}</span>;
     const cancelButton = (
-      <Button outline color="danger" size="xs" className="btn btn-outline-danger rounded-pill" onClick={cancelButtonClickedHandler}>
+      <Button
+        outline
+        color="danger"
+        size="xs"
+        className="btn btn-outline-danger rounded-pill"
+        onClick={cancelButtonClickedHandler}
+      >
         Cancel
       </Button>
     );

--- a/packages/app/src/components/PageEditor/CodeMirrorEditor.module.scss
+++ b/packages/app/src/components/PageEditor/CodeMirrorEditor.module.scss
@@ -59,6 +59,11 @@
     pre.CodeMirror-line-like.CodeMirror-placeholder {
       color: bs.$text-muted;
     }
+
+    // overwrite .CodeMirror-scroll
+    .CodeMirror-scroll {
+      box-sizing: border-box;
+    }
   }
 
   // patch to fix https://github.com/codemirror/CodeMirror/issues/4089


### PR DESCRIPTION
タスク: https://redmine.weseek.co.jp/issues/104913

- あったこと：CommentEditorのボタンが使えない箇所があった。
- 原因：CodeMirror-scrollが被っていた。CodeMirror-scrollはSCSSモジュールの中で外部ライブラリとしてscssインポートされていたため、box-sizing: content-box; が優先されていた。
- 修正：box-sizing: border-boxが適用されてほしいのでscssモジュール内で上書き

### After (左: v6, 右: v5)
![image](https://user-images.githubusercontent.com/68407388/190338331-8e820210-85d7-4119-a43d-8835079b7134.png)

### Before
![image](https://user-images.githubusercontent.com/68407388/190339973-f936bc47-cf94-410e-abeb-2c1f02e3a404.png)
