### PR TITLE
fix: show language lists in admin app setting

### DIFF
--- a/packages/app/public/static/locales/en_US/admin.json
+++ b/packages/app/public/static/locales/en_US/admin.json
@@ -1,4 +1,7 @@
 {
+  "meta": {
+    "display_name": "English"
+  },
   "wiki_management_home_page": "Wiki Management Home Page",
   "app_settings": "App Settings",
   "security_settings": {

--- a/packages/app/public/static/locales/ja_JP/admin.json
+++ b/packages/app/public/static/locales/ja_JP/admin.json
@@ -1,4 +1,7 @@
 {
+  "meta": {
+    "display_name": "日本語"
+  },
   "Update": "更新",
   "Delete": "削除",
   "User": "ユーザー",

--- a/packages/app/public/static/locales/zh_CN/admin.json
+++ b/packages/app/public/static/locales/zh_CN/admin.json
@@ -1,4 +1,7 @@
 {
+  "meta": {
+    "display_name": "简体中文"
+  },
   "Update": "更新",
   "Delete": "删除",
   "User": "用户",

--- a/packages/app/src/components/Admin/App/AppSetting.jsx
+++ b/packages/app/src/components/Admin/App/AppSetting.jsx
@@ -79,8 +79,8 @@ const AppSetting = (props) => {
         <div className="col-md-6 py-2">
           {
             i18nConfig.locales.map((locale) => {
-              const fixedT = i18n.getFixedT(locale);
-              i18n.loadLanguages(i18nConfig.locales);
+              if (i18n == null) { return }
+              const fixedT = i18n.getFixedT(locale, 'admin');
 
               return (
                 <div key={locale} className="custom-control custom-radio custom-control-inline">

--- a/packages/app/src/pages/admin/[[...path]].page.tsx
+++ b/packages/app/src/pages/admin/[[...path]].page.tsx
@@ -307,7 +307,8 @@ async function injectServerConfigurations(context: GetServerSidePropsContext, pr
  * @param namespacesRequired
  */
 async function injectNextI18NextConfigurations(context: GetServerSidePropsContext, props: Props, namespacesRequired?: string[] | undefined): Promise<void> {
-  const nextI18NextConfig = await getNextI18NextConfig(serverSideTranslations, context, namespacesRequired);
+  // preload all languages because of language lists in user setting
+  const nextI18NextConfig = await getNextI18NextConfig(serverSideTranslations, context, namespacesRequired, true);
   props._nextI18Next = nextI18NextConfig._nextI18Next;
 }
 


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/105556

admin画面のアプリ設定画面で言語リストが正常に表示されていなかったのを修正しました

修正前
<img width="680" alt="admin_i18n_before" src="https://user-images.githubusercontent.com/65263895/192259947-ddc1b449-dfbb-44bf-90c4-09335759c99b.PNG">

修正後
<img width="466" alt="admin_i18n_after" src="https://user-images.githubusercontent.com/65263895/192259955-fd891536-af44-421c-8e6f-8d8f41e963ed.PNG">

