### PR TITLE
fix: Cannot show putback button menu in page item control for newly deleted page

### DIFF
--- a/packages/app/src/components/PutbackPageModal.jsx
+++ b/packages/app/src/components/PutbackPageModal.jsx
@@ -9,6 +9,7 @@ import {
 import { apiPost } from '~/client/util/apiv1-client';
 import { PathAlreadyExistsError } from '~/server/models/errors';
 import { usePutBackPageModal } from '~/stores/modal';
+import { usePageInfoTermManager } from '~/stores/page';
 
 import ApiErrorMessageList from './PageManagement/ApiErrorMessageList';
 
@@ -16,6 +17,7 @@ const PutBackPageModal = () => {
   const { t } = useTranslation();
 
   const { data: pageDataToRevert, close: closePutBackPageModal } = usePutBackPageModal();
+  const { advance: advancePi } = usePageInfoTermManager();
   const { isOpened, page } = pageDataToRevert;
   const { pageId, path } = page;
   const onPutBacked = pageDataToRevert.opts?.onPutBacked;
@@ -41,6 +43,7 @@ const PutBackPageModal = () => {
         page_id: pageId,
         recursively,
       });
+      advancePi();
 
       if (onPutBacked != null) {
         onPutBacked(response.page.path);

--- a/packages/app/src/components/Sidebar/PageTree/ItemsTree.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/ItemsTree.tsx
@@ -15,7 +15,7 @@ import { useIsEnabledAttachTitleHeader } from '~/stores/context';
 import {
   IPageForPageDuplicateModal, usePageDuplicateModal, usePageDeleteModal,
 } from '~/stores/modal';
-import { useCurrentPagePath, useSWRxCurrentPage } from '~/stores/page';
+import { useCurrentPagePath, usePageInfoTermManager, useSWRxCurrentPage } from '~/stores/page';
 import {
   usePageTreeTermManager, useSWRxPageAncestorsChildren, useSWRxRootPage, useDescendantsPageListForCurrentPathTermManager,
 } from '~/stores/page-listing';
@@ -117,6 +117,7 @@ const ItemsTree = (props: ItemsTreeProps): JSX.Element => {
   const { advance: advancePt } = usePageTreeTermManager();
   const { advance: advanceFts } = useFullTextSearchTermManager();
   const { advance: advanceDpl } = useDescendantsPageListForCurrentPathTermManager();
+  const { advance: advancePi } = usePageInfoTermManager();
 
   const [isInitialScrollCompleted, setIsInitialScrollCompleted] = useState(false);
 
@@ -186,6 +187,7 @@ const ItemsTree = (props: ItemsTreeProps): JSX.Element => {
       advancePt();
       advanceFts();
       advanceDpl();
+      advancePi();
 
       if (currentPagePath === pathOrPathsToDelete) {
         mutateCurrentPage();

--- a/packages/app/src/stores/page.tsx
+++ b/packages/app/src/stores/page.tsx
@@ -83,7 +83,7 @@ export const useSWRxTagsInfo = (pageId: Nullable<string>): SWRResponse<IPageTags
 };
 
 export const usePageInfoTermManager = (isDisabled?: boolean) : SWRResponse<number, Error> & ITermNumberManagerUtil => {
-  return useTermNumberManager(isDisabled === true ? null : 'descendantsPageListForCurrentPathTermNumber');
+  return useTermNumberManager(isDisabled === true ? null : 'pageInfoTermNumber');
 };
 
 export const useSWRxPageInfo = (


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/107883

以下のタイミングでSWR  を使って  `/page/info`  対してGET リクエストを投げている
- ページツリーからページ削除をするために3点ボタンをクリックした時
- `/trash` ページから「 ページを元に戻す」をするために3点ボタンをクリックした時

同じページを対象にしている場合、2回目の key が 1回目と同じ key になるためリクエストが投げられずにキャッシュされた値を使っているみたいなので `isRevertible` が1回目の操作と変わらず今回のバグになっていた模様。（上記の操作順を変えても同じ現象になる。）
なので、termNumberManager を追加し新規リクエストを投げるようにした。

失敗↓
![fail-show-putback-btn](https://user-images.githubusercontent.com/35527421/202217296-3c2da396-f24e-433a-a921-57c55e71c184.gif)

成功↓
![success-show-putback-btn](https://user-images.githubusercontent.com/35527421/202217331-1245b6ea-1578-4c42-8254-8cfa7bbfa467.gif)
