### PR TITLE
fix: Password reset link appears on login form when password reset is not enabled

### DIFF
--- a/packages/app/src/pages/login.page.tsx
+++ b/packages/app/src/pages/login.page.tsx
@@ -45,7 +45,6 @@ const LoginPage: NextPage<Props> = (props: Props) => {
   return (
     <NoLoginLayout title={useCustomTitle(props, 'GROWI')} className={classNames.join(' ')}>
       <LoginForm
-        // Todo: These props should be set properly. https://redmine.weseek.co.jp/issues/104847
         objOfIsExternalAuthEnableds={props.enabledStrategies}
         isLocalStrategySetup={props.isLocalStrategySetup}
         isLdapStrategySetup={props.isLdapStrategySetup}

--- a/packages/app/src/pages/login.page.tsx
+++ b/packages/app/src/pages/login.page.tsx
@@ -28,6 +28,7 @@ type Props = CommonProps & {
   isLocalStrategySetup: boolean,
   isLdapStrategySetup: boolean,
   isLdapSetupFailed: boolean,
+  isPasswordResetEnabled: boolean,
   isEmailAuthenticationEnabled: boolean,
 };
 
@@ -51,7 +52,7 @@ const LoginPage: NextPage<Props> = (props: Props) => {
         isLdapSetupFailed={props.isLdapSetupFailed}
         isEmailAuthenticationEnabled={props.isEmailAuthenticationEnabled}
         registrationWhiteList={props.registrationWhiteList}
-        isPasswordResetEnabled={true}
+        isPasswordResetEnabled={props.isPasswordResetEnabled}
         isMailerSetup={props.isMailerSetup}
         registrationMode={props.registrationMode}
       />
@@ -99,6 +100,7 @@ async function injectServerConfigurations(context: GetServerSidePropsContext, pr
     passportService,
   } = crowi;
 
+  props.isPasswordResetEnabled = crowi.configManager.getConfig('crowi', 'security:passport-local:isPasswordResetEnabled');
   props.isMailerSetup = mailService.isMailerSetup;
   props.isLocalStrategySetup = passportService.isLocalStrategySetup;
   props.isLdapStrategySetup = passportService.isLdapStrategySetup;


### PR DESCRIPTION
## Task
[#108733](https://redmine.weseek.co.jp/issues/108733) [Next.js] ユーザーによるパスワード再設定 が有効でない時にログインフォームにパスワードリセットへのリンクが表示されてしまっている
└ [#108734](https://redmine.weseek.co.jp/issues/108734) 修正