### PR TITLE
support: refactor customize layout in admin

### DIFF
--- a/packages/app/src/components/Admin/Customize/CustomizeLayoutSetting.tsx
+++ b/packages/app/src/components/Admin/Customize/CustomizeLayoutSetting.tsx
@@ -42,6 +42,14 @@ const CustomizeLayoutSetting = (): JSX.Element => {
     }
   }, [isContainerFluid, updateLayoutSetting, t]);
 
+  if (isContainerFluid == null) {
+    return (
+      <div className="text-muted text-center">
+        <i className="fa fa-2x fa-spinner fa-pulse"></i>
+      </div>
+    );
+  }
+
   return (
     <React.Fragment>
       <div className="row">

--- a/packages/app/src/components/Admin/Customize/CustomizeLayoutSetting.tsx
+++ b/packages/app/src/components/Admin/Customize/CustomizeLayoutSetting.tsx
@@ -31,9 +31,9 @@ const CustomizeLayoutSetting = (): JSX.Element => {
   const { isContainerFluid, setIsContainerFluid, updateLayoutSetting } = useIsContainerFluid();
   const [retrieveError, setRetrieveError] = useState<any>();
 
-  const onClickSubmit = useCallback(() => {
+  const onClickSubmit = useCallback(async() => {
     try {
-      updateLayoutSetting({ isContainerFluid });
+      await updateLayoutSetting({ isContainerFluid });
       toastSuccess(t('toaster.update_successed', { target: t('customize_settings.layout'), ns: 'commons' }));
     }
     catch (err) {

--- a/packages/app/src/components/Admin/Customize/CustomizeLayoutSetting.tsx
+++ b/packages/app/src/components/Admin/Customize/CustomizeLayoutSetting.tsx
@@ -42,8 +42,6 @@ const CustomizeLayoutSetting = (): JSX.Element => {
     }
   }, [isContainerFluid, updateLayoutSetting, t]);
 
-  if (isContainerFluid == null) { return <></> }
-
   return (
     <React.Fragment>
       <div className="row">

--- a/packages/app/src/components/Admin/Customize/CustomizeLayoutSetting.tsx
+++ b/packages/app/src/components/Admin/Customize/CustomizeLayoutSetting.tsx
@@ -17,7 +17,7 @@ const useIsContainerFluid = () => {
   }, [layoutSetting?.isContainerFluid]);
 
   return {
-    isContainerFluid: isContainerFluid ?? false,
+    isContainerFluid,
     setIsContainerFluid,
     updateLayoutSetting,
   };
@@ -32,6 +32,7 @@ const CustomizeLayoutSetting = (): JSX.Element => {
   const [retrieveError, setRetrieveError] = useState<any>();
 
   const onClickSubmit = useCallback(async() => {
+    if (isContainerFluid == null) { return }
     try {
       await updateLayoutSetting({ isContainerFluid });
       toastSuccess(t('toaster.update_successed', { target: t('customize_settings.layout'), ns: 'commons' }));
@@ -40,6 +41,8 @@ const CustomizeLayoutSetting = (): JSX.Element => {
       toastError(err);
     }
   }, [isContainerFluid, updateLayoutSetting, t]);
+
+  if (isContainerFluid == null) { return <></> }
 
   return (
     <React.Fragment>

--- a/packages/app/src/components/Admin/Customize/CustomizeLayoutSetting.tsx
+++ b/packages/app/src/components/Admin/Customize/CustomizeLayoutSetting.tsx
@@ -1,4 +1,6 @@
-import React, { useCallback, useState } from 'react';
+import React, {
+  useCallback, useEffect, useState,
+} from 'react';
 
 import { useTranslation } from 'next-i18next';
 
@@ -6,18 +8,32 @@ import { toastSuccess, toastError } from '~/client/util/apiNotification';
 import { useSWRxLayoutSetting } from '~/stores/admin/customize';
 import { useNextThemes } from '~/stores/use-next-themes';
 
+const useIsContainerFluid = () => {
+  const { data: layoutSetting, update: updateLayoutSetting } = useSWRxLayoutSetting();
+  const [isContainerFluid, setIsContainerFluid] = useState<boolean>();
+
+  useEffect(() => {
+    setIsContainerFluid(layoutSetting?.isContainerFluid);
+  }, [layoutSetting?.isContainerFluid]);
+
+  return {
+    isContainerFluid: isContainerFluid ?? false,
+    setIsContainerFluid,
+    updateLayoutSetting,
+  };
+};
+
 const CustomizeLayoutSetting = (): JSX.Element => {
   const { t } = useTranslation('admin');
 
   const { resolvedTheme } = useNextThemes();
-  const { data: layoutSetting, update: updateLayoutSetting } = useSWRxLayoutSetting();
 
-  const [isContainerFluid, setIsContainerFluid] = useState<boolean>(layoutSetting?.isContainerFluid ?? false);
+  const { isContainerFluid, setIsContainerFluid, updateLayoutSetting } = useIsContainerFluid();
   const [retrieveError, setRetrieveError] = useState<any>();
 
-  const onClickSubmit = useCallback(async() => {
+  const onClickSubmit = useCallback(() => {
     try {
-      await updateLayoutSetting({ isContainerFluid });
+      updateLayoutSetting({ isContainerFluid });
       toastSuccess(t('toaster.update_successed', { target: t('customize_settings.layout'), ns: 'commons' }));
     }
     catch (err) {


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/108654

## やったこと
- 管理者画面 => カスタマイズ のレイアウトの項目で初期値がうまく設定されていなかった不具合を修正
- ~~ワイドビューを切り替えるスイッチの挙動を修正~~スイッチの切り替えと同時に、ページの再レンダリングが走るのでスイッチ切り替え後にドロップダウンの表示を保持するのは無理なので、何も修正していません