### PR TITLE
fix: CustomCss does not work

### DIFF
--- a/packages/app/src/components/Layout/AdminLayout.tsx
+++ b/packages/app/src/components/Layout/AdminLayout.tsx
@@ -14,19 +14,20 @@ const HotkeysManager = dynamic(() => import('../Hotkeys/HotkeysManager'), { ssr:
 type Props = {
   title?: string
   componentTitle?: string
-  children?: ReactNode
+  children?: ReactNode,
+  customCss?: string
 }
 
 
 const AdminLayout = ({
-  children, title, componentTitle,
+  children, title, componentTitle, customCss,
 }: Props): JSX.Element => {
 
   const AdminNavigation = dynamic(() => import('~/components/Admin/Common/AdminNavigation'), { ssr: false });
   const SystemVersion = dynamic(() => import('../SystemVersion'), { ssr: false });
 
   return (
-    <RawLayout title={title}>
+    <RawLayout title={title} customCss={customCss}>
       <div className={`admin-page ${styles['admin-page']}`}>
         <GrowiNavbar />
 

--- a/packages/app/src/components/Layout/BasicLayout.tsx
+++ b/packages/app/src/components/Layout/BasicLayout.tsx
@@ -31,17 +31,18 @@ type Props = {
   title: string
   className?: string,
   expandContainer?: boolean,
-  children?: ReactNode
+  children?: ReactNode,
+  customCss: string
 }
 
 export const BasicLayout = ({
-  children, title, className, expandContainer,
+  children, title, className, expandContainer, customCss,
 }: Props): JSX.Element => {
 
   const myClassName = `${className ?? ''} ${expandContainer ? 'growi-layout-fluid' : ''}`;
 
   return (
-    <RawLayout title={title} className={myClassName}>
+    <RawLayout title={title} className={myClassName} customCss={customCss}>
 
       <DndProvider backend={HTML5Backend}>
         <GrowiNavbar />

--- a/packages/app/src/components/Layout/BasicLayout.tsx
+++ b/packages/app/src/components/Layout/BasicLayout.tsx
@@ -32,7 +32,7 @@ type Props = {
   className?: string,
   expandContainer?: boolean,
   children?: ReactNode,
-  customCss: string
+  customCss?: string
 }
 
 export const BasicLayout = ({

--- a/packages/app/src/components/Layout/NoLoginLayout.tsx
+++ b/packages/app/src/components/Layout/NoLoginLayout.tsx
@@ -10,17 +10,18 @@ type Props = {
   title: string,
   className?: string,
   children?: ReactNode,
+  customCss?: string,
 }
 
 export const NoLoginLayout = ({
-  children, title, className,
+  children, title, className, customCss,
 }: Props): JSX.Element => {
   const classNames: string[] = ['wrapper'];
   if (className != null) {
     classNames.push(className);
   }
   return (
-    <RawLayout title={title} className={`${commonStyles.nologin}`}>
+    <RawLayout title={title} className={`${commonStyles.nologin}`} customCss={customCss}>
       <div className="nologin">
         <div id="wrapper">
           <div id="page-wrapper">

--- a/packages/app/src/components/Layout/RawLayout.tsx
+++ b/packages/app/src/components/Layout/RawLayout.tsx
@@ -18,9 +18,12 @@ type Props = {
   title?: string,
   className?: string,
   children?: ReactNode,
+  customCss?: string,
 }
 
-export const RawLayout = ({ children, title, className }: Props): JSX.Element => {
+export const RawLayout = ({
+  children, title, className, customCss,
+}: Props): JSX.Element => {
   const classNames: string[] = ['layout-root', 'growi'];
   if (className != null) {
     classNames.push(className);
@@ -43,6 +46,9 @@ export const RawLayout = ({ children, title, className }: Props): JSX.Element =>
         <title>{title}</title>
         <meta charSet="utf-8" />
         <meta name="viewport" content="initial-scale=1.0, width=device-width" />
+        <style>
+          {customCss}
+        </style>
       </Head>
       <NextThemesProvider>
         <GrowiThemeProvider theme={growiTheme} colorScheme={colorScheme}>

--- a/packages/app/src/components/Layout/SearchResultLayout.tsx
+++ b/packages/app/src/components/Layout/SearchResultLayout.tsx
@@ -8,10 +8,11 @@ type Props = {
   title: string,
   className?: string,
   children?: ReactNode,
+  customCss?: string,
 }
 
 const SearchResultLayout = ({
-  children, title, className,
+  children, title, className, customCss,
 }: Props): JSX.Element => {
 
   const classNames: string[] = [];
@@ -21,7 +22,7 @@ const SearchResultLayout = ({
 
   return (
     <div className={`on-search ${commonStyles['on-search']}`}>
-      <BasicLayout title={title} className={classNames.join(' ')}>
+      <BasicLayout title={title} className={classNames.join(' ')} customCss={customCss}>
         <div id="grw-fav-sticky-trigger" className="sticky-top"></div>
         <div id="main" className="main search-page mt-0">
           { children }

--- a/packages/app/src/components/Layout/ShareLinkLayout.tsx
+++ b/packages/app/src/components/Layout/ShareLinkLayout.tsx
@@ -19,17 +19,18 @@ type Props = {
   title: string
   className?: string,
   expandContainer?: boolean,
-  children?: ReactNode
+  children?: ReactNode,
+  customCss?: string,
 }
 
 export const ShareLinkLayout = ({
-  children, title, className, expandContainer,
+  children, title, className, expandContainer, customCss,
 }: Props): JSX.Element => {
 
   const myClassName = `${className ?? ''} ${expandContainer ? 'growi-layout-fluid' : ''}`;
 
   return (
-    <RawLayout title={title} className={myClassName}>
+    <RawLayout title={title} className={myClassName} customCss={customCss}>
       <GrowiNavbar />
 
       <div className="page-wrapper d-flex d-print-block">

--- a/packages/app/src/pages/[[...path]].page.tsx
+++ b/packages/app/src/pages/[[...path]].page.tsx
@@ -174,6 +174,8 @@ type Props = CommonProps & {
   userUISettings?: IUserUISettings
   // Sidebar
   sidebarConfig: ISidebarConfig,
+
+  customCss: string,
 };
 
 const GrowiPage: NextPage<Props> = (props: Props) => {
@@ -295,7 +297,7 @@ const GrowiPage: NextPage<Props> = (props: Props) => {
         {renderHighlightJsStyleTag(props.highlightJsStyle)}
         */}
       </Head>
-      <BasicLayout title={useCustomTitle(props, 'GROWI')} className={classNames.join(' ')} expandContainer={isContainerFluid}>
+      <BasicLayout title={useCustomTitle(props, 'GROWI')} className={classNames.join(' ')} expandContainer={isContainerFluid} customCss={props.customCss}>
         <div className="h-100 d-flex flex-column justify-content-between">
           <header className="py-0 position-relative">
             <div id="grw-subnav-container">
@@ -503,7 +505,7 @@ function injectServerConfigurations(context: GetServerSidePropsContext, props: P
   const req: CrowiRequest = context.req as CrowiRequest;
   const { crowi } = req;
   const {
-    appService, searchService, configManager, aclService, slackNotificationService, mailService,
+    appService, searchService, configManager, aclService, slackNotificationService, mailService, customizeService,
   } = crowi;
 
   props.isSearchServiceConfigured = searchService.isConfigured;
@@ -553,6 +555,8 @@ function injectServerConfigurations(context: GetServerSidePropsContext, props: P
     isSidebarDrawerMode: configManager.getConfig('crowi', 'customize:isSidebarDrawerMode'),
     isSidebarClosedAtDockMode: configManager.getConfig('crowi', 'customize:isSidebarClosedAtDockMode'),
   };
+
+  props.customCss = customizeService.getCustomCss();
 }
 
 /**

--- a/packages/app/src/pages/[[...path]].page.tsx
+++ b/packages/app/src/pages/[[...path]].page.tsx
@@ -174,8 +174,6 @@ type Props = CommonProps & {
   userUISettings?: IUserUISettings
   // Sidebar
   sidebarConfig: ISidebarConfig,
-
-  customCss: string,
 };
 
 const GrowiPage: NextPage<Props> = (props: Props) => {

--- a/packages/app/src/pages/_private-legacy-pages.page.tsx
+++ b/packages/app/src/pages/_private-legacy-pages.page.tsx
@@ -41,6 +41,8 @@ type Props = CommonProps & {
   // Render config
   rendererConfig: RendererConfig,
 
+  customCss: string,
+
 };
 
 const PrivateLegacyPage: NextPage<Props> = (props: Props) => {
@@ -78,7 +80,7 @@ const PrivateLegacyPage: NextPage<Props> = (props: Props) => {
         */}
       </Head>
 
-      <SearchResultLayout title={useCustomTitle(props, 'GROWI')}>
+      <SearchResultLayout title={useCustomTitle(props, 'GROWI')} customCss={props.customCss}>
         <div id="private-regacy-pages">
           <PrivateLegacyPages />
         </div>
@@ -103,7 +105,7 @@ async function injectUserUISettings(context: GetServerSidePropsContext, props: P
 async function injectServerConfigurations(context: GetServerSidePropsContext, props: Props): Promise<void> {
   const req: CrowiRequest = context.req as CrowiRequest;
   const { crowi } = req;
-  const { configManager, searchService } = crowi;
+  const { configManager, searchService, customizeService } = crowi;
 
   props.isSearchServiceConfigured = searchService.isConfigured;
   props.isSearchServiceReachable = searchService.isReachable;
@@ -129,6 +131,8 @@ async function injectServerConfigurations(context: GetServerSidePropsContext, pr
     tagWhiteList: crowi.xssService.getTagWhiteList(),
     highlightJsStyleBorder: crowi.configManager.getConfig('crowi', 'customize:highlightJsStyleBorder'),
   };
+
+  props.customCss = customizeService.getCustomCss();
 }
 
 /**

--- a/packages/app/src/pages/_private-legacy-pages.page.tsx
+++ b/packages/app/src/pages/_private-legacy-pages.page.tsx
@@ -40,9 +40,6 @@ type Props = CommonProps & {
 
   // Render config
   rendererConfig: RendererConfig,
-
-  customCss: string,
-
 };
 
 const PrivateLegacyPage: NextPage<Props> = (props: Props) => {
@@ -105,7 +102,7 @@ async function injectUserUISettings(context: GetServerSidePropsContext, props: P
 async function injectServerConfigurations(context: GetServerSidePropsContext, props: Props): Promise<void> {
   const req: CrowiRequest = context.req as CrowiRequest;
   const { crowi } = req;
-  const { configManager, searchService, customizeService } = crowi;
+  const { configManager, searchService } = crowi;
 
   props.isSearchServiceConfigured = searchService.isConfigured;
   props.isSearchServiceReachable = searchService.isReachable;
@@ -131,8 +128,6 @@ async function injectServerConfigurations(context: GetServerSidePropsContext, pr
     tagWhiteList: crowi.xssService.getTagWhiteList(),
     highlightJsStyleBorder: crowi.configManager.getConfig('crowi', 'customize:highlightJsStyleBorder'),
   };
-
-  props.customCss = customizeService.getCustomCss();
 }
 
 /**

--- a/packages/app/src/pages/_search.page.tsx
+++ b/packages/app/src/pages/_search.page.tsx
@@ -122,7 +122,7 @@ async function injectUserUISettings(context: GetServerSidePropsContext, props: P
 function injectServerConfigurations(context: GetServerSidePropsContext, props: Props): void {
   const req: CrowiRequest = context.req as CrowiRequest;
   const { crowi } = req;
-  const { configManager, searchService, customizeService } = crowi;
+  const { configManager, searchService } = crowi;
 
   props.isSearchServiceConfigured = searchService.isConfigured;
   props.isSearchServiceReachable = searchService.isReachable;
@@ -151,7 +151,6 @@ function injectServerConfigurations(context: GetServerSidePropsContext, props: P
   };
 
   props.showPageLimitationL = configManager.getConfig('crowi', 'customize:showPageLimitationL');
-  props.customCss = customizeService.getCustomCss();
 }
 
 /**

--- a/packages/app/src/pages/_search.page.tsx
+++ b/packages/app/src/pages/_search.page.tsx
@@ -48,6 +48,7 @@ type Props = CommonProps & {
 
   isContainerFluid: boolean,
 
+  customCss: string,
 };
 
 const SearchResultPage: NextPage<Props> = (props: Props) => {
@@ -96,7 +97,7 @@ const SearchResultPage: NextPage<Props> = (props: Props) => {
         */}
       </Head>
 
-      <SearchResultLayout title={useCustomTitle(props, 'GROWI')} className={classNames.join(' ')}>
+      <SearchResultLayout title={useCustomTitle(props, 'GROWI')} className={classNames.join(' ')} customCss={props.customCss}>
         <div id="search-page">
           <SearchPage />
         </div>
@@ -123,7 +124,7 @@ async function injectUserUISettings(context: GetServerSidePropsContext, props: P
 function injectServerConfigurations(context: GetServerSidePropsContext, props: Props): void {
   const req: CrowiRequest = context.req as CrowiRequest;
   const { crowi } = req;
-  const { configManager, searchService } = crowi;
+  const { configManager, searchService, customizeService } = crowi;
 
   props.isSearchServiceConfigured = searchService.isConfigured;
   props.isSearchServiceReachable = searchService.isReachable;
@@ -152,6 +153,7 @@ function injectServerConfigurations(context: GetServerSidePropsContext, props: P
   };
 
   props.showPageLimitationL = configManager.getConfig('crowi', 'customize:showPageLimitationL');
+  props.customCss = customizeService.getCustomCss();
 }
 
 /**

--- a/packages/app/src/pages/_search.page.tsx
+++ b/packages/app/src/pages/_search.page.tsx
@@ -47,8 +47,6 @@ type Props = CommonProps & {
   showPageLimitationL: number
 
   isContainerFluid: boolean,
-
-  customCss: string,
 };
 
 const SearchResultPage: NextPage<Props> = (props: Props) => {

--- a/packages/app/src/pages/admin/[...path].page.tsx
+++ b/packages/app/src/pages/admin/[...path].page.tsx
@@ -18,7 +18,7 @@ const AdminAppPage: NextPage<CommonProps> = (props) => {
   useCurrentUser(props.currentUser ?? null);
 
   return (
-    <AdminLayout>
+    <AdminLayout customCss={props.customCss}>
       <AdminNotFoundPage />
     </AdminLayout>
   );

--- a/packages/app/src/pages/admin/app.page.tsx
+++ b/packages/app/src/pages/admin/app.page.tsx
@@ -34,7 +34,7 @@ const AdminAppPage: NextPage<CommonProps> = (props) => {
 
   return (
     <Provider inject={[...injectableContainers]}>
-      <AdminLayout title={useCustomTitle(props, title)} componentTitle={title} >
+      <AdminLayout title={useCustomTitle(props, title)} componentTitle={title} customCss={props.customCss}>
         <AppSettingsPageContents />
       </AdminLayout>
     </Provider>

--- a/packages/app/src/pages/admin/audit-log.page.tsx
+++ b/packages/app/src/pages/admin/audit-log.page.tsx
@@ -31,7 +31,7 @@ const AdminAuditLogPage: NextPage<Props> = (props) => {
   const title = t('audit_log_management.audit_log');
 
   return (
-    <AdminLayout title={useCustomTitle(props, title)} componentTitle={title} >
+    <AdminLayout title={useCustomTitle(props, title)} componentTitle={title} customCss={props.customCss}>
       <AuditLogManagement />
     </AdminLayout>
   );

--- a/packages/app/src/pages/admin/customize.page.tsx
+++ b/packages/app/src/pages/admin/customize.page.tsx
@@ -39,7 +39,7 @@ const AdminCustomizeSettingsPage: NextPage<Props> = (props) => {
 
   return (
     <Provider inject={[...injectableContainers]}>
-      <AdminLayout title={useCustomTitle(props, title)} componentTitle={title} >
+      <AdminLayout title={useCustomTitle(props, title)} componentTitle={title} customCss={props.customCss}>
         <CustomizeSettingContents />
       </AdminLayout>
     </Provider>

--- a/packages/app/src/pages/admin/export.page.tsx
+++ b/packages/app/src/pages/admin/export.page.tsx
@@ -30,7 +30,7 @@ const AdminExportDataArchivePage: NextPage<CommonProps> = (props) => {
 
   return (
     <Provider inject={[...injectableContainers]}>
-      <AdminLayout title={useCustomTitle(props, title)} componentTitle={title} >
+      <AdminLayout title={useCustomTitle(props, title)} componentTitle={title} customCss={props.customCss} customCss={props.customCss}>
         <ExportArchiveDataPage />
       </AdminLayout>
     </Provider>

--- a/packages/app/src/pages/admin/export.page.tsx
+++ b/packages/app/src/pages/admin/export.page.tsx
@@ -30,7 +30,7 @@ const AdminExportDataArchivePage: NextPage<CommonProps> = (props) => {
 
   return (
     <Provider inject={[...injectableContainers]}>
-      <AdminLayout title={useCustomTitle(props, title)} componentTitle={title} customCss={props.customCss} customCss={props.customCss}>
+      <AdminLayout title={useCustomTitle(props, title)} componentTitle={title} customCss={props.customCss}>
         <ExportArchiveDataPage />
       </AdminLayout>
     </Provider>

--- a/packages/app/src/pages/admin/global-notification/[globalNotificationId].page.tsx
+++ b/packages/app/src/pages/admin/global-notification/[globalNotificationId].page.tsx
@@ -56,7 +56,7 @@ const AdminGlobalNotificationNewPage: NextPage<CommonProps> = (props) => {
 
   return (
     <Provider inject={[...injectableContainers]}>
-      <AdminLayout title={customTitle} componentTitle={title} >
+      <AdminLayout title={customTitle} componentTitle={title} customCss={props.customCss}>
         {
           currentGlobalNotificationId != null && router.isReady
       && <ManageGlobalNotification globalNotificationId={currentGlobalNotificationId} />

--- a/packages/app/src/pages/admin/global-notification/new.page.tsx
+++ b/packages/app/src/pages/admin/global-notification/new.page.tsx
@@ -31,7 +31,7 @@ const AdminGlobalNotificationNewPage: NextPage<CommonProps> = (props) => {
 
   return (
     <Provider inject={[...injectableContainers]}>
-      <AdminLayout title={useCustomTitle(props, title)} componentTitle={title} >
+      <AdminLayout title={useCustomTitle(props, title)} componentTitle={title} customCss={props.customCss}>
         <ManageGlobalNotification />
       </AdminLayout>
     </Provider>

--- a/packages/app/src/pages/admin/importer.page.tsx
+++ b/packages/app/src/pages/admin/importer.page.tsx
@@ -31,7 +31,7 @@ const AdminDataImportPage: NextPage<CommonProps> = (props) => {
 
   return (
     <Provider inject={[...injectableContainers]}>
-      <AdminLayout title={useCustomTitle(props, title)} componentTitle={title} >
+      <AdminLayout title={useCustomTitle(props, title)} componentTitle={title} customCss={props.customCss}>
         <DataImportPageContents />
       </AdminLayout>
     </Provider>

--- a/packages/app/src/pages/admin/index.page.tsx
+++ b/packages/app/src/pages/admin/index.page.tsx
@@ -47,7 +47,7 @@ const AdminHomePage: NextPage<Props> = (props) => {
 
   return (
     <Provider inject={[...injectableContainers]}>
-      <AdminLayout title={useCustomTitle(props, title)} componentTitle={title} >
+      <AdminLayout title={useCustomTitle(props, title)} componentTitle={title} customCss={props.customCss}>
         <AdminHome
           nodeVersion={props.nodeVersion}
           npmVersion={props.npmVersion}

--- a/packages/app/src/pages/admin/markdown.page.tsx
+++ b/packages/app/src/pages/admin/markdown.page.tsx
@@ -32,7 +32,7 @@ const AdminMarkdownPage: NextPage<CommonProps> = (props) => {
 
   return (
     <Provider inject={[...injectableContainers]}>
-      <AdminLayout title={useCustomTitle(props, title)} componentTitle={title} >
+      <AdminLayout title={useCustomTitle(props, title)} componentTitle={title} customCss={props.customCss}>
         <MarkDownSettingContents />
       </AdminLayout>
     </Provider>

--- a/packages/app/src/pages/admin/notification.page.tsx
+++ b/packages/app/src/pages/admin/notification.page.tsx
@@ -32,7 +32,7 @@ const AdminExternalNotificationPage: NextPage<CommonProps> = (props) => {
 
   return (
     <Provider inject={[...injectableContainers]}>
-      <AdminLayout title={useCustomTitle(props, title)} componentTitle={title} >
+      <AdminLayout title={useCustomTitle(props, title)} componentTitle={title} customCss={props.customCss}>
         <NotificationSetting />
       </AdminLayout>
     </Provider>

--- a/packages/app/src/pages/admin/search.page.tsx
+++ b/packages/app/src/pages/admin/search.page.tsx
@@ -29,7 +29,7 @@ const AdminFullTextSearchManagementPage: NextPage<Props> = (props) => {
   const title = t('full_text_search_management.full_text_search_management');
 
   return (
-    <AdminLayout title={useCustomTitle(props, title)} componentTitle={title} >
+    <AdminLayout title={useCustomTitle(props, title)} componentTitle={title} customCss={props.customCss}>
       <FullTextSearchManagement />
     </AdminLayout>
   );

--- a/packages/app/src/pages/admin/security.page.tsx
+++ b/packages/app/src/pages/admin/security.page.tsx
@@ -72,7 +72,7 @@ const AdminSecuritySettingsPage: NextPage<Props> = (props) => {
 
   return (
     <Provider inject={[...adminSecurityContainers]}>
-      <AdminLayout title={useCustomTitle(props, title)} componentTitle={title} >
+      <AdminLayout title={useCustomTitle(props, title)} componentTitle={title} customCss={props.customCss}>
         <SecurityManagement />
       </AdminLayout>
     </Provider>

--- a/packages/app/src/pages/admin/slack-integration-legacy.page.tsx
+++ b/packages/app/src/pages/admin/slack-integration-legacy.page.tsx
@@ -31,7 +31,7 @@ const AdminLegacySlackIntegrationPage: NextPage<CommonProps> = (props) => {
 
   return (
     <Provider inject={[...injectableContainers]}>
-      <AdminLayout title={useCustomTitle(props, title)} componentTitle={title} >
+      <AdminLayout title={useCustomTitle(props, title)} componentTitle={title} customCss={props.customCss}>
         <LegacySlackIntegration />
       </AdminLayout>
     </Provider>

--- a/packages/app/src/pages/admin/slack-integration.page.tsx
+++ b/packages/app/src/pages/admin/slack-integration.page.tsx
@@ -28,7 +28,7 @@ const AdminSlackIntegrationPage: NextPage<Props> = (props) => {
   const title = t('slack_integration.slack_integration');
 
   return (
-    <AdminLayout title={useCustomTitle(props, title)} componentTitle={title} >
+    <AdminLayout title={useCustomTitle(props, title)} componentTitle={title} customCss={props.customCss}>
       <SlackIntegration />
     </AdminLayout>
   );

--- a/packages/app/src/pages/admin/user-group-detail/[userGroupId].page.tsx
+++ b/packages/app/src/pages/admin/user-group-detail/[userGroupId].page.tsx
@@ -34,7 +34,7 @@ const AdminUserGroupDetailPage: NextPage<Props> = (props: Props) => {
   useIsAclEnabled(props.isAclEnabled);
 
   return (
-    <AdminLayout title={customTitle} componentTitle={title} >
+    <AdminLayout title={customTitle} componentTitle={title} customCss={props.customCss}>
       {
         currentUserGroupId != null && router.isReady
       && <UserGroupDetailPage userGroupId={currentUserGroupId} />

--- a/packages/app/src/pages/admin/user-groups.page.tsx
+++ b/packages/app/src/pages/admin/user-groups.page.tsx
@@ -27,7 +27,7 @@ const AdminUserGroupPage: NextPage<Props> = (props) => {
   const title = t('user_group_management.user_group_management');
 
   return (
-    <AdminLayout title={useCustomTitle(props, title)} componentTitle={title} >
+    <AdminLayout title={useCustomTitle(props, title)} componentTitle={title} customCss={props.customCss}>
       <UserGroupPage />
     </AdminLayout>
   );

--- a/packages/app/src/pages/admin/users/external-accounts.page.tsx
+++ b/packages/app/src/pages/admin/users/external-accounts.page.tsx
@@ -34,7 +34,7 @@ const AdminUserManagementPage: NextPage<CommonProps> = (props) => {
 
   return (
     <Provider inject={[...injectableContainers]}>
-      <AdminLayout title={useCustomTitle(props, title)} componentTitle={title} >
+      <AdminLayout title={useCustomTitle(props, title)} componentTitle={title} customCss={props.customCss}>
         <ManageExternalAccount />
       </AdminLayout>
     </Provider>

--- a/packages/app/src/pages/admin/users/index.page.tsx
+++ b/packages/app/src/pages/admin/users/index.page.tsx
@@ -40,7 +40,7 @@ const AdminUserManagementPage: NextPage<Props> = (props) => {
 
   return (
     <Provider inject={[...injectableContainers]}>
-      <AdminLayout title={useCustomTitle(props, title)} componentTitle={title} >
+      <AdminLayout title={useCustomTitle(props, title)} componentTitle={title} customCss={props.customCss}>
         <UserManagement />
       </AdminLayout>
     </Provider>

--- a/packages/app/src/pages/installer.page.tsx
+++ b/packages/app/src/pages/installer.page.tsx
@@ -27,7 +27,6 @@ async function injectNextI18NextConfigurations(context: GetServerSidePropsContex
 }
 
 type Props = CommonProps & {
-
   pageWithMetaStr: string,
 };
 

--- a/packages/app/src/pages/installer.page.tsx
+++ b/packages/app/src/pages/installer.page.tsx
@@ -42,7 +42,7 @@ const InstallerPage: NextPage<Props> = (props: Props) => {
   const classNames: string[] = [];
 
   return (
-    <NoLoginLayout title={useCustomTitle(props, 'GROWI')} className={classNames.join(' ')}>
+    <NoLoginLayout title={useCustomTitle(props, 'GROWI')} className={classNames.join(' ')} customCss={props.customCss}>
       <div id="installer-form-container">
         <InstallerForm />
       </div>

--- a/packages/app/src/pages/invited.page.tsx
+++ b/packages/app/src/pages/invited.page.tsx
@@ -32,7 +32,7 @@ const InvitedPage: NextPage<Props> = (props: Props) => {
   const classNames: string[] = ['invited-page'];
 
   return (
-    <NoLoginLayout title={useCustomTitle(props, 'GROWI')} className={classNames.join(' ')}>
+    <NoLoginLayout title={useCustomTitle(props, 'GROWI')} className={classNames.join(' ')} customCss={props.customCss}>
       <InvitedForm invitedFormUsername={props.invitedFormUsername} invitedFormName={props.invitedFormName} />
     </NoLoginLayout>
   );

--- a/packages/app/src/pages/login.page.tsx
+++ b/packages/app/src/pages/login.page.tsx
@@ -43,7 +43,7 @@ const LoginPage: NextPage<Props> = (props: Props) => {
   const classNames: string[] = ['login-page'];
 
   return (
-    <NoLoginLayout title={useCustomTitle(props, 'GROWI')} className={classNames.join(' ')}>
+    <NoLoginLayout title={useCustomTitle(props, 'GROWI')} className={classNames.join(' ')} customCss={props.customCss}>
       <LoginForm
         objOfIsExternalAuthEnableds={props.enabledStrategies}
         isLocalStrategySetup={props.isLocalStrategySetup}

--- a/packages/app/src/pages/me/[[...path]].page.tsx
+++ b/packages/app/src/pages/me/[[...path]].page.tsx
@@ -145,7 +145,6 @@ async function injectServerConfigurations(context: GetServerSidePropsContext, pr
   const {
     searchService,
     configManager,
-    customizeService,
   } = crowi;
 
   props.isSearchServiceConfigured = searchService.isConfigured;
@@ -160,8 +159,6 @@ async function injectServerConfigurations(context: GetServerSidePropsContext, pr
     isSidebarDrawerMode: configManager.getConfig('crowi', 'customize:isSidebarDrawerMode'),
     isSidebarClosedAtDockMode: configManager.getConfig('crowi', 'customize:isSidebarClosedAtDockMode'),
   };
-
-  props.customCss = customizeService.getCustomCss();
 }
 
 // /**

--- a/packages/app/src/pages/me/[[...path]].page.tsx
+++ b/packages/app/src/pages/me/[[...path]].page.tsx
@@ -43,8 +43,6 @@ type Props = CommonProps & {
 
   // config
   registrationWhiteList: string[],
-
-  customCss: string,
 };
 
 const PersonalSettings = dynamic(() => import('~/components/Me/PersonalSettings'), { ssr: false });

--- a/packages/app/src/pages/me/[[...path]].page.tsx
+++ b/packages/app/src/pages/me/[[...path]].page.tsx
@@ -43,6 +43,8 @@ type Props = CommonProps & {
 
   // config
   registrationWhiteList: string[],
+
+  customCss: string,
 };
 
 const PersonalSettings = dynamic(() => import('~/components/Me/PersonalSettings'), { ssr: false });
@@ -107,7 +109,7 @@ const MePage: NextPage<Props> = (props: Props) => {
 
   return (
     <>
-      <BasicLayout title={useCustomTitle(props, 'GROWI')}>
+      <BasicLayout title={useCustomTitle(props, 'GROWI')} customCss={props.customCss}>
 
         <header className="py-3">
           <div className="container-fluid">
@@ -145,6 +147,7 @@ async function injectServerConfigurations(context: GetServerSidePropsContext, pr
   const {
     searchService,
     configManager,
+    customizeService,
   } = crowi;
 
   props.isSearchServiceConfigured = searchService.isConfigured;
@@ -159,6 +162,8 @@ async function injectServerConfigurations(context: GetServerSidePropsContext, pr
     isSidebarDrawerMode: configManager.getConfig('crowi', 'customize:isSidebarDrawerMode'),
     isSidebarClosedAtDockMode: configManager.getConfig('crowi', 'customize:isSidebarClosedAtDockMode'),
   };
+
+  props.customCss = customizeService.getCustomCss();
 }
 
 // /**

--- a/packages/app/src/pages/share/[[...path]].page.tsx
+++ b/packages/app/src/pages/share/[[...path]].page.tsx
@@ -63,7 +63,7 @@ const SharedPage: NextPage<Props> = (props: Props) => {
   const shareLink = props.shareLink;
 
   return (
-    <ShareLinkLayout title={useCustomTitle(props, 'GROWI')} expandContainer={props.isContainerFluid}>
+    <ShareLinkLayout title={useCustomTitle(props, 'GROWI')} expandContainer={props.isContainerFluid} customCss={props.customCss}>
       <div className="h-100 d-flex flex-column justify-content-between">
         <header className="py-0 position-relative">
           {isShowSharedPage && <GrowiContextualSubNavigation isLinkSharingDisabled={props.disableLinkSharing} />}

--- a/packages/app/src/pages/tags.page.tsx
+++ b/packages/app/src/pages/tags.page.tsx
@@ -40,8 +40,6 @@ type Props = CommonProps & {
 
   // sidebar
   sidebarConfig: ISidebarConfig,
-
-  customCss: string
 };
 
 const TagList = dynamic(() => import('~/components/TagList'), { ssr: false });
@@ -128,7 +126,7 @@ function injectServerConfigurations(context: GetServerSidePropsContext, props: P
   const req: CrowiRequest = context.req as CrowiRequest;
   const { crowi } = req;
   const {
-    searchService, configManager, customizeService,
+    searchService, configManager,
   } = crowi;
 
   props.isSearchServiceConfigured = searchService.isConfigured;
@@ -139,7 +137,6 @@ function injectServerConfigurations(context: GetServerSidePropsContext, props: P
     isSidebarDrawerMode: configManager.getConfig('crowi', 'customize:isSidebarDrawerMode'),
     isSidebarClosedAtDockMode: configManager.getConfig('crowi', 'customize:isSidebarClosedAtDockMode'),
   };
-  props.customCss = customizeService.getCustomCss();
 }
 
 export const getServerSideProps: GetServerSideProps = async(context: GetServerSidePropsContext) => {

--- a/packages/app/src/pages/tags.page.tsx
+++ b/packages/app/src/pages/tags.page.tsx
@@ -40,6 +40,8 @@ type Props = CommonProps & {
 
   // sidebar
   sidebarConfig: ISidebarConfig,
+
+  customCss: string
 };
 
 const TagList = dynamic(() => import('~/components/TagList'), { ssr: false });
@@ -77,7 +79,7 @@ const TagPage: NextPage<CommonProps> = (props: Props) => {
     <>
       <Head>
       </Head>
-      <BasicLayout title={useCustomTitle(props, 'GROWI')} className={classNames.join(' ')}>
+      <BasicLayout title={useCustomTitle(props, 'GROWI')} className={classNames.join(' ')} customCss={props.customCss}>
         <div className="grw-container-convertible mb-5 pb-5" data-testid="tags-page">
           <h2 className="my-3">{`${t('Tags')}(${totalCount})`}</h2>
           <div className="px-3 mb-5 text-center">
@@ -126,7 +128,7 @@ function injectServerConfigurations(context: GetServerSidePropsContext, props: P
   const req: CrowiRequest = context.req as CrowiRequest;
   const { crowi } = req;
   const {
-    searchService, configManager,
+    searchService, configManager, customizeService,
   } = crowi;
 
   props.isSearchServiceConfigured = searchService.isConfigured;
@@ -137,6 +139,7 @@ function injectServerConfigurations(context: GetServerSidePropsContext, props: P
     isSidebarDrawerMode: configManager.getConfig('crowi', 'customize:isSidebarDrawerMode'),
     isSidebarClosedAtDockMode: configManager.getConfig('crowi', 'customize:isSidebarClosedAtDockMode'),
   };
+  props.customCss = customizeService.getCustomCss();
 }
 
 export const getServerSideProps: GetServerSideProps = async(context: GetServerSidePropsContext) => {

--- a/packages/app/src/pages/trash.page.tsx
+++ b/packages/app/src/pages/trash.page.tsx
@@ -109,7 +109,7 @@ function injectServerConfigurations(context: GetServerSidePropsContext, props: P
   const req: CrowiRequest = context.req as CrowiRequest;
   const { crowi } = req;
   const {
-    searchService, configManager, customizeService,
+    searchService, configManager,
   } = crowi;
 
   props.isSearchServiceConfigured = searchService.isConfigured;
@@ -121,8 +121,6 @@ function injectServerConfigurations(context: GetServerSidePropsContext, props: P
     isSidebarDrawerMode: configManager.getConfig('crowi', 'customize:isSidebarDrawerMode'),
     isSidebarClosedAtDockMode: configManager.getConfig('crowi', 'customize:isSidebarClosedAtDockMode'),
   };
-
-  props.customCss = customizeService.getCustomCss();
 }
 
 /**

--- a/packages/app/src/pages/trash.page.tsx
+++ b/packages/app/src/pages/trash.page.tsx
@@ -40,8 +40,6 @@ type Props = CommonProps & {
   userUISettings?: IUserUISettings
   // Sidebar
   sidebarConfig: ISidebarConfig,
-
-  customCss: string,
 };
 
 const TrashPage: NextPage<CommonProps> = (props: Props) => {

--- a/packages/app/src/pages/trash.page.tsx
+++ b/packages/app/src/pages/trash.page.tsx
@@ -40,6 +40,8 @@ type Props = CommonProps & {
   userUISettings?: IUserUISettings
   // Sidebar
   sidebarConfig: ISidebarConfig,
+
+  customCss: string,
 };
 
 const TrashPage: NextPage<CommonProps> = (props: Props) => {
@@ -67,7 +69,7 @@ const TrashPage: NextPage<CommonProps> = (props: Props) => {
 
   return (
     <>
-      <BasicLayout title={useCustomTitle(props, 'GROWI')} >
+      <BasicLayout title={useCustomTitle(props, 'GROWI')} customCss={props.customCss}>
         <header className="py-0 position-relative">
           <GrowiSubNavigation
             pagePath="/trash"
@@ -109,7 +111,7 @@ function injectServerConfigurations(context: GetServerSidePropsContext, props: P
   const req: CrowiRequest = context.req as CrowiRequest;
   const { crowi } = req;
   const {
-    searchService, configManager,
+    searchService, configManager, customizeService,
   } = crowi;
 
   props.isSearchServiceConfigured = searchService.isConfigured;
@@ -121,6 +123,8 @@ function injectServerConfigurations(context: GetServerSidePropsContext, props: P
     isSidebarDrawerMode: configManager.getConfig('crowi', 'customize:isSidebarDrawerMode'),
     isSidebarClosedAtDockMode: configManager.getConfig('crowi', 'customize:isSidebarClosedAtDockMode'),
   };
+
+  props.customCss = customizeService.getCustomCss();
 }
 
 /**

--- a/packages/app/src/pages/user-activation.page.tsx
+++ b/packages/app/src/pages/user-activation.page.tsx
@@ -22,7 +22,7 @@ type Props = CommonProps & {
 
 const UserActivationPage: NextPage<Props> = (props: Props) => {
   return (
-    <NoLoginLayout title={useCustomTitle(props, 'GROWI')}>
+    <NoLoginLayout title={useCustomTitle(props, 'GROWI')} customCss={props.customCss}>
       <CompleteUserRegistrationForm
         token={props.token}
         email={props.email}

--- a/packages/app/src/pages/utils/commons.ts
+++ b/packages/app/src/pages/utils/commons.ts
@@ -24,6 +24,7 @@ export type CommonProps = {
   redirectDestination: string | null,
   customizedLogoSrc?: string,
   currentUser?: IUser,
+  customCss?: string,
 } & Partial<SSRConfig>;
 
 // eslint-disable-next-line max-len
@@ -64,6 +65,7 @@ export const getServerSideCommonProps: GetServerSideProps<CommonProps> = async(c
     redirectDestination,
     customizedLogoSrc: isDefaultLogo ? null : configManager.getConfig('crowi', 'customize:customizedLogoSrc'),
     currentUser,
+    customCss: customizeService.getCustomCss(),
   };
 
   return { props };


### PR DESCRIPTION
## Task
[Nextjs] [Admin] Custom CSS を機能させる
┗[106125](https://redmine.weseek.co.jp/issues/106125) 修正

## Description
### CustomCSS が機能していなかった原因
layout.html で style に　`customizeService.getCustomCss()` を挿入していたが、layout.htmlは v6 で使われなくなったから
https://github.com/weseek/growi/blob/f4fc5ed1fa2c145bcbf518b8f96ce54f5445a517/packages/app/src/server/views/layout/layout.html#L55-L57

## やったこと
RawLayout の Head タグに customCSSのスタイルをセットするようにしました。

## ScreenShots
- Customize CSS に以下を設定

```
h1, h2, h3, h4, h5, h6 {
    font-family: 'Open Sans','Hiragino Sans','ヒラギノ角ゴシック','Hiragino Kaku Gothic ProN','ヒラギノ角ゴ ProN W3','Helvetica Neue',Helvetica,Arial,sans-serif;
    color: red;
}
```

### /search
<img width="1426" alt="Screen Shot 2022-11-28 at 16 47 05" src="https://user-images.githubusercontent.com/59536731/204222190-f2264d24-bcd0-41c1-aac8-e19cd582653d.png">

### /share link
<img width="1822" alt="Screen Shot 2022-11-28 at 16 47 11" src="https://user-images.githubusercontent.com/59536731/204222194-d98d4308-5da8-4620-bacc-83ae31e28667.png">

### /me
<img width="1432" alt="Screen Shot 2022-11-28 at 16 48 02" src="https://user-images.githubusercontent.com/59536731/204222198-6dd5306d-8842-4290-be17-8285566129ae.png">

### /admin
<img width="1424" alt="Screen Shot 2022-11-28 at 16 48 15" src="https://user-images.githubusercontent.com/59536731/204222202-c161b577-f5f1-406c-8e47-26ef0237d4a4.png">

