### PR TITLE
fix: Disabled rename button when rename modal is opened

### DIFF
--- a/packages/app/src/components/PageRenameModal.tsx
+++ b/packages/app/src/components/PageRenameModal.tsx
@@ -50,7 +50,6 @@ const PageRenameModal = (): JSX.Element => {
 
   const [subordinatedPages, setSubordinatedPages] = useState([]);
   const [existingPaths, setExistingPaths] = useState<string[]>([]);
-  const [canRename, setCanRename] = useState(false);
   const [isRenameRecursively, setIsRenameRecursively] = useState(true);
   const [isRenameRedirect, setIsRenameRedirect] = useState(false);
   const [isRemainMetadata, setIsRemainMetadata] = useState(false);
@@ -80,6 +79,16 @@ const PageRenameModal = (): JSX.Element => {
       setPageNameInput(page.data.path);
     }
   }, [isOpened, page, updateSubordinatedList]);
+
+  const canRename = useMemo(() => {
+    if (page == null || isMatchedWithUserHomePagePath || page.data.path === pageNameInput) {
+      return false;
+    }
+    if (isV5Compatible(page.meta)) {
+      return existingPaths.length === 0; // v5 data
+    }
+    return isRenameRecursively; // v4 data
+  }, [existingPaths.length, isMatchedWithUserHomePagePath, isRenameRecursively, page, pageNameInput]);
 
   const rename = useCallback(async() => {
     if (page == null || !canRename) {
@@ -127,9 +136,6 @@ const PageRenameModal = (): JSX.Element => {
     try {
       const res = await apiv3Get<{ existPaths: string[]}>('/page/exist-paths', { fromPath, toPath });
       const { existPaths } = res.data;
-      if (existPaths.length === 0) {
-        setCanRename(true);
-      }
       setExistingPaths(existPaths);
     }
     catch (err) {
@@ -156,13 +162,6 @@ const PageRenameModal = (): JSX.Element => {
       checkIsUsersHomePageDebounce(pageNameInput);
     }
   }, [isOpened, pageNameInput, subordinatedPages, checkExistPathsDebounce, page, checkIsUsersHomePageDebounce]);
-
-  useEffect(() => {
-    if (isOpened && page != null) {
-      setCanRename(false);
-    }
-  }, [isOpened, page, pageNameInput]);
-
 
   function ppacInputChangeHandler(value) {
     setErrs(null);
@@ -330,24 +329,6 @@ const PageRenameModal = (): JSX.Element => {
       return <></>;
     }
 
-    let submitButtonDisabled = true;
-
-    if (isMatchedWithUserHomePagePath) {
-      submitButtonDisabled = true;
-    }
-    else if (page.data.path === pageNameInput) {
-      submitButtonDisabled = true;
-    }
-    else if (!canRename) {
-      submitButtonDisabled = true;
-    }
-    else if (isV5Compatible(page.meta)) {
-      submitButtonDisabled = existingPaths.length !== 0; // v5 data
-    }
-    else {
-      submitButtonDisabled = !isRenameRecursively; // v4 data
-    }
-
     return (
       <>
         <ApiErrorMessageList errs={errs} targetPath={pageNameInput} />
@@ -355,7 +336,7 @@ const PageRenameModal = (): JSX.Element => {
           type="button"
           className="btn btn-primary"
           onClick={rename}
-          disabled={submitButtonDisabled}
+          disabled={!canRename}
         >Rename
         </button>
       </>

--- a/packages/app/src/components/PageRenameModal.tsx
+++ b/packages/app/src/components/PageRenameModal.tsx
@@ -330,9 +330,12 @@ const PageRenameModal = (): JSX.Element => {
       return <></>;
     }
 
-    let submitButtonDisabled = false;
+    let submitButtonDisabled = true;
 
     if (isMatchedWithUserHomePagePath) {
+      submitButtonDisabled = true;
+    }
+    else if (page.data.path === pageNameInput) {
       submitButtonDisabled = true;
     }
     else if (!canRename) {
@@ -344,6 +347,7 @@ const PageRenameModal = (): JSX.Element => {
     else {
       submitButtonDisabled = !isRenameRecursively; // v4 data
     }
+
     return (
       <>
         <ApiErrorMessageList errs={errs} targetPath={pageNameInput} />

--- a/packages/app/src/components/PageRenameModal.tsx
+++ b/packages/app/src/components/PageRenameModal.tsx
@@ -329,6 +329,8 @@ const PageRenameModal = (): JSX.Element => {
       return <></>;
     }
 
+    const submitButtonDisabled = !canRename;
+
     return (
       <>
         <ApiErrorMessageList errs={errs} targetPath={pageNameInput} />
@@ -336,7 +338,7 @@ const PageRenameModal = (): JSX.Element => {
           type="button"
           className="btn btn-primary"
           onClick={rename}
-          disabled={!canRename}
+          disabled={submitButtonDisabled}
         >Rename
         </button>
       </>


### PR DESCRIPTION
## Task
[#109950](https://redmine.weseek.co.jp/issues/109950) [Next.js] リネームモーダルを開いた時に、リネームボタンが押下可能になってしまっている
└ [#109954](https://redmine.weseek.co.jp/issues/109954) 修正