### PR TITLE
fix: Unable to update pages that have already been created

### DIFF
--- a/packages/app/src/components/PageEditor.tsx
+++ b/packages/app/src/components/PageEditor.tsx
@@ -194,12 +194,22 @@ const PageEditor = React.memo((): JSX.Element => {
       return;
     }
 
-    const isSuccess = await save();
-    if (isSuccess) {
+    const page = await save();
+    if (page) {
       toastSuccess(t('toaster.save_succeeded'));
     }
+    else {
+      return;
+    }
 
-  }, [editorMode, save, t]);
+    if (isNotFound) {
+      await router.push(`/${page._id}`);
+    }
+    else {
+      await mutateCurrentPageId(page._id);
+      await mutateCurrentPage();
+    }
+  }, [editorMode, isNotFound, mutateCurrentPage, mutateCurrentPageId, router, save, t]);
 
 
   /**

--- a/packages/app/src/components/PageEditor.tsx
+++ b/packages/app/src/components/PageEditor.tsx
@@ -123,7 +123,6 @@ const PageEditor = React.memo((): JSX.Element => {
     setMarkdownWithDebounce(value, isClean);
   }, [setMarkdownWithDebounce]);
 
-  // return true if the save succeeds, otherwise false.
   const save = useCallback(async(opts?: {overwriteScopesOfDescendants: boolean}): Promise<IPageHasId | null> => {
     if (grantData == null || isSlackEnabled == null || currentPathname == null) {
       logger.error('Some materials to save are invalid', { grantData, isSlackEnabled, currentPathname });
@@ -195,7 +194,7 @@ const PageEditor = React.memo((): JSX.Element => {
     }
 
     const page = await save();
-    if (page) {
+    if (page != null) {
       toastSuccess(t('toaster.save_succeeded'));
       await mutateCurrentPageId(page._id);
       await mutateCurrentPage();

--- a/packages/app/src/components/PageEditor.tsx
+++ b/packages/app/src/components/PageEditor.tsx
@@ -197,19 +197,10 @@ const PageEditor = React.memo((): JSX.Element => {
     const page = await save();
     if (page) {
       toastSuccess(t('toaster.save_succeeded'));
-    }
-    else {
-      return;
-    }
-
-    if (isNotFound) {
-      await router.push(`/${page._id}`);
-    }
-    else {
       await mutateCurrentPageId(page._id);
       await mutateCurrentPage();
     }
-  }, [editorMode, isNotFound, mutateCurrentPage, mutateCurrentPageId, router, save, t]);
+  }, [editorMode, mutateCurrentPage, mutateCurrentPageId, save, t]);
 
 
   /**

--- a/packages/app/test/cypress/integration/20-basic-features/use-tools.spec.ts
+++ b/packages/app/test/cypress/integration/20-basic-features/use-tools.spec.ts
@@ -439,10 +439,12 @@ context('Shortcuts', () => {
     });
   });
 
-  it('Successfully updating a page using a shortcut on a previously created page',{ scrollBehavior: false }, () => {
+  it('Successfully updating a page using a shortcut on a previously created page', () => {
+    const body1 = 'hello';
+    const body2 = 'world';
     const savePageShortcutKey = '{ctrl+s}'
 
-    cy.visit('/Sandbox');
+    cy.visit('/Sandbox/child');
     cy.waitUntilSkeletonDisappear();
 
     cy.get('#grw-subnav-container').within(() => {
@@ -453,14 +455,20 @@ context('Shortcuts', () => {
     cy.get('.grw-editor-navbar-bottom').should('be.visible');
 
     // 1st
+    cy.get('.CodeMirror').type(body1);
+    cy.get('.page-editor-preview-body').contains(body1);
     cy.get('.CodeMirror').type(savePageShortcutKey);
+
     cy.get('.toast').should('be.visible').trigger('mouseover');
     cy.screenshot(`${ssPrefix}-update-page-1`);
     cy.get('.toast-close-button').click();
     cy.get('.toast').should('not.exist');
 
     // 2nd
+    cy.get('.CodeMirror').type(body2);
+    cy.get('.page-editor-preview-body').contains(body2);
     cy.get('.CodeMirror').type(savePageShortcutKey);
+
     cy.get('.toast').should('be.visible').trigger('mouseover');
     cy.screenshot(`${ssPrefix}-update-page-2`);
   });

--- a/packages/app/test/cypress/integration/20-basic-features/use-tools.spec.ts
+++ b/packages/app/test/cypress/integration/20-basic-features/use-tools.spec.ts
@@ -456,6 +456,7 @@ context('Shortcuts', () => {
 
     // 1st
     cy.get('.CodeMirror').type(body1);
+    cy.get('.CodeMirror').contains(body1);
     cy.get('.page-editor-preview-body').contains(body1);
     cy.get('.CodeMirror').type(savePageShortcutKey);
 
@@ -466,6 +467,7 @@ context('Shortcuts', () => {
 
     // 2nd
     cy.get('.CodeMirror').type(body2);
+    cy.get('.CodeMirror').contains(body2);
     cy.get('.page-editor-preview-body').contains(body2);
     cy.get('.CodeMirror').type(savePageShortcutKey);
 

--- a/packages/app/test/cypress/integration/20-basic-features/use-tools.spec.ts
+++ b/packages/app/test/cypress/integration/20-basic-features/use-tools.spec.ts
@@ -439,12 +439,10 @@ context('Shortcuts', () => {
     });
   });
 
-  it('Successfully updating a page using a shortcut on a previously created page', () => {
-    const body1 = 'hello';
-    const body2 = 'world';
+  it('Successfully updating a page using a shortcut on a previously created page',{ scrollBehavior: false }, () => {
     const savePageShortcutKey = '{ctrl+s}'
 
-    cy.visit('/Sandbox/child');
+    cy.visit('/Sandbox');
     cy.waitUntilSkeletonDisappear();
 
     cy.get('#grw-subnav-container').within(() => {
@@ -455,20 +453,14 @@ context('Shortcuts', () => {
     cy.get('.grw-editor-navbar-bottom').should('be.visible');
 
     // 1st
-    cy.get('.CodeMirror').type(body1);
-    cy.get('.page-editor-preview-body').contains(body1);
     cy.get('.CodeMirror').type(savePageShortcutKey);
-
     cy.get('.toast').should('be.visible').trigger('mouseover');
     cy.screenshot(`${ssPrefix}-update-page-1`);
     cy.get('.toast-close-button').click();
     cy.get('.toast').should('not.exist');
 
     // 2nd
-    cy.get('.CodeMirror').type(body2);
-    cy.get('.page-editor-preview-body').contains(body2);
     cy.get('.CodeMirror').type(savePageShortcutKey);
-
     cy.get('.toast').should('be.visible').trigger('mouseover');
     cy.screenshot(`${ssPrefix}-update-page-2`);
   });

--- a/packages/app/test/cypress/integration/20-basic-features/use-tools.spec.ts
+++ b/packages/app/test/cypress/integration/20-basic-features/use-tools.spec.ts
@@ -427,3 +427,48 @@ context('Tag Oprations', { scrollBehavior: false }, () =>{
     cy.screenshot(`${ssPrefix}4-new-page-name-applied`);
   });
 });
+
+context('Shortcuts', () => {
+  const ssPrefix = 'shortcuts';
+
+  beforeEach(() => {
+    // login
+    cy.fixture("user-admin.json").then(user => {
+      cy.login(user.username, user.password);
+    });
+  });
+
+  it('Successfully updating a page using a shortcut on a previously created page', () => {
+    const body1 = 'hello';
+    const body2 = 'world';
+    const savePageShortcutKey = '{ctrl+s}'
+
+    cy.visit('/Sandbox/child');
+    cy.waitUntilSkeletonDisappear();
+
+    cy.get('#grw-subnav-container').within(() => {
+      cy.getByTestid('editor-button').should('be.visible').click();
+    })
+
+    cy.get('.layout-root').should('have.class', 'editing');
+    cy.get('.grw-editor-navbar-bottom').should('be.visible');
+
+    // 1st
+    cy.get('.CodeMirror').type(body1);
+    cy.get('.page-editor-preview-body').contains(body1);
+    cy.get('.CodeMirror').type(savePageShortcutKey);
+
+    cy.get('.toast').should('be.visible').trigger('mouseover');
+    cy.screenshot(`${ssPrefix}-update-page-1`);
+    cy.get('.toast-close-button').click();
+    cy.get('.toast').should('not.exist');
+
+    // 2nd
+    cy.get('.CodeMirror').type(body2);
+    cy.get('.page-editor-preview-body').contains(body2);
+    cy.get('.CodeMirror').type(savePageShortcutKey);
+
+    cy.get('.toast').should('be.visible').trigger('mouseover');
+    cy.screenshot(`${ssPrefix}-update-page-2`);
+  });
+});


### PR DESCRIPTION
## Task
[#110140](https://redmine.weseek.co.jp/issues/110140) [Next.js] 作成済みのページの更新ができない
└ [#110188](https://redmine.weseek.co.jp/issues/110188) 修正
└ [#110200](https://redmine.weseek.co.jp/issues/110200) [VRT] エディター画面でショートカット（ctrl  + s）を使ったページの保存