### PR TITLE
fix: No transition to edit screen when creating a new page

### DIFF
--- a/packages/app/src/components/PageCreateModal.jsx
+++ b/packages/app/src/components/PageCreateModal.jsx
@@ -13,6 +13,7 @@ import { debounce } from 'throttle-debounce';
 import { toastError } from '~/client/util/apiNotification';
 import { useCurrentUser, useIsSearchServiceReachable } from '~/stores/context';
 import { usePageCreateModal } from '~/stores/modal';
+import { EditorMode, useEditorMode } from '~/stores/ui';
 
 import PagePathAutoComplete from './PagePathAutoComplete';
 
@@ -35,6 +36,8 @@ const PageCreateModal = () => {
   const isCreatable = isCreatablePage(pathname) || isUsersHomePage(pathname);
   const pageNameInputInitialValue = isCreatable ? pathUtils.addTrailingSlash(pathname) : '/';
   const now = format(new Date(), 'yyyy/MM/dd');
+
+  const { mutate: mutateEditorMode } = useEditorMode();
 
   const [todayInput1, setTodayInput1] = useState(t('Memo'));
   const [todayInput2, setTodayInput2] = useState('');
@@ -99,8 +102,9 @@ const PageCreateModal = () => {
    */
   async function redirectToEditor(...paths) {
     try {
-      const editorPath = await generateEditorPath(...paths);
-      router.push(editorPath);
+      const editorPath = generateEditorPath(...paths);
+      await router.push(editorPath);
+      mutateEditorMode(EditorMode.Editor);
 
       // close modal
       closeCreateModal();


### PR DESCRIPTION
## Task
[#106319](https://redmine.weseek.co.jp/issues/106319) [Next.js] ページを新規作成した時にエディター画面に遷移しない
└ [#106323](https://redmine.weseek.co.jp/issues/106323) 修正