### PR TITLE
feat: check storage limit before g2g

### DIFF
--- a/packages/app/src/components/Admin/G2GDataTransfer.tsx
+++ b/packages/app/src/components/Admin/G2GDataTransfer.tsx
@@ -4,10 +4,8 @@ import { useTranslation } from 'react-i18next';
 
 import { useGenerateTransferKeyWithThrottle } from '~/client/services/g2g-transfer';
 import { toastError } from '~/client/util/apiNotification';
-import { apiv3Get } from '~/client/util/apiv3-client';
+import { apiv3Get, apiv3Post } from '~/client/util/apiv3-client';
 import { useAdminSocket } from '~/stores/socket-io';
-import customAxios from '~/utils/axios';
-
 
 import CustomCopyToClipBoard from '../Common/CustomCopyToClipBoard';
 
@@ -94,14 +92,14 @@ const G2GDataTransfer = (): JSX.Element => {
     e.preventDefault();
 
     try {
-      await customAxios.post('/_api/v3/g2g-transfer/transfer', {
+      await apiv3Post('/g2g-transfer/transfer', {
         transferKey: startTransferKey,
         collections: Array.from(selectedCollections),
         optionsMap,
       });
     }
     catch (errs) {
-      toastError('Failed to transfer');
+      toastError(errs);
     }
   }, [startTransferKey, selectedCollections, optionsMap]);
 

--- a/packages/app/src/server/models/user.js
+++ b/packages/app/src/server/models/user.js
@@ -447,12 +447,16 @@ module.exports = function(crowi) {
 
     const userUpperLimit = configManager.getConfig('crowi', 'security:userUpperLimit');
 
-    const activeUsers = await this.countListByStatus(STATUS_ACTIVE);
+    const activeUsers = await this.countActiveUsers();
     if (userUpperLimit <= activeUsers) {
       return true;
     }
 
     return false;
+  };
+
+  userSchema.statics.countActiveUsers = async function() {
+    return this.countListByStatus(STATUS_ACTIVE);
   };
 
   userSchema.statics.countListByStatus = async function(status) {

--- a/packages/app/src/server/routes/apiv3/g2g-transfer.ts
+++ b/packages/app/src/server/routes/apiv3/g2g-transfer.ts
@@ -379,10 +379,10 @@ module.exports = (crowi: Crowi): Router => {
     }
 
     // Check if can transfer
-    const canTransfer = await g2gTransferPusherService.canTransfer(toGROWIInfo);
-    if (!canTransfer) {
+    const transferability = await g2gTransferPusherService.getTransferability(toGROWIInfo);
+    if (!transferability.canTransfer) {
       logger.debug('Could not transfer.');
-      return res.apiv3Err(new ErrorV3('GROWI is incompatible to transfer data.', 'growi_incompatible_to_transfer'));
+      return res.apiv3Err(new ErrorV3(transferability.reason, 'growi_incompatible_to_transfer'));
     }
 
     // Start transfer

--- a/packages/app/src/server/service/config-manager.ts
+++ b/packages/app/src/server/service/config-manager.ts
@@ -4,9 +4,10 @@ import loggerFactory from '~/utils/logger';
 
 import ConfigModel from '../models/config';
 import S2sMessage from '../models/vo/s2s-message';
+
+import ConfigLoader, { ConfigObject } from './config-loader';
 import { S2sMessagingService } from './s2s-messaging/base';
 import { S2sMessageHandlable } from './s2s-messaging/handlable';
-import ConfigLoader, { ConfigObject } from './config-loader';
 
 const logger = loggerFactory('growi:service:ConfigManager');
 
@@ -373,6 +374,18 @@ export default class ConfigManager implements S2sMessageHandlable {
   async handleS2sMessage(s2sMessage) {
     logger.info('Reload configs by pubsub notification');
     return this.loadConfigs();
+  }
+
+  /**
+   * Returns file upload total limit in bytes.
+   * @returns file upload total limit in bytes
+   */
+  getFileUploadTotalLimit(): number {
+    const fileUploadTotalLimit = this.getConfig('crowi', 'app:fileUploadType') === 'mongodb'
+      // Use app:fileUploadTotalLimit if gridfs:totalLimit is null (default for gridfs:totalLimitd is null)
+      ? this.getConfig('crowi', 'gridfs:totalLimit') ?? this.getConfig('crowi', 'app:fileUploadTotalLimit')
+      : this.getConfig('crowi', 'app:fileUploadTotalLimit');
+    return fileUploadTotalLimit;
   }
 
 }

--- a/packages/app/src/server/service/config-manager.ts
+++ b/packages/app/src/server/service/config-manager.ts
@@ -378,11 +378,12 @@ export default class ConfigManager implements S2sMessageHandlable {
 
   /**
    * Returns file upload total limit in bytes.
+   * {@link https://github.com/weseek/growi/blob/798e44f14ad01544c1d75ba83d4dfb321a94aa0b/src/server/service/file-uploader/gridfs.js#L86-L88 Reference to previous implementation.}
    * @returns file upload total limit in bytes
    */
   getFileUploadTotalLimit(): number {
     const fileUploadTotalLimit = this.getConfig('crowi', 'app:fileUploadType') === 'mongodb'
-      // Use app:fileUploadTotalLimit if gridfs:totalLimit is null (default for gridfs:totalLimitd is null)
+      // Use app:fileUploadTotalLimit if gridfs:totalLimit is null (default for gridfs:totalLimit is null)
       ? this.getConfig('crowi', 'gridfs:totalLimit') ?? this.getConfig('crowi', 'app:fileUploadTotalLimit')
       : this.getConfig('crowi', 'app:fileUploadTotalLimit');
     return fileUploadTotalLimit;

--- a/packages/app/src/server/service/file-uploader/gridfs.js
+++ b/packages/app/src/server/service/file-uploader/gridfs.js
@@ -1,8 +1,9 @@
 import loggerFactory from '~/utils/logger';
 
 const logger = loggerFactory('growi:service:fileUploaderGridfs');
-const mongoose = require('mongoose');
 const util = require('util');
+
+const mongoose = require('mongoose');
 
 module.exports = function(crowi) {
   const Uploader = require('./uploader');
@@ -85,11 +86,8 @@ module.exports = function(crowi) {
    */
   lib.checkLimit = async(uploadFileSize) => {
     const maxFileSize = crowi.configManager.getConfig('crowi', 'app:maxFileSize');
-
-    // Use app:fileUploadTotalLimit if gridfs:totalLimit is null (default for gridfs:totalLimitd is null)
-    const gridfsTotalLimit = crowi.configManager.getConfig('crowi', 'gridfs:totalLimit')
-      || crowi.configManager.getConfig('crowi', 'app:fileUploadTotalLimit');
-    return lib.doCheckLimit(uploadFileSize, maxFileSize, gridfsTotalLimit);
+    const totalLimit = crowi.configManager.getFileUploadTotalLimit();
+    return lib.doCheckLimit(uploadFileSize, maxFileSize, totalLimit);
   };
 
   lib.uploadFile = async function(fileStream, attachment) {

--- a/packages/app/src/server/service/g2g-transfer.ts
+++ b/packages/app/src/server/service/g2g-transfer.ts
@@ -229,6 +229,7 @@ export class G2GTransferPusherService implements Pusher {
     if (version !== toGROWIInfo.version) {
       return {
         canTransfer: false,
+        // TODO: i18n for reason
         reason: `Growi versions mismatch. This Growi: ${version} / new Growi: ${toGROWIInfo.version}.`,
       };
     }
@@ -237,6 +238,7 @@ export class G2GTransferPusherService implements Pusher {
     if ((toGROWIInfo.userUpperLimit ?? Infinity) < activeUserCount) {
       return {
         canTransfer: false,
+        // TODO: i18n for reason
         reason: `The number of active users (${activeUserCount} users) exceeds the limit of new Growi (to up ${toGROWIInfo.userUpperLimit} users).`,
       };
     }
@@ -244,6 +246,7 @@ export class G2GTransferPusherService implements Pusher {
     if (toGROWIInfo.fileUploadDisabled) {
       return {
         canTransfer: false,
+        // TODO: i18n for reason
         reason: 'File upload is disabled in new Growi.',
       };
     }
@@ -252,6 +255,7 @@ export class G2GTransferPusherService implements Pusher {
     if ((toGROWIInfo.fileUploadTotalLimit ?? Infinity) < totalFileSize) {
       return {
         canTransfer: false,
+        // TODO: i18n for reason
         // eslint-disable-next-line max-len, @typescript-eslint/no-non-null-assertion
         reason: `Total file size exceeds file upload limit of new Growi. Requires ${totalFileSize.toLocaleString()} bytes, but got ${toGROWIInfo.fileUploadTotalLimit!.toLocaleString()} bytes.`,
       };

--- a/packages/app/src/server/service/g2g-transfer.ts
+++ b/packages/app/src/server/service/g2g-transfer.ts
@@ -159,9 +159,7 @@ const generateGROWIInfo = async(crowi: any): Promise<IDataGROWIInfo> => {
   const { configManager } = crowi;
   const userUpperLimit = configManager.getConfig('crowi', 'security:userUpperLimit');
   const fileUploadDisabled = configManager.getConfig('crowi', 'app:fileUploadDisabled');
-  const fileUploadTotalLimit = configManager.getConfig('crowi', 'app:fileUploadType') === 'mongodb'
-    ? configManager.getConfig('crowi', 'gridfs:totalLimit') ?? configManager.getConfig('crowi', 'app:fileUploadTotalLimit')
-    : configManager.getConfig('crowi', 'app:fileUploadTotalLimit');
+  const fileUploadTotalLimit = configManager.getFileUploadTotalLimit();
   const version = crowi.version;
   const writable = await hasWritePermission(crowi);
 

--- a/packages/app/src/server/service/g2g-transfer.ts
+++ b/packages/app/src/server/service/g2g-transfer.ts
@@ -119,7 +119,7 @@ const generateAxiosRequestConfigWithTransferKey = (tk: TransferKey, additionalHe
  * @param crowi Crowi instance
  * @returns Whether the storage is writable
  */
-const getWritePermission = async(crowi: any): Promise<boolean> => {
+const hasWritePermission = async(crowi: any): Promise<boolean> => {
   const { fileUploadService } = crowi;
 
   let writable = true;
@@ -158,7 +158,7 @@ const generateGROWIInfo = async(crowi: any): Promise<IDataGROWIInfo> => {
     ? configManager.getConfig('crowi', 'gridfs:totalLimit') ?? configManager.getConfig('crowi', 'app:fileUploadTotalLimit')
     : configManager.getConfig('crowi', 'app:fileUploadTotalLimit');
   const version = crowi.version;
-  const writable = await getWritePermission(crowi);
+  const writable = await hasWritePermission(crowi);
 
   const attachmentInfo = {
     type: configManager.getConfig('crowi', 'app:fileUploadType'),

--- a/packages/app/src/server/service/g2g-transfer.ts
+++ b/packages/app/src/server/service/g2g-transfer.ts
@@ -256,8 +256,8 @@ export class G2GTransferPusherService implements Pusher {
       return {
         canTransfer: false,
         // TODO: i18n for reason
-        // eslint-disable-next-line max-len, @typescript-eslint/no-non-null-assertion
-        reason: `Total file size exceeds file upload limit of new Growi. Requires ${totalFileSize.toLocaleString()} bytes, but got ${toGROWIInfo.fileUploadTotalLimit!.toLocaleString()} bytes.`,
+        // eslint-disable-next-line max-len
+        reason: `Total file size exceeds file upload limit of new Growi. Requires ${totalFileSize.toLocaleString()} bytes, but got ${(toGROWIInfo.fileUploadTotalLimit ?? Infinity).toLocaleString()} bytes.`,
       };
     }
 


### PR DESCRIPTION
- [x] 移行先のストレージ容量が添付ファイルの合計容量を上回っていた場合、転送が開始できないとして処理を終了し、エラーをクライアントに表示する

https://redmine.weseek.co.jp/issues/106571