### PR TITLE
support: bump version to 6.0.0 rc.3

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,7 @@
 {
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "6.0.0-RC.1",
+  "version": "6.0.0-RC.2",
   "packages": [
     "packages/*"
   ]

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,7 @@
 {
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "6.0.0-RC.2",
+  "version": "6.0.0-RC.3",
   "packages": [
     "packages/*"
   ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "growi",
-  "version": "6.0.0-RC.1",
+  "version": "6.0.0-RC.2",
   "description": "Team collaboration software using markdown",
   "tags": [
     "wiki",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "growi",
-  "version": "6.0.0-RC.2",
+  "version": "6.0.0-RC.3",
   "description": "Team collaboration software using markdown",
   "tags": [
     "wiki",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@growi/app",
-  "version": "6.0.0-RC.1",
+  "version": "6.0.0-RC.2",
   "license": "MIT",
   "scripts": {
     "//// for production": "",
@@ -64,11 +64,11 @@
     "@elastic/elasticsearch7": "npm:@elastic/elasticsearch@^7.17.0",
     "@godaddy/terminus": "^4.9.0",
     "@google-cloud/storage": "^5.8.5",
-    "@growi/codemirror-textlint": "^6.0.0-RC.1",
-    "@growi/core": "^6.0.0-RC.1",
-    "@growi/plugin-attachment-refs": "^6.0.0-RC.1",
-    "@growi/plugin-lsx": "^6.0.0-RC.1",
-    "@growi/slack": "^6.0.0-RC.1",
+    "@growi/codemirror-textlint": "^6.0.0-RC.2",
+    "@growi/core": "^6.0.0-RC.2",
+    "@growi/plugin-attachment-refs": "^6.0.0-RC.2",
+    "@growi/plugin-lsx": "^6.0.0-RC.2",
+    "@growi/slack": "^6.0.0-RC.2",
     "@promster/express": "^7.0.2",
     "@promster/server": "^7.0.4",
     "@slack/events-api": "^3.0.0",
@@ -203,7 +203,7 @@
   },
   "devDependencies": {
     "@alienfast/i18next-loader": "^1.1.4",
-    "@growi/ui": "^6.0.0-RC.1",
+    "@growi/ui": "^6.0.0-RC.2",
     "@handsontable/react": "=2.1.0",
     "@icon/themify-icons": "1.0.1-alpha.3",
     "@next/bundle-analyzer": "^12.2.3",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@growi/app",
-  "version": "6.0.0-RC.2",
+  "version": "6.0.0-RC.3",
   "license": "MIT",
   "scripts": {
     "//// for production": "",
@@ -64,11 +64,11 @@
     "@elastic/elasticsearch7": "npm:@elastic/elasticsearch@^7.17.0",
     "@godaddy/terminus": "^4.9.0",
     "@google-cloud/storage": "^5.8.5",
-    "@growi/codemirror-textlint": "^6.0.0-RC.2",
-    "@growi/core": "^6.0.0-RC.2",
-    "@growi/plugin-attachment-refs": "^6.0.0-RC.2",
-    "@growi/plugin-lsx": "^6.0.0-RC.2",
-    "@growi/slack": "^6.0.0-RC.2",
+    "@growi/codemirror-textlint": "^6.0.0-RC.3",
+    "@growi/core": "^6.0.0-RC.3",
+    "@growi/plugin-attachment-refs": "^6.0.0-RC.3",
+    "@growi/plugin-lsx": "^6.0.0-RC.3",
+    "@growi/slack": "^6.0.0-RC.3",
     "@promster/express": "^7.0.2",
     "@promster/server": "^7.0.4",
     "@slack/events-api": "^3.0.0",
@@ -203,7 +203,7 @@
   },
   "devDependencies": {
     "@alienfast/i18next-loader": "^1.1.4",
-    "@growi/ui": "^6.0.0-RC.2",
+    "@growi/ui": "^6.0.0-RC.3",
     "@handsontable/react": "=2.1.0",
     "@icon/themify-icons": "1.0.1-alpha.3",
     "@next/bundle-analyzer": "^12.2.3",

--- a/packages/codemirror-textlint/package.json
+++ b/packages/codemirror-textlint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@growi/codemirror-textlint",
-  "version": "6.0.0-RC.1",
+  "version": "6.0.0-RC.2",
   "license": "MIT",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/codemirror-textlint/package.json
+++ b/packages/codemirror-textlint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@growi/codemirror-textlint",
-  "version": "6.0.0-RC.2",
+  "version": "6.0.0-RC.3",
   "license": "MIT",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@growi/core",
-  "version": "6.0.0-RC.1",
+  "version": "6.0.0-RC.2",
   "description": "GROWI Core Libraries",
   "license": "MIT",
   "keywords": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@growi/core",
-  "version": "6.0.0-RC.2",
+  "version": "6.0.0-RC.3",
   "description": "GROWI Core Libraries",
   "license": "MIT",
   "keywords": [

--- a/packages/plugin-attachment-refs/package.json
+++ b/packages/plugin-attachment-refs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@growi/plugin-attachment-refs",
-  "version": "6.0.0-RC.1",
+  "version": "6.0.0-RC.2",
   "description": "GROWI Plugin to add ref/refimg/refs/refsimg tags",
   "license": "MIT",
   "keywords": [

--- a/packages/plugin-attachment-refs/package.json
+++ b/packages/plugin-attachment-refs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@growi/plugin-attachment-refs",
-  "version": "6.0.0-RC.2",
+  "version": "6.0.0-RC.3",
   "description": "GROWI Plugin to add ref/refimg/refs/refsimg tags",
   "license": "MIT",
   "keywords": [

--- a/packages/plugin-lsx/package.json
+++ b/packages/plugin-lsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@growi/plugin-lsx",
-  "version": "6.0.0-RC.1",
+  "version": "6.0.0-RC.2",
   "description": "GROWI plugin to list pages",
   "license": "MIT",
   "keywords": ["growi", "growi-plugin"],
@@ -23,9 +23,9 @@
     "test": ""
   },
   "dependencies": {
-    "@growi/core": "^6.0.0-RC.1",
-    "@growi/remark-growi-plugin": "^6.0.0-RC.1",
-    "@growi/ui": "^6.0.0-RC.1"
+    "@growi/core": "^6.0.0-RC.2",
+    "@growi/remark-growi-plugin": "^6.0.0-RC.2",
+    "@growi/ui": "^6.0.0-RC.2"
   },
   "devDependencies": {
     "eslint-plugin-regex": "^1.8.0",

--- a/packages/plugin-lsx/package.json
+++ b/packages/plugin-lsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@growi/plugin-lsx",
-  "version": "6.0.0-RC.2",
+  "version": "6.0.0-RC.3",
   "description": "GROWI plugin to list pages",
   "license": "MIT",
   "keywords": ["growi", "growi-plugin"],
@@ -23,9 +23,9 @@
     "test": ""
   },
   "dependencies": {
-    "@growi/core": "^6.0.0-RC.2",
-    "@growi/remark-growi-plugin": "^6.0.0-RC.2",
-    "@growi/ui": "^6.0.0-RC.2"
+    "@growi/core": "^6.0.0-RC.3",
+    "@growi/remark-growi-plugin": "^6.0.0-RC.3",
+    "@growi/ui": "^6.0.0-RC.3"
   },
   "devDependencies": {
     "eslint-plugin-regex": "^1.8.0",

--- a/packages/remark-growi-plugin/package.json
+++ b/packages/remark-growi-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@growi/remark-growi-plugin",
-  "version": "6.0.0-RC.1",
+  "version": "6.0.0-RC.2",
   "description": "remark plugin to support GROWI plugin (forked from remark-directive@2.0.1)",
   "license": "MIT",
   "keywords": [

--- a/packages/remark-growi-plugin/package.json
+++ b/packages/remark-growi-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@growi/remark-growi-plugin",
-  "version": "6.0.0-RC.2",
+  "version": "6.0.0-RC.3",
   "description": "remark plugin to support GROWI plugin (forked from remark-directive@2.0.1)",
   "license": "MIT",
   "keywords": [

--- a/packages/slack/package.json
+++ b/packages/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@growi/slack",
-  "version": "6.0.0-RC.1",
+  "version": "6.0.0-RC.2",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/packages/slack/package.json
+++ b/packages/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@growi/slack",
-  "version": "6.0.0-RC.2",
+  "version": "6.0.0-RC.3",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/packages/slackbot-proxy/package.json
+++ b/packages/slackbot-proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@growi/slackbot-proxy",
-  "version": "6.0.0-slackbot-proxy.1",
+  "version": "6.0.0-RC.2",
   "license": "MIT",
   "scripts": {
     "build": "yarn tsc && tsc-alias -p tsconfig.build.json",
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@godaddy/terminus": "^4.9.0",
-    "@growi/slack": "^6.0.0-RC.1",
+    "@growi/slack": "^6.0.0-RC.2",
     "@slack/oauth": "^2.0.1",
     "@slack/web-api": "^6.2.4",
     "@tsed/common": "^6.43.0",

--- a/packages/slackbot-proxy/package.json
+++ b/packages/slackbot-proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@growi/slackbot-proxy",
-  "version": "6.0.0-RC.2",
+  "version": "6.0.0-RC.3",
   "license": "MIT",
   "scripts": {
     "build": "yarn tsc && tsc-alias -p tsconfig.build.json",
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@godaddy/terminus": "^4.9.0",
-    "@growi/slack": "^6.0.0-RC.2",
+    "@growi/slack": "^6.0.0-RC.3",
     "@slack/oauth": "^2.0.1",
     "@slack/web-api": "^6.2.4",
     "@tsed/common": "^6.43.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@growi/ui",
-  "version": "6.0.0-RC.1",
+  "version": "6.0.0-RC.2",
   "description": "GROWI UI Libraries",
   "license": "MIT",
   "keywords": ["growi"],
@@ -17,7 +17,7 @@
     "test": "jest --verbose"
   },
   "dependencies": {
-    "@growi/core": "^6.0.0-RC.1"
+    "@growi/core": "^6.0.0-RC.2"
   },
   "devDependencies": {
     "eslint-plugin-regex": "^1.8.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@growi/ui",
-  "version": "6.0.0-RC.2",
+  "version": "6.0.0-RC.3",
   "description": "GROWI UI Libraries",
   "license": "MIT",
   "keywords": ["growi"],
@@ -17,7 +17,7 @@
     "test": "jest --verbose"
   },
   "dependencies": {
-    "@growi/core": "^6.0.0-RC.2"
+    "@growi/core": "^6.0.0-RC.3"
   },
   "devDependencies": {
     "eslint-plugin-regex": "^1.8.0",


### PR DESCRIPTION
# やったこと
masterのバージョンを`6.0.0-RC.1` から`6.0.0-RC.3`にバージョンアップした

バージョンアップは`yarn bump-versions:rc`コマンドで行っています。

# 備考
`6.0.0-RC.3`の前に`6.0.0-RC.2`をリリースしていますが、hackmdの関係でビルドできず動かせませんでした。
通貫テストがあったのでhackmdの変更を含まない`6.0.0-RC.3`をリリースした結果`6.0.0-RC.2`と`6.0.0-RC.3`をほぼ同時にリリースすることになったのでこのPRでは`6.0.0-RC.1`から`6.0.0-RC.3`にバージョンが上がっています。