### PR TITLE
fix: accessory modal vrt

### DIFF
--- a/packages/app/src/components/User/UserDate.jsx
+++ b/packages/app/src/components/User/UserDate.jsx
@@ -16,7 +16,7 @@ export default class UserDate extends React.Component {
     const dt = format(date, this.props.format);
 
     return (
-      <span className={this.props.className} data-hide-in-vrt="true">
+      <span className={this.props.className} data-hide-in-vrt>
         {dt}
       </span>
     );

--- a/packages/app/src/components/User/UserDate.jsx
+++ b/packages/app/src/components/User/UserDate.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import { format } from 'date-fns';
+import PropTypes from 'prop-types';
+
 
 /**
  * UserDate
@@ -15,7 +16,7 @@ export default class UserDate extends React.Component {
     const dt = format(date, this.props.format);
 
     return (
-      <span className={this.props.className}>
+      <span className={this.props.className} data-hide-in-vrt="true">
         {dt}
       </span>
     );

--- a/packages/app/test/cypress/integration/20-basic-features/use-tools.spec.ts
+++ b/packages/app/test/cypress/integration/20-basic-features/use-tools.spec.ts
@@ -176,7 +176,7 @@ context('Page Accessories Modal', () => {
   });
 
   it('Page History is shown successfully', () => {
-     cy.visit('/Sandbox/Bootstrap4', {  });
+     cy.visit('/Sandbox/Bootstrap4');
      cy.get('#grw-subnav-container').within(() => {
       cy.getByTestid('open-page-item-control-btn').within(() => {
         cy.get('button.btn-page-item-control').click({force: true});


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/107995

##やったこと
VRTエラーの修正

修正前
https://growi-vrt-snapshots.s3.amazonaws.com/6752b5389f7284fc5d551e1c869269fe83f49897/index.html?id=changed-20-basic-features/use-tools.spec.ts/access-to-page-accessories-modal-open-page-history-bootstrap4.png#changed-20-basic-features/access-to-page.spec.ts/access-to-page--sandbox-edit-page.png

修正後

日付の部分をブラックアウトしたので、差分が出ていますがafterの方が正しいので無視しています