### PR TITLE
fix: Reset alerts for every registration challenge

### DIFF
--- a/packages/app/src/components/LoginForm.tsx
+++ b/packages/app/src/components/LoginForm.tsx
@@ -263,6 +263,11 @@ export const LoginForm = (props: LoginFormProps): JSX.Element => {
     );
   }, [props, renderExternalAuthInput]);
 
+  const resetRegisterErrors = useCallback(() => {
+    if (registerErrors.length === 0) return;
+    setRegisterErrors([]);
+  }, [registerErrors.length]);
+
   const handleRegisterFormSubmit = useCallback(async(e, requestPath) => {
     e.preventDefault();
     setEmailForRegistrationOrder('');
@@ -276,6 +281,9 @@ export const LoginForm = (props: LoginFormProps): JSX.Element => {
     };
     try {
       const res = await apiv3Post(requestPath, { registerForm });
+
+      resetRegisterErrors();
+
       const { redirectTo } = res.data;
       router.push(redirectTo ?? '/');
 
@@ -291,12 +299,7 @@ export const LoginForm = (props: LoginFormProps): JSX.Element => {
       }
     }
     return;
-  }, [emailForRegister, nameForRegister, passwordForRegister, router, usernameForRegister, isEmailAuthenticationEnabled]);
-
-  const resetRegisterErrors = useCallback(() => {
-    if (registerErrors.length === 0) return;
-    setRegisterErrors([]);
-  }, [registerErrors.length]);
+  }, [usernameForRegister, nameForRegister, emailForRegister, passwordForRegister, resetRegisterErrors, router, isEmailAuthenticationEnabled]);
 
   const switchForm = useCallback(() => {
     setIsRegistering(!isRegistering);


### PR DESCRIPTION
## Task
[#107539](https://redmine.weseek.co.jp/issues/107539) [Next.js] メールからの招待による新規ユーザーの有効化(activation)ができる
└ [#108505](https://redmine.weseek.co.jp/issues/108505) メール未設定時のエラーアラートを表示した後に、メール設定をしてメール送信完了アラートを表示した後にエラーアラートが残り続けてしまっているバグの修正