### PR TITLE
support: Fix Page List VRT with force to focus the element

### DIFF
--- a/packages/app/src/components/PageList/PageListItemL.tsx
+++ b/packages/app/src/components/PageList/PageListItemL.tsx
@@ -163,6 +163,7 @@ const PageListItemLSubstance: ForwardRefRenderFunction<ISelectable, Props> = (pr
     <li
       key={pageData._id}
       className={`list-group-item d-flex align-items-center px-3 px-md-1 ${styleListGroupItem} ${styleActive}`}
+      data-testid="page-list-item-L"
       onClick={clickHandler}
     >
       <div className="text-break w-100">

--- a/packages/app/test/cypress/integration/20-basic-features/use-tools.spec.ts
+++ b/packages/app/test/cypress/integration/20-basic-features/use-tools.spec.ts
@@ -209,6 +209,7 @@ context('Tag Oprations', () =>{
     cy.getByTestid('search-result-base').should('be.visible');
     cy.getByTestid('search-result-list').should('be.visible');
     cy.get('#wiki').should('be.visible');
+    // force to click element to pass VRT: https://github.com/weseek/growi/pull/6603
     cy.getByTestid('page-list-item-L').first().click();
     cy.screenshot(`${ssPrefix}1-click-tag-name`, {capture: 'viewport'});
 

--- a/packages/app/test/cypress/integration/20-basic-features/use-tools.spec.ts
+++ b/packages/app/test/cypress/integration/20-basic-features/use-tools.spec.ts
@@ -211,8 +211,8 @@ context('Tag Oprations', () =>{
     cy.getByTestid('search-result-list').should('be.visible');
     cy.getByTestid('search-result-content').should('be.visible');
     cy.get('#wiki').should('be.visible');
-    // force to click element to pass VRT: https://github.com/weseek/growi/pull/6603
-    cy.getByTestid('page-list-item-L').first().click();
+    // force to add 'active' to pass VRT: https://github.com/weseek/growi/pull/6603
+    cy.getByTestid('page-list-item-L').first().invoke('addClass', 'active');
     cy.screenshot(`${ssPrefix}1-click-tag-name`, {capture: 'viewport'});
 
     cy.getByTestid('open-page-item-control-btn').first().click({force: true});

--- a/packages/app/test/cypress/integration/20-basic-features/use-tools.spec.ts
+++ b/packages/app/test/cypress/integration/20-basic-features/use-tools.spec.ts
@@ -209,6 +209,7 @@ context('Tag Oprations', () =>{
     cy.getByTestid('search-result-base').should('be.visible');
     cy.getByTestid('search-result-list').should('be.visible');
     cy.get('#wiki').should('be.visible');
+    cy.getByTestid('page-list-item-L').first().click();
     cy.screenshot(`${ssPrefix}1-click-tag-name`, {capture: 'viewport'});
 
     cy.getByTestid('open-page-item-control-btn').first().click({force: true});

--- a/packages/app/test/cypress/integration/30-search/search.spec.ts
+++ b/packages/app/test/cypress/integration/30-search/search.spec.ts
@@ -98,6 +98,8 @@ context('Search all pages', () => {
     cy.getByTestid('search-result-base').should('be.visible');
     cy.getByTestid('search-result-list').should('be.visible');
     cy.getByTestid('search-result-content').should('be.visible');
+    // force to click element to pass VRT: https://github.com/weseek/growi/pull/6603
+    cy.getByTestid('page-list-item-L').first().click();
     cy.screenshot(`${ssPrefix}3-search-page-results`, { capture: 'viewport'});
 
     cy.getByTestid('open-page-item-control-btn').eq(1).click();
@@ -159,6 +161,8 @@ context('Search all pages', () => {
     cy.getByTestid('search-result-list').should('be.visible');
     cy.getByTestid('search-result-content').should('be.visible');
 
+    // force to click element to pass VRT: https://github.com/weseek/growi/pull/6603
+    cy.getByTestid('page-list-item-L').first().click();
     cy.screenshot(`${ssPrefix}2-search-with-tag-result`, {capture: 'viewport'});
     cy.getByTestid('open-page-item-control-btn').first().click();
     cy.screenshot(`${ssPrefix}3-click-three-dots-menu-search-with-tag`, {capture: 'viewport'});
@@ -172,6 +176,8 @@ context('Search all pages', () => {
     cy.getByTestid('search-result-base').should('be.visible');
     cy.getByTestid('search-result-list').should('be.visible');
     cy.getByTestid('search-result-content').should('be.visible');
+    // force to click element to pass VRT: https://github.com/weseek/growi/pull/6603
+    cy.getByTestid('page-list-item-L').first().click();
     cy.screenshot(`${ssPrefix}1-tag-order-click-tag-name`, {capture: 'viewport'});
 
     cy.get('.grw-search-page-nav').within(() => {

--- a/packages/app/test/cypress/integration/30-search/search.spec.ts
+++ b/packages/app/test/cypress/integration/30-search/search.spec.ts
@@ -161,8 +161,6 @@ context('Search all pages', () => {
     cy.getByTestid('search-result-list').should('be.visible');
     cy.getByTestid('search-result-content').should('be.visible');
 
-    // force to click element to pass VRT: https://github.com/weseek/growi/pull/6603
-    cy.getByTestid('page-list-item-L').first().click();
     cy.screenshot(`${ssPrefix}2-search-with-tag-result`, {capture: 'viewport'});
     cy.getByTestid('open-page-item-control-btn').first().click();
     cy.screenshot(`${ssPrefix}3-click-three-dots-menu-search-with-tag`, {capture: 'viewport'});

--- a/packages/app/test/cypress/integration/30-search/search.spec.ts
+++ b/packages/app/test/cypress/integration/30-search/search.spec.ts
@@ -170,6 +170,8 @@ context('Search all pages', () => {
     cy.getByTestid('search-result-list').should('be.visible');
     cy.getByTestid('search-result-content').should('be.visible');
     cy.get('#wiki').should('be.visible');
+    // force to add 'active' to pass VRT: https://github.com/weseek/growi/pull/6603
+    cy.getByTestid('page-list-item-L').first().invoke('addClass', 'active');
     cy.screenshot(`${ssPrefix}2-search-with-tag-result`, {capture: 'viewport'});
 
     cy.getByTestid('open-page-item-control-btn').first().click();

--- a/packages/app/test/cypress/integration/30-search/search.spec.ts
+++ b/packages/app/test/cypress/integration/30-search/search.spec.ts
@@ -103,8 +103,8 @@ context('Search all pages', () => {
     cy.get('#wiki').should('be.visible');
     // eslint-disable-next-line cypress/no-unnecessary-waiting
     cy.wait(500); // wait for 500 ms for Scroll
-    // force to click element to pass VRT: https://github.com/weseek/growi/pull/6603
-    cy.getByTestid('page-list-item-L').first().click();
+    // force to add 'active' to pass VRT: https://github.com/weseek/growi/pull/6603
+    cy.getByTestid('page-list-item-L').first().invoke('addClass', 'active');
     cy.screenshot(`${ssPrefix}3-search-page-results`, { capture: 'viewport'});
 
     cy.getByTestid('open-page-item-control-btn').eq(1).click();
@@ -188,8 +188,8 @@ context('Search all pages', () => {
     cy.getByTestid('search-result-list').should('be.visible');
     cy.getByTestid('search-result-content').should('be.visible');
     cy.get('#wiki').should('be.visible');
-    // force to click element to pass VRT: https://github.com/weseek/growi/pull/6603
-    cy.getByTestid('page-list-item-L').first().click();
+    // force to add 'active' to pass VRT: https://github.com/weseek/growi/pull/6603
+    cy.getByTestid('page-list-item-L').first().invoke('addClass', 'active');
     cy.screenshot(`${ssPrefix}1-tag-order-click-tag-name`, {capture: 'viewport'});
 
     cy.get('.grw-search-page-nav').within(() => {


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/105162

期待されるスクショ
<img width="1086" alt="VRT_正常" src="https://user-images.githubusercontent.com/65263895/191423308-cd613641-5d75-4ad7-afeb-15efd91df4cf.PNG">

実際のスクショ
<img width="1082" alt="VRT_エラー" src="https://user-images.githubusercontent.com/65263895/191423321-95261e84-12b0-4df4-a76b-43ad43a56ed6.PNG">

アプリ側で検索後にページリストで選択状態にならない不具合があったのでそこをcypress側で無理やりつじつまを合わせました。この不具合は武井さんも認識していましたが、割と沼りそうなのと、Next化に伴って表示のロジックが変わるため、アプリ側の修正ではなく、VRTのエラーをいったん無くすという方針になりました。

VRTでこれ関係のエラーが2つ出ていますが
- https://growi-vrt-snapshots.s3.amazonaws.com/904cd9d76552c3be55834a7293232e73e6257efe/index.html?id=changed-20-basic-features/use-tools.spec.ts/tag-operations-page-duplicate-1-click-tag-name.png
- https://growi-vrt-snapshots.s3.amazonaws.com/904cd9d76552c3be55834a7293232e73e6257efe/index.html?id=changed-20-basic-features/use-tools.spec.ts/tag-operations-page-duplicate-2-click-three-dots-menu.png
afterのスクショの方が本来の挙動なので、比較元のbeforeのスクショが間違っており、このエラーは無視しても大丈夫です

メモ
- VRTではなく、アプリ側がおかしいのでページのリストのDOMを直接操作してactiveクラスを付与する方法でVRTを通す
- なぜそのような方法で実装したのかをPRノURLとともにコード中にメモる