### PR TITLE
fix: Hide in-app notification that contain invalid values

### DIFF
--- a/packages/app/src/components/InAppNotification/InAppNotificationList.tsx
+++ b/packages/app/src/components/InAppNotification/InAppNotificationList.tsx
@@ -26,7 +26,7 @@ const InAppNotificationList: FC<Props> = (props: Props) => {
     );
   }
 
-  const notifications = inAppNotificationData.docs;
+  const notifications = inAppNotificationData.docs.filter((notification) => { return typeof notification.snapshot === 'string' });
 
   return (
     <>


### PR DESCRIPTION
## Task
[#110128](https://redmine.weseek.co.jp/issues/110128) [Next.js] 不正な値が含まれる in-app-notification ドキュメントを削除するマイグレーションファイルの作成
└ [#110434](https://redmine.weseek.co.jp/issues/110434) 不正な値が含まれる in-app notification は表示させない

## 当ストーリーが作成された経緯
[#106908](https://redmine.weseek.co.jp/issues/106908) [Nextjs][トップのナビゲーション]アプリ内通知が来た時に、画面全体で`Internal Server Error.` と表示されてしまう というバグがあった。これはページ更新時に生成される in-app notification の snapshot に不正な値が入っていたことが原因でこの PR (https://github.com/weseek/growi/pull/6819) で不正な値にならないように修正している。ただ不正になってしまう in-app notification は DB に残り続けるのでそのデータを削除するためにマイグレーションが必要だと思った。

### 不正な値とは
現状 in-app notifiaction の snapshot には下記のオブジェクトを stringify したものになっている
- page の path
- page を作成した user の object id 

この PR (https://github.com/weseek/growi/pull/6819) までは page document 全体が snapshot に含まれてしまっていた。PR 前後関係無く DB には stringify されたオブジェクトが保存されこの時点では不正な値にはなっておらず、axios でデータフェッチした際に page document 全体を snapshot していた値は `Invalid Date` になってしまっていた。これを不正な値と呼んでいる。　

- stackoverflow でも同じ症状の人はいた. 
  -  https://stackoverflow.com/questions/71025609/axios-request-returning-invalid-date-in-react-but-api-response-in-network-call

- chrome dev tools のネットワークタブを確認したが、この時点では `Invalid Date` にはなっていなかった

### 提案
axios によって不正な値に変化してしまうことは分かったが、不正な値になる条件がわかっていない。ただ、同じ string だけど入れる値によって不正な値に変化してしまうことは分かった。以上のことから今後 snapshot に入れる値が変更されるケースも考えマイグレーションはせず、この PR で実装した、fetch されたデータの snapshot の typeof をみて string 以外のもを弾くという処理で終わらせようと思っています。



