### PR TITLE
refactor hackmd build

### DIFF
--- a/packages/app/docker/Dockerfile
+++ b/packages/app/docker/Dockerfile
@@ -115,9 +115,6 @@ COPY packages/hackmd packages/hackmd
 # build
 RUN yarn lerna run build
 
-# for hackmd build: https://github.com/weseek/growi/pull/6763
-COPY packages/hackmd/src/index.js packages/hackmd/dist
-
 # make artifacts
 RUN tar -cf packages.tar \
   package.json \

--- a/packages/app/docker/Dockerfile
+++ b/packages/app/docker/Dockerfile
@@ -115,6 +115,8 @@ COPY packages/hackmd packages/hackmd
 # build
 RUN yarn lerna run build
 
+COPY packages/hackmd/src/index.js packages/hackmd/dist
+
 # make artifacts
 RUN tar -cf packages.tar \
   package.json \

--- a/packages/app/docker/Dockerfile
+++ b/packages/app/docker/Dockerfile
@@ -115,6 +115,7 @@ COPY packages/hackmd packages/hackmd
 # build
 RUN yarn lerna run build
 
+# for hackmd build: https://github.com/weseek/growi/pull/6763
 COPY packages/hackmd/src/index.js packages/hackmd/dist
 
 # make artifacts

--- a/packages/hackmd/package.json
+++ b/packages/hackmd/package.json
@@ -4,7 +4,7 @@
   "description": "GROWI js and css files to use hackmd",
   "license": "MIT",
   "scripts": {
-    "build": "vite build"
+    "build": "vite build && cp ./src/index.js ./dist"
   },
   "dependencies": {
   },

--- a/packages/hackmd/src/index.js
+++ b/packages/hackmd/src/index.js
@@ -2,9 +2,10 @@ const fs = require('fs');
 const path = require('path');
 
 const isProduction = process.env.NODE_ENV === 'production';
-const stylesJSFile = fs.readFileSync(path.resolve(__dirname, isProduction ? './styles.js' : '../dist/styles.js'));
-const agentJSFile = fs.readFileSync(path.resolve(__dirname, isProduction ? './agent.js' : '../dist/agent.js'));
-const stylesCSSFile = fs.readFileSync(path.resolve(__dirname, isProduction ? './styles.css' : '../dist/styles.css'));
+const dirPath = isProduction ? '.' : '../dist';
+const stylesJSFile = fs.readFileSync(path.resolve(__dirname, `${dirPath}/styles.js`));
+const agentJSFile = fs.readFileSync(path.resolve(__dirname, `${dirPath}/agent.js`));
+const stylesCSSFile = fs.readFileSync(path.resolve(__dirname, `${dirPath}/styles.css`));
 
 // export to app as string
 export const stylesJS = stylesJSFile.toString();

--- a/packages/hackmd/src/index.js
+++ b/packages/hackmd/src/index.js
@@ -1,9 +1,10 @@
 const fs = require('fs');
 const path = require('path');
 
-const stylesJSFile = fs.readFileSync(path.resolve(__dirname, '../dist/assets/styles_bundle.js'));
-const agentJSFile = fs.readFileSync(path.resolve(__dirname, '../dist/assets/agent_bundle.js'));
-const stylesCSSFile = fs.readFileSync(path.resolve(__dirname, '../dist/assets/styles_bundle.css'));
+const isProduction = process.env.NODE_ENV === 'production';
+const stylesJSFile = fs.readFileSync(path.resolve(__dirname, isProduction ? './styles.js' : '../dist/styles.js'));
+const agentJSFile = fs.readFileSync(path.resolve(__dirname, isProduction ? './agent.js' : '../dist/agent.js'));
+const stylesCSSFile = fs.readFileSync(path.resolve(__dirname, isProduction ? './styles.css' : '../dist/styles.css'));
 
 // export to app as string
 export const stylesJS = stylesJSFile.toString();

--- a/packages/hackmd/vite.config.js
+++ b/packages/hackmd/vite.config.js
@@ -5,7 +5,6 @@ import { defineConfig } from 'vite';
 
 export default defineConfig({
   build: {
-    manifest: false,
     rollupOptions: {
       input: {
         styles: resolve(__dirname, 'src/hackmd-styles.js'),

--- a/packages/hackmd/vite.config.js
+++ b/packages/hackmd/vite.config.js
@@ -5,7 +5,7 @@ import { defineConfig } from 'vite';
 
 export default defineConfig({
   build: {
-    manifest: true,
+    manifest: false,
     rollupOptions: {
       input: {
         styles: resolve(__dirname, 'src/hackmd-styles.js'),
@@ -13,8 +13,8 @@ export default defineConfig({
         stylesCSS: resolve(__dirname, 'src/styles.scss'),
       },
       output: {
-        entryFileNames: 'assets/[name]_bundle.js',
-        assetFileNames: 'assets/[name]_bundle.css',
+        entryFileNames: '[name].js',
+        assetFileNames: '[name].css',
       },
     },
   },


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/106758

## やったこと
本番ビルドでhackmdが使えるようにした

開発用
```
- package/hackmd
    - src
        - index.js
    - dist
        - ビルドされたファイル
```
  
本番用

```
- package/hackmd
    - dist
        - index.js
        - ビルドされたファイル
```

という構成になるのでindex.jsでのパスをフラグで出しわけています