### PR TITLE
feat: HandsonTableModal direct editing from Page

### DIFF
--- a/packages/app/src/components/Page.module.scss
+++ b/packages/app/src/components/Page.module.scss
@@ -1,0 +1,15 @@
+// mobile
+.page-mobile :global {
+  .wiki .revision-head {
+    .revision-head-link,
+    .revision-head-edit-button {
+      opacity: 0.3;
+    }
+  }
+
+  .editable-with-handsontable {
+    .handsontable-modal-trigger {
+      opacity: 0.3;
+    }
+  }
+}

--- a/packages/app/src/components/Page.module.scss
+++ b/packages/app/src/components/Page.module.scss
@@ -1,15 +1,6 @@
 // mobile
 .page-mobile :global {
-  .wiki .revision-head {
-    .revision-head-link,
-    .revision-head-edit-button {
-      opacity: 0.3;
-    }
-  }
-
-  .editable-with-handsontable {
-    .handsontable-modal-trigger {
-      opacity: 0.3;
-    }
+  .editable-with-handsontable .handsontable-modal-trigger {
+    opacity: 0.3;
   }
 }

--- a/packages/app/src/components/Page.tsx
+++ b/packages/app/src/components/Page.tsx
@@ -31,6 +31,8 @@ import RevisionRenderer from './Page/RevisionRenderer';
 import mdu from './PageEditor/MarkdownDrawioUtil';
 import mtu from './PageEditor/MarkdownTableUtil';
 
+import styles from './Page.module.scss';
+
 
 declare global {
   // eslint-disable-next-line vars-on-top, no-var
@@ -203,7 +205,7 @@ export const Page = (props) => {
   const { _id: revisionId, body: markdown } = currentPage.revision;
 
   return (
-    <div className={`mb-5 ${isMobile ? 'page-mobile' : ''}`}>
+    <div className={`mb-5 ${isMobile ? `page-mobile ${styles['page-mobile']}` : ''}`}>
 
       { revisionId != null && (
         <RevisionRenderer rendererOptions={rendererOptions} markdown={markdown} />

--- a/packages/app/src/components/Page.tsx
+++ b/packages/app/src/components/Page.tsx
@@ -161,25 +161,14 @@ export const Page = (props) => {
     }
   }, [currentPage, mutateCurrentPage, mutateEditingMarkdown, saveOrUpdate, t, tagsInfo]);
 
-
-  const tableByHandsontableModal = useCallback((beginLineNumber, endLineNumber) => {
-    if (currentPage == null) {
-      return;
-    }
-
-    const markdown = currentPage.revision.body;
-    const tableLines = markdown.split(/\r\n|\r|\n/).slice(beginLineNumber - 1, endLineNumber).join('\n');
-    const table = MarkdownTable.fromMarkdownString(tableLines);
-    return table;
-  }, [currentPage]);
-
   // set handler to open HandsonTableModal
   useEffect(() => {
-    const handler = (bol, eol) => {
-      const table = tableByHandsontableModal(bol, eol);
-      if (table == null) {
+    const handler = (bol: number, eol: number) => {
+      if (currentPage == null) {
         return;
       }
+      const markdown = currentPage.revision.body;
+      const table = mtu.getMarkdownTableFromLine(markdown, bol, eol);
       openHandsontableModal(table, undefined, false, table => saveByHandsontableModal(table, bol, eol));
     };
     globalEmitter.on('launchHandsonTableModal', handler);
@@ -187,7 +176,7 @@ export const Page = (props) => {
     return function cleanup() {
       globalEmitter.removeListener('launchHandsonTableModal', handler);
     };
-  }, [openHandsontableModal, saveByHandsontableModal, tableByHandsontableModal]);
+  }, [currentPage, openHandsontableModal, saveByHandsontableModal]);
 
   if (currentPage == null || isGuestUser == null || rendererOptions == null) {
     const entries = Object.entries({

--- a/packages/app/src/components/Page.tsx
+++ b/packages/app/src/components/Page.tsx
@@ -135,7 +135,7 @@ export const Page = (props) => {
   }, [openDrawioModal, saveByDrawioModal, shareLinkId]);
 
   const saveByHandsontableModal = useCallback(async(table: MarkdownTable, bol: number, eol: number) => {
-    if (currentPage == null || tagsInfo == null) {
+    if (currentPage == null || tagsInfo == null || shareLinkId != null) {
       return;
     }
 
@@ -169,24 +169,25 @@ export const Page = (props) => {
       logger.error('failed to save', error);
       toastError(error);
     }
-  }, [currentPage, mutateCurrentPage, mutateEditingMarkdown, saveOrUpdate, t, tagsInfo]);
+  }, [currentPage, mutateCurrentPage, mutateEditingMarkdown, saveOrUpdate, shareLinkId, t, tagsInfo]);
 
   // set handler to open HandsonTableModal
   useEffect(() => {
+    if (currentPage == null || shareLinkId != null) {
+      return;
+    }
+
     const handler = (bol: number, eol: number) => {
-      if (currentPage == null) {
-        return;
-      }
       const markdown = currentPage.revision.body;
-      const table = mtu.getMarkdownTableFromLine(markdown, bol, eol);
-      openHandsontableModal(table, undefined, false, table => saveByHandsontableModal(table, bol, eol));
+      const currentMarkdownTable = mtu.getMarkdownTableFromLine(markdown, bol, eol);
+      openHandsontableModal(currentMarkdownTable, undefined, false, table => saveByHandsontableModal(table, bol, eol));
     };
     globalEmitter.on('launchHandsonTableModal', handler);
 
     return function cleanup() {
       globalEmitter.removeListener('launchHandsonTableModal', handler);
     };
-  }, [currentPage, openHandsontableModal, saveByHandsontableModal]);
+  }, [currentPage, openHandsontableModal, saveByHandsontableModal, shareLinkId]);
 
   if (currentPage == null || isGuestUser == null || rendererOptions == null) {
     const entries = Object.entries({

--- a/packages/app/src/components/Page.tsx
+++ b/packages/app/src/components/Page.tsx
@@ -77,6 +77,7 @@ export const Page = (props) => {
   }, [mutateCurrentPageTocNode, tocRef.current]); // include tocRef.current to call mutateCurrentPageTocNode when tocRef.current changes
 
 
+  // TODO: refactor commonize saveByDrawioModal and saveByHandsontableModal
   const saveByDrawioModal = useCallback(async(drawioMxFile: string, bol: number, eol: number) => {
     if (currentPage == null || tagsInfo == null) {
       return;

--- a/packages/app/src/components/PageEditor/CodeMirrorEditor.jsx
+++ b/packages/app/src/components/PageEditor/CodeMirrorEditor.jsx
@@ -891,6 +891,16 @@ class CodeMirrorEditor extends AbstractEditor {
     );
   }
 
+  clickTableIconHandler() {
+    const markdownTable = mtu.getMarkdownTable(this.getCodeMirror());
+
+    this.props.onClickTableBtn(
+      markdownTable,
+      this.getCodeMirror(),
+      this.props.editorSettings.autoFormatMarkdownTable,
+    );
+  }
+
   getNavbarItems() {
     return [
       <Button
@@ -1016,13 +1026,7 @@ class CodeMirrorEditor extends AbstractEditor {
         color={null}
         size="sm"
         title="Table"
-        onClick={() => {
-          this.props.onClickTableBtn(
-            mtu.getMarkdownTable(this.getCodeMirror()),
-            this.getCodeMirror(),
-            this.props.editorSettings.autoFormatMarkdownTable,
-          );
-        }}
+        onClick={this.clickTableIconHandler}
       >
         <EditorIcon icon="Table" />
       </Button>,
@@ -1164,8 +1168,8 @@ const CodeMirrorEditorFc = React.forwardRef((props, ref) => {
     openDrawioModal(drawioMxFile, onSave);
   }, [openDrawioModal]);
 
-  const openTableModalHandler = useCallback((table, editor, autoFormatMarkdownTable) => {
-    openHandsontableModal(table, editor, autoFormatMarkdownTable);
+  const openTableModalHandler = useCallback((markdownTable, editor, autoFormatMarkdownTable) => {
+    openHandsontableModal(markdownTable, editor, autoFormatMarkdownTable);
   }, [openHandsontableModal]);
 
   return (

--- a/packages/app/src/components/PageEditor/CodeMirrorEditor.jsx
+++ b/packages/app/src/components/PageEditor/CodeMirrorEditor.jsx
@@ -159,6 +159,7 @@ class CodeMirrorEditor extends AbstractEditor {
 
     this.foldDrawioSection = this.foldDrawioSection.bind(this);
     this.clickDrawioIconHandler = this.clickDrawioIconHandler.bind(this);
+    this.clickTableIconHandler = this.clickTableIconHandler.bind(this);
 
   }
 

--- a/packages/app/src/components/PageEditor/HandsontableModal.tsx
+++ b/packages/app/src/components/PageEditor/HandsontableModal.tsx
@@ -36,6 +36,7 @@ export const HandsontableModal = (): JSX.Element => {
   const table = handsontableModalData?.table;
   const autoFormatMarkdownTable = handsontableModalData?.autoFormatMarkdownTable ?? false;
   const editor = handsontableModalData?.editor;
+  const onSave = handsontableModalData?.onSave;
 
   const defaultMarkdownTable = () => {
     return new MarkdownTable(
@@ -121,7 +122,7 @@ export const HandsontableModal = (): JSX.Element => {
   };
 
   const save = () => {
-    if (hotTable == null || editor == null) {
+    if (hotTable == null) {
       return;
     }
 
@@ -130,8 +131,13 @@ export const HandsontableModal = (): JSX.Element => {
       markdownTableOption.latest,
     ).normalizeCells();
 
-    mtu.replaceFocusedMarkdownTableWithEditor(editor, newMarkdownTable);
+    if (onSave != null) {
+      onSave(newMarkdownTable);
+      cancel();
+      return;
+    }
 
+    mtu.replaceFocusedMarkdownTableWithEditor(editor, newMarkdownTable);
     cancel();
   };
 

--- a/packages/app/src/components/PageEditor/HandsontableModal.tsx
+++ b/packages/app/src/components/PageEditor/HandsontableModal.tsx
@@ -37,7 +37,7 @@ export const HandsontableModal = (): JSX.Element => {
   const table = handsontableModalData?.table;
   const autoFormatMarkdownTable = handsontableModalData?.autoFormatMarkdownTable ?? false;
   const editor = handsontableModalData?.editor;
-  const onSaveDirectlyFromPage = handsontableModalData?.onSave;
+  const onSave = handsontableModalData?.onSave;
 
   const defaultMarkdownTable = () => {
     return new MarkdownTable(
@@ -132,9 +132,9 @@ export const HandsontableModal = (): JSX.Element => {
       markdownTableOption.latest,
     ).normalizeCells();
 
-    // onSaveDirectlyFromPage is passed only when editing table directly from the page.
-    if (onSaveDirectlyFromPage != null) {
-      onSaveDirectlyFromPage(newMarkdownTable);
+    // onSave is passed only when editing table directly from the page.
+    if (onSave != null) {
+      onSave(newMarkdownTable);
       cancel();
       return;
     }

--- a/packages/app/src/components/PageEditor/HandsontableModal.tsx
+++ b/packages/app/src/components/PageEditor/HandsontableModal.tsx
@@ -32,6 +32,7 @@ export const HandsontableModal = (): JSX.Element => {
 
   const { t } = useTranslation('commons');
   const { data: handsontableModalData, close: closeHandsontableModal } = useHandsontableModal();
+
   const isOpened = handsontableModalData?.isOpened ?? false;
   const table = handsontableModalData?.table;
   const autoFormatMarkdownTable = handsontableModalData?.autoFormatMarkdownTable ?? false;

--- a/packages/app/src/components/PageEditor/HandsontableModal.tsx
+++ b/packages/app/src/components/PageEditor/HandsontableModal.tsx
@@ -37,7 +37,7 @@ export const HandsontableModal = (): JSX.Element => {
   const table = handsontableModalData?.table;
   const autoFormatMarkdownTable = handsontableModalData?.autoFormatMarkdownTable ?? false;
   const editor = handsontableModalData?.editor;
-  const onSave = handsontableModalData?.onSave;
+  const onSaveDirectlyFromPage = handsontableModalData?.onSave;
 
   const defaultMarkdownTable = () => {
     return new MarkdownTable(
@@ -132,8 +132,9 @@ export const HandsontableModal = (): JSX.Element => {
       markdownTableOption.latest,
     ).normalizeCells();
 
-    if (onSave != null) {
-      onSave(newMarkdownTable);
+    // onSaveDirectlyFromPage is passed only when editing table directly from the page.
+    if (onSaveDirectlyFromPage != null) {
+      onSaveDirectlyFromPage(newMarkdownTable);
       cancel();
       return;
     }

--- a/packages/app/src/components/PageEditor/MarkdownTableUtil.js
+++ b/packages/app/src/components/PageEditor/MarkdownTableUtil.js
@@ -96,6 +96,11 @@ class MarkdownTableUtil {
     return MarkdownTable.fromMarkdownString(strFromBotToEot);
   }
 
+  getMarkdownTableFromLine(markdown, bol, eol) {
+    const tableLines = markdown.split(/\r\n|\r|\n/).slice(bol - 1, eol).join('\n');
+    return MarkdownTable.fromMarkdownString(tableLines);
+  }
+
   /**
    * return boolean value whether the cursor position is end of line
    */

--- a/packages/app/src/components/ReactMarkdownComponents/DrawioViewerWithEditButton.tsx
+++ b/packages/app/src/components/ReactMarkdownComponents/DrawioViewerWithEditButton.tsx
@@ -8,7 +8,7 @@ import {
 } from '@growi/remark-drawio-plugin';
 import { useTranslation } from 'next-i18next';
 
-import { useIsGuestUser, useIsSharedUser } from '~/stores/context';
+import { useIsGuestUser, useIsSharedUser, useShareLinkId } from '~/stores/context';
 
 import styles from './DrawioViewerWithEditButton.module.scss';
 
@@ -26,6 +26,7 @@ export const DrawioViewerWithEditButton = React.memo((props: DrawioViewerProps):
 
   const { data: isGuestUser } = useIsGuestUser();
   const { data: isSharedUser } = useIsSharedUser();
+  const { data: shareLinkId } = useShareLinkId();
 
   const [isRendered, setRendered] = useState(false);
   const [mxfile, setMxfile] = useState('');
@@ -49,7 +50,7 @@ export const DrawioViewerWithEditButton = React.memo((props: DrawioViewerProps):
     }
   }, []);
 
-  const showEditButton = isRendered && !isGuestUser && !isSharedUser;
+  const showEditButton = isRendered && !isGuestUser && !isSharedUser && shareLinkId == null;
 
   return (
     <div className={`drawio-viewer-with-edit-button ${styles['drawio-viewer-with-edit-button']}`}>

--- a/packages/app/src/components/ReactMarkdownComponents/Header.tsx
+++ b/packages/app/src/components/ReactMarkdownComponents/Header.tsx
@@ -5,8 +5,9 @@ import EventEmitter from 'events';
 import { useRouter } from 'next/router';
 import { Element } from 'react-markdown/lib/rehype-filter';
 
-import { NextLink } from './NextLink';
+import { useIsGuestUser, useIsSharedUser, useShareLinkId } from '~/stores/context';
 
+import { NextLink } from './NextLink';
 
 import styles from './Header.module.scss';
 
@@ -55,6 +56,10 @@ export const Header = (props: HeaderProps): JSX.Element => {
     node, id, children, level,
   } = props;
 
+  const { data: isGuestUser } = useIsGuestUser();
+  const { data: isSharedUser } = useIsSharedUser();
+  const { data: shareLinkId } = useShareLinkId();
+
   const router = useRouter();
 
   const [isActive, setActive] = useState(false);
@@ -80,13 +85,17 @@ export const Header = (props: HeaderProps): JSX.Element => {
     };
   }, [activateByHash, router.events]);
 
+  const showEditButton = !isGuestUser && !isSharedUser && shareLinkId == null;
+
   return (
     <CustomTag id={id} className={`revision-head ${styles['revision-head']} ${isActive ? 'blink' : ''}`}>
       {children}
       <NextLink href={`#${id}`} className="revision-head-link">
         <span className="icon-link"></span>
       </NextLink>
-      <EditLink line={node.position?.start.line} />
+      {showEditButton && (
+        <EditLink line={node.position?.start.line} />
+      )}
     </CustomTag>
   );
 };

--- a/packages/app/src/components/ReactMarkdownComponents/TableWithEditButton.module.scss
+++ b/packages/app/src/components/ReactMarkdownComponents/TableWithEditButton.module.scss
@@ -1,0 +1,30 @@
+/**
+ * for table with handsontable modal button
+ */
+.test :global {
+  .editable-with-handsontable {
+    position: relative;
+
+    .handsontable-modal-trigger {
+      position: absolute;
+      top: 11px;
+      right: 10px;
+      padding: 0;
+      font-size: 16px;
+      line-height: 1;
+      vertical-align: bottom;
+      background-color: transparent;
+      border: none;
+      opacity: 0;
+    }
+
+    .page-mobile & .handsontable-modal-trigger {
+      opacity: 0.3;
+    }
+
+    &:hover .handsontable-modal-trigger {
+      opacity: 1;
+    }
+  }
+}
+

--- a/packages/app/src/components/ReactMarkdownComponents/TableWithEditButton.module.scss
+++ b/packages/app/src/components/ReactMarkdownComponents/TableWithEditButton.module.scss
@@ -1,30 +1,25 @@
 /**
  * for table with handsontable modal button
  */
-.test :global {
-  .editable-with-handsontable {
-    position: relative;
+.editable-with-handsontable :global {
+  position: relative;
 
-    .handsontable-modal-trigger {
-      position: absolute;
-      top: 11px;
-      right: 10px;
-      padding: 0;
-      font-size: 16px;
-      line-height: 1;
-      vertical-align: bottom;
-      background-color: transparent;
-      border: none;
-      opacity: 0;
-    }
-
-    .page-mobile & .handsontable-modal-trigger {
-      opacity: 0.3;
-    }
-
-    &:hover .handsontable-modal-trigger {
-      opacity: 1;
-    }
+  .handsontable-modal-trigger {
+    position: absolute;
+    top: 11px;
+    right: 10px;
+    padding: 0;
+    font-size: 16px;
+    line-height: 1;
+    vertical-align: bottom;
+    background-color: transparent;
+    border: none;
+    opacity: 0;
   }
 }
 
+.editable-with-handsontable:hover :global {
+  .handsontable-modal-trigger {
+    opacity: 1;
+  }
+}

--- a/packages/app/src/components/ReactMarkdownComponents/TableWithEditButton.tsx
+++ b/packages/app/src/components/ReactMarkdownComponents/TableWithEditButton.tsx
@@ -18,7 +18,6 @@ type TableWithEditButtonProps = {
   node: Element,
 }
 
-
 export const TableWithEditButton = React.memo((props: TableWithEditButtonProps): JSX.Element => {
   const { node, children } = props;
 
@@ -35,17 +34,15 @@ export const TableWithEditButton = React.memo((props: TableWithEditButtonProps):
   const showEditButton = !isGuestUser && !isSharedUser;
 
   return (
-    <div className={`${styles.test}`}>
-      <div className={`editable-with-handsontable ${styles['editable-with-handsontable']}`}>
-        { showEditButton && (
-          <button className="handsontable-modal-trigger" onClick={editButtonClickHandler}>
-            <i className="icon-note"></i>
-          </button>
-        )}
-        <table className="table table-bordered">
-          {children}
-        </table>
-      </div>
+    <div className={`editable-with-handsontable ${styles['editable-with-handsontable']}`}>
+      { showEditButton && (
+        <button className="handsontable-modal-trigger" onClick={editButtonClickHandler}>
+          <i className="icon-note"></i>
+        </button>
+      )}
+      <table className="table table-bordered">
+        {children}
+      </table>
     </div>
   );
 });

--- a/packages/app/src/components/ReactMarkdownComponents/TableWithEditButton.tsx
+++ b/packages/app/src/components/ReactMarkdownComponents/TableWithEditButton.tsx
@@ -1,0 +1,52 @@
+import React, { useCallback } from 'react';
+
+import EventEmitter from 'events';
+
+import { Element } from 'react-markdown/lib/rehype-filter';
+
+import { useIsGuestUser, useIsSharedUser } from '~/stores/context';
+
+import styles from './TableWithEditButton.module.scss';
+
+declare global {
+  // eslint-disable-next-line vars-on-top, no-var
+  var globalEmitter: EventEmitter;
+}
+
+type TableWithEditButtonProps = {
+  children: React.ReactNode,
+  node: Element,
+}
+
+
+export const TableWithEditButton = React.memo((props: TableWithEditButtonProps): JSX.Element => {
+  const { node, children } = props;
+
+  const { data: isGuestUser } = useIsGuestUser();
+  const { data: isSharedUser } = useIsSharedUser();
+
+  const bol = node.position?.start.line;
+  const eol = node.position?.end.line;
+
+  const editButtonClickHandler = useCallback(() => {
+    globalEmitter.emit('launchHandsonTableModal', bol, eol);
+  }, [bol, eol]);
+
+  const showEditButton = !isGuestUser && !isSharedUser;
+
+  return (
+    <div className={`${styles.test}`}>
+      <div className={`editable-with-handsontable ${styles['editable-with-handsontable']}`}>
+        { showEditButton && (
+          <button className="handsontable-modal-trigger" onClick={editButtonClickHandler}>
+            <i className="icon-note"></i>
+          </button>
+        )}
+        <table className="table table-bordered">
+          {children}
+        </table>
+      </div>
+    </div>
+  );
+});
+TableWithEditButton.displayName = 'TableWithEditButton';

--- a/packages/app/src/components/ReactMarkdownComponents/TableWithEditButton.tsx
+++ b/packages/app/src/components/ReactMarkdownComponents/TableWithEditButton.tsx
@@ -15,13 +15,13 @@ declare global {
 
 type TableWithEditButtonProps = {
   children: React.ReactNode,
-  className: string
   node: Element,
+  className?: string
 }
 
 export const TableWithEditButton = React.memo((props: TableWithEditButtonProps): JSX.Element => {
 
-  const { children, className, node } = props;
+  const { children, node, className } = props;
 
   const { data: isGuestUser } = useIsGuestUser();
   const { data: isSharedUser } = useIsSharedUser();

--- a/packages/app/src/components/ReactMarkdownComponents/TableWithEditButton.tsx
+++ b/packages/app/src/components/ReactMarkdownComponents/TableWithEditButton.tsx
@@ -4,7 +4,7 @@ import EventEmitter from 'events';
 
 import { Element } from 'react-markdown/lib/rehype-filter';
 
-import { useIsGuestUser, useIsSharedUser } from '~/stores/context';
+import { useIsGuestUser, useIsSharedUser, useShareLinkId } from '~/stores/context';
 
 import styles from './TableWithEditButton.module.scss';
 
@@ -23,6 +23,7 @@ export const TableWithEditButton = React.memo((props: TableWithEditButtonProps):
 
   const { data: isGuestUser } = useIsGuestUser();
   const { data: isSharedUser } = useIsSharedUser();
+  const { data: shareLinkId } = useShareLinkId();
 
   const bol = node.position?.start.line;
   const eol = node.position?.end.line;
@@ -31,7 +32,7 @@ export const TableWithEditButton = React.memo((props: TableWithEditButtonProps):
     globalEmitter.emit('launchHandsonTableModal', bol, eol);
   }, [bol, eol]);
 
-  const showEditButton = !isGuestUser && !isSharedUser;
+  const showEditButton = !isGuestUser && !isSharedUser && shareLinkId == null;
 
   return (
     <div className={`editable-with-handsontable ${styles['editable-with-handsontable']}`}>

--- a/packages/app/src/components/ReactMarkdownComponents/TableWithEditButton.tsx
+++ b/packages/app/src/components/ReactMarkdownComponents/TableWithEditButton.tsx
@@ -15,11 +15,13 @@ declare global {
 
 type TableWithEditButtonProps = {
   children: React.ReactNode,
+  className: string
   node: Element,
 }
 
 export const TableWithEditButton = React.memo((props: TableWithEditButtonProps): JSX.Element => {
-  const { node, children } = props;
+
+  const { children, className, node } = props;
 
   const { data: isGuestUser } = useIsGuestUser();
   const { data: isSharedUser } = useIsSharedUser();
@@ -41,7 +43,7 @@ export const TableWithEditButton = React.memo((props: TableWithEditButtonProps):
           <i className="icon-note"></i>
         </button>
       )}
-      <table className="table table-bordered">
+      <table className={`${className}`}>
         {children}
       </table>
     </div>

--- a/packages/app/src/services/renderer/renderer.tsx
+++ b/packages/app/src/services/renderer/renderer.tsx
@@ -26,6 +26,7 @@ import { CodeBlock } from '~/components/ReactMarkdownComponents/CodeBlock';
 import { DrawioViewerWithEditButton } from '~/components/ReactMarkdownComponents/DrawioViewerWithEditButton';
 import { Header } from '~/components/ReactMarkdownComponents/Header';
 import { NextLink } from '~/components/ReactMarkdownComponents/NextLink';
+import { TableWithEditButton } from '~/components/ReactMarkdownComponents/TableWithEditButton';
 import { RendererConfig } from '~/interfaces/services/renderer';
 import loggerFactory from '~/utils/logger';
 
@@ -353,6 +354,7 @@ export const generateViewOptions = (
     components.h3 = Header;
     components.lsx = props => <Lsx {...props} forceToFetchData />;
     components.drawio = DrawioViewerWithEditButton;
+    components.table = TableWithEditButton;
   }
 
   // // Add configurers for viewer

--- a/packages/app/src/stores/modal.tsx
+++ b/packages/app/src/stores/modal.tsx
@@ -489,14 +489,15 @@ export const useDrawioModal = (status?: DrawioModalStatus): SWRResponse<DrawioMo
 /*
 * HandsonTableModal
 */
-// TODO: Define editor type
 type HandsonTableModalSaveHandler = (table: MarkdownTable) => void;
 
 type HandsontableModalStatus = {
   isOpened: boolean,
   table: MarkdownTable,
+  // TODO: Define editor type
   editor?: any,
   autoFormatMarkdownTable?: boolean,
+  // onSave is passed only when editing table directly from the page.
   onSave?: HandsonTableModalSaveHandler
 }
 
@@ -510,20 +511,20 @@ type HandsontableModalStatusUtils = {
   close(): void
 }
 
-export const useHandsontableModal = (status?: HandsontableModalStatus): SWRResponse<HandsontableModalStatus, Error> & HandsontableModalStatusUtils => {
-  const defaultMarkdownTable = () => {
-    return new MarkdownTable(
-      [
-        ['col1', 'col2', 'col3'],
-        ['', '', ''],
-        ['', '', ''],
-      ],
-      {
-        align: ['', '', ''],
-      },
-    );
-  };
+const defaultMarkdownTable = () => {
+  return new MarkdownTable(
+    [
+      ['col1', 'col2', 'col3'],
+      ['', '', ''],
+      ['', '', ''],
+    ],
+    {
+      align: ['', '', ''],
+    },
+  );
+};
 
+export const useHandsontableModal = (status?: HandsontableModalStatus): SWRResponse<HandsontableModalStatus, Error> & HandsontableModalStatusUtils => {
   const initialData: HandsontableModalStatus = {
     isOpened: false,
     table: defaultMarkdownTable(),

--- a/packages/app/src/stores/modal.tsx
+++ b/packages/app/src/stores/modal.tsx
@@ -489,43 +489,60 @@ export const useDrawioModal = (status?: DrawioModalStatus): SWRResponse<DrawioMo
 /*
 * HandsonTableModal
 */
+// TODO: Define editor type
+type HandsonTableModalSaveHandler = (table: MarkdownTable) => void;
+
 type HandsontableModalStatus = {
   isOpened: boolean,
-  table?: MarkdownTable,
+  table: MarkdownTable,
   editor?: any,
   autoFormatMarkdownTable?: boolean,
-  onSave?: (table) => any,
+  onSave?: HandsonTableModalSaveHandler
 }
 
 type HandsontableModalStatusUtils = {
   open(
-    table?: MarkdownTable,
+    table: MarkdownTable,
     editor?: any,
     autoFormatMarkdownTable?: boolean,
-    onSave?: (table) => any
-  ): void // Promise<HandsontableModalStatus | undefined>
-  close(): void // Promise<HandsontableModalStatus | undefined>
+    onSave?: HandsonTableModalSaveHandler
+  ): void
+  close(): void
 }
 
 export const useHandsontableModal = (status?: HandsontableModalStatus): SWRResponse<HandsontableModalStatus, Error> & HandsontableModalStatusUtils => {
+  const defaultMarkdownTable = () => {
+    return new MarkdownTable(
+      [
+        ['col1', 'col2', 'col3'],
+        ['', '', ''],
+        ['', '', ''],
+      ],
+      {
+        align: ['', '', ''],
+      },
+    );
+  };
+
   const initialData: HandsontableModalStatus = {
     isOpened: false,
-    table: undefined,
+    table: defaultMarkdownTable(),
     editor: undefined,
     autoFormatMarkdownTable: false,
   };
+
   const swrResponse = useStaticSWR<HandsontableModalStatus, Error>('handsontableModalStatus', status, { fallbackData: initialData });
 
   const { mutate } = swrResponse;
 
-  const open = useCallback((table: MarkdownTable, editor?: any, autoFormatMarkdownTable?: boolean, onSave?: (table) => any): void => {
+  const open = useCallback((table: MarkdownTable, editor?: any, autoFormatMarkdownTable?: boolean, onSave?: HandsonTableModalSaveHandler): void => {
     mutate({
       isOpened: true, table, editor, autoFormatMarkdownTable, onSave,
     });
   }, [mutate]);
   const close = useCallback((): void => {
     mutate({
-      isOpened: false, table: undefined, editor: undefined, autoFormatMarkdownTable: false, onSave: undefined,
+      isOpened: false, table: defaultMarkdownTable(), editor: undefined, autoFormatMarkdownTable: false, onSave: undefined,
     });
   }, [mutate]);
 

--- a/packages/app/src/stores/modal.tsx
+++ b/packages/app/src/stores/modal.tsx
@@ -492,27 +492,42 @@ export const useDrawioModal = (status?: DrawioModalStatus): SWRResponse<DrawioMo
 type HandsontableModalStatus = {
   isOpened: boolean,
   table?: MarkdownTable,
-  editor: any,
-  autoFormatMarkdownTable: boolean,
+  editor?: any,
+  autoFormatMarkdownTable?: boolean,
+  onSave?: (table) => any,
 }
 
 type HandsontableModalStatusUtils = {
-  open(table: MarkdownTable, editor: any, autoFormatMarkdownTable: boolean): Promise<HandsontableModalStatus | undefined>
-  close(): Promise<HandsontableModalStatus | undefined>
+  open(
+    table?: MarkdownTable,
+    editor?: any,
+    autoFormatMarkdownTable?: boolean,
+    onSave?: (table) => any
+  ): void // Promise<HandsontableModalStatus | undefined>
+  close(): void // Promise<HandsontableModalStatus | undefined>
 }
 
 export const useHandsontableModal = (status?: HandsontableModalStatus): SWRResponse<HandsontableModalStatus, Error> & HandsontableModalStatusUtils => {
   const initialData: HandsontableModalStatus = {
-    isOpened: false, table: undefined, editor: undefined, autoFormatMarkdownTable: false,
+    isOpened: false,
+    table: undefined,
+    editor: undefined,
+    autoFormatMarkdownTable: false,
   };
   const swrResponse = useStaticSWR<HandsontableModalStatus, Error>('handsontableModalStatus', status, { fallbackData: initialData });
 
-  const open = (table: MarkdownTable, editor: any, autoFormatMarkdownTable: boolean) => swrResponse.mutate({
-    isOpened: true, table, editor, autoFormatMarkdownTable,
-  });
-  const close = () => swrResponse.mutate({
-    isOpened: false, table: undefined, editor: undefined, autoFormatMarkdownTable: false,
-  });
+  const { mutate } = swrResponse;
+
+  const open = useCallback((table: MarkdownTable, editor?: any, autoFormatMarkdownTable?: boolean, onSave?: (table) => any): void => {
+    mutate({
+      isOpened: true, table, editor, autoFormatMarkdownTable, onSave,
+    });
+  }, [mutate]);
+  const close = useCallback((): void => {
+    mutate({
+      isOpened: false, table: undefined, editor: undefined, autoFormatMarkdownTable: false, onSave: undefined,
+    });
+  }, [mutate]);
 
   return {
     ...swrResponse,

--- a/packages/app/src/styles/_page.scss
+++ b/packages/app/src/styles/_page.scss
@@ -1,34 +1,6 @@
 // // import diff2html styles
 // @import '~/diff2html/bundles/css/diff2html.min.css';
 
-/**
- * for table with handsontable modal button
- */
-.editable-with-handsontable {
-  position: relative;
-
-  .handsontable-modal-trigger {
-    position: absolute;
-    top: 11px;
-    right: 10px;
-    padding: 0;
-    font-size: 16px;
-    line-height: 1;
-    vertical-align: bottom;
-    background-color: transparent;
-    border: none;
-    opacity: 0;
-  }
-
-  .page-mobile & .handsontable-modal-trigger {
-    opacity: 0.3;
-  }
-
-  &:hover .handsontable-modal-trigger {
-    opacity: 1;
-  }
-}
-
 .card.grw-page-status-alert {
   $margin-bottom: $grw-navbar-bottom-height + 10px;
 

--- a/packages/app/src/styles/organisms/_wiki.scss
+++ b/packages/app/src/styles/organisms/_wiki.scss
@@ -235,6 +235,15 @@
   }
 }
 
+// mobile
+.page-mobile .wiki .revision-head {
+
+  .revision-head-link,
+  .revision-head-edit-button {
+    opacity: 0.3;
+  }
+}
+
 @include bs.media-breakpoint-down(sm) {
   .main .wiki {
     img {

--- a/packages/app/src/styles/organisms/_wiki.scss
+++ b/packages/app/src/styles/organisms/_wiki.scss
@@ -244,6 +244,12 @@
   }
 }
 
+.page-mobile .editable-with-handsontable {
+  .handsontable-modal-trigger {
+    opacity: 0.3;
+  }
+}
+
 @include bs.media-breakpoint-down(sm) {
   .main .wiki {
     img {

--- a/packages/app/src/styles/organisms/_wiki.scss
+++ b/packages/app/src/styles/organisms/_wiki.scss
@@ -235,21 +235,6 @@
   }
 }
 
-// mobile
-.page-mobile .wiki .revision-head {
-
-  .revision-head-link,
-  .revision-head-edit-button {
-    opacity: 0.3;
-  }
-}
-
-.page-mobile .editable-with-handsontable {
-  .handsontable-modal-trigger {
-    opacity: 0.3;
-  }
-}
-
 @include bs.media-breakpoint-down(sm) {
   .main .wiki {
     img {


### PR DESCRIPTION
task: https://redmine.weseek.co.jp/issues/108177

## 概要

- Table の右肩に編集アイコンがつく
- 編集アイコンから Table の情報を取得した HandsonTableModal が表示される
- HandsonTableModal を更新することで Page から直接(editモードに移動せずに)テーブルの更新ができる