### PR TITLE
support: add error handling to PageEditorByHackmd

### DIFF
--- a/packages/app/src/components/PageEditorByHackmd.tsx
+++ b/packages/app/src/components/PageEditorByHackmd.tsx
@@ -96,6 +96,7 @@ export const PageEditorByHackmd = (): JSX.Element => {
 
       await saveOrUpdate(optionsToSave, { pageId, path: currentPagePath || currentPathname, revisionId: revision?._id }, markdown);
       await mutatePageData();
+      await mutateTagsInfo();
       mutateEditorMode(EditorMode.View);
       toastSuccess(t('successfully_saved_the_page'));
     }

--- a/packages/app/src/components/PageEditorByHackmd.tsx
+++ b/packages/app/src/components/PageEditorByHackmd.tsx
@@ -187,14 +187,13 @@ export const PageEditorByHackmd = (): JSX.Element => {
    * @param {string} markdown
    */
   const onSaveWithShortcut = useCallback(async(markdown) => {
-    if (
-      isSlackEnabled == null || grant == null || slackChannels == null || pageId == null || revisionIdHackmdSynced == null || currentPathname == null
-    ) { return }
-    const optionsToSave = getOptionsToSave(
-      isSlackEnabled, slackChannels, grant.grant, grant.grantedGroup?.id, grant.grantedGroup?.name, pageTags ?? [], true,
-    );
-
     try {
+      if (
+        isSlackEnabled == null || grant == null || slackChannels == null || pageId == null || revisionIdHackmdSynced == null || currentPathname == null
+      ) { throw new Error('Some materials to save are invalid') }
+      const optionsToSave = getOptionsToSave(
+        isSlackEnabled, slackChannels, grant.grant, grant.grantedGroup?.id, grant.grantedGroup?.name, pageTags ?? [], true,
+      );
       const res = await saveOrUpdate(optionsToSave, { pageId, path: currentPagePath || currentPathname, revisionId: revisionIdHackmdSynced }, markdown);
 
       // update pageData

--- a/packages/app/src/components/PageEditorByHackmd.tsx
+++ b/packages/app/src/components/PageEditorByHackmd.tsx
@@ -16,7 +16,7 @@ import {
   useCurrentPagePath, useCurrentPageId, useHackmdUri, usePageIdOnHackmd, useHasDraftOnHackmd, useRevisionIdHackmdSynced,
 } from '~/stores/context';
 import { useSWRxSlackChannels, useIsSlackEnabled, usePageTagsForEditors } from '~/stores/editor';
-import { useSWRxCurrentPage } from '~/stores/page';
+import { useSWRxCurrentPage, useSWRxTagsInfo } from '~/stores/page';
 import {
   EditorMode,
   useEditorMode, useSelectedGrant,
@@ -43,6 +43,7 @@ export const PageEditorByHackmd = (): JSX.Element => {
   const { data: isSlackEnabled } = useIsSlackEnabled();
   const { data: pageId } = useCurrentPageId();
   const { data: pageTags } = usePageTagsForEditors(pageId);
+  const { mutate: mutateTagsInfo } = useSWRxTagsInfo(pageId);
   const { data: grant } = useSelectedGrant();
   const { data: hackmdUri } = useHackmdUri();
 
@@ -207,6 +208,7 @@ export const PageEditorByHackmd = (): JSX.Element => {
       setRemoteRevisionId(revision?._id);
       mutateRevisionIdHackmdSynced(pageData.revisionHackmdSynced);
       mutateHasDraftOnHackmd(pageData.hasDraftOnHackmd);
+      mutateTagsInfo();
 
       // call reset
       setIsInitialized(false);
@@ -220,7 +222,7 @@ export const PageEditorByHackmd = (): JSX.Element => {
       toastError(error.message);
     }
   }, [
-    grant, isSlackEnabled, pageTags, slackChannels, pageId, currentPagePath, currentPathname,
+    grant, isSlackEnabled, pageTags, slackChannels, pageId, currentPagePath, currentPathname, mutateTagsInfo, revision?._id,
     revisionIdHackmdSynced, mutatePageData, mutateHasDraftOnHackmd, mutateRevisionIdHackmdSynced, t, pageData,
   ]);
 

--- a/packages/app/src/components/PageEditorByHackmd.tsx
+++ b/packages/app/src/components/PageEditorByHackmd.tsx
@@ -42,7 +42,7 @@ export const PageEditorByHackmd = (): JSX.Element => {
   const { data: slackChannelsData } = useSWRxSlackChannels(currentPagePath);
   const { data: isSlackEnabled } = useIsSlackEnabled();
   const { data: pageId } = useCurrentPageId();
-  const { data: pageTags, mutate: updatePageTagsForEditors } = usePageTagsForEditors(pageId);
+  const { data: pageTags } = usePageTagsForEditors(pageId);
   const { data: grant } = useSelectedGrant();
   const { data: hackmdUri } = useHackmdUri();
 
@@ -196,16 +196,17 @@ export const PageEditorByHackmd = (): JSX.Element => {
       const optionsToSave = getOptionsToSave(
         isSlackEnabled, slackChannels, grant.grant, grant.grantedGroup?.id, grant.grantedGroup?.name, pageTags ?? [], true,
       );
-      const res = await saveOrUpdate(optionsToSave, { pageId, path: currentPagePathOrPathname, revisionId: revisionIdHackmdSynced }, markdown);
-
-      // set updated data
-      setRemoteRevisionId(res.revision._id);
-      mutateRevisionIdHackmdSynced(res.page.revisionHackmdSynced);
-      mutateHasDraftOnHackmd(res.page.hasDraftOnHackmd);
-      updatePageTagsForEditors(res.tags);
+      await saveOrUpdate(optionsToSave, { pageId, path: currentPagePathOrPathname, revisionId: revisionIdHackmdSynced }, markdown);
 
       // update pageData
-      mutatePageData();
+      await mutatePageData();
+
+      if (pageData == null) { throw Error('page data is null') }
+
+      // set updated data
+      setRemoteRevisionId(revision?._id);
+      mutateRevisionIdHackmdSynced(pageData.revisionHackmdSynced);
+      mutateHasDraftOnHackmd(pageData.hasDraftOnHackmd);
 
       // call reset
       setIsInitialized(false);
@@ -219,8 +220,8 @@ export const PageEditorByHackmd = (): JSX.Element => {
       toastError(error.message);
     }
   }, [
-    grant, isSlackEnabled, pageTags, slackChannels, updatePageTagsForEditors, pageId, currentPagePath, currentPathname,
-    revisionIdHackmdSynced, mutatePageData, mutateHasDraftOnHackmd, mutateRevisionIdHackmdSynced, t,
+    grant, isSlackEnabled, pageTags, slackChannels, pageId, currentPagePath, currentPathname,
+    revisionIdHackmdSynced, mutatePageData, mutateHasDraftOnHackmd, mutateRevisionIdHackmdSynced, t, pageData,
   ]);
 
   /**

--- a/packages/app/src/components/PageEditorByHackmd.tsx
+++ b/packages/app/src/components/PageEditorByHackmd.tsx
@@ -188,13 +188,15 @@ export const PageEditorByHackmd = (): JSX.Element => {
    */
   const onSaveWithShortcut = useCallback(async(markdown) => {
     try {
+      const currentPagePathOrPathname = currentPagePath || currentPathname;
       if (
-        isSlackEnabled == null || grant == null || slackChannels == null || pageId == null || revisionIdHackmdSynced == null || currentPathname == null
+        isSlackEnabled == null || grant == null || slackChannels == null || pageId == null
+        || revisionIdHackmdSynced == null || currentPagePathOrPathname == null
       ) { throw new Error('Some materials to save are invalid') }
       const optionsToSave = getOptionsToSave(
         isSlackEnabled, slackChannels, grant.grant, grant.grantedGroup?.id, grant.grantedGroup?.name, pageTags ?? [], true,
       );
-      const res = await saveOrUpdate(optionsToSave, { pageId, path: currentPagePath || currentPathname, revisionId: revisionIdHackmdSynced }, markdown);
+      const res = await saveOrUpdate(optionsToSave, { pageId, path: currentPagePathOrPathname, revisionId: revisionIdHackmdSynced }, markdown);
 
       // update pageData
       mutatePageData();

--- a/packages/app/src/components/PageEditorByHackmd.tsx
+++ b/packages/app/src/components/PageEditorByHackmd.tsx
@@ -198,14 +198,14 @@ export const PageEditorByHackmd = (): JSX.Element => {
       );
       const res = await saveOrUpdate(optionsToSave, { pageId, path: currentPagePathOrPathname, revisionId: revisionIdHackmdSynced }, markdown);
 
-      // update pageData
-      mutatePageData();
-
       // set updated data
       setRemoteRevisionId(res.revision._id);
       mutateRevisionIdHackmdSynced(res.page.revisionHackmdSynced);
       mutateHasDraftOnHackmd(res.page.hasDraftOnHackmd);
       updatePageTagsForEditors(res.tags);
+
+      // update pageData
+      mutatePageData();
 
       // call reset
       setIsInitialized(false);

--- a/packages/app/src/components/PageEditorByHackmd.tsx
+++ b/packages/app/src/components/PageEditorByHackmd.tsx
@@ -198,21 +198,16 @@ export const PageEditorByHackmd = (): JSX.Element => {
       const optionsToSave = getOptionsToSave(
         isSlackEnabled, slackChannels, grant.grant, grant.grantedGroup?.id, grant.grantedGroup?.name, pageTags ?? [], true,
       );
-      await saveOrUpdate(optionsToSave, { pageId, path: currentPagePathOrPathname, revisionId: revisionIdHackmdSynced }, markdown);
+      const res = await saveOrUpdate(optionsToSave, { pageId, path: currentPagePathOrPathname, revisionId: revisionIdHackmdSynced }, markdown);
 
       // update pageData
-      await mutatePageData();
-
-      if (pageData == null) { throw Error('page data is null') }
+      mutatePageData(res);
 
       // set updated data
-      setRemoteRevisionId(revision?._id);
-      mutateRevisionIdHackmdSynced(pageData.revisionHackmdSynced);
-      mutateHasDraftOnHackmd(pageData.hasDraftOnHackmd);
+      setRemoteRevisionId(res.revision._id);
+      mutateRevisionIdHackmdSynced(res.page.revisionHackmdSynced);
+      mutateHasDraftOnHackmd(res.page.hasDraftOnHackmd);
       mutateTagsInfo();
-
-      // call reset
-      setIsInitialized(false);
 
       logger.debug('success to save');
 


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/105164

参考: https://github.com/weseek/growi/pull/6482#discussion_r971867533

PageEditorByHackmd内でエラーハンドリングできていなかった部分を追加