### PR TITLE
support: fix dependabot alert jquery-ui

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -12870,9 +12870,9 @@ jquery-slimscroll@^1.3.8:
     jquery ">= 1.7"
 
 jquery-ui@^1.12.1:
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/jquery-ui/-/jquery-ui-1.13.0.tgz#ab5ac65f37ca093c51b3478c4097f55bbc008f36"
-  integrity sha512-Osf7ECXNTYHtKBkn9xzbIf9kifNrBhfywFEKxOeB/OVctVmLlouV9mfc2qXCp6uyO4Pn72PXKOnj09qXetopCw==
+  version "1.13.2"
+  resolved "https://registry.yarnpkg.com/jquery-ui/-/jquery-ui-1.13.2.tgz#de03580ae6604773602f8d786ad1abfb75232034"
+  integrity sha512-wBZPnqWs5GaYJmo1Jj0k/mrSkzdQzKDwhXNtHKcBdAcKVxMM3KNYFq+iJ2i1rwiG53Z8M4mTn3Qxrm17uH1D4Q==
   dependencies:
     jquery ">=1.8.0 <4.0.0"
 


### PR DESCRIPTION
https://youtrack.weseek.co.jp/issue/GW-7883
- Update  jquery-ui@^1.12.1, resolved by version  1.13.2