### PR TITLE
support: VRT fix waitind for pagelist rendering

### DIFF
--- a/packages/app/test/cypress/integration/20-basic-features/access-to-pagelist.spec.ts
+++ b/packages/app/test/cypress/integration/20-basic-features/access-to-pagelist.spec.ts
@@ -76,6 +76,7 @@ context('Access to timeline', () => {
     cy.getByTestid('page-accessories-modal').parent().should('have.class','show').within(() => {
       cy.get('.nav-title > li').eq(1).find('a').click();
     });
+    cy.get('#wiki').should('be.visible'); // wait for rendering
     cy.screenshot(`${ssPrefix}1-timeline-list`, {capture: 'viewport'});
   });
 


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/105391

PageList→TimeLine表示のVRTでページのレンダリングを待って、スクショを撮るようにした

https://growi-vrt-snapshots.s3.amazonaws.com/5542da4806158eb4f4d38b0c164310e948bbbb2b/index.html?id=changed-20-basic-features/access-to-page.spec.ts/access-to-page--sandbox-headers.png
上記のVRTで差分が出ていますが、beforeのスクショが間違っているのでスルーでいいと思います