### PR TITLE
fix: CustomCss does not work

### DIFF
--- a/packages/app/src/pages/_document.page.tsx
+++ b/packages/app/src/pages/_document.page.tsx
@@ -6,25 +6,35 @@ import Document, {
   Html, Head, Main, NextScript,
 } from 'next/document';
 
+import { CrowiRequest } from '~/interfaces/crowi-request';
+
 
 // type GrowiDocumentProps = {};
 // declare type GrowiDocumentInitialProps = GrowiDocumentProps & DocumentInitialProps;
-declare type GrowiDocumentInitialProps = DocumentInitialProps;
+declare type GrowiDocumentInitialProps = DocumentInitialProps & { customCss: string };
 
 
-class GrowiDocument extends Document {
+class GrowiDocument extends Document<GrowiDocumentInitialProps> {
 
   static override async getInitialProps(ctx: DocumentContext): Promise<GrowiDocumentInitialProps> {
     const initialProps: DocumentInitialProps = await Document.getInitialProps(ctx);
+    const { crowi } = ctx.req as CrowiRequest<any>;
+    const { customizeService } = crowi;
+    const customCss: string = customizeService.getCustomCss();
 
-    return initialProps;
+    const props = { ...initialProps, customCss };
+    return props;
   }
 
   override render(): JSX.Element {
+    const { customCss } = this.props;
 
     return (
       <Html>
         <Head>
+          <style>
+            {customCss}
+          </style>
           {/*
           {renderScriptTagsByGroup('basis')}
           {renderStyleTagsByGroup('basis')}


### PR DESCRIPTION
## Task
[Nextjs] [Admin] Custom CSS を機能させる
┗[106125](https://redmine.weseek.co.jp/issues/106125) 修正

## Description
https://github.com/weseek/growi/pull/7004/files#r1033416574 のFB対応をしました。

## Reference
https://stackoverflow.com/questions/70514762/how-to-add-custom-property-and-extend-documentinitialprops-type-in-document
