### PR TITLE
fix: 105878 me routing 105879 i18n

### DIFF
--- a/packages/app/src/pages/me/[[...path]].page.tsx
+++ b/packages/app/src/pages/me/[[...path]].page.tsx
@@ -196,7 +196,7 @@ export const getServerSideProps: GetServerSideProps = async(context: GetServerSi
 
   await injectUserUISettings(context, props);
   await injectServerConfigurations(context, props);
-  await injectNextI18NextConfigurations(context, props, ['translation']);
+  await injectNextI18NextConfigurations(context, props, ['translation', 'admin']);
 
   return {
     props,

--- a/packages/app/src/server/routes/index.js
+++ b/packages/app/src/server/routes/index.js
@@ -203,6 +203,7 @@ module.exports = function(crowi, app) {
   // app.get('/tags'                     , loginRequired, tag.showPage);
   app.get('/tags', loginRequired, next.delegateToNext);
 
+  app.get('/me'                                 , loginRequiredStrictly, injectUserUISettings, next.delegateToNext);
   app.get('/me/*'                                 , loginRequiredStrictly, injectUserUISettings, next.delegateToNext);
   // external-accounts
   // my in-app-notifications


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/105879
https://redmine.weseek.co.jp/issues/105878

軽微な修正だったので2つのタスクを1つのPRにまとめました

## やったこと
- 未ログイン状態でもmeページにアクセスできてしまっていたのを修正
- adminの翻訳ファイルが適用されていなかったことの修正

before

<img width="926" alt="i18n_before" src="https://user-images.githubusercontent.com/65263895/193019627-d8ae69f1-088d-4628-aa8e-7a69af376b46.PNG">

after
<img width="881" alt="i18n_after" src="https://user-images.githubusercontent.com/65263895/193019631-d39e8a4c-462b-49f1-8721-57d42df74a5b.PNG">

