### PR TITLE
fix: CodeMirror focus

### DIFF
--- a/packages/app/src/components/PageEditor/CodeMirrorEditor.jsx
+++ b/packages/app/src/components/PageEditor/CodeMirrorEditor.jsx
@@ -230,10 +230,10 @@ class CodeMirrorEditor extends AbstractEditor {
    * @inheritDoc
    */
   forceToFocus() {
-    const editor = this.getCodeMirror();
     // use setInterval with reluctance -- 2018.01.11 Yuki Takei
     const intervalId = setInterval(() => {
-      this.getCodeMirror().focus();
+      const editor = this.getCodeMirror();
+      editor.focus();
       if (editor.hasFocus()) {
         clearInterval(intervalId);
         // refresh


### PR DESCRIPTION
Redmine: https://redmine.weseek.co.jp/issues/105814

CodeMirror の forceToFocus メソッドの setInterval の callback が走り続けてしまうのを修正しました。