### PR TITLE
fix: VRT page Item control position

### DIFF
--- a/packages/app/src/components/Common/Dropdown/PageItemControl.tsx
+++ b/packages/app/src/components/Common/Dropdown/PageItemControl.tsx
@@ -245,7 +245,12 @@ const PageItemControlDropdownMenu = React.memo((props: DropdownMenuProps): JSX.E
   }
 
   return (
-    <DropdownMenu positionFixed modifiers={{ preventOverflow: { boundariesElement: undefined } }} right={alignRight}>
+    <DropdownMenu
+      data-testid="page-item-control-menu"
+      positionFixed
+      modifiers={{ preventOverflow: { boundariesElement: undefined } }}
+      right={alignRight}
+    >
       {contents}
     </DropdownMenu>
   );

--- a/packages/app/test/cypress/integration/20-basic-features/access-to-pagelist.spec.ts
+++ b/packages/app/test/cypress/integration/20-basic-features/access-to-pagelist.spec.ts
@@ -25,7 +25,7 @@ context('Access to pagelist', () => {
         cy.wait(300);
         cy.screenshot(`${ssPrefix}2-open-page-item-control-menu`);
       });
-    })
+    });
     cy.getByTestid('page-duplicate-modal').should('be.visible').screenshot(`${ssPrefix}3-duplicate-page-modal-opened`);
     cy.getByTestid('page-duplicate-modal').should('be.visible').within(() => {
       cy.get('.rbt-input-main').type('-duplicate', {force: true})

--- a/packages/app/test/cypress/integration/20-basic-features/access-to-pagelist.spec.ts
+++ b/packages/app/test/cypress/integration/20-basic-features/access-to-pagelist.spec.ts
@@ -15,7 +15,7 @@ context('Access to pagelist', () => {
     cy.getByTestid('page-accessories-modal').should('be.visible').screenshot(`${ssPrefix}1-open-pagelist-modal`);
   });
 
-  it('Successfully add a bookmark from page list', () => {
+  it('Successfully duplicate a page from page list', () => {
     cy.visit('/');
     cy.getByTestid('pageListButton').click({force: true});
     cy.getByTestid('page-accessories-modal').parent().should('have.class','show').within(() => {
@@ -26,17 +26,6 @@ context('Access to pagelist', () => {
         cy.screenshot(`${ssPrefix}2-open-page-item-control-menu`);
       });
     })
-  });
-
-  it('Successfully duplicate a page from page list', () => {
-    cy.visit('/');
-    cy.getByTestid('pageListButton').click({force: true});
-    cy.getByTestid('page-accessories-modal').parent().should('have.class','show').within(() => {
-      cy.getByTestid('open-page-item-control-btn').first().click();
-      cy.get('.dropdown-menu').should('have.class', 'show').first().within(() => {
-        cy.getByTestid('open-page-duplicate-modal-btn').click();
-      });
-    });
     cy.getByTestid('page-duplicate-modal').should('be.visible').screenshot(`${ssPrefix}3-duplicate-page-modal-opened`);
     cy.getByTestid('page-duplicate-modal').should('be.visible').within(() => {
       cy.get('.rbt-input-main').type('-duplicate', {force: true})

--- a/packages/app/test/cypress/integration/20-basic-features/access-to-pagelist.spec.ts
+++ b/packages/app/test/cypress/integration/20-basic-features/access-to-pagelist.spec.ts
@@ -10,18 +10,29 @@ context('Access to pagelist', () => {
   });
 
   it('Page list modal is successfully opened ', () => {
-    cy.visit('/');
+    cy.visit('/Sandbox');
     cy.getByTestid('pageListButton').click({force: true});
-    cy.getByTestid('page-accessories-modal').parent().should('have.class','show');
-    cy.screenshot(`${ssPrefix}1-open-pagelist-modal`);
+    cy.getByTestid('page-accessories-modal').should('be.visible').screenshot(`${ssPrefix}1-open-pagelist-modal`);
   });
 
-  it('Successfully duplicate a page from page list', () => {
-    cy.visit('/');
+  it('Successfully add a bookmark from page list', () => {
+    cy.visit('/Sandbox');
     cy.getByTestid('pageListButton').click({force: true});
     cy.getByTestid('page-accessories-modal').parent().should('have.class','show').within(() => {
       cy.getByTestid('open-page-item-control-btn').first().click();
-      cy.screenshot(`${ssPrefix}2-click-on-three-dots-menu`);
+      cy.getByTestid('page-item-control-menu').should('have.class', 'show').first().within(() => {
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
+        cy.wait(300);
+        cy.screenshot(`${ssPrefix}2-open-page-item-control-menu`);
+      });
+    })
+  });
+
+  it('Successfully duplicate a page from page list', () => {
+    cy.visit('/Sandbox');
+    cy.getByTestid('pageListButton').click({force: true});
+    cy.getByTestid('page-accessories-modal').parent().should('have.class','show').within(() => {
+      cy.getByTestid('open-page-item-control-btn').first().click();
       cy.get('.dropdown-menu').should('have.class', 'show').first().within(() => {
         cy.getByTestid('open-page-duplicate-modal-btn').click();
       });
@@ -43,7 +54,7 @@ context('Access to pagelist', () => {
   });
 
   it('Successfully expand and close modal', () => {
-    cy.visit('/');
+    cy.visit('/Sandbox');
     cy.getByTestid('pageListButton').click({force: true});
     cy.getByTestid('page-accessories-modal').parent().should('have.class','show');
     cy.screenshot(`${ssPrefix}6-page-list-modal-size-normal`, {capture: 'viewport'});
@@ -80,7 +91,7 @@ context('Access to timeline', () => {
   });
 
   it('Successfully expand and close modal', () => {
-    cy.visit('/');
+    cy.visit('/Sandbox');
     cy.getByTestid('pageListButton').click({force: true});
     cy.getByTestid('page-accessories-modal').parent().should('have.class','show').within(() => {
       cy.get('.nav-title > li').eq(1).find('a').click();

--- a/packages/app/test/cypress/integration/20-basic-features/access-to-pagelist.spec.ts
+++ b/packages/app/test/cypress/integration/20-basic-features/access-to-pagelist.spec.ts
@@ -24,6 +24,7 @@ context('Access to pagelist', () => {
         // eslint-disable-next-line cypress/no-unnecessary-waiting
         cy.wait(300);
         cy.screenshot(`${ssPrefix}2-open-page-item-control-menu`);
+        cy.getByTestid('open-page-duplicate-modal-btn').click();
       });
     });
     cy.getByTestid('page-duplicate-modal').should('be.visible').screenshot(`${ssPrefix}3-duplicate-page-modal-opened`);

--- a/packages/app/test/cypress/integration/20-basic-features/access-to-pagelist.spec.ts
+++ b/packages/app/test/cypress/integration/20-basic-features/access-to-pagelist.spec.ts
@@ -10,13 +10,13 @@ context('Access to pagelist', () => {
   });
 
   it('Page list modal is successfully opened ', () => {
-    cy.visit('/Sandbox');
+    cy.visit('/');
     cy.getByTestid('pageListButton').click({force: true});
     cy.getByTestid('page-accessories-modal').should('be.visible').screenshot(`${ssPrefix}1-open-pagelist-modal`);
   });
 
   it('Successfully add a bookmark from page list', () => {
-    cy.visit('/Sandbox');
+    cy.visit('/');
     cy.getByTestid('pageListButton').click({force: true});
     cy.getByTestid('page-accessories-modal').parent().should('have.class','show').within(() => {
       cy.getByTestid('open-page-item-control-btn').first().click();
@@ -29,7 +29,7 @@ context('Access to pagelist', () => {
   });
 
   it('Successfully duplicate a page from page list', () => {
-    cy.visit('/Sandbox');
+    cy.visit('/');
     cy.getByTestid('pageListButton').click({force: true});
     cy.getByTestid('page-accessories-modal').parent().should('have.class','show').within(() => {
       cy.getByTestid('open-page-item-control-btn').first().click();
@@ -54,7 +54,7 @@ context('Access to pagelist', () => {
   });
 
   it('Successfully expand and close modal', () => {
-    cy.visit('/Sandbox');
+    cy.visit('/');
     cy.getByTestid('pageListButton').click({force: true});
     cy.getByTestid('page-accessories-modal').parent().should('have.class','show');
     cy.screenshot(`${ssPrefix}6-page-list-modal-size-normal`, {capture: 'viewport'});
@@ -91,7 +91,7 @@ context('Access to timeline', () => {
   });
 
   it('Successfully expand and close modal', () => {
-    cy.visit('/Sandbox');
+    cy.visit('/');
     cy.getByTestid('pageListButton').click({force: true});
     cy.getByTestid('page-accessories-modal').parent().should('have.class','show').within(() => {
       cy.get('.nav-title > li').eq(1).find('a').click();


### PR DESCRIPTION
## Task
VRT正常化_2022_09_16
┗[105459](https://redmine.weseek.co.jp/issues/105459) pagelist 3点ボタンメニュー

## Screenshots
### ①
モーダルの要素だけのスクショを撮るようにした　(ついで)
| Before | After | 
| ---- | ---- | 
| ![Screen Shot 2022-09-27 at 2 48 05](https://user-images.githubusercontent.com/59536731/192346041-1bd58083-35b1-46d7-81d3-ada8ef190fb8.png)     |  ![Screen Shot 2022-09-27 at 2 48 09](https://user-images.githubusercontent.com/59536731/192346049-14029709-2b4b-4d5c-875b-3999aedf40e6.png)    |  



### ②
pageItemControl の dropdown menu の要素のみのスクショを撮ることで、menu の場所が移動する差分が検出するのを防ぎました。

![Screen Shot 2022-09-27 at 2 48 27](https://user-images.githubusercontent.com/59536731/192346143-809c6df0-960a-4429-9273-da3bd8959c9d.png)


