### PR TITLE
support: add wait for header style in VRT

### DIFF
--- a/packages/app/src/components/PageEditor/Editor.tsx
+++ b/packages/app/src/components/PageEditor/Editor.tsx
@@ -242,7 +242,7 @@ const Editor = React.forwardRef((props: EditorPropsType, ref): JSX.Element => {
         <ul className="pl-2 nav nav-navbar">
           { methods.getNavbarItems?.().map((item, idx) => {
             // eslint-disable-next-line react/no-array-index-key
-            return <li key={`navbarItem-${idx}`}>{item}</li>;
+            return <li key={`navbarItem-${idx}`} data-testid="editor-navbar-button">{item}</li>;
           }) }
         </ul>
       </div>

--- a/packages/app/src/components/PageEditor/Editor.tsx
+++ b/packages/app/src/components/PageEditor/Editor.tsx
@@ -242,7 +242,7 @@ const Editor = React.forwardRef((props: EditorPropsType, ref): JSX.Element => {
         <ul className="pl-2 nav nav-navbar">
           { methods.getNavbarItems?.().map((item, idx) => {
             // eslint-disable-next-line react/no-array-index-key
-            return <li key={`navbarItem-${idx}`} data-testid="editor-navbar-button">{item}</li>;
+            return <li key={`navbarItem-${idx}`}>{item}</li>;
           }) }
         </ul>
       </div>

--- a/packages/app/test/cypress/integration/20-basic-features/access-to-page.spec.ts
+++ b/packages/app/test/cypress/integration/20-basic-features/access-to-page.spec.ts
@@ -21,9 +21,10 @@ context('Access to page', () => {
     // hide fab
     cy.getByTestid('grw-fab-container').invoke('attr', 'style', 'display: none');
 
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(2000); // wait for 2 seconds for Header style
-    cy.screenshot(`${ssPrefix}-sandbox-headers`);
+    // black out Headers: https://github.com/weseek/growi/pull/6649
+    cy.screenshot(`${ssPrefix}-sandbox-headers`, {
+      blackout: ['#Headers'],
+    });
   });
 
   it('/Sandbox/Math is successfully loaded', () => {

--- a/packages/app/test/cypress/integration/20-basic-features/access-to-page.spec.ts
+++ b/packages/app/test/cypress/integration/20-basic-features/access-to-page.spec.ts
@@ -22,7 +22,9 @@ context('Access to page', () => {
     cy.getByTestid('grw-fab-container').invoke('attr', 'style', 'display: none');
 
     // remove animation for screenshot
-    cy.get('#Headers').invoke('attr', 'style', 'animation: none');
+    // remove 'blink' class because ::after element cannot be operated
+    // https://stackoverflow.com/questions/5041494/selecting-and-manipulating-css-pseudo-elements-such-as-before-and-after-usin/21709814#21709814
+    cy.get('#Headers').invoke('removeClass', 'blink');
 
     cy.screenshot(`${ssPrefix}-sandbox-headers`);
   });

--- a/packages/app/test/cypress/integration/20-basic-features/access-to-page.spec.ts
+++ b/packages/app/test/cypress/integration/20-basic-features/access-to-page.spec.ts
@@ -21,6 +21,8 @@ context('Access to page', () => {
     // hide fab
     cy.getByTestid('grw-fab-container').invoke('attr', 'style', 'display: none');
 
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(1000); // wait for 1 seconds for Header style
     cy.screenshot(`${ssPrefix}-sandbox-headers`);
   });
 

--- a/packages/app/test/cypress/integration/20-basic-features/access-to-page.spec.ts
+++ b/packages/app/test/cypress/integration/20-basic-features/access-to-page.spec.ts
@@ -40,7 +40,7 @@ context('Access to page', () => {
   it('/Sandbox with edit is successfully loaded', () => {
     cy.visit('/Sandbox#edit');
     // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(500);
+    cy.wait(2500);
     cy.screenshot(`${ssPrefix}-sandbox-edit-page`);
   })
 

--- a/packages/app/test/cypress/integration/20-basic-features/access-to-page.spec.ts
+++ b/packages/app/test/cypress/integration/20-basic-features/access-to-page.spec.ts
@@ -21,10 +21,10 @@ context('Access to page', () => {
     // hide fab
     cy.getByTestid('grw-fab-container').invoke('attr', 'style', 'display: none');
 
-    // black out Headers: https://github.com/weseek/growi/pull/6649
-    cy.screenshot(`${ssPrefix}-sandbox-headers`, {
-      blackout: ['#Headers'],
-    });
+    // remove animation for screenshot
+    cy.getByTestid('#Headers').invoke('removeClass', 'blink');
+
+    cy.screenshot(`${ssPrefix}-sandbox-headers`);
   });
 
   it('/Sandbox/Math is successfully loaded', () => {

--- a/packages/app/test/cypress/integration/20-basic-features/access-to-page.spec.ts
+++ b/packages/app/test/cypress/integration/20-basic-features/access-to-page.spec.ts
@@ -22,7 +22,7 @@ context('Access to page', () => {
     cy.getByTestid('grw-fab-container').invoke('attr', 'style', 'display: none');
 
     // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(1500); // wait for 1 seconds for Header style
+    cy.wait(1500); // wait for 1.5 seconds for Header style
     cy.screenshot(`${ssPrefix}-sandbox-headers`);
   });
 

--- a/packages/app/test/cypress/integration/20-basic-features/access-to-page.spec.ts
+++ b/packages/app/test/cypress/integration/20-basic-features/access-to-page.spec.ts
@@ -67,7 +67,7 @@ context('Access to /me page', () => {
   it('/me is successfully loaded', () => {
     cy.visit('/me', {  });
     // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(1000); // wait loading image
+    cy.wait(500); // wait loading image
     cy.screenshot(`${ssPrefix}-me`);
   });
 

--- a/packages/app/test/cypress/integration/20-basic-features/access-to-page.spec.ts
+++ b/packages/app/test/cypress/integration/20-basic-features/access-to-page.spec.ts
@@ -39,7 +39,6 @@ context('Access to page', () => {
 
   it('/Sandbox with edit is successfully loaded', () => {
     cy.visit('/Sandbox#edit');
-    cy.getByTestid('editor-navbar-button').should('be.visible');
     cy.screenshot(`${ssPrefix}-sandbox-edit-page`);
   })
 

--- a/packages/app/test/cypress/integration/20-basic-features/access-to-page.spec.ts
+++ b/packages/app/test/cypress/integration/20-basic-features/access-to-page.spec.ts
@@ -22,7 +22,7 @@ context('Access to page', () => {
     cy.getByTestid('grw-fab-container').invoke('attr', 'style', 'display: none');
 
     // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(1500); // wait for 1.5 seconds for Header style
+    cy.wait(2000); // wait for 2 seconds for Header style
     cy.screenshot(`${ssPrefix}-sandbox-headers`);
   });
 

--- a/packages/app/test/cypress/integration/20-basic-features/access-to-page.spec.ts
+++ b/packages/app/test/cypress/integration/20-basic-features/access-to-page.spec.ts
@@ -22,7 +22,7 @@ context('Access to page', () => {
     cy.getByTestid('grw-fab-container').invoke('attr', 'style', 'display: none');
 
     // remove animation for screenshot
-    cy.getByTestid('#Headers').invoke('removeClass', 'blink');
+    cy.get('#Headers').invoke('removeClass', 'blink');
 
     cy.screenshot(`${ssPrefix}-sandbox-headers`);
   });

--- a/packages/app/test/cypress/integration/20-basic-features/access-to-page.spec.ts
+++ b/packages/app/test/cypress/integration/20-basic-features/access-to-page.spec.ts
@@ -22,7 +22,7 @@ context('Access to page', () => {
     cy.getByTestid('grw-fab-container').invoke('attr', 'style', 'display: none');
 
     // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(1000); // wait for 1 seconds for Header style
+    cy.wait(1500); // wait for 1 seconds for Header style
     cy.screenshot(`${ssPrefix}-sandbox-headers`);
   });
 

--- a/packages/app/test/cypress/integration/20-basic-features/access-to-page.spec.ts
+++ b/packages/app/test/cypress/integration/20-basic-features/access-to-page.spec.ts
@@ -64,6 +64,8 @@ context('Access to /me page', () => {
 
   it('/me is successfully loaded', () => {
     cy.visit('/me', {  });
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(1000); // wait loading image
     cy.screenshot(`${ssPrefix}-me`);
   });
 

--- a/packages/app/test/cypress/integration/20-basic-features/access-to-page.spec.ts
+++ b/packages/app/test/cypress/integration/20-basic-features/access-to-page.spec.ts
@@ -39,8 +39,7 @@ context('Access to page', () => {
 
   it('/Sandbox with edit is successfully loaded', () => {
     cy.visit('/Sandbox#edit');
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(2500);
+    cy.getByTestid('editor-navbar-button').should('be.visible');
     cy.screenshot(`${ssPrefix}-sandbox-edit-page`);
   })
 

--- a/packages/app/test/cypress/integration/20-basic-features/access-to-page.spec.ts
+++ b/packages/app/test/cypress/integration/20-basic-features/access-to-page.spec.ts
@@ -39,6 +39,8 @@ context('Access to page', () => {
 
   it('/Sandbox with edit is successfully loaded', () => {
     cy.visit('/Sandbox#edit');
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(500);
     cy.screenshot(`${ssPrefix}-sandbox-edit-page`);
   })
 

--- a/packages/app/test/cypress/integration/20-basic-features/access-to-page.spec.ts
+++ b/packages/app/test/cypress/integration/20-basic-features/access-to-page.spec.ts
@@ -22,7 +22,7 @@ context('Access to page', () => {
     cy.getByTestid('grw-fab-container').invoke('attr', 'style', 'display: none');
 
     // remove animation for screenshot
-    cy.get('#Headers').invoke('removeClass', 'blink');
+    cy.get('#Headers').invoke('attr', 'style', 'animation: none');
 
     cy.screenshot(`${ssPrefix}-sandbox-headers`);
   });

--- a/packages/app/test/cypress/integration/30-search/search.spec.ts
+++ b/packages/app/test/cypress/integration/30-search/search.spec.ts
@@ -263,8 +263,12 @@ context('Search current tree with "prefix":', () => {
     cy.getByTestid('search-result-list').should('be.visible');
     cy.getByTestid('search-result-content').should('be.visible');
     cy.get('#wiki').should('be.visible');
+    // force to add 'active' to pass VRT: https://github.com/weseek/growi/pull/6603
+    cy.getByTestid('page-list-item-L').first().invoke('addClass', 'active');
     // for avoid mismatch by auto scrolling
     cy.get('.search-result-content-body-container').scrollTo('top');
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(1500);
     cy.screenshot(`${ssPrefix}3-search-page-results`, { capture: 'viewport'});
 
     cy.getByTestid('open-page-item-control-btn').first().click();

--- a/packages/app/test/cypress/integration/40-admin/access-to-admin-page.spec.ts
+++ b/packages/app/test/cypress/integration/40-admin/access-to-admin-page.spec.ts
@@ -52,7 +52,7 @@ context('Access to Admin page', () => {
     cy.visit('/admin/customize');
     cy.getByTestid('admin-customize').should('be.visible');
     /* eslint-disable cypress/no-unnecessary-waiting */
-    cy.wait(1000); // wait for loading layout image
+    cy.wait(500); // wait for loading layout image
     cy.screenshot(`${ssPrefix}-admin-customize`);
   });
 


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/105468

## 対象のVRT
https://growi-vrt-snapshots.s3.amazonaws.com/ea85240af5df47c008876257774ef76570a37657/index.html?id=changed-20-basic-features/access-to-page.spec.ts/access-to-page--sandbox-headers.png

## やったこと
- Sandbox#Headersにアクセスした直後は「Headers」という文字の背景が灰色っぽく、時間がたつにつれて薄くなる仕様になっており、その途中でスクショがとられてVRTで差分が出ていたので、header部分のアニメーションを削除してスクショを撮るようにしました。
- ページリストの表示で強制的にactiveクラスを付与する部分の抜けがあったため、追加しました。

