### PR TITLE
support: Update spec ts for VRT normalization

### DIFF
--- a/packages/app/src/components/Sidebar/RecentChanges.tsx
+++ b/packages/app/src/components/Sidebar/RecentChanges.tsx
@@ -30,7 +30,7 @@ function PageItemLower({ page }) {
         <div className="icon-bubble mr-1 d-inline-block"></div>
         <div className="mr-2 grw-list-counts d-inline-block">{page.commentCount}</div>
       </div>
-      <div className="grw-formatted-distance-date small mt-auto">
+      <div className="grw-formatted-distance-date small mt-auto" data-hide-in-vrt>
         <FormattedDistanceDate id={page._id} date={page.updatedAt} />
       </div>
     </div>

--- a/packages/app/test/cypress/integration/20-basic-features/access-to-pagelist.spec.ts
+++ b/packages/app/test/cypress/integration/20-basic-features/access-to-pagelist.spec.ts
@@ -50,7 +50,7 @@ context('Access to pagelist', () => {
     cy.getByTestid('page-accessories-modal').parent().should('have.class','show').within(() => {
       cy.get('button.close').eq(0).click();
     });
-    cy.get('.modal')
+    cy.get('.modal').should('be.visible').scrollTo('top');
     cy.screenshot(`${ssPrefix}7-page-list-modal-size-fullscreen`, {capture: 'viewport'});
 
     cy.getByTestid('page-accessories-modal').parent().should('have.class','show').within(() => {

--- a/packages/app/test/cypress/integration/20-basic-features/access-to-pagelist.spec.ts
+++ b/packages/app/test/cypress/integration/20-basic-features/access-to-pagelist.spec.ts
@@ -50,7 +50,7 @@ context('Access to pagelist', () => {
     cy.getByTestid('page-accessories-modal').parent().should('have.class','show').within(() => {
       cy.get('button.close').eq(0).click();
     });
-    cy.get('.modal').should('be.visible').scrollTo('top');
+    cy.get('.modal')
     cy.screenshot(`${ssPrefix}7-page-list-modal-size-fullscreen`, {capture: 'viewport'});
 
     cy.getByTestid('page-accessories-modal').parent().should('have.class','show').within(() => {

--- a/packages/app/test/cypress/integration/20-basic-features/access-to-pagelist.spec.ts
+++ b/packages/app/test/cypress/integration/20-basic-features/access-to-pagelist.spec.ts
@@ -50,7 +50,7 @@ context('Access to pagelist', () => {
     cy.getByTestid('page-accessories-modal').parent().should('have.class','show').within(() => {
       cy.get('button.close').eq(0).click();
     });
-    cy.get('.modal')
+
     cy.screenshot(`${ssPrefix}7-page-list-modal-size-fullscreen`, {capture: 'viewport'});
 
     cy.getByTestid('page-accessories-modal').parent().should('have.class','show').within(() => {

--- a/packages/app/test/cypress/integration/20-basic-features/access-to-pagelist.spec.ts
+++ b/packages/app/test/cypress/integration/20-basic-features/access-to-pagelist.spec.ts
@@ -50,7 +50,7 @@ context('Access to pagelist', () => {
     cy.getByTestid('page-accessories-modal').parent().should('have.class','show').within(() => {
       cy.get('button.close').eq(0).click();
     });
-    cy.get('.modal').scrollTo('top');
+    cy.get('.modal').should('be.visible').scrollTo('top');
     cy.screenshot(`${ssPrefix}7-page-list-modal-size-fullscreen`, {capture: 'viewport'});
 
     cy.getByTestid('page-accessories-modal').parent().should('have.class','show').within(() => {
@@ -88,7 +88,7 @@ context('Access to timeline', () => {
       cy.get('.nav-title > li').eq(1).find('a').click();
       cy.get('button.close').eq(0).click();
     });
-    cy.get('.modal').scrollTo('top');
+    cy.get('.modal').should('be.visible').scrollTo('top');
     cy.screenshot(`${ssPrefix}2-timeline-list-fullscreen`, {capture: 'viewport'});
     cy.getByTestid('page-accessories-modal').parent().should('have.class','show').within(() => {
       cy.get('button.close').eq(1).click();

--- a/packages/app/test/cypress/integration/20-basic-features/access-to-pagelist.spec.ts
+++ b/packages/app/test/cypress/integration/20-basic-features/access-to-pagelist.spec.ts
@@ -50,6 +50,7 @@ context('Access to pagelist', () => {
     cy.getByTestid('page-accessories-modal').parent().should('have.class','show').within(() => {
       cy.get('button.close').eq(0).click();
     });
+    cy.get('.modal').scrollTo('top');
     cy.screenshot(`${ssPrefix}7-page-list-modal-size-fullscreen`, {capture: 'viewport'});
 
     cy.getByTestid('page-accessories-modal').parent().should('have.class','show').within(() => {
@@ -87,6 +88,7 @@ context('Access to timeline', () => {
       cy.get('.nav-title > li').eq(1).find('a').click();
       cy.get('button.close').eq(0).click();
     });
+    cy.get('.modal').scrollTo('top');
     cy.screenshot(`${ssPrefix}2-timeline-list-fullscreen`, {capture: 'viewport'});
     cy.getByTestid('page-accessories-modal').parent().should('have.class','show').within(() => {
       cy.get('button.close').eq(1).click();

--- a/packages/app/test/cypress/integration/50-sidebar/access-to-side-bar.spec.ts
+++ b/packages/app/test/cypress/integration/50-sidebar/access-to-side-bar.spec.ts
@@ -30,13 +30,16 @@ context('Access to sidebar', () => {
     cy.get('.list-group-item').should('be.visible');
 
     // Avoid blackout misalignment
+    cy.scrollTo('center');
     cy.screenshot(`${ssPrefix}recent-changes-1-page-list`);
 
     cy.get('#grw-sidebar-contents-wrapper').within(() => {
       cy.get('#recentChangesResize').click({force: true});
       cy.get('.list-group-item').should('be.visible');
     });
+
     // Avoid blackout misalignment
+    cy.scrollTo('center');
     cy.screenshot(`${ssPrefix}recent-changes-2-switch-sidebar-size`);
   });
 

--- a/packages/app/test/cypress/integration/50-sidebar/access-to-side-bar.spec.ts
+++ b/packages/app/test/cypress/integration/50-sidebar/access-to-side-bar.spec.ts
@@ -27,13 +27,17 @@ context('Access to sidebar', () => {
     });
 
     cy.getByTestid('grw-recent-changes').should('be.visible');
+    cy.get('.list-group-item').should('be.visible');
 
-    cy.getByTestid('grw-contextual-navigation-sub').screenshot(`${ssPrefix}recent-changes-1-page-list`);
+    // Avoid blackout misalignment
+    cy.screenshot(`${ssPrefix}recent-changes-1-page-list`);
 
     cy.get('#grw-sidebar-contents-wrapper').within(() => {
       cy.get('#recentChangesResize').click({force: true});
-      cy.screenshot(`${ssPrefix}recent-changes-2-switch-sidebar-size`);
+      cy.get('.list-group-item').should('be.visible');
     });
+    // Avoid blackout misalignment
+    cy.screenshot(`${ssPrefix}recent-changes-2-switch-sidebar-size`);
   });
 
   it('Successfully create a custom sidebar page', () => {


### PR DESCRIPTION
タスク:

- https://redmine.weseek.co.jp/issues/105464

 -> 時刻のため, Blackoutで対応. CSSコンテナを指定するとblackoutがずれるので全画面キャプチャに変更

- https://redmine.weseek.co.jp/issues/105501

- https://redmine.weseek.co.jp/issues/105460

 -> should('be.visible').scrollTo() で対応.

- https://redmine.weseek.co.jp/issues/105463

 -> こちらはその後確認できないため、一旦そのまま。