### PR TITLE
feat: Enable PasteFiles and ScrollCursorIntoView on CodeMirrorEditor

### DIFF
--- a/packages/app/src/components/PageEditor/CodeMirrorEditor.jsx
+++ b/packages/app/src/components/PageEditor/CodeMirrorEditor.jsx
@@ -1064,12 +1064,6 @@ class CodeMirrorEditor extends AbstractEditor {
           ref={this.cm}
           className={additionalClasses}
           placeholder="search"
-          // == temporary deactivate editorDidMount to use https://github.com/scniro/react-codemirror2/issues/284#issuecomment-1155928554
-          // editorDidMount={(editor) => {
-          // // add event handlers
-          //   editor.on('paste', this.pasteHandler);
-          //   editor.on('scrollCursorIntoView', this.scrollCursorIntoViewHandler);
-          // }}
           value={this.props.value}
           options={{
             indentUnit: this.props.indentSize,
@@ -1116,8 +1110,8 @@ class CodeMirrorEditor extends AbstractEditor {
           }}
           onKeyPress={this.keyPressHandler}
           onKeyDown={this.keyDownHandler}
-          pasteHandler={this.pasteHandler}
-          scrollCursorIntoViewHandler={this.scrollCursorIntoViewHandler}
+          onPasteFiles={this.pasteHandler}
+          onScrollCursorIntoView={this.scrollCursorIntoViewHandler}
         />
 
         { this.renderLoadingKeymapOverlay() }

--- a/packages/app/src/components/PageEditor/CodeMirrorEditor.jsx
+++ b/packages/app/src/components/PageEditor/CodeMirrorEditor.jsx
@@ -1116,6 +1116,8 @@ class CodeMirrorEditor extends AbstractEditor {
           }}
           onKeyPress={this.keyPressHandler}
           onKeyDown={this.keyDownHandler}
+          pasteHandler={this.pasteHandler}
+          scrollCursorIntoViewHandler={this.scrollCursorIntoViewHandler}
         />
 
         { this.renderLoadingKeymapOverlay() }

--- a/packages/app/src/components/UncontrolledCodeMirror.tsx
+++ b/packages/app/src/components/UncontrolledCodeMirror.tsx
@@ -26,17 +26,27 @@ export interface UncontrolledCodeMirrorProps extends ICodeMirror {
   onSave?: () => Promise<void>;
   onPasteFiles?: (event: Event) => void;
   onCtrlEnter?: (event: Event) => void;
+  pasteHandler: (editor: any, event: Event) => void;
+  scrollCursorIntoViewHandler: (editor: any, event: Event) => void;
 }
 
 export const UncontrolledCodeMirror = React.forwardRef<CodeMirror|null, UncontrolledCodeMirrorProps>((props, forwardedRef): JSX.Element => {
 
-  const wrapperRef = useRef<CodeMirror|null>();
+  const {
+    value, lineNumbers, options,
+    pasteHandler, scrollCursorIntoViewHandler,
+    ...rest
+  } = props;
 
   const editorRef = useRef<Editor>();
 
+  const wrapperRef = useRef<CodeMirror|null>();
+
   const editorDidMountHandler = useCallback((editor: Editor): void => {
     editorRef.current = editor;
-  }, []);
+    editor.on('paste', pasteHandler);
+    editor.on('scrollCursorIntoView', scrollCursorIntoViewHandler);
+  }, [pasteHandler, scrollCursorIntoViewHandler]);
 
   const editorWillUnmountHandler = useCallback((): void => {
     // workaround to fix editor duplicating by https://github.com/scniro/react-codemirror2/issues/284#issuecomment-1155928554
@@ -47,11 +57,6 @@ export const UncontrolledCodeMirror = React.forwardRef<CodeMirror|null, Uncontro
       (wrapperRef.current as any).hydrated = false;
     }
   }, []);
-
-  const {
-    value, lineNumbers, options,
-    ...rest
-  } = props;
 
   // default true
   const isGfmMode = rest.isGfmMode ?? true;

--- a/packages/app/src/components/UncontrolledCodeMirror.tsx
+++ b/packages/app/src/components/UncontrolledCodeMirror.tsx
@@ -26,8 +26,8 @@ export interface UncontrolledCodeMirrorProps extends ICodeMirror {
   onSave?: () => Promise<void>;
   onPasteFiles?: (event: Event) => void;
   onCtrlEnter?: (event: Event) => void;
-  pasteHandler: (editor: any, event: Event) => void;
-  scrollCursorIntoViewHandler: (editor: any, event: Event) => void;
+  pasteHandler?: (editor: any, event: Event) => void;
+  scrollCursorIntoViewHandler?: (editor: any, event: Event) => void;
 }
 
 export const UncontrolledCodeMirror = React.forwardRef<CodeMirror|null, UncontrolledCodeMirrorProps>((props, forwardedRef): JSX.Element => {
@@ -44,8 +44,13 @@ export const UncontrolledCodeMirror = React.forwardRef<CodeMirror|null, Uncontro
 
   const editorDidMountHandler = useCallback((editor: Editor): void => {
     editorRef.current = editor;
-    editor.on('paste', pasteHandler);
-    editor.on('scrollCursorIntoView', scrollCursorIntoViewHandler);
+
+    if (pasteHandler != null) {
+      editor.on('paste', pasteHandler);
+    }
+    if (scrollCursorIntoViewHandler != null) {
+      editor.on('scrollCursorIntoView', scrollCursorIntoViewHandler);
+    }
   }, [pasteHandler, scrollCursorIntoViewHandler]);
 
   const editorWillUnmountHandler = useCallback((): void => {

--- a/packages/app/src/components/UncontrolledCodeMirror.tsx
+++ b/packages/app/src/components/UncontrolledCodeMirror.tsx
@@ -22,19 +22,17 @@ export interface UncontrolledCodeMirrorProps extends ICodeMirror {
   value: string;
   isGfmMode?: boolean;
   lineNumbers?: boolean;
-  onScrollCursorIntoView?: (line: number) => void;
   onSave?: () => Promise<void>;
-  onPasteFiles?: (event: Event) => void;
   onCtrlEnter?: (event: Event) => void;
-  pasteHandler?: (editor: any, event: Event) => void;
-  scrollCursorIntoViewHandler?: (editor: any, event: Event) => void;
+  onPasteFiles?: (editor: any, event: Event) => void;
+  onScrollCursorIntoView?: (editor: any, event: Event) => void;
 }
 
 export const UncontrolledCodeMirror = React.forwardRef<CodeMirror|null, UncontrolledCodeMirrorProps>((props, forwardedRef): JSX.Element => {
 
   const {
     value, lineNumbers, options,
-    pasteHandler, scrollCursorIntoViewHandler,
+    onPasteFiles, onScrollCursorIntoView,
     ...rest
   } = props;
 
@@ -44,14 +42,13 @@ export const UncontrolledCodeMirror = React.forwardRef<CodeMirror|null, Uncontro
 
   const editorDidMountHandler = useCallback((editor: Editor): void => {
     editorRef.current = editor;
-
-    if (pasteHandler != null) {
-      editor.on('paste', pasteHandler);
+    if (onPasteFiles != null) {
+      editor.on('paste', onPasteFiles);
     }
-    if (scrollCursorIntoViewHandler != null) {
-      editor.on('scrollCursorIntoView', scrollCursorIntoViewHandler);
+    if (onScrollCursorIntoView != null) {
+      editor.on('scrollCursorIntoView', onScrollCursorIntoView);
     }
-  }, [pasteHandler, scrollCursorIntoViewHandler]);
+  }, [onPasteFiles, onScrollCursorIntoView]);
 
   const editorWillUnmountHandler = useCallback((): void => {
     // workaround to fix editor duplicating by https://github.com/scniro/react-codemirror2/issues/284#issuecomment-1155928554


### PR DESCRIPTION
task: [107525](https://redmine.weseek.co.jp/issues/107525)
scrollCursorIntoViewHandler の有効化もこのPRに含めました

- [x] Editor に clipboard から attachment の貼り付けができる
- [x] Editor の任意の行をクリックすると、View 画面がその行を表す場所までスクロールする
