### PR TITLE
fix: VRT Check GROWI User Group Table is shown

### DIFF
--- a/packages/app/src/components/Admin/UserGroup/UserGroupTable.tsx
+++ b/packages/app/src/components/Admin/UserGroup/UserGroupTable.tsx
@@ -126,7 +126,7 @@ export const UserGroupTable: FC<Props> = (props: Props) => {
   }, [props.userGroupRelations, props.childUserGroups]);
 
   return (
-    <>
+    <div data-testid="grw-user-group-table">
       <h2>{props.headerLabel}</h2>
 
       <table className="table table-bordered table-user-list">
@@ -216,6 +216,6 @@ export const UserGroupTable: FC<Props> = (props: Props) => {
           })}
         </tbody>
       </table>
-    </>
+    </div>
   );
 };

--- a/packages/app/test/cypress/integration/40-admin/access-to-admin-page.spec.ts
+++ b/packages/app/test/cypress/integration/40-admin/access-to-admin-page.spec.ts
@@ -106,6 +106,7 @@ context('Access to Admin page', () => {
   it('/admin/user-groups is successfully loaded', () => {
     cy.visit('/admin/user-groups');
     cy.getByTestid('admin-user-groups').should('be.visible');
+    cy.getByTestid('grw-user-group-table').should('be.visible');
     cy.screenshot(`${ssPrefix}-admin-user-groups`);
   });
 


### PR DESCRIPTION
## Task
VRT 正常化 (40-admin)
┗[109930](https://redmine.weseek.co.jp/issues/109930) access-to-admin-page.spec.ts/access-to-admin-page--admin-user-groups.png の修正