### PR TITLE
fix: SearchResultContent page scroll for chrome

### DIFF
--- a/packages/app/src/components/Layout/SearchResultLayout.module.scss
+++ b/packages/app/src/components/Layout/SearchResultLayout.module.scss
@@ -67,7 +67,7 @@
       }
 
       .search-result-content-body-container {
-        position: relative;
+        position: relative; // correct apply overflow scrolling for react-markdown on Chrome OS
         overflow-y: auto;
 
         .wiki {

--- a/packages/app/src/components/Layout/SearchResultLayout.module.scss
+++ b/packages/app/src/components/Layout/SearchResultLayout.module.scss
@@ -74,7 +74,6 @@
           padding: 16px;
           font-size: 13px;
         }
-
       }
     }
   }

--- a/packages/app/src/components/Layout/SearchResultLayout.module.scss
+++ b/packages/app/src/components/Layout/SearchResultLayout.module.scss
@@ -67,7 +67,10 @@
       }
 
       .search-result-content-body-container {
-        position: relative; // correct apply overflow scrolling for react-markdown on Chrome OS
+        // correct apply overflow scrolling for react-markdown on Google Chrome
+        // see: https://github.com/weseek/growi/pull/6731
+        position: relative;
+
         overflow-y: auto;
 
         .wiki {

--- a/packages/app/src/components/Layout/SearchResultLayout.module.scss
+++ b/packages/app/src/components/Layout/SearchResultLayout.module.scss
@@ -70,7 +70,7 @@
         position: relative;
         overflow-y: auto;
 
-        .wiki{
+        .wiki {
           padding: 16px;
           font-size: 13px;
         }

--- a/packages/app/src/components/Layout/SearchResultLayout.module.scss
+++ b/packages/app/src/components/Layout/SearchResultLayout.module.scss
@@ -67,12 +67,14 @@
       }
 
       .search-result-content-body-container {
+        position: relative;
         overflow-y: auto;
 
-        .wiki {
+        .wiki{
           padding: 16px;
           font-size: 13px;
         }
+
       }
     }
   }

--- a/packages/app/src/components/SearchPage/SearchResultContent.tsx
+++ b/packages/app/src/components/SearchPage/SearchResultContent.tsx
@@ -211,7 +211,7 @@ export const SearchResultContent: FC<Props> = (props: Props) => {
           additionalClasses={['px-4']}
         />
       </div>
-      <div className="search-result-content-body-container" ref={scrollElementRef} >
+      <div className="search-result-content-body-container" ref={scrollElementRef}>
         <RevisionLoader
           rendererOptions={rendererOptions}
           pageId={page._id}

--- a/packages/app/src/components/SearchPage/SearchResultContent.tsx
+++ b/packages/app/src/components/SearchPage/SearchResultContent.tsx
@@ -211,7 +211,7 @@ export const SearchResultContent: FC<Props> = (props: Props) => {
           additionalClasses={['px-4']}
         />
       </div>
-      <div className="search-result-content-body-container" ref={scrollElementRef} style={{ position: 'relative' }}>
+      <div className="search-result-content-body-container" ref={scrollElementRef} >
         <RevisionLoader
           rendererOptions={rendererOptions}
           pageId={page._id}

--- a/packages/app/src/components/SearchPage/SearchResultContent.tsx
+++ b/packages/app/src/components/SearchPage/SearchResultContent.tsx
@@ -211,7 +211,7 @@ export const SearchResultContent: FC<Props> = (props: Props) => {
           additionalClasses={['px-4']}
         />
       </div>
-      <div className="search-result-content-body-container" ref={scrollElementRef}>
+      <div className="search-result-content-body-container" ref={scrollElementRef} style={{ position: 'relative' }}>
         <RevisionLoader
           rendererOptions={rendererOptions}
           pageId={page._id}


### PR DESCRIPTION
タスク: https://redmine.weseek.co.jp/issues/106129

1. `remark-math`などのプラグインで生成されるhtmlがblink系のブラウザでoverflowが正常に機能していなかった。
1. v5系で使用していたmathjaxでは `position: relative` が適用されていた.
1. `position: relative` を適用した。