### PR TITLE
fix: FullTextSearchManagement header is not shown

### DIFF
--- a/packages/app/src/components/Admin/FullTextSearchManagement.tsx
+++ b/packages/app/src/components/Admin/FullTextSearchManagement.tsx
@@ -4,8 +4,8 @@ import { useTranslation } from 'next-i18next';
 
 import ElasticsearchManagement from './ElasticsearchManagement/ElasticsearchManagement';
 
-const FullTextSearchManagement = (): JSX.Element => {
-  const { t } = useTranslation();
+export const FullTextSearchManagement = (): JSX.Element => {
+  const { t } = useTranslation('admin');
 
   return (
     <div data-testid="admin-full-text-search">
@@ -14,5 +14,3 @@ const FullTextSearchManagement = (): JSX.Element => {
     </div>
   );
 };
-
-export default FullTextSearchManagement;

--- a/packages/app/src/pages/admin/[[...path]].page.tsx
+++ b/packages/app/src/pages/admin/[[...path]].page.tsx
@@ -58,7 +58,9 @@ const SlackIntegration = dynamic(() => import('../../components/Admin/SlackInteg
 const LegacySlackIntegration = dynamic(() => import('../../components/Admin/LegacySlackIntegration/LegacySlackIntegration'), { ssr: false });
 const UserManagement = dynamic(() => import('../../components/Admin/UserManagement'), { ssr: false });
 const ManageExternalAccount = dynamic(() => import('../../components/Admin/ManageExternalAccount'), { ssr: false });
-const ElasticsearchManagement = dynamic(() => import('../../components/Admin/ElasticsearchManagement/ElasticsearchManagement'), { ssr: false });
+const FullTextSearchManagement = dynamic(
+  () => import('../../components/Admin/FullTextSearchManagement').then(mod => mod.FullTextSearchManagement), { ssr: false },
+);
 const UserGroupDetailPage = dynamic(() => import('../../components/Admin/UserGroupDetail/UserGroupDetailPage'), { ssr: false });
 const AdminLayout = dynamic(() => import('../../components/Layout/AdminLayout'), { ssr: false });
 // named export
@@ -176,7 +178,7 @@ const AdminPage: NextPage<Props> = (props: Props) => {
     },
     search: {
       title: t('full_text_search_management.full_text_search_management'),
-      component: <ElasticsearchManagement />,
+      component: <FullTextSearchManagement />,
     },
     'audit-log': {
       title: t('audit_log_management.audit_log'),


### PR DESCRIPTION
## Task
[Next.js][Admin][Full Text Search Management] admin-full-text-search-managementのh2タグが無い のを修正
┗[107335](https://redmine.weseek.co.jp/issues/107335) 修正

## ScreenShot
### Before
<img width="1247" alt="Screen Shot 2022-10-25 at 1 34 32" src="https://user-images.githubusercontent.com/59536731/197578489-8dfc1d0f-1743-4874-84b7-2cba434468f5.png">



### After
<img width="1246" alt="Screen Shot 2022-10-25 at 1 30 42" src="https://user-images.githubusercontent.com/59536731/197578069-07f6cf73-491a-4347-a22c-384479d7c8a4.png">
