### PR TITLE
add code to redirect to /me#password

### DIFF
--- a/packages/app/src/server/routes/login.js
+++ b/packages/app/src/server/routes/login.js
@@ -29,7 +29,13 @@ module.exports = function(crowi, app) {
         });
       }
 
-      const { redirectTo } = req.session;
+      let redirectTo;
+      if (userData.password) {
+        redirectTo = req.session.redirectTo;
+      }
+      else {
+        redirectTo = '/me#password';
+      }
       // remove session.redirectTo
       delete req.session.redirectTo;
 

--- a/packages/app/src/server/routes/login.js
+++ b/packages/app/src/server/routes/login.js
@@ -29,13 +29,11 @@ module.exports = function(crowi, app) {
         });
       }
 
-      let redirectTo;
-      if (userData.password) {
-        redirectTo = req.session.redirectTo;
-      }
-      else {
-        redirectTo = '/me#password';
-      }
+
+      // userData.password cann't be empty but, prepare redirect because password property in User Model is optional
+      // https://github.com/weseek/growi/pull/6670
+      const redirectTo = userData.password ? req.session.redirectTo : '/me#password';
+
       // remove session.redirectTo
       delete req.session.redirectTo;
 


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/99075

新規登録時にパスワードがない場合、/ページではなく、/me#passwordにリダイレクトする処理を追加

- 修正したコードで新規登録したあと、/ページにリダイレクトすることを確認（正常な場合）
- コードの条件分岐部分を削除して、強制的に/me#passwordにリダイレクトする状況を作り、動作確認をしたところ新規登録後、/me#passwordにリダイレクトすることを確認