### PR TITLE
fix: Visiting the trash page with the sidebar closed when in guest mode (VRT)

### DIFF
--- a/packages/app/test/cypress/integration/21-basic-features-for-guest/access-to-page.spec.ts
+++ b/packages/app/test/cypress/integration/21-basic-features-for-guest/access-to-page.spec.ts
@@ -56,13 +56,9 @@ context('Access to /me page', () => {
 context('Access to special pages by guest', () => {
   const ssPrefix = 'access-to-special-pages-by-guest-';
 
-  beforeEach(() => {
-    // collapse sidebar
-    cy.collapseSidebar(true);
-  });
-
   it('/trash is successfully loaded', () => {
     cy.visit('/trash', {  });
+    cy.collapseSidebar(true, true);
     cy.getByTestid('trash-page-list').should('be.visible');
     cy.screenshot(`${ssPrefix}-trash`);
   });


### PR DESCRIPTION
## Task

[#105213](https://redmine.weseek.co.jp/issues/105213) ゲストモード時はサイドバーを閉じた状態でtrash ページに訪れる