### PR TITLE
fix: Can transition to installer page with installed GROWI

### DIFF
--- a/packages/app/src/pages/installer.page.tsx
+++ b/packages/app/src/pages/installer.page.tsx
@@ -7,7 +7,6 @@ import {
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 
 import { NoLoginLayout } from '~/components/Layout/NoLoginLayout';
-import { CrowiRequest } from '~/interfaces/crowi-request';
 
 import InstallerForm from '../components/InstallerForm';
 import {
@@ -53,17 +52,6 @@ const InstallerPage: NextPage<Props> = (props: Props) => {
 
 export const getServerSideProps: GetServerSideProps = async(context: GetServerSidePropsContext) => {
   const result = await getServerSideCommonProps(context);
-
-  const req = context.req as CrowiRequest;
-  const isInstalled = req.crowi.configManager.getConfig('crowi', 'app:installed');
-  if (isInstalled) {
-    return {
-      redirect: {
-        permanent: false,
-        destination: '/',
-      },
-    };
-  }
 
   // check for presence
   // see: https://github.com/vercel/next.js/issues/19271#issuecomment-730006862

--- a/packages/app/src/pages/installer.page.tsx
+++ b/packages/app/src/pages/installer.page.tsx
@@ -7,6 +7,7 @@ import {
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 
 import { NoLoginLayout } from '~/components/Layout/NoLoginLayout';
+import { CrowiRequest } from '~/interfaces/crowi-request';
 
 import InstallerForm from '../components/InstallerForm';
 import {
@@ -52,6 +53,17 @@ const InstallerPage: NextPage<Props> = (props: Props) => {
 
 export const getServerSideProps: GetServerSideProps = async(context: GetServerSidePropsContext) => {
   const result = await getServerSideCommonProps(context);
+
+  const req = context.req as CrowiRequest;
+  const isInstalled = req.crowi.configManager.getConfig('crowi', 'app:installed');
+  if (isInstalled) {
+    return {
+      redirect: {
+        permanent: false,
+        destination: '/',
+      },
+    };
+  }
 
   // check for presence
   // see: https://github.com/vercel/next.js/issues/19271#issuecomment-730006862

--- a/packages/app/src/server/middlewares/application-not-installed.js
+++ b/packages/app/src/server/middlewares/application-not-installed.js
@@ -5,8 +5,7 @@ module.exports = (crowi) => {
     const isDBInitialized = await appService.isDBInitialized(true);
 
     if (isDBInitialized) {
-      req.flash('errorMessage', req.t('message.application_already_installed'));
-      return res.redirect('admin');
+      return res.redirect('/');
     }
 
     return next();

--- a/packages/app/src/server/routes/apiv3/index.js
+++ b/packages/app/src/server/routes/apiv3/index.js
@@ -16,7 +16,8 @@ const router = express.Router();
 const routerForAdmin = express.Router();
 const routerForAuth = express.Router();
 
-module.exports = (crowi, app, isInstalled) => {
+module.exports = (crowi, app) => {
+  const isInstalled = crowi.configManager.getConfig('crowi', 'app:installed');
 
   // add custom functions to express response
   require('./response')(express, crowi);

--- a/packages/app/src/server/routes/index.js
+++ b/packages/app/src/server/routes/index.js
@@ -56,11 +56,10 @@ module.exports = function(crowi, app) {
   const unavailableWhenMaintenanceMode = generateUnavailableWhenMaintenanceModeMiddleware(crowi);
   const unavailableWhenMaintenanceModeForApi = generateUnavailableWhenMaintenanceModeMiddlewareForApi(crowi);
 
-  const isInstalled = crowi.configManager.getConfig('crowi', 'app:installed');
 
   /* eslint-disable max-len, comma-spacing, no-multi-spaces */
 
-  const [apiV3Router, apiV3AdminRouter, apiV3AuthRouter] = require('./apiv3')(crowi, app, isInstalled);
+  const [apiV3Router, apiV3AdminRouter, apiV3AuthRouter] = require('./apiv3')(crowi, app);
 
   app.use('/api-docs', require('./apiv3/docs')(crowi, app));
 
@@ -91,10 +90,7 @@ module.exports = function(crowi, app) {
   app.get('/admin'                    , applicationInstalled, loginRequiredStrictly , adminRequired , next.delegateToNext);
 
   // installer
-  if (!isInstalled) {
-    app.get('/installer'              , applicationNotInstalled, next.delegateToNext);
-    return;
-  }
+  app.get('/installer'                , applicationNotInstalled, next.delegateToNext);
 
   // OAuth
   app.get('/passport/google'                      , loginPassport.loginWithGoogle, loginPassport.loginFailureForExternalAccount);


### PR DESCRIPTION
## Task
[#110135](https://redmine.weseek.co.jp/issues/110135) [Next.js]インストール済みの GROWI で /installer に遷移できてしまう
└ [#110283](https://redmine.weseek.co.jp/issues/110283) 修正