### PR TITLE
fix: share link modal vrt

### DIFF
--- a/packages/app/test/cypress/integration/20-basic-features/use-tools.spec.ts
+++ b/packages/app/test/cypress/integration/20-basic-features/use-tools.spec.ts
@@ -206,6 +206,7 @@ context('Page Accessories Modal', () => {
       cy.getByTestid('open-page-item-control-btn').within(() => {
         cy.get('button.btn-page-item-control').click({force: true});
       });
+      cy.getByTestid('open-page-accessories-modal-btn-with-share-link-management-data-tab').should('be.visible');
       cy.getByTestid('open-page-accessories-modal-btn-with-share-link-management-data-tab').click();
    });
 


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/108869

修正前
https://growi-vrt-snapshots.s3.amazonaws.com/4a4d3cd24e7f0d6ea6d98b7360acacd2d323b69b/index.html?id=new-20-basic-features/use-tools.spec.ts/Page%20Accessories%20Modal%20--%20Share%20Link%20Management%20is%20shown%20successfully%20(failed).png#new-20-basic-features/use-tools.spec.ts/Page%20Accessories%20Modal%20--%20Share%20Link%20Management%20is%20shown%20successfully%20(failed).png


修正後
https://growi-vrt-snapshots.s3.amazonaws.com/e1e9c34c0e6390f6c2a40bf2422021cb6020f114/index.html?id=passed-20-basic-features/use-tools.spec.ts/access-to-page-accessories-modal-open-share-link-management-bootstrap4.png#passed-20-basic-features/access-to-pagelist.spec.ts/access-to-pagelist-4-input-duplicated-page-name.png
