### PR TITLE
fix: VRT 40 Admin Page Security

### DIFF
--- a/packages/app/test/cypress/integration/40-admin/access-to-admin-page.spec.ts
+++ b/packages/app/test/cypress/integration/40-admin/access-to-admin-page.spec.ts
@@ -39,6 +39,8 @@ context('Access to Admin page', () => {
   it('/admin/security is successfully loaded', () => {
     cy.visit('/admin/security');
     cy.getByTestid('admin-security').should('be.visible');
+    cy.get('#isShowRestrictedByOwner').should('be.checked')
+    cy.get('#isShowRestrictedByGroup').should('be.checked')
     cy.screenshot(`${ssPrefix}-admin-security`);
   });
 


### PR DESCRIPTION
## Task
VRT 正常化 (40-admin)
┗ access-to-admin-page.spec.ts/access-to-admin-page--admin-security.png の修正

## Description
初期データが取得できた状態でスクリーンショットを撮るように変更

https://growi-vrt-snapshots.s3.amazonaws.com/0862e0d115609e9b84705951ddc2b49de30a95d0/index.html?id=changed-40-admin/access-to-admin-page.spec.ts/access-to-admin-page--admin-security.png#changed-40-admin/access-to-admin-page.spec.ts/access-to-admin-page--admin-security.png