### PR TITLE
fix: Error when opening notification created on page update

### DIFF
--- a/packages/app/src/server/routes/page.js
+++ b/packages/app/src/server/routes/page.js
@@ -1077,7 +1077,7 @@ module.exports = function(crowi, app) {
       target: page,
       action: SupportedAction.ACTION_PAGE_UPDATE,
     };
-    activityEvent.emit('update', res.locals.activity._id, parameters, page);
+    activityEvent.emit('update', res.locals.activity._id, parameters, { path: page.path, creator: page.creator._id.toString() });
   };
 
   /**


### PR DESCRIPTION
## Task
[#106908](https://redmine.weseek.co.jp/issues/106908) [Nextjs][トップのナビゲーション]アプリ内通知が来た時に、画面全体で`Internal Server Error.` と表示されてしまう
└ [#107300](https://redmine.weseek.co.jp/issues/107300) 修正