### PR TITLE
fix: input focus color is not applied

### DIFF
--- a/packages/app/src/styles/theme/_apply-colors-dark.scss
+++ b/packages/app/src/styles/theme/_apply-colors-dark.scss
@@ -65,6 +65,7 @@ textarea.form-control {
   background-color: darken($bgcolor-global, 5%);
   border-color: $border-color-global;
   &:focus {
+    color: $color-global;
     background-color: $bgcolor-global;
   }
   // FIXME: accent color

--- a/packages/app/src/styles/theme/_apply-colors-dark.scss
+++ b/packages/app/src/styles/theme/_apply-colors-dark.scss
@@ -65,7 +65,6 @@ textarea.form-control {
   background-color: darken($bgcolor-global, 5%);
   border-color: $border-color-global;
   &:focus {
-    color: $color-global;
     background-color: $bgcolor-global;
   }
   // FIXME: accent color

--- a/packages/app/src/styles/theme/_apply-colors.scss
+++ b/packages/app/src/styles/theme/_apply-colors.scss
@@ -85,11 +85,6 @@ code:not([class^='language-']) {
   }
 }
 
-// Form
-.form-control {
-  // @include form-control-focus();
-}
-
 // Tabs
 .nav.nav-tabs .nav-link.active {
   color: $color-link !important;

--- a/packages/app/src/styles/theme/_apply-colors.scss
+++ b/packages/app/src/styles/theme/_apply-colors.scss
@@ -85,6 +85,11 @@ code:not([class^='language-']) {
   }
 }
 
+// Form
+.form-control {
+  @include form-control-focus();
+}
+
 // Tabs
 .nav.nav-tabs .nav-link.active {
   color: $color-link !important;

--- a/packages/app/src/styles/theme/_apply-colors.scss
+++ b/packages/app/src/styles/theme/_apply-colors.scss
@@ -1,8 +1,11 @@
 @use '../variables' as var;
-@use '../bootstrap/init' as *;
 @use '../mixins';
 @use './mixins/tables'; // comment out and use _reboot-bootstrap-tables instead -- 2020.05.28 Yuki Takei
 @use '../atoms/mixins/code';
+
+@import '../bootstrap/init';
+
+
 
 //
 //== Apply to Bootstrap

--- a/packages/app/src/styles/theme/_apply-colors.scss
+++ b/packages/app/src/styles/theme/_apply-colors.scss
@@ -87,7 +87,7 @@ code:not([class^='language-']) {
 
 // Form
 .form-control {
-  @include form-control-focus();
+  // @include form-control-focus();
 }
 
 // Tabs

--- a/packages/app/src/styles/theme/_apply-colors.scss
+++ b/packages/app/src/styles/theme/_apply-colors.scss
@@ -5,8 +5,6 @@
 
 @import '../bootstrap/init';
 
-
-
 //
 //== Apply to Bootstrap
 //


### PR DESCRIPTION
## Task
[Next.js][Style] ダークモード時のインプットの入力中文字のスタイルを見やすくする(v5 に揃える)
┗[109440](https://redmine.weseek.co.jp/issues/109440) 修正

## Description
ダークモードで、input focus時の色が薄くなってしまうのを修正しました。



## Before
- dark modeで、input focus 時に、テキストを入力すると、色が薄くなってしまう
- (focus していない時は期待する色になります)

<img width="646" alt="Screen Shot 2022-11-22 at 14 22 08" src="https://user-images.githubusercontent.com/59536731/203228680-a20e1837-9c71-4cdb-833e-553df9da8b27.png">
<img width="315" alt="Screen Shot 2022-11-22 at 14 22 15" src="https://user-images.githubusercontent.com/59536731/203228683-5d6b0a16-b625-4747-b2c0-440924590470.png">

## After
<img width="637" alt="Screen Shot 2022-11-22 at 14 24 36" src="https://user-images.githubusercontent.com/59536731/203228942-cb218571-422e-4fdd-bfa7-af980c14ec6d.png">
<img width="273" alt="Screen Shot 2022-11-22 at 14 24 44" src="https://user-images.githubusercontent.com/59536731/203228947-227b6e42-0f5c-4178-a19d-7563b3b5aab8.png">


## Demo(v5.1.8)
<img width="612" alt="Screen Shot 2022-11-22 at 14 23 48" src="https://user-images.githubusercontent.com/59536731/203228819-34d2ea5e-2ffe-4c06-9ec0-9da512cb07dd.png">
<img width="367" alt="Screen Shot 2022-11-22 at 14 23 53" src="https://user-images.githubusercontent.com/59536731/203228822-1cd8b2cc-d735-4840-9b16-404a15c9ddfd.png">


