### PR TITLE
fix: refactor method to put back page from trash

### DIFF
--- a/packages/app/src/components/PutbackPageModal.jsx
+++ b/packages/app/src/components/PutbackPageModal.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 
 
 import { useTranslation } from 'react-i18next';
@@ -53,10 +53,15 @@ const PutBackPageModal = () => {
     }
   }
 
+  const closeModalHandler = useCallback(() => {
+    closePutBackPageModal();
+    setErrs(null);
+  }, [closePutBackPageModal]);
+
 
   return (
-    <Modal isOpen={isOpened} toggle={closePutBackPageModal} className="grw-create-page">
-      <ModalHeader tag="h4" toggle={closePutBackPageModal} className="bg-info text-light">
+    <Modal isOpen={isOpened} toggle={closeModalHandler} className="grw-create-page">
+      <ModalHeader tag="h4" toggle={closeModalHandler} className="bg-info text-light">
         <i className="icon-action-undo mr-2" aria-hidden="true"></i> { t('modal_putback.label.Put Back Page') }
       </ModalHeader>
       <ModalBody>

--- a/packages/app/src/server/service/page.ts
+++ b/packages/app/src/server/service/page.ts
@@ -2022,8 +2022,12 @@ class PageService {
     const shouldReplace = originPage != null && originPage.isEmpty;
     let updatedPage = await Page.findByIdAndUpdate(page._id, {
       $set: {
-        // eslint-disable-next-line max-len
-        path: newPath, status: Page.STATUS_PUBLISHED, lastUpdateUser: user._id, deleteUser: null, deletedAt: null, descendantCount: shouldReplace ? originPage.descendantCount : 0,
+        path: newPath,
+        status: Page.STATUS_PUBLISHED,
+        lastUpdateUser: user._id,
+        deleteUser: null,
+        deletedAt: null,
+        descendantCount: shouldReplace ? originPage.descendantCount : 0,
       },
     }, { new: true });
 

--- a/packages/app/src/server/service/page.ts
+++ b/packages/app/src/server/service/page.ts
@@ -2013,7 +2013,7 @@ class PageService {
     const originPage = await Page.findByPath(newPath, includeEmpty);
 
     // throw if any page already exists when recursively operation
-    if ((originPage != null && !originPage.isEmpty) || isRecursively === true) {
+    if (originPage != null && (!originPage.isEmpty || isRecursively === true)) {
       throw new PathAlreadyExistsError('already_exists', originPage.path);
     }
 

--- a/packages/app/src/server/service/page.ts
+++ b/packages/app/src/server/service/page.ts
@@ -2013,7 +2013,7 @@ class PageService {
     const originPage = await Page.findByPath(newPath, includeEmpty);
 
     // throw if any page already exists when recursively operation
-    if (originPage != null && isRecursively === true) {
+    if ((originPage != null && !originPage.isEmpty) || isRecursively === true) {
       throw new PathAlreadyExistsError('already_exists', originPage.path);
     }
 

--- a/packages/app/src/server/service/page.ts
+++ b/packages/app/src/server/service/page.ts
@@ -2027,6 +2027,7 @@ class PageService {
         lastUpdateUser: user._id,
         deleteUser: null,
         deletedAt: null,
+        parent: parent._id,
         descendantCount: shouldReplace ? originPage.descendantCount : 0,
       },
     }, { new: true });

--- a/packages/app/src/server/service/page.ts
+++ b/packages/app/src/server/service/page.ts
@@ -2013,28 +2013,22 @@ class PageService {
     const originPage = await Page.findByPath(newPath, includeEmpty);
 
     // throw if any page already exists when recursively operation
-    if (originPage != null && (!originPage.isEmpty || isRecursively === true)) {
+    if (originPage != null && (!originPage.isEmpty || isRecursively)) {
       throw new PathAlreadyExistsError('already_exists', originPage.path);
     }
 
     // 2. Revert target
     const parent = await this.getParentAndFillAncestorsByUser(user, newPath);
-    let updatedPage;
-    if (originPage != null) {
-      updatedPage = await Page.findByIdAndUpdate(page._id, {
-        $set: {
-          // eslint-disable-next-line max-len
-          path: newPath, status: Page.STATUS_PUBLISHED, lastUpdateUser: user._id, deleteUser: null, deletedAt: null, descendantCount: originPage.descendantCount,
-        },
-      }, { new: true });
+    const shouldReplace = originPage != null && originPage.isEmpty;
+    let updatedPage = await Page.findByIdAndUpdate(page._id, {
+      $set: {
+        // eslint-disable-next-line max-len
+        path: newPath, status: Page.STATUS_PUBLISHED, lastUpdateUser: user._id, deleteUser: null, deletedAt: null, descendantCount: shouldReplace ? originPage.descendantCount : 0,
+      },
+    }, { new: true });
+
+    if (shouldReplace) {
       updatedPage = await Page.replaceTargetWithPage(originPage, updatedPage, true);
-    }
-    else {
-      updatedPage = await Page.findByIdAndUpdate(page._id, {
-        $set: {
-          path: newPath, status: Page.STATUS_PUBLISHED, lastUpdateUser: user._id, deleteUser: null, deletedAt: null, parent: parent._id, descendantCount: 0,
-        },
-      }, { new: true });
     }
 
     await PageTagRelation.updateMany({ relatedPage: page._id }, { $set: { isPageTrashed: false } });


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/107353

## やったこと
1. 親子ページを削除する
2. 子ページのみを元に戻す
3. 親ページと同じ名前の空ページが生成され、子ページが元に戻る
4. 親ページを元に戻そうとするとすでに同じパスのページが存在してもとに戻せない

上の手順で再現される不具合を修正
masterでも再現されるのでレビューが通り次第同じ内容の修正をmasterに向けて出します
