### PR TITLE
fix: Cannot Login to GROWI by local machine in VRT

### DIFF
--- a/packages/app/test/cypress/support/commands.ts
+++ b/packages/app/test/cypress/support/commands.ts
@@ -34,7 +34,10 @@ Cypress.Commands.add('login', (username, password) => {
     cy.visit('/page-to-return-after-login');
     cy.getByTestid('tiUsernameForLogin').type(username);
     cy.getByTestid('tiPasswordForLogin').type(password);
+
+    cy.intercept('POST', '/_api/v3/login').as('login');
     cy.getByTestid('btnSubmitForLogin').click();
+    cy.wait('@login')
   });
 });
 


### PR DESCRIPTION
## Task
[#108841](https://redmine.weseek.co.jp/issues/108841) [VRT] ローカルマシンで Cypress のテストを行う際に GROWI にログインできない
└ [#108842](https://redmine.weseek.co.jp/issues/108842) 修正