### PR TITLE
fix: Page model updatePage method

### DIFF
--- a/packages/app/src/interfaces/page.ts
+++ b/packages/app/src/interfaces/page.ts
@@ -43,6 +43,10 @@ export const PageGrant = {
 } as const;
 type UnionPageGrantKeys = keyof typeof PageGrant;
 export type PageGrant = typeof PageGrant[UnionPageGrantKeys];
+
+/**
+ * Neither pages with grant `GRANT_RESTRICTED` nor `GRANT_SPECIFIED` can be on a page tree.
+ */
 export type PageGrantCanBeOnTree = typeof PageGrant[Exclude<UnionPageGrantKeys, 'GRANT_RESTRICTED' | 'GRANT_SPECIFIED'>];
 
 export type IPageHasId = IPage & HasObjectId;

--- a/packages/app/src/interfaces/page.ts
+++ b/packages/app/src/interfaces/page.ts
@@ -41,7 +41,9 @@ export const PageGrant = {
   GRANT_OWNER: 4,
   GRANT_USER_GROUP: 5,
 } as const;
-export type PageGrant = typeof PageGrant[keyof typeof PageGrant];
+type UnionPageGrantKeys = keyof typeof PageGrant;
+export type PageGrant = typeof PageGrant[UnionPageGrantKeys];
+export type PageGrantCanBeOnTree = typeof PageGrant[Exclude<UnionPageGrantKeys, 'GRANT_RESTRICTED' | 'GRANT_SPECIFIED'>];
 
 export type IPageHasId = IPage & HasObjectId;
 

--- a/packages/app/src/server/models/page.ts
+++ b/packages/app/src/server/models/page.ts
@@ -1012,7 +1012,7 @@ export default (crowi: Crowi): any => {
       let isGrantNormalized = false;
       try {
         // TODO: fix
-        const shouldCheckDescendants = options.overwriteScopesOfDescendants !== true;
+        const shouldCheckDescendants = !options.overwriteScopesOfDescendants;
         isGrantNormalized = await pageGrantService.isGrantNormalized(user, pageData.path, grant, grantedUserIds, grantUserGroupId, shouldCheckDescendants);
       }
       catch (err) {
@@ -1021,6 +1021,15 @@ export default (crowi: Crowi): any => {
       }
       if (!isGrantNormalized) {
         throw Error('The selected grant or grantedGroup is not assignable to this page.');
+      }
+
+      if (options.overwriteScopesOfDescendants) {
+        const updateGrantInfo = await pageGrantService.generateUpdateGrantInfo(user, grant, options.grantUserGroupId);
+        const canOverwriteDescendants = await pageGrantService.canOverwriteDescendants(pageData, user, updateGrantInfo);
+
+        if (!canOverwriteDescendants) {
+          throw Error('Cannot overwrite scopes of descendants.');
+        }
       }
 
       if (!wasOnTree) {

--- a/packages/app/src/server/models/page.ts
+++ b/packages/app/src/server/models/page.ts
@@ -338,7 +338,7 @@ export class PageQueryBuilder {
           { grant: { $ne: GRANT_SPECIFIED } },
         ],
       });
-    this.addConditionAsNotMigrated();
+    this.addConditionAsRootOrNotOnTree();
     this.addConditionAsNonRootPage();
     this.addConditionToExcludeTrashed();
     await this.addConditionForParentNormalization(user);
@@ -380,7 +380,7 @@ export class PageQueryBuilder {
     return this;
   }
 
-  addConditionAsNotMigrated() {
+  addConditionAsRootOrNotOnTree() {
     this.query = this.query
       .and({ parent: null });
 
@@ -938,6 +938,7 @@ export type PageCreateOptions = {
   format?: string
   grantUserGroupId?: ObjectIdLike
   grant?: number
+  overwriteScopesOfDescendants?: boolean
 }
 
 /*
@@ -1024,7 +1025,7 @@ export default (crowi: Crowi): any => {
 
       if (options.overwriteScopesOfDescendants) {
         const updateGrantInfo = await pageGrantService.generateUpdateGrantInfo(user, grant, options.grantUserGroupId);
-        const canOverwriteDescendants = await pageGrantService.canOverwriteDescendants(pageData, user, updateGrantInfo);
+        const canOverwriteDescendants = await pageGrantService.canOverwriteDescendants(pageData.path, user, updateGrantInfo);
 
         if (!canOverwriteDescendants) {
           throw Error('Cannot overwrite scopes of descendants.');
@@ -1091,6 +1092,12 @@ export default (crowi: Crowi): any => {
     }
 
     // Sub operation
+    // update scopes for descendants
+    // TODO: remove await (cause: tests are not working with await)
+    if (options.overwriteScopesOfDescendants) {
+      await this.applyScopesToDescendantsAsyncronously(savedPage, user);
+    }
+
     // 1. Update descendantCount
     const shouldPlusDescCount = !wasOnTree && shouldBeOnTree;
     const shouldMinusDescCount = wasOnTree && !shouldBeOnTree;

--- a/packages/app/src/server/models/page.ts
+++ b/packages/app/src/server/models/page.ts
@@ -1093,9 +1093,8 @@ export default (crowi: Crowi): any => {
 
     // Sub operation
     // update scopes for descendants
-    // TODO: remove await (cause: tests are not working with await)
     if (options.overwriteScopesOfDescendants) {
-      await this.applyScopesToDescendantsAsyncronously(savedPage, user);
+      this.applyScopesToDescendantsAsyncronously(savedPage, user);
     }
 
     // 1. Update descendantCount

--- a/packages/app/src/server/models/page.ts
+++ b/packages/app/src/server/models/page.ts
@@ -1011,7 +1011,6 @@ export default (crowi: Crowi): any => {
     if (shouldBeOnTree) {
       let isGrantNormalized = false;
       try {
-        // TODO: fix
         const shouldCheckDescendants = !options.overwriteScopesOfDescendants;
         isGrantNormalized = await pageGrantService.isGrantNormalized(user, pageData.path, grant, grantedUserIds, grantUserGroupId, shouldCheckDescendants);
       }

--- a/packages/app/src/server/models/page.ts
+++ b/packages/app/src/server/models/page.ts
@@ -1024,7 +1024,7 @@ export default (crowi: Crowi): any => {
       }
 
       if (options.overwriteScopesOfDescendants) {
-        const updateGrantInfo = await pageGrantService.generateUpdateGrantInfo(user, grant, options.grantUserGroupId);
+        const updateGrantInfo = await pageGrantService.generateUpdateGrantInfoToOverwriteDescendants(user, grant, options.grantUserGroupId);
         const canOverwriteDescendants = await pageGrantService.canOverwriteDescendants(pageData.path, user, updateGrantInfo);
 
         if (!canOverwriteDescendants) {

--- a/packages/app/src/server/models/user-group-relation.js
+++ b/packages/app/src/server/models/user-group-relation.js
@@ -93,6 +93,15 @@ class UserGroupRelation {
       .exec();
   }
 
+  static async findAllUserIdsForUserGroup(userGroup) {
+    const relations = await this
+      .find({ relatedGroup: userGroup })
+      .select('relatedUser')
+      .exec();
+
+    return relations.map(r => r.relatedUser);
+  }
+
   /**
    * find all user and group relation of UserGroups
    *

--- a/packages/app/src/server/models/user-group.ts
+++ b/packages/app/src/server/models/user-group.ts
@@ -108,6 +108,7 @@ schema.statics.findGroupsWithAncestorsRecursively = async function(group, ancest
 };
 
 /**
+ * TODO: use $graphLookup
  * Find all descendant groups starting from the UserGroups in the initial groups in "groups".
  * Set "descendants" as "[]" if the initial groups are unnecessary as result.
  * @param groups UserGroupDocument[] including at least one UserGroup

--- a/packages/app/src/server/routes/apiv3/pages.js
+++ b/packages/app/src/server/routes/apiv3/pages.js
@@ -299,7 +299,7 @@ module.exports = (crowi) => {
     // check whether path starts slash
     path = pathUtils.addHeadingSlash(path);
 
-    const options = {};
+    const options = { overwriteScopesOfDescendants };
     if (grant != null) {
       options.grant = grant;
       options.grantUserGroupId = grantUserGroupId;
@@ -323,11 +323,6 @@ module.exports = (crowi) => {
       tags: savedTags,
       revision: serializeRevisionSecurely(createdPage.revision),
     };
-
-    // update scopes for descendants
-    if (overwriteScopesOfDescendants) {
-      Page.applyScopesToDescendantsAsyncronously(createdPage, req.user);
-    }
 
     const parameters = {
       targetModel: SupportedTargetModel.MODEL_PAGE,

--- a/packages/app/src/server/routes/page.js
+++ b/packages/app/src/server/routes/page.js
@@ -870,7 +870,7 @@ module.exports = function(crowi, app) {
       return res.json(ApiResponse.error('Page exists', 'already_exists'));
     }
 
-    const options = {};
+    const options = { overwriteScopesOfDescendants };
     if (grant != null) {
       options.grant = grant;
       options.grantUserGroupId = grantUserGroupId;
@@ -890,11 +890,6 @@ module.exports = function(crowi, app) {
       tags: savedTags,
     };
     res.json(ApiResponse.success(result));
-
-    // update scopes for descendants
-    if (overwriteScopesOfDescendants) {
-      Page.applyScopesToDescendantsAsyncronously(createdPage, req.user);
-    }
 
     // global notification
     try {
@@ -1043,11 +1038,6 @@ module.exports = function(crowi, app) {
       tags: savedTags,
     };
     res.json(ApiResponse.success(result));
-
-    // update scopes for descendants
-    if (overwriteScopesOfDescendants) {
-      Page.applyScopesToDescendantsAsyncronously(page, req.user);
-    }
 
     // global notification
     try {

--- a/packages/app/src/server/service/page-grant.ts
+++ b/packages/app/src/server/service/page-grant.ts
@@ -36,6 +36,10 @@ type ComparableDescendants = {
   grantedGroupIds: ObjectIdLike[],
 };
 
+/**
+ * @param grantedUserGroupInfo This parameter has info to calculate whether the update operation is allowed.
+ *   - See the `calcCanOverwriteDescendants` private method for detail.
+ */
 type UpdateGrantInfo = {
   grant: typeof PageGrant.GRANT_PUBLIC,
 } | {

--- a/packages/app/src/server/service/page-grant.ts
+++ b/packages/app/src/server/service/page-grant.ts
@@ -558,7 +558,8 @@ class PageGrantService {
       if (grantUserGroupId == null) {
         throw Error('The parameter `grantUserGroupId` is required.');
       }
-      const userIds = await UserGroup.findAllUserIdsForUserGroup(grantUserGroupId);
+      const UserGroupRelation = mongoose.model('UserGroupRelation') as any; // TODO: Typescriptize model
+      const userIds = await UserGroupRelation.findAllUserIdsForUserGroup(grantUserGroupId);
       updateGrantInfo = {
         grant: PageGrant.GRANT_USER_GROUP,
         grantedUserGroupInfo: {

--- a/packages/app/src/server/service/page-grant.ts
+++ b/packages/app/src/server/service/page-grant.ts
@@ -560,12 +560,14 @@ class PageGrantService {
       }
       const UserGroupRelation = mongoose.model('UserGroupRelation') as any; // TODO: Typescriptize model
       const userIds = await UserGroupRelation.findAllUserIdsForUserGroup(grantUserGroupId);
+      const childrenOrItselfGroupIds = await UserGroup.findGroupsWithDescendantsById(grantUserGroupId).map(d => d._id);
+
       updateGrantInfo = {
         grant: PageGrant.GRANT_USER_GROUP,
         grantedUserGroupInfo: {
           groupId: grantUserGroupId,
           userIds: new Set<ObjectIdLike>(userIds),
-          childrenOrItselfGroupIds: new Set<ObjectIdLike>(),
+          childrenOrItselfGroupIds: new Set<ObjectIdLike>(childrenOrItselfGroupIds),
         },
       };
     }

--- a/packages/app/src/server/service/page-grant.ts
+++ b/packages/app/src/server/service/page-grant.ts
@@ -544,7 +544,7 @@ class PageGrantService {
     return this.calcCanOverwriteDescendants(operatorGrantInfo, updateGrantInfo, descendantPagesGrantInfo);
   }
 
-  async generateUpdateGrantInfo(operator, updateGrant: PageGrantCanBeOnTree, grantUserGroupId?: ObjectIdLike): Promise<UpdateGrantInfo> {
+  async generateUpdateGrantInfoToOverwriteDescendants(operator, updateGrant: PageGrantCanBeOnTree, grantUserGroupId?: ObjectIdLike): Promise<UpdateGrantInfo> {
     let updateGrantInfo: UpdateGrantInfo | null = null;
 
     if (updateGrant === PageGrant.GRANT_PUBLIC) {

--- a/packages/app/src/server/service/page-grant.ts
+++ b/packages/app/src/server/service/page-grant.ts
@@ -560,7 +560,8 @@ class PageGrantService {
       }
       const UserGroupRelation = mongoose.model('UserGroupRelation') as any; // TODO: Typescriptize model
       const userIds = await UserGroupRelation.findAllUserIdsForUserGroup(grantUserGroupId);
-      const childrenOrItselfGroupIds = await UserGroup.findGroupsWithDescendantsById(grantUserGroupId).map(d => d._id);
+      const childrenOrItselfGroups = await UserGroup.findGroupsWithDescendantsById(grantUserGroupId);
+      const childrenOrItselfGroupIds = childrenOrItselfGroups.map(d => d._id);
 
       updateGrantInfo = {
         grant: PageGrant.GRANT_USER_GROUP,

--- a/packages/app/src/server/service/page.ts
+++ b/packages/app/src/server/service/page.ts
@@ -3460,7 +3460,7 @@ class PageService {
       }
 
       if (options?.overwriteScopesOfDescendants) {
-        const updateGrantInfo = await this.crowi.pageGrantService.generateUpdateGrantInfo(user, grant, options.grantUserGroupId);
+        const updateGrantInfo = await this.crowi.pageGrantService.generateUpdateGrantInfoToOverwriteDescendants(user, grant, options.grantUserGroupId);
         const canOverwriteDescendants = await this.crowi.pageGrantService.canOverwriteDescendants(path, user, updateGrantInfo);
 
         if (!canOverwriteDescendants) {

--- a/packages/app/src/server/service/page.ts
+++ b/packages/app/src/server/service/page.ts
@@ -342,7 +342,7 @@ class PageService {
     const { PageQueryBuilder } = Page;
 
     const builder = new PageQueryBuilder(Page.find(), true)
-      .addConditionAsNotMigrated() // to avoid affecting v5 pages
+      .addConditionAsRootOrNotOnTree() // to avoid affecting v5 pages
       .addConditionToListOnlyDescendants(targetPagePath);
 
     await Page.addConditionToFilteringByViewerToEdit(builder, userToOperate);
@@ -2379,7 +2379,7 @@ class PageService {
 
     // This validation is not 100% correct since it ignores user to count
     const builder = new PageQueryBuilder(Page.find());
-    builder.addConditionAsNotMigrated();
+    builder.addConditionAsRootOrNotOnTree();
     builder.addConditionToListWithDescendants(path);
     const nEstimatedNormalizationTarget: number = await builder.query.exec('count');
     if (nEstimatedNormalizationTarget === 0) {
@@ -3418,6 +3418,7 @@ class PageService {
       },
       shouldValidateGrant: boolean,
       user?,
+      options?: Partial<PageCreateOptions>,
   ): Promise<boolean> {
     const Page = mongoose.model('Page') as unknown as PageModel;
 
@@ -3456,6 +3457,15 @@ class PageService {
       }
       if (!isGrantNormalized) {
         throw Error('The selected grant or grantedGroup is not assignable to this page.');
+      }
+
+      if (options?.overwriteScopesOfDescendants) {
+        const updateGrantInfo = await this.crowi.pageGrantService.generateUpdateGrantInfo(user, grant, options.grantUserGroupId);
+        const canOverwriteDescendants = await this.crowi.pageGrantService.canOverwriteDescendants(path, user, updateGrantInfo);
+
+        if (!canOverwriteDescendants) {
+          throw Error('Cannot overwrite scopes of descendants.');
+        }
       }
     }
 
@@ -3540,6 +3550,11 @@ class PageService {
     catch (err) {
       // no throw
       logger.error('Failed to delete PageRedirect');
+    }
+
+    // update scopes for descendants
+    if (options.overwriteScopesOfDescendants) {
+      Page.applyScopesToDescendantsAsyncronously(savedPage, user);
     }
 
     return savedPage;

--- a/packages/app/test/integration/models/v5.page.test.js
+++ b/packages/app/test/integration/models/v5.page.test.js
@@ -1208,7 +1208,7 @@ describe('Page', () => {
 
 
   // see: https://dev.growi.org/635a314eac6bcd85cbf359fc about the specification
-  describe.only('updatePage with overwriteScopesOfDescendants true', () => {
+  describe('updatePage with overwriteScopesOfDescendants true', () => {
     test('(case 1) it should update all granted descendant pages when update grant is GRANT_PUBLIC', async() => {
       const upodPagegAB = await Page.findOne({ path: '/gAB_upod_1' });
       const upodPagegB = await Page.findOne({ path: '/gAB_upod_1/gB_upod_1' });
@@ -1280,7 +1280,7 @@ describe('Page', () => {
       expect(upodPageonlyAUpdated.grant).toBe(newGrant);
       expect(upodPageonlyAUpdated.grantedUsers).toStrictEqual(newGrantedUsers);
     });
-    test.only(`(case 3) it should update all granted descendant pages when update grant is GRANT_USER_GROUP
+    test(`(case 3) it should update all granted descendant pages when update grant is GRANT_USER_GROUP
     , all user groups of descendants are the children or itself of the update user group
     , and all users of descendants belong to the update user group`, async() => {
       const upodPagePublic = await Page.findOne({ path: '/public_upod_3' });
@@ -1314,12 +1314,12 @@ describe('Page', () => {
       const newGrant = PageGrant.GRANT_USER_GROUP;
       const newGrantedGroup = upodUserGroupIdAB;
       expect(updatedPage.grant).toBe(newGrant);
-      expect(updatedPage.grantedGroup).toStrictEqual(newGrantedGroup);
+      expect(updatedPage.grantedGroup._id).toStrictEqual(newGrantedGroup);
       expect(upodPagegABUpdated.grant).toBe(newGrant);
-      expect(upodPagegABUpdated.grantedGroup).toStrictEqual(newGrantedGroup);
+      expect(upodPagegABUpdated.grantedGroup._id).toStrictEqual(newGrantedGroup);
       // Not changed
       expect(upodPagegBUpdated.grant).toBe(PageGrant.GRANT_USER_GROUP);
-      expect(upodPagegBUpdated.grantedGroup).toStrictEqual(upodPagegB.grantedGroup);
+      expect(upodPagegBUpdated.grantedGroup._id).toStrictEqual(upodPagegB.grantedGroup);
       expect(upodPageonlyBUpdated.grant).toBe(PageGrant.GRANT_OWNER);
       expect(upodPageonlyBUpdated.grantedUsers).toStrictEqual(upodPageonlyB.grantedUsers);
     });

--- a/packages/app/test/integration/models/v5.page.test.js
+++ b/packages/app/test/integration/models/v5.page.test.js
@@ -1207,7 +1207,7 @@ describe('Page', () => {
 
 
   // see: https://dev.growi.org/635a314eac6bcd85cbf359fc about the specification
-  describe.only('updatePage with overwriteScopesOfDescendants true', () => {
+  describe('updatePage with overwriteScopesOfDescendants true', () => {
     test('(case 1) it should update all granted descendant pages when update grant is GRANT_PUBLIC', async() => {
       const upodPagegAB = await Page.findOne({ path: '/gAB_upod_1' });
       const upodPagegB = await Page.findOne({ path: '/gAB_upod_1/gB_upod_1' });

--- a/packages/app/test/integration/models/v5.page.test.js
+++ b/packages/app/test/integration/models/v5.page.test.js
@@ -777,10 +777,22 @@ describe('Page', () => {
 
   describe('update', () => {
 
+    // TODO*
     const updatePage = async(page, newRevisionBody, oldRevisionBody, user, options = {}) => {
       const mockedEmitPageEventUpdate = jest.spyOn(Page, 'emitPageEventUpdate').mockReturnValue(null);
+      const mockedApplyScopesToDescendantsAsyncronously = jest.spyOn(Page, 'applyScopesToDescendantsAsyncronously').mockReturnValue(null);
+
       const savedPage = await Page.updatePage(page, newRevisionBody, oldRevisionBody, user, options);
+
+      const argsForApplyScopesToDescendantsAsyncronously = mockedApplyScopesToDescendantsAsyncronously.mock.calls[0];
+
       mockedEmitPageEventUpdate.mockRestore();
+      mockedApplyScopesToDescendantsAsyncronously.mockRestore();
+
+      if (options.overwriteScopesOfDescendants) {
+        await Page.applyScopesToDescendantsAsyncronously(...argsForApplyScopesToDescendantsAsyncronously);
+      }
+
       return savedPage;
     };
 
@@ -1222,11 +1234,11 @@ describe('Page', () => {
 
       // Changed
       const newGrant = PageGrant.GRANT_PUBLIC;
-      expect(updatedPage.grant).toBeNull(newGrant);
+      expect(updatedPage.grant).toBe(newGrant);
       // Not changed
-      expect(upodPagegBUpdated.grant).toBeNull(PageGrant.GRANT_USER_GROUP);
+      expect(upodPagegBUpdated.grant).toBe(PageGrant.GRANT_USER_GROUP);
       expect(upodPagegBUpdated.grantedGroup).toStrictEqual(upodPagegB.grantedGroup);
-      expect(upodPageonlyBUpdated.grant).toBeNull(PageGrant.GRANT_OWNER);
+      expect(upodPageonlyBUpdated.grant).toBe(PageGrant.GRANT_OWNER);
       expect(upodPageonlyBUpdated.grantedUsers).toStrictEqual(upodPageonlyB.grantedUsers);
     });
     test('(case 2) it should update all granted descendant pages when all descendant pages are granted by the operator', async() => {
@@ -1262,13 +1274,13 @@ describe('Page', () => {
       expect(updatedPage.grant).toBe(newGrant);
       expect(updatedPage.grantedUsers).toStrictEqual(newGrantedUsers);
       expect(upodPagegAUpdated.grant).toBe(newGrant);
-      expect(upodPagegAUpdated.grantedGroup).toStrictEqual(newGrantedUsers);
+      expect(upodPagegAUpdated.grantedUsers).toStrictEqual(newGrantedUsers);
       expect(upodPagegAIsolatedUpdated.grant).toBe(newGrant);
-      expect(upodPagegAIsolatedUpdated.grantedGroup).toStrictEqual(newGrantedUsers);
+      expect(upodPagegAIsolatedUpdated.grantedUsers).toStrictEqual(newGrantedUsers);
       expect(upodPageonlyAUpdated.grant).toBe(newGrant);
-      expect(upodPageonlyAUpdated.grantedGroup).toStrictEqual(newGrantedUsers);
+      expect(upodPageonlyAUpdated.grantedUsers).toStrictEqual(newGrantedUsers);
     });
-    test(`(case 3) it should update all granted descendant pages when update grant is GRANT_USER_GROUP
+    test.only(`(case 3) it should update all granted descendant pages when update grant is GRANT_USER_GROUP
     , all user groups of descendants are the children or itself of the update user group
     , and all users of descendants belong to the update user group`, async() => {
       const upodPagePublic = await Page.findOne({ path: '/public_upod_3' });

--- a/packages/app/test/integration/models/v5.page.test.js
+++ b/packages/app/test/integration/models/v5.page.test.js
@@ -138,7 +138,7 @@ describe('Page', () => {
         parent: rootPage._id,
       },
       {
-        path: '/gB_upod_1',
+        path: '/gAB_upod_1/gB_upod_1',
         grant: PageGrant.GRANT_USER_GROUP,
         creator: upodUserB,
         lastUpdateUser: upodUserB,
@@ -147,7 +147,7 @@ describe('Page', () => {
         parent: upodPageIdgAB1,
       },
       {
-        path: '/onlyB_upod_1',
+        path: '/gAB_upod_1/onlyB_upod_1',
         grant: PageGrant.GRANT_OWNER,
         creator: upodUserB,
         lastUpdateUser: upodUserB,
@@ -167,7 +167,7 @@ describe('Page', () => {
         parent: rootPage._id,
       },
       {
-        path: '/gA_upod_2',
+        path: '/public_upod_2/gA_upod_2',
         grant: PageGrant.GRANT_USER_GROUP,
         creator: upodUserA,
         lastUpdateUser: upodUserA,
@@ -176,7 +176,7 @@ describe('Page', () => {
         parent: upodPageIdPublic2,
       },
       {
-        path: '/gAIsolated_upod_2',
+        path: '/public_upod_2/gAIsolated_upod_2',
         grant: PageGrant.GRANT_USER_GROUP,
         creator: upodUserA,
         lastUpdateUser: upodUserA,
@@ -185,7 +185,7 @@ describe('Page', () => {
         parent: upodPageIdPublic2,
       },
       {
-        path: '/onlyA_upod_2',
+        path: '/public_upod_2/onlyA_upod_2',
         grant: PageGrant.GRANT_OWNER,
         creator: upodUserA,
         lastUpdateUser: upodUserA,
@@ -205,7 +205,7 @@ describe('Page', () => {
         parent: rootPage._id,
       },
       {
-        path: '/gAB_upod_3',
+        path: '/public_upod_3/gAB_upod_3',
         grant: PageGrant.GRANT_USER_GROUP,
         creator: upodUserA,
         lastUpdateUser: upodUserA,
@@ -214,7 +214,7 @@ describe('Page', () => {
         parent: upodPageIdPublic3,
       },
       {
-        path: '/gB_upod_3',
+        path: '/public_upod_3/gB_upod_3',
         grant: PageGrant.GRANT_USER_GROUP,
         creator: upodUserB,
         lastUpdateUser: upodUserB,
@@ -223,7 +223,7 @@ describe('Page', () => {
         parent: upodPageIdPublic3,
       },
       {
-        path: '/onlyB_upod_3',
+        path: '/public_upod_3/onlyB_upod_3',
         grant: PageGrant.GRANT_OWNER,
         creator: upodUserB,
         lastUpdateUser: upodUserB,
@@ -243,7 +243,7 @@ describe('Page', () => {
         parent: rootPage._id,
       },
       {
-        path: '/gA_upod_4',
+        path: '/public_upod_4/gA_upod_4',
         grant: PageGrant.GRANT_USER_GROUP,
         creator: upodUserA,
         lastUpdateUser: upodUserA,
@@ -252,7 +252,7 @@ describe('Page', () => {
         parent: upodPageIdPublic4,
       },
       {
-        path: '/gC_upod_4',
+        path: '/public_upod_4/gC_upod_4',
         grant: PageGrant.GRANT_USER_GROUP,
         creator: upodUserC,
         lastUpdateUser: upodUserC,
@@ -272,7 +272,7 @@ describe('Page', () => {
         parent: rootPage._id,
       },
       {
-        path: '/gA_upod_5',
+        path: '/public_upod_5/gA_upod_5',
         grant: PageGrant.GRANT_USER_GROUP,
         creator: upodUserA,
         lastUpdateUser: upodUserA,
@@ -281,7 +281,7 @@ describe('Page', () => {
         parent: upodPageIdPublic5,
       },
       {
-        path: '/onlyC_upod_5',
+        path: '/public_upod_5/onlyC_upod_5',
         grant: PageGrant.GRANT_OWNER,
         creator: upodUserC,
         lastUpdateUser: upodUserC,
@@ -301,7 +301,7 @@ describe('Page', () => {
         parent: rootPage._id,
       },
       {
-        path: '/onlyC_upod_6',
+        path: '/public_upod_6/onlyC_upod_6',
         grant: PageGrant.GRANT_OWNER,
         creator: upodUserC,
         lastUpdateUser: upodUserC,
@@ -1196,11 +1196,11 @@ describe('Page', () => {
 
 
   // see: https://dev.growi.org/635a314eac6bcd85cbf359fc about the specification
-  describe('updatePage with overwriteScopesOfDescendants true', () => {
+  describe.only('updatePage with overwriteScopesOfDescendants true', () => {
     test('(case 1) it should update all granted descendant pages when update grant is GRANT_PUBLIC', async() => {
       const upodPagegAB = await Page.findOne({ path: '/gAB_upod_1' });
-      const upodPagegB = await Page.findOne({ path: '/gB_upod_1' });
-      const upodPageonlyB = await Page.findOne({ path: '/onlyB_upod_1' });
+      const upodPagegB = await Page.findOne({ path: '/gAB_upod_1/gB_upod_1' });
+      const upodPageonlyB = await Page.findOne({ path: '/gAB_upod_1/onlyB_upod_1' });
 
       expect(upodPagegAB).not.toBeNull();
       expect(upodPagegB).not.toBeNull();
@@ -1217,8 +1217,8 @@ describe('Page', () => {
       };
       const updatedPage = await Page.updatePage(upodPagegAB, 'newRevisionBody', 'oldRevisionBody', upodUserA, options);
 
-      const upodPagegBUpdated = await Page.findOne({ path: '/gB_upod_1' });
-      const upodPageonlyBUpdated = await Page.findOne({ path: '/onlyB_upod_1' });
+      const upodPagegBUpdated = await Page.findOne({ path: '/gAB_upod_1/gB_upod_1' });
+      const upodPageonlyBUpdated = await Page.findOne({ path: '/gAB_upod_1/onlyB_upod_1' });
 
       // Changed
       const newGrant = PageGrant.GRANT_PUBLIC;
@@ -1231,9 +1231,9 @@ describe('Page', () => {
     });
     test('(case 2) it should update all granted descendant pages when all descendant pages are granted by the operator', async() => {
       const upodPagePublic = await Page.findOne({ path: '/public_upod_2' });
-      const upodPagegA = await Page.findOne({ path: '/gA_upod_2' });
-      const upodPagegAIsolated = await Page.findOne({ path: '/gAIsolated_upod_2' });
-      const upodPageonlyA = await Page.findOne({ path: '/onlyA_upod_2' });
+      const upodPagegA = await Page.findOne({ path: '/public_upod_2/gA_upod_2' });
+      const upodPagegAIsolated = await Page.findOne({ path: '/public_upod_2/gAIsolated_upod_2' });
+      const upodPageonlyA = await Page.findOne({ path: '/public_upod_2/onlyA_upod_2' });
 
       expect(upodPagePublic).not.toBeNull();
       expect(upodPagegA).not.toBeNull();
@@ -1252,9 +1252,9 @@ describe('Page', () => {
       };
       const updatedPage = await Page.updatePage(upodPagePublic, 'newRevisionBody', 'oldRevisionBody', upodUserA, options);
 
-      const upodPagegAUpdated = await Page.findOne({ path: '/gA_upod_2' });
-      const upodPagegAIsolatedUpdated = await Page.findOne({ path: '/gAIsolated_upod_2' });
-      const upodPageonlyAUpdated = await Page.findOne({ path: '/onlyA_upod_2' });
+      const upodPagegAUpdated = await Page.findOne({ path: '/public_upod_2/gA_upod_2' });
+      const upodPagegAIsolatedUpdated = await Page.findOne({ path: '/public_upod_2/gAIsolated_upod_2' });
+      const upodPageonlyAUpdated = await Page.findOne({ path: '/public_upod_2/onlyA_upod_2' });
 
       // Changed
       const newGrant = PageGrant.GRANT_OWNER;
@@ -1272,9 +1272,9 @@ describe('Page', () => {
     , all user groups of descendants are the children or itself of the update user group
     , and all users of descendants belong to the update user group`, async() => {
       const upodPagePublic = await Page.findOne({ path: '/public_upod_3' });
-      const upodPagegAB = await Page.findOne({ path: '/gAB_upod_3' });
-      const upodPagegB = await Page.findOne({ path: '/gB_upod_3' });
-      const upodPageonlyB = await Page.findOne({ path: '/onlyB_upod_3' });
+      const upodPagegAB = await Page.findOne({ path: '/public_upod_3/gAB_upod_3' });
+      const upodPagegB = await Page.findOne({ path: '/public_upod_3/gB_upod_3' });
+      const upodPageonlyB = await Page.findOne({ path: '/public_upod_3/onlyB_upod_3' });
 
       expect(upodPagePublic).not.toBeNull();
       expect(upodPagegAB).not.toBeNull();
@@ -1294,9 +1294,9 @@ describe('Page', () => {
       };
       const updatedPage = await Page.updatePage(upodPagePublic, 'newRevisionBody', 'oldRevisionBody', upodUserA, options);
 
-      const upodPagegABUpdated = await Page.findOne({ path: '/gAB_upod_3' });
-      const upodPagegBUpdated = await Page.findOne({ path: '/gB_upod_3' });
-      const upodPageonlyBUpdated = await Page.findOne({ path: '/onlyB_upod_3' });
+      const upodPagegABUpdated = await Page.findOne({ path: '/public_upod_3/gAB_upod_3' });
+      const upodPagegBUpdated = await Page.findOne({ path: '/public_upod_3/gB_upod_3' });
+      const upodPageonlyBUpdated = await Page.findOne({ path: '/public_upod_3/onlyB_upod_3' });
 
       // Changed
       const newGrant = PageGrant.GRANT_USER_GROUP;
@@ -1315,8 +1315,8 @@ describe('Page', () => {
     , update grant is GRANT_USER_GROUP
     , and some of user groups of descendants are not children or itself of the update user group`, async() => {
       const upodPagePublic = await Page.findOne({ path: '/public_upod_4' });
-      const upodPagegA = await Page.findOne({ path: '/gA_upod_4' });
-      const upodPagegC = await Page.findOne({ path: '/gC_upod_4' });
+      const upodPagegA = await Page.findOne({ path: '/public_upod_4/gA_upod_4' });
+      const upodPagegC = await Page.findOne({ path: '/public_upod_4/gC_upod_4' });
 
       expect(upodPagePublic).not.toBeNull();
       expect(upodPagegA).not.toBeNull();
@@ -1334,14 +1334,14 @@ describe('Page', () => {
       };
       const updatedPagePromise = Page.updatePage(upodPagePublic, 'newRevisionBody', 'oldRevisionBody', upodUserA, options);
 
-      await expect(updatedPagePromise).toThrowError();
+      await expect(updatedPagePromise).rejects.toThrowError();
     });
     test(`(case 5) it should throw when some of descendants is not granted
     , update grant is GRANT_USER_GROUP
     , and some of users of descendants does NOT belong to the update user group`, async() => {
       const upodPagePublic = await Page.findOne({ path: '/public_upod_5' });
-      const upodPagegA = await Page.findOne({ path: '/gA_upod_5' });
-      const upodPageonlyC = await Page.findOne({ path: '/onlyC_upod_5' });
+      const upodPagegA = await Page.findOne({ path: '/public_upod_5/gA_upod_5' });
+      const upodPageonlyC = await Page.findOne({ path: '/public_upod_5/onlyC_upod_5' });
 
       expect(upodPagePublic).not.toBeNull();
       expect(upodPagegA).not.toBeNull();
@@ -1359,11 +1359,11 @@ describe('Page', () => {
       };
       const updatedPagePromise = Page.updatePage(upodPagePublic, 'newRevisionBody', 'oldRevisionBody', upodUserA, options);
 
-      await expect(updatedPagePromise).toThrowError();
+      await expect(updatedPagePromise).rejects.toThrowError();
     });
     test('(case 6) it should throw when some of descendants is not granted and update grant is GRANT_OWNER', async() => {
       const upodPagePublic = await Page.findOne({ path: '/public_upod_6' });
-      const upodPageonlyC = await Page.findOne({ path: '/onlyC_upod_6' });
+      const upodPageonlyC = await Page.findOne({ path: '/public_upod_6/onlyC_upod_6' });
 
       expect(upodPagePublic).not.toBeNull();
       expect(upodPageonlyC).not.toBeNull();
@@ -1379,7 +1379,7 @@ describe('Page', () => {
       };
       const updatedPagePromise = Page.updatePage(upodPagePublic, 'newRevisionBody', 'oldRevisionBody', upodUserA, options);
 
-      await expect(updatedPagePromise).toThrowError();
+      await expect(updatedPagePromise).rejects.toThrowError();
     });
   });
 });


### PR DESCRIPTION
`updatePage`, `updatePageV4`, `PageService.create`, `PageService.createV4` を改修しました。

- [x] `overwriteScopesOfDescendants` オプションが効く
- [x] テストが通っている

Redmine:
- https://redmine.weseek.co.jp/issues/107937
- https://redmine.weseek.co.jp/issues/107646
- https://redmine.weseek.co.jp/issues/108387
