### PR TITLE
fix: text-truncate does not work on Recent Changes

### DIFF
--- a/packages/app/src/components/Sidebar/RecentChanges.tsx
+++ b/packages/app/src/components/Sidebar/RecentChanges.tsx
@@ -112,7 +112,7 @@ const SmallPageItem = memo(({ page }: PageItemProps): JSX.Element => {
   }
 
   return (
-    <li className="list-group-item py-2 px-0">
+    <li className={`list-group-item ${styles['list-group-item']} py-2 px-0`}>
       <div className="d-flex w-100">
         <UserPicture user={page.lastUpdateUser} size="md" noTooltip />
         <div className="flex-grow-1 ml-2">


### PR DESCRIPTION
## Task
[Next.js] RecentChanges を S サイズにしても、長文タイトルが truncate されない
┗[110376](https://redmine.weseek.co.jp/issues/110376) 修正

## Before
<img width="372" alt="Screen Shot 2022-12-05 at 18 30 46" src="https://user-images.githubusercontent.com/59536731/205602658-85091960-8e16-4f53-88f3-e867b3dd7c40.png">

## After
<img width="443" alt="Screen Shot 2022-12-05 at 18 29 55" src="https://user-images.githubusercontent.com/59536731/205602670-ac106a45-5196-4ee5-8333-cecd472a60f2.png">

## GROWI Demo
<img width="387" alt="Screen Shot 2022-12-05 at 18 39 37" src="https://user-images.githubusercontent.com/59536731/205604330-a2b310ca-1569-4808-872e-e1f0240b2f7a.png">
