### PR TITLE
imprv: VRT Check isEnabledLinebreaksInComments is enabled

### DIFF
--- a/packages/app/test/cypress/integration/40-admin/access-to-admin-page.spec.ts
+++ b/packages/app/test/cypress/integration/40-admin/access-to-admin-page.spec.ts
@@ -45,6 +45,7 @@ context('Access to Admin page', () => {
   it('/admin/markdown is successfully loaded', () => {
     cy.visit('/admin/markdown');
     cy.getByTestid('admin-markdown').should('be.visible');
+    cy.get('#isEnabledLinebreaksInComments').should('be.checked')
     cy.screenshot(`${ssPrefix}-admin-markdown`);
   });
 


### PR DESCRIPTION
## Task
VRT 正常化 (40-admin)
┗[109429](https://redmine.weseek.co.jp/issues/109429) access-to-admin-page--admin-markdown の修正

## Description
- Markdown Settings の Line break setting にて、`Enable line break in comment`　にチェックがついた状態でスクリーンショットが取られるように修正しました。

### ローカル
<img width="1415" alt="Screen Shot 2022-11-24 at 12 37 19" src="https://user-images.githubusercontent.com/59536731/203688616-e3f83e9d-3dcf-4ee5-9311-f553e2b9bb7f.png">

### VRT(本PR)
https://growi-vrt-snapshots.s3.amazonaws.com/8333c2fcefe15cfdf619b839512c24175a06c70c/index.html?id=passed-40-admin/access-to-admin-page.spec.ts/access-to-admin-page--admin-markdown.png#passed-40-admin/access-to-admin-page.spec.ts/access-to-admin-page--admin-markdown.png

<img width="1201" alt="Screen Shot 2022-11-24 at 12 49 44" src="https://user-images.githubusercontent.com/59536731/203689887-5fc9a16d-c05d-4071-b852-d287408eacea.png">

