### PR TITLE
fix: Show page control dropdown in empty page

### DIFF
--- a/packages/app/src/components/Navbar/GrowiContextualSubNavigation.tsx
+++ b/packages/app/src/components/Navbar/GrowiContextualSubNavigation.tsx
@@ -323,7 +323,7 @@ const GrowiContextualSubNavigation = (props: GrowiContextualSubNavigationProps):
         <div className="d-flex">
           <div className="d-flex flex-column align-items-end justify-content-center py-md-2" style={{ gap: `${isCompactMode ? '5px' : '7px'}` }}>
             { isViewMode && (
-              <div className="h-50 w-100">
+              <div className="h-50">
                 { pageId != null && (
                   <SubNavButtons
                     isCompactMode={isCompactMode}

--- a/packages/app/src/stores/ui.tsx
+++ b/packages/app/src/stores/ui.tsx
@@ -414,10 +414,11 @@ export const useIsAbleToShowPageManagement = (): SWRResponse<boolean, Error> => 
   const pageId = currentPageId;
   const includesUndefined = [pageId, isTrashPage, isSharedUser, isNotFound].some(v => v === undefined);
   const isPageExist = (pageId != null) && !isNotFound;
+  const isEmptyPage = (pageId != null) && isNotFound;
 
   return useSWRImmutable(
     includesUndefined ? null : [key, pageId],
-    () => isPageExist && !isTrashPage && !isSharedUser,
+    () => (isPageExist && !isTrashPage && !isSharedUser) || (isEmptyPage != null && isEmptyPage),
   );
 };
 


### PR DESCRIPTION
## Task
[#103753](https://redmine.weseek.co.jp/issues/103753) [Next.js] empty page 時に三点ボタンが表示されない
└ [#104409](https://redmine.weseek.co.jp/issues/104409) 修正