### PR TITLE
fix: Do not wait to save user-ui-settings (VRT)

### DIFF
--- a/packages/app/test/cypress/integration/50-sidebar/access-to-side-bar.spec.ts
+++ b/packages/app/test/cypress/integration/50-sidebar/access-to-side-bar.spec.ts
@@ -57,7 +57,7 @@ context('Access to sidebar', () => {
 
     cy.getByTestid('grw-sidebar-nav-primary-custom-sidebar').then(($el) => {
       if (!$el.hasClass('active')) {
-        cy.wrap($el).click().should('be.visible');
+        cy.wrap($el).click();
         cy.getByTestid('grw-contextual-navigation-sub').should('be.visible');
       }
     });

--- a/packages/app/test/cypress/integration/50-sidebar/access-to-side-bar.spec.ts
+++ b/packages/app/test/cypress/integration/50-sidebar/access-to-side-bar.spec.ts
@@ -54,6 +54,14 @@ context('Access to sidebar', () => {
     cy.screenshot(`${ssPrefix}custom-sidebar-2-custom-sidebar-editor`);
     cy.get('.dropup > .btn-submit').click();
     cy.get('body').should('not.have.class', 'on-edit');
+
+    cy.getByTestid('grw-sidebar-nav-primary-custom-sidebar').then(($el) => {
+      if (!$el.hasClass('active')) {
+        cy.wrap($el).click().should('be.visible');
+        cy.getByTestid('grw-contextual-navigation-sub').should('be.visible');
+      }
+    });
+
     cy.getByTestid('grw-contextual-navigation-sub').screenshot(`${ssPrefix}custom-sidebar-3-custom-sidebar-created`);
   });
 

--- a/packages/app/test/cypress/integration/50-sidebar/access-to-side-bar.spec.ts
+++ b/packages/app/test/cypress/integration/50-sidebar/access-to-side-bar.spec.ts
@@ -58,10 +58,10 @@ context('Access to sidebar', () => {
     cy.getByTestid('grw-sidebar-nav-primary-custom-sidebar').then(($el) => {
       if (!$el.hasClass('active')) {
         cy.wrap($el).click();
-        cy.getByTestid('grw-contextual-navigation-sub').should('be.visible');
       }
     });
 
+    cy.get('grw-custom-sidebar-content').should('be.visible');
     cy.getByTestid('grw-contextual-navigation-sub').screenshot(`${ssPrefix}custom-sidebar-3-custom-sidebar-created`);
   });
 

--- a/packages/app/test/cypress/integration/50-sidebar/access-to-side-bar.spec.ts
+++ b/packages/app/test/cypress/integration/50-sidebar/access-to-side-bar.spec.ts
@@ -61,7 +61,7 @@ context('Access to sidebar', () => {
       }
     });
 
-    cy.get('grw-custom-sidebar-content').should('be.visible');
+    cy.get('.grw-custom-sidebar-content').should('be.visible');
     cy.getByTestid('grw-contextual-navigation-sub').screenshot(`${ssPrefix}custom-sidebar-3-custom-sidebar-created`);
   });
 

--- a/packages/app/test/cypress/integration/50-sidebar/access-to-side-bar.spec.ts
+++ b/packages/app/test/cypress/integration/50-sidebar/access-to-side-bar.spec.ts
@@ -55,6 +55,7 @@ context('Access to sidebar', () => {
     cy.get('.dropup > .btn-submit').click();
     cy.get('body').should('not.have.class', 'on-edit');
 
+    // What to do when UserUISettings is not saved in time
     cy.getByTestid('grw-sidebar-nav-primary-custom-sidebar').then(($el) => {
       if (!$el.hasClass('active')) {
         cy.wrap($el).click();


### PR DESCRIPTION
## Task
[#105237](https://redmine.weseek.co.jp/issues/105237) UserUiSettings の保存を待たずにカスタムサイドバーのスクリーンショットを撮影する

## 修正箇所
[access-to-sidebar-custom-sidebar-3-custom-sidebar-created.png](https://growi-vrt-snapshots.s3.amazonaws.com/254b050e9b981bda33ac5c51e999b9e6d30c856e/index.html?id=changed-50-sidebar/access-to-side-bar.spec.ts/access-to-sidebar-custom-sidebar-3-custom-sidebar-created.png#changed-50-sidebar/access-to-side-bar.spec.ts/access-to-sidebar-custom-sidebar-3-custom-sidebar-created.png)