### PR TITLE
imprv: Show AdminNotFoundPage

### DIFF
--- a/packages/app/public/static/locales/en_US/commons.json
+++ b/packages/app/public/static/locales/en_US/commons.json
@@ -24,5 +24,8 @@
     "Page Path": "Page Path",
     "expire": "Expiration",
     "description": "Description"
+  },
+  "not_found_page": {
+    "page_not_exist": "This page does not exist.",
   }
 }

--- a/packages/app/public/static/locales/en_US/translation.json
+++ b/packages/app/public/static/locales/en_US/translation.json
@@ -172,11 +172,6 @@
     "invalid_syntax": "The syntax of %s is invalid.",
     "title_required": "Title is required."
   },
-  "not_found_page": {
-    "Create Page": "Create Page",
-    "page_not_exist": "This page does not exist.",
-    "page_not_exist_alert": "This page does not exist. Please create a new page."
-  },
   "not_creatable_page": {
     "could_not_creata_path": "Couldn't create path."
   },

--- a/packages/app/public/static/locales/ja_JP/commons.json
+++ b/packages/app/public/static/locales/ja_JP/commons.json
@@ -24,5 +24,8 @@
     "Page Path": "ページパス",
     "expire": "有効期限",
     "description": "概要"
+  },
+  "not_found_page": {
+    "page_not_exist": "このページは存在しません。"
   }
 }

--- a/packages/app/public/static/locales/ja_JP/translation.json
+++ b/packages/app/public/static/locales/ja_JP/translation.json
@@ -168,11 +168,6 @@
     "invalid_syntax": "%sの構文が不正です",
     "title_required": "タイトルを入力してください"
   },
-  "not_found_page": {
-    "Create Page": "ページを作成する",
-    "page_not_exist": "このページは存在しません。",
-    "page_not_exist_alert": "このページは存在しません。新たに作成する必要があります。"
-  },
   "not_creatable_page": {
     "could_not_creata_path": "パスを作成できませんでした。"
   },

--- a/packages/app/public/static/locales/zh_CN/commons.json
+++ b/packages/app/public/static/locales/zh_CN/commons.json
@@ -24,5 +24,8 @@
     "Page Path": "Page Path",
     "expire": "Expiration",
     "description": "Description"
+  },
+  "not_found_page": {
+    "page_not_exist": "该页面不存在"
   }
 }

--- a/packages/app/public/static/locales/zh_CN/translation.json
+++ b/packages/app/public/static/locales/zh_CN/translation.json
@@ -169,11 +169,6 @@
 		"invalid_syntax": "%s的语法无效。",
     "title_required": "标题是必需的。"
   },
-  "not_found_page": {
-    "Create Page": "创建页面",
-    "page_not_exist": "该页面不存在",
-    "page_not_exist_alert": "该页面不存在，请创建一个新页面"
-  },
   "not_creatable_page": {
     "could_not_creata_path": "无法创建路径"
   },

--- a/packages/app/src/components/Admin/NotFoundPage.tsx
+++ b/packages/app/src/components/Admin/NotFoundPage.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { useTranslation } from 'next-i18next';
 
 export const AdminNotFoundPage = (): JSX.Element => {
-  const { t } = useTranslation();
+  const { t } = useTranslation('commons');
 
   return (
     <h1 className="title">{t('not_found_page.page_not_exist')}</h1>

--- a/packages/app/src/components/Layout/AdminLayout.tsx
+++ b/packages/app/src/components/Layout/AdminLayout.tsx
@@ -8,15 +8,12 @@ import { RawLayout } from './RawLayout';
 
 import styles from './Admin.module.scss';
 
-
 const HotkeysManager = dynamic(() => import('../Hotkeys/HotkeysManager'), { ssr: false });
-
-const AdminNotFoundPage = dynamic(() => import('../Admin/NotFoundPage').then(mod => mod.AdminNotFoundPage), { ssr: false });
 
 
 type Props = {
-  title: string
-  componentTitle: string
+  title?: string
+  componentTitle?: string
   children?: ReactNode
 }
 
@@ -43,7 +40,7 @@ const AdminLayout = ({
                 <AdminNavigation />
               </div>
               <div className="col-lg-9">
-                {children || <AdminNotFoundPage />}
+                {children}
               </div>
             </div>
           </div>

--- a/packages/app/src/components/RevisionComparer/RevisionComparer.tsx
+++ b/packages/app/src/components/RevisionComparer/RevisionComparer.tsx
@@ -29,7 +29,7 @@ type RevisionComparerProps = {
 }
 
 export const RevisionComparer = (props: RevisionComparerProps): JSX.Element => {
-  const { t } = useTranslation();
+  const { t } = useTranslation(['translation', 'commons']);
 
   const {
     sourceRevision, targetRevision, currentPageId,

--- a/packages/app/src/pages/admin/[...path].page.tsx
+++ b/packages/app/src/pages/admin/[...path].page.tsx
@@ -1,0 +1,32 @@
+import {
+  NextPage, GetServerSideProps, GetServerSidePropsContext,
+} from 'next';
+import dynamic from 'next/dynamic';
+
+import { CommonProps } from '~/pages/utils/commons';
+import { useIsMaintenanceMode } from '~/stores/maintenanceMode';
+
+import { retrieveServerSideProps } from '../../utils/admin-page-util';
+
+const AdminLayout = dynamic(() => import('~/components/Layout/AdminLayout'), { ssr: false });
+const AdminNotFoundPage = dynamic(() => import('~/components/Admin/NotFoundPage').then(mod => mod.AdminNotFoundPage), { ssr: false });
+
+
+const AdminAppPage: NextPage<CommonProps> = (props) => {
+  useIsMaintenanceMode(props.isMaintenanceMode);
+
+
+  return (
+    <AdminLayout>
+      <AdminNotFoundPage />
+    </AdminLayout>
+  );
+};
+
+export const getServerSideProps: GetServerSideProps = async(context: GetServerSidePropsContext) => {
+  const props = await retrieveServerSideProps(context);
+  return props;
+};
+
+
+export default AdminAppPage;


### PR DESCRIPTION
## Task
[Next.js][要調査]adminPagesMapのリファクタ
┗[108056](https://redmine.weseek.co.jp/issues/108056) AdminNotFoundPage の表示

## Description
admin で存在しないパス(例: /admin/hoge) にアクセスした場合に、NotFoundPageを表示させるようにしました。

## ScreenShot

<img width="1113" alt="Screen Shot 2022-11-02 at 1 58 52" src="https://user-images.githubusercontent.com/59536731/199292076-a2039ab6-54c8-4628-84be-e56383fbc80b.png">

## GROWI Demo

<img width="1361" alt="Screen Shot 2022-11-02 at 2 00 22" src="https://user-images.githubusercontent.com/59536731/199292434-34e99289-5429-4997-8631-3f4f05331fdb.png">
