### PR TITLE
fix: Gear button does not appear on user group details

### DIFF
--- a/packages/app/src/pages/admin/user-group-detail/[userGroupId].page.tsx
+++ b/packages/app/src/pages/admin/user-group-detail/[userGroupId].page.tsx
@@ -42,14 +42,15 @@ const AdminUserGroupDetailPage: NextPage<Props> = (props: Props) => {
   );
 };
 
-export const getServerSideProps: GetServerSideProps = async(context: GetServerSidePropsContext) => {
-  const props = await retrieveServerSideProps(context);
+const injectServerConfigurations = async(context: GetServerSidePropsContext, props: Props): Promise<void> => {
+  const req: CrowiRequest = context.req as CrowiRequest;
+  props.isAclEnabled = req.crowi.aclService.isAclEnabled();
+};
 
-  const req = context.req as CrowiRequest;
-  props.props.isAclEnabled = req.crowi.aclService.isAclEnabled();
+export const getServerSideProps: GetServerSideProps = async(context: GetServerSidePropsContext) => {
+  const props = await retrieveServerSideProps(context, injectServerConfigurations);
 
   return props;
 };
-
 
 export default AdminUserGroupDetailPage;

--- a/packages/app/src/pages/admin/user-group-detail/[userGroupId].page.tsx
+++ b/packages/app/src/pages/admin/user-group-detail/[userGroupId].page.tsx
@@ -5,7 +5,9 @@ import { useTranslation } from 'next-i18next';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
 
+import { CrowiRequest } from '~/interfaces/crowi-request';
 import { CommonProps, useCustomTitle } from '~/pages/utils/commons';
+import { useIsAclEnabled } from '~/stores/context';
 import { useIsMaintenanceMode } from '~/stores/maintenanceMode';
 
 import { retrieveServerSideProps } from '../../../utils/admin-page-util';
@@ -13,8 +15,11 @@ import { retrieveServerSideProps } from '../../../utils/admin-page-util';
 const AdminLayout = dynamic(() => import('~/components/Layout/AdminLayout'), { ssr: false });
 const UserGroupDetailPage = dynamic(() => import('~/components/Admin/UserGroupDetail/UserGroupDetailPage'), { ssr: false });
 
+type Props = CommonProps & {
+  isAclEnabled: boolean
+}
 
-const AdminUserGroupDetailPage: NextPage<CommonProps> = (props) => {
+const AdminUserGroupDetailPage: NextPage<Props> = (props: Props) => {
   const { t } = useTranslation('admin');
   useIsMaintenanceMode(props.isMaintenanceMode);
   const router = useRouter();
@@ -23,8 +28,9 @@ const AdminUserGroupDetailPage: NextPage<CommonProps> = (props) => {
   const title = t('user_group_management.user_group_management');
   const customTitle = useCustomTitle(props, title);
 
-
   const currentUserGroupId = Array.isArray(userGroupId) ? userGroupId[0] : userGroupId;
+
+  useIsAclEnabled(props.isAclEnabled);
 
   return (
     <AdminLayout title={customTitle} componentTitle={title} >
@@ -38,6 +44,10 @@ const AdminUserGroupDetailPage: NextPage<CommonProps> = (props) => {
 
 export const getServerSideProps: GetServerSideProps = async(context: GetServerSidePropsContext) => {
   const props = await retrieveServerSideProps(context);
+
+  const req = context.req as CrowiRequest;
+  props.props.isAclEnabled = req.crowi.aclService.isAclEnabled();
+
   return props;
 };
 


### PR DESCRIPTION
## Task
[#108151](https://redmine.weseek.co.jp/issues/108151) [Next.js][Admin][UserGroup] 詳細画面の子グループ一覧テーブル右端に歯車ボタンが存在ない
└ [#108153](https://redmine.weseek.co.jp/issues/108153) 修正