### PR TITLE
fix: page item controll VRT

### DIFF
--- a/packages/app/src/components/PageList/PageListItemL.tsx
+++ b/packages/app/src/components/PageList/PageListItemL.tsx
@@ -248,7 +248,7 @@ const PageListItemLSubstance: ForwardRefRenderFunction<ISelectable, Props> = (pr
                   <div dangerouslySetInnerHTML={{ __html: elasticSearchResult.snippet }}></div>
                 ) }
                 { revisionShortBody != null && (
-                  <div>{revisionShortBody}</div>
+                  <div data-testid="revision-short-body-in-page-list-item-L">{revisionShortBody}</div>
                 ) }
                 {
                   !canRenderESSnippet && !canRenderRevisionSnippet && (

--- a/packages/app/test/cypress/integration/20-basic-features/use-tools.spec.ts
+++ b/packages/app/test/cypress/integration/20-basic-features/use-tools.spec.ts
@@ -313,14 +313,15 @@ context('Tag Oprations', () =>{
           cy.wrap($row).within(() => {
             cy.getByTestid('open-page-item-control-btn').first().click();
             cy.getByTestid('page-item-control-menu').should('have.class', 'show').first().within(() => {
-            // eslint-disable-next-line cypress/no-unnecessary-waiting
-            cy.wait(300);
-            cy.screenshot(`${ssPrefix}2-open-page-item-control-menu`);
             })
           });
         }
       });
     });
+
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(300);
+    cy.screenshot(`${ssPrefix}2-open-page-item-control-menu`);
 
     cy.getByTestid('search-result-list').within(() => {
       cy.get('.list-group-item').each(($row) => {

--- a/packages/app/test/cypress/integration/20-basic-features/use-tools.spec.ts
+++ b/packages/app/test/cypress/integration/20-basic-features/use-tools.spec.ts
@@ -313,15 +313,14 @@ context('Tag Oprations', () =>{
           cy.wrap($row).within(() => {
             cy.getByTestid('open-page-item-control-btn').first().click();
             cy.getByTestid('page-item-control-menu').should('have.class', 'show').first().within(() => {
+              // empty sentence in page list empty: https://github.com/weseek/growi/pull/6880
+              cy.getByTestid('revision-short-body-in-page-list-item-L').invoke('text', '');
+              cy.screenshot(`${ssPrefix}2-open-page-item-control-menu`);
             })
           });
         }
       });
     });
-
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(300);
-    cy.screenshot(`${ssPrefix}2-open-page-item-control-menu`);
 
     cy.getByTestid('search-result-list').within(() => {
       cy.get('.list-group-item').each(($row) => {


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/107997

## やったこと
https://growi-vrt-snapshots.s3.amazonaws.com/6752b5389f7284fc5d551e1c869269fe83f49897/index.html?id=changed-20-basic-features/use-tools.spec.ts/tag-operations-page-rename-2-open-page-item-control-menu.png#changed-20-basic-features/access-to-page.spec.ts/access-to-page--sandbox-edit-page.png
VRTエラーの修正

PageItemControllのVRTですが、後ろのコンポーネントの文字で差分が出ていたっぽいので、後ろのコンポーネントの文字を空文字にしてスクショを撮りました