### PR TITLE
support: Add wait for loading layout image in VRT

### DIFF
--- a/packages/app/test/cypress/integration/30-search/search.spec.ts
+++ b/packages/app/test/cypress/integration/30-search/search.spec.ts
@@ -32,6 +32,9 @@ context('Access to search result page', () => {
     // for avoid mismatch by auto scrolling
     cy.get('.search-result-content-body-container').scrollTo('top');
 
+    // force to add 'active' to pass VRT: https://github.com/weseek/growi/pull/6603
+    cy.getByTestid('page-list-item-L').first().invoke('addClass', 'active');
+
     cy.getByTestid('cb-select').first().click({force: true});
     cy.screenshot(`${ssPrefix}the-first-checkbox-on`);
     cy.getByTestid('cb-select').first().click({force: true});

--- a/packages/app/test/cypress/integration/40-admin/access-to-admin-page.spec.ts
+++ b/packages/app/test/cypress/integration/40-admin/access-to-admin-page.spec.ts
@@ -51,6 +51,8 @@ context('Access to Admin page', () => {
   it('/admin/customize is successfully loaded', () => {
     cy.visit('/admin/customize');
     cy.getByTestid('admin-customize').should('be.visible');
+    /* eslint-disable cypress/no-unnecessary-waiting */
+    cy.wait(1000); // wait for loading layout image
     cy.screenshot(`${ssPrefix}-admin-customize`);
   });
 


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/105469

## 対象のVRTの差分
https://growi-vrt-snapshots.s3.amazonaws.com/ea85240af5df47c008876257774ef76570a37657/index.html?id=changed-40-admin/access-to-admin-page.spec.ts/access-to-admin-page--admin-customize.png

## やったこと
- admin画面の画像のローディング&スタイル適用が完了していない段階でスクリーンショットがとられてしまっていたのでwaitを追加してタイミングを合わせるようにしました。
- 対象のタスクではないですが、ページリストに強制的にactiveクラスを付与するコードの抜けがあったので追加しました。

## その他
あたらしい差分があったのでタスクを作りました
https://redmine.weseek.co.jp/issues/105501