### PR TITLE
feat: Common translation files

### DIFF
--- a/packages/app/public/static/locales/en_US/commons.json
+++ b/packages/app/public/static/locales/en_US/commons.json
@@ -1,0 +1,11 @@
+{
+  "meta": {
+    "display_name": "English"
+  },
+  "toaster": {
+    "create_succeeded": "Succeeded to create {{target}}",
+    "create_failed": "Failed to create {{target}}",
+    "update_successed": "Succeeded to update {{target}}",
+    "update_failed": "Failed to update {{target}}"
+  }
+}

--- a/packages/app/public/static/locales/en_US/translation.json
+++ b/packages/app/public/static/locales/en_US/translation.json
@@ -523,10 +523,6 @@
     "page_not_found_in_preview": "\"{{path}}\" is not a GROWI page."
   },
   "toaster": {
-    "create_succeeded": "Succeeded to create {{target}}",
-    "create_failed": "Failed to create {{target}}",
-    "update_successed": "Succeeded to update {{target}}",
-    "update_failed": "Failed to update {{target}}",
     "file_upload_succeeded": "File upload succeeded.",
     "file_upload_failed": "File upload failed.",
     "initialize_successed": "Succeeded to initialize {{target}}",

--- a/packages/app/public/static/locales/ja_JP/commons.json
+++ b/packages/app/public/static/locales/ja_JP/commons.json
@@ -1,0 +1,11 @@
+{
+  "meta": {
+    "display_name": "日本語"
+  },
+  "toaster": {
+    "create_succeeded": "新しい{{target}}が作成されました",
+    "create_failed": "{{target}}の作成に失敗しました",
+    "update_successed": "{{target}}を更新しました",
+    "update_failed": "{{target}}の更新に失敗しました"
+  }
+}

--- a/packages/app/public/static/locales/ja_JP/translation.json
+++ b/packages/app/public/static/locales/ja_JP/translation.json
@@ -514,10 +514,6 @@
     "page_not_found_in_preview": "\"{{path}}\" というページはありません。"
   },
   "toaster": {
-    "create_succeeded": "新しい{{target}}が作成されました",
-    "create_failed": "{{target}}の作成に失敗しました",
-    "update_successed": "{{target}}を更新しました",
-    "update_failed": "{{target}}の更新に失敗しました",
     "file_upload_succeeded": "ファイルをアップロードしました",
     "file_upload_failed": "ファイルのアップロードに失敗しました",
     "initialize_successed": "{{target}}を初期化しました",

--- a/packages/app/public/static/locales/zh_CN/commons.json
+++ b/packages/app/public/static/locales/zh_CN/commons.json
@@ -1,0 +1,11 @@
+{
+  "meta": {
+    "display_name": "简体中文"
+  },
+  "toaster": {
+    "create_succeeded": "Succeeded to create {{target}}",
+    "create_failed": "Failed to create {{target}}",
+    "update_successed": "Succeeded to update {{target}}",
+    "update_failed": "Failed to update {{target}}"
+  }
+}

--- a/packages/app/public/static/locales/zh_CN/translation.json
+++ b/packages/app/public/static/locales/zh_CN/translation.json
@@ -496,10 +496,6 @@
     "page_not_found_in_preview": "\"{{path}}\" is not a GROWI page."
   },
 	"toaster": {
-    "create_succeeded": "Succeeded to create {{target}}",
-    "create_failed": "Failed to create {{target}}",
-		"update_successed": "Succeeded to update {{target}}",
-    "update_failed": "Failed to update {{target}}",
     "file_upload_succeeded": "文件上传成功",
     "file_upload_failed": "文件上传失败",
     "initialize_successed": "Succeeded to initialize {{target}}",


### PR DESCRIPTION
## Task
[#107043](https://redmine.weseek.co.jp/issues/107043) [Next] admin / non-admin ページ共通で利用できる name space を新たに追加し適用する
└ [#107044](https://redmine.weseek.co.jp/issues/107044) commons.json を作成し、admin  / non-admin ページ共通で利用できる翻訳データを作成する