### PR TITLE
fix: VRT 20 basic-features-use-tools.spec.ts-Tag Oprations

### DIFF
--- a/packages/app/test/cypress/integration/20-basic-features/use-tools.spec.ts
+++ b/packages/app/test/cypress/integration/20-basic-features/use-tools.spec.ts
@@ -241,7 +241,10 @@ context('Tag Oprations', () =>{
     cy.visit('/Sandbox');
     cy.waitUntilSkeletonDisappear();
 
-    cy.get('#edit-tags-btn-wrapper-for-tooltip > a').should('be.visible').click();
+    cy.get('#edit-tags-btn-wrapper-for-tooltip > a').should('be.visible');
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(200);
+    cy.get('#edit-tags-btn-wrapper-for-tooltip > a').click();
     cy.get('#edit-tag-modal').should('be.visible').screenshot(`${ssPrefix}1-edit-tag-input`);
 
     cy.get('#edit-tag-modal').within(() => {


### PR DESCRIPTION
Redmine: https://redmine.weseek.co.jp/issues/108859

# もとの VRT
https://growi-vrt-snapshots.s3.amazonaws.com/4a4d3cd24e7f0d6ea6d98b7360acacd2d323b69b/index.html?id=changed-20-basic-features/use-tools.spec.ts/Tag%20Oprations%20--%20Successfully%20add%20new%20tag%20(failed).png#changed-20-basic-features/use-tools.spec.ts/Tag%20Oprations%20--%20Successfully%20add%20new%20tag%20(failed).png

# 今
https://growi-vrt-snapshots.s3.amazonaws.com/1c603df1849c2ee3eebe9fd53cb71c9ed8e5e787/index.html#passed-20-basic-features/use-tools.spec.ts/tag-operations-add-new-tag-1-edit-tag-input.png

成功してるっぽい？です