### PR TITLE
fix: Infinity Spinner of Page Item Control on Trash Page List

### DIFF
--- a/packages/app/src/components/PageList/PageListItemL.tsx
+++ b/packages/app/src/components/PageList/PageListItemL.tsx
@@ -162,6 +162,8 @@ const PageListItemLSubstance: ForwardRefRenderFunction<ISelectable, Props> = (pr
   const canRenderESSnippet = elasticSearchResult != null && elasticSearchResult.snippet != null;
   const canRenderRevisionSnippet = revisionShortBody != null;
 
+  const hasBrowsingRights = canRenderESSnippet || canRenderRevisionSnippet;
+
   return (
     <li
       key={pageData._id}
@@ -228,7 +230,8 @@ const PageListItemLSubstance: ForwardRefRenderFunction<ISelectable, Props> = (pr
               </div>
 
               {/* doropdown icon includes page control buttons */}
-              <div className="ml-auto">
+              {hasBrowsingRights
+              && <div className="ml-auto">
                 <PageItemControl
                   alignRight
                   pageId={pageData._id}
@@ -242,6 +245,7 @@ const PageListItemLSubstance: ForwardRefRenderFunction<ISelectable, Props> = (pr
                   onClickRevertMenuItem={revertMenuItemClickHandler}
                 />
               </div>
+              }
             </div>
             <div className="page-list-snippet py-1">
               <Clamp lines={2}>
@@ -253,7 +257,7 @@ const PageListItemLSubstance: ForwardRefRenderFunction<ISelectable, Props> = (pr
                   <div data-testid="revision-short-body-in-page-list-item-L">{revisionShortBody}</div>
                 ) }
                 {
-                  !canRenderESSnippet && !canRenderRevisionSnippet && (
+                  !hasBrowsingRights && (
                     <>
                       <i className="icon-exclamation p-1"></i>
                       {t('not_allowed_to_see_this_page')}


### PR DESCRIPTION
## Task
[Next.js][/trash][要相談] 閲覧権限のないページの3点ボタンをクリックすると、dropdown menu に spinner が表示され続ける
┗[110288](https://redmine.weseek.co.jp/issues/110288) 修正

## Description
- /trash にて、閲覧権限のないユーザーがページの3点ボタンを押した時に、dropdown menu に spinner が表示され続けてしまうのを修正しました。

## Before
### `kaori` (閲覧権限のあるユーザー)
<img width="1107" alt="Screen Shot 2022-12-05 at 15 59 31" src="https://user-images.githubusercontent.com/59536731/205570407-6b412441-3734-4fc5-955f-e85f1eddc229.png">

### `kaori2` (閲覧権限のないユーザー)
┗ページリストの3点ボタンのメニューが永遠にspinner のままになって表示されない
<img width="1097" alt="Screen Shot 2022-12-05 at 16 00 04" src="https://user-images.githubusercontent.com/59536731/205570447-482389bf-9ad2-46f6-a20b-0ea17a6de639.png">


## After
#### `kaori` (閲覧権限のあるユーザー)

<img width="1101" alt="Screen Shot 2022-12-05 at 15 57 22" src="https://user-images.githubusercontent.com/59536731/205569502-d6d46b62-9303-44ab-ba8c-30896463bc26.png">


### `kaori2` (閲覧権限のないユーザー)
┗ページリストの3点ボタン自体を表示させなくしました。
<img width="1107" alt="Screen Shot 2022-12-05 at 15 54 07" src="https://user-images.githubusercontent.com/59536731/205568883-46007c65-2613-48bf-b98b-441998bdf8ac.png">



