### PR TITLE
fix: reload page tree after convrtting pages by path

### DIFF
--- a/packages/app/src/components/PrivateLegacyPages.tsx
+++ b/packages/app/src/components/PrivateLegacyPages.tsx
@@ -455,6 +455,7 @@ const PrivateLegacyPages = (): JSX.Element => {
             toastSuccess(t('private_legacy_pages.by_path_modal.success'));
             setOpenConvertModal(false);
             mutate();
+            advancePt();
           }
           catch (errs) {
             if (errs.length === 1) {


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/106699

## やったこと
待避所でパスでページを変換した後にページツリーに変換後のページが表示されていなかったのを修正