### PR TITLE
fix:  Err messages on Duplicated Modal

### DIFF
--- a/packages/app/src/components/PageDuplicateModal.tsx
+++ b/packages/app/src/components/PageDuplicateModal.tsx
@@ -271,7 +271,6 @@ const PageDuplicateModal = (): JSX.Element => {
         {bodyContent()}
       </ModalBody>
       <ModalFooter>
-        <ApiErrorMessageList errs={errs} targetPath={pageNameInput} />
         {footerContent()}
       </ModalFooter>
     </Modal>

--- a/packages/app/src/components/PageDuplicateModal.tsx
+++ b/packages/app/src/components/PageDuplicateModal.tsx
@@ -151,7 +151,7 @@ const PageDuplicateModal = (): JSX.Element => {
   }, [isOpened]);
 
 
-  const bodyContent = () => {
+  const renderBodyContent = () => {
     if (!isOpened || page == null) {
       return <></>;
     }
@@ -238,7 +238,7 @@ const PageDuplicateModal = (): JSX.Element => {
     );
   };
 
-  const footerContent = () => {
+  const renderFooterContent = () => {
     if (!isOpened || page == null) {
       return <></>;
     }
@@ -268,10 +268,10 @@ const PageDuplicateModal = (): JSX.Element => {
         { t('modal_duplicate.label.Duplicate page') }
       </ModalHeader>
       <ModalBody>
-        {bodyContent()}
+        {renderBodyContent()}
       </ModalBody>
       <ModalFooter>
-        {footerContent()}
+        {renderFooterContent()}
       </ModalFooter>
     </Modal>
   );


### PR DESCRIPTION
## Task
[Next.js][/user/username] ページを複製しようとすると「Invalid Path」の赤文字エラーが2つModal Footer に表示されてしまう
┗[110195](https://redmine.weseek.co.jp/issues/110195) 修正