### PR TITLE
support: 110607 show conflict diff modal

### DIFF
--- a/packages/app/src/components/Page/DisplaySwitcher.tsx
+++ b/packages/app/src/components/Page/DisplaySwitcher.tsx
@@ -12,7 +12,9 @@ import {
 } from '~/stores/context';
 import { useDescendantsPageListModal } from '~/stores/modal';
 import { useCurrentPagePath, useSWRxCurrentPage } from '~/stores/page';
-import { useRemoteRevisionId, useRemoteRevisionLastUpdatUser } from '~/stores/remote-latest-page';
+import {
+  useRemoteRevisionBody, useRemoteRevisionId, useRemoteRevisionLastUpdatedAt, useRemoteRevisionLastUpdatUser,
+} from '~/stores/remote-latest-page';
 import { EditorMode, useEditorMode } from '~/stores/ui';
 import { useGlobalSocket } from '~/stores/websocket';
 
@@ -49,6 +51,8 @@ const PageView = React.memo((): JSX.Element => {
   const { open: openDescendantPageListModal } = useDescendantsPageListModal();
   const { mutate: mutateRemoteRevisionId } = useRemoteRevisionId();
   const { mutate: mutateRemoteRevisionLastUpdateUser } = useRemoteRevisionLastUpdatUser();
+  const { mutate: mutateRemoteRevisionBody } = useRemoteRevisionBody();
+  const { mutate: mutateRemoteRevisionLastUpdatedAt } = useRemoteRevisionLastUpdatedAt();
 
   const isTopPagePath = isTopPage(currentPagePath ?? '');
   const isUsersHomePagePath = isUsersHomePage(currentPagePath ?? '');
@@ -59,8 +63,10 @@ const PageView = React.memo((): JSX.Element => {
     const { s2cMessagePageUpdated } = data;
 
     mutateRemoteRevisionId(s2cMessagePageUpdated.revisionId);
+    mutateRemoteRevisionBody(s2cMessagePageUpdated.revisionBody);
     mutateRemoteRevisionLastUpdateUser(s2cMessagePageUpdated.remoteLastUpdateUser);
-  }, [mutateRemoteRevisionId, mutateRemoteRevisionLastUpdateUser]);
+    mutateRemoteRevisionLastUpdatedAt(s2cMessagePageUpdated.revisionUpdateAt);
+  }, [mutateRemoteRevisionBody, mutateRemoteRevisionId, mutateRemoteRevisionLastUpdateUser, mutateRemoteRevisionLastUpdatedAt]);
 
   // listen socket for someone updating this page
   useEffect(() => {

--- a/packages/app/src/components/PageEditor.tsx
+++ b/packages/app/src/components/PageEditor.tsx
@@ -518,8 +518,7 @@ const PageEditor = React.memo((): JSX.Element => {
       </div>
       <ConflictDiffModal
         isOpen={conflictDiffModalStatus?.isOpened}
-        onClose={() => closeConflictDiffModal()} // use useCallback
-        // pageContainer={pageContainer}
+        onClose={() => closeConflictDiffModal()}
         markdownOnEdit={markdownToPreview}
         optionsToSave={undefined} // replace undefined
       />

--- a/packages/app/src/components/PageEditor.tsx
+++ b/packages/app/src/components/PageEditor.tsx
@@ -28,6 +28,7 @@ import {
   useIsConflict,
   useEditingMarkdown,
 } from '~/stores/editor';
+import { useConflictDiffModal } from '~/stores/modal';
 import { useCurrentPagePath, useSWRxCurrentPage } from '~/stores/page';
 import { usePreviewOptions } from '~/stores/renderer';
 import {
@@ -40,6 +41,7 @@ import loggerFactory from '~/utils/logger';
 
 
 // import { ConflictDiffModal } from './PageEditor/ConflictDiffModal';
+import { ConflictDiffModal } from './PageEditor/ConflictDiffModal';
 import Editor from './PageEditor/Editor';
 import Preview from './PageEditor/Preview';
 import scrollSyncHelper from './PageEditor/ScrollSyncHelper';
@@ -83,6 +85,7 @@ const PageEditor = React.memo((): JSX.Element => {
   const { data: currentIndentSize, mutate: mutateCurrentIndentSize } = useCurrentIndentSize();
   const { data: isUploadableFile } = useIsUploadableFile();
   const { data: isUploadableImage } = useIsUploadableImage();
+  const { data: conflictDiffModalStatus, close: closeConflictDiffModal } = useConflictDiffModal();
 
   const { data: rendererOptions, mutate: mutateRendererOptions } = usePreviewOptions();
   const { mutate: mutateIsEnabledUnsavedWarning } = useIsEnabledUnsavedWarning();
@@ -513,13 +516,13 @@ const PageEditor = React.memo((): JSX.Element => {
           onScroll={offset => scrollEditorByPreviewScrollWithThrottle(offset)}
         />
       </div>
-      {/* <ConflictDiffModal
-        isOpen={pageContainer.state.isConflictDiffModalOpen}
-        onClose={() => pageContainer.setState({ isConflictDiffModalOpen: false })}
-        pageContainer={pageContainer}
-        markdownOnEdit={markdown}
-        optionsToSave={optionsToSave}
-      /> */}
+      <ConflictDiffModal
+        isOpen={conflictDiffModalStatus?.isOpened}
+        onClose={() => closeConflictDiffModal()} // use useCallback
+        // pageContainer={pageContainer}
+        markdownOnEdit={markdownToPreview}
+        optionsToSave={undefined} // replace undefined
+      />
     </div>
   );
 });

--- a/packages/app/src/components/PageStatusAlert.tsx
+++ b/packages/app/src/components/PageStatusAlert.tsx
@@ -7,6 +7,7 @@ import { useEditingMarkdown, useIsConflict } from '~/stores/editor';
 import {
   useHasDraftOnHackmd, useIsHackmdDraftUpdatingInRealtime, useRevisionIdHackmdSynced,
 } from '~/stores/hackmd';
+import { useConflictDiffModal } from '~/stores/modal';
 import { useSWRxCurrentPage } from '~/stores/page';
 import { useRemoteRevisionId, useRemoteRevisionLastUpdatUser } from '~/stores/remote-latest-page';
 
@@ -27,6 +28,7 @@ export const PageStatusAlert = (): JSX.Element => {
   const { data: hasDraftOnHackmd } = useHasDraftOnHackmd();
   const { data: isConflict } = useIsConflict();
   const { mutate: mutateEditingMarkdown } = useEditingMarkdown();
+  const { open: openConflictDiffModal } = useConflictDiffModal();
 
   // store remote latest page data
   const { data: revisionIdHackmdSynced } = useRevisionIdHackmdSynced();
@@ -42,10 +44,8 @@ export const PageStatusAlert = (): JSX.Element => {
   }, [mutateEditingMarkdown, mutatePageData]);
 
   const onClickResolveConflict = useCallback(() => {
-    // this.props.pageContainer.setState({
-    //   isConflictDiffModalOpen: true,
-    // });
-  }, []);
+    openConflictDiffModal();
+  }, [openConflictDiffModal]);
 
   const getContentsForSomeoneEditingAlert = useCallback((): AlertComponentContents => {
     return {

--- a/packages/app/src/stores/modal.tsx
+++ b/packages/app/src/stores/modal.tsx
@@ -571,13 +571,12 @@ export const useConflictDiffModal = (): SWRResponse<ConflictDiffModalStatus, Err
   const initialStatus: ConflictDiffModalStatus = { isOpened: false };
   const swrResponse = useStaticSWR<ConflictDiffModalStatus, Error>('conflictDiffModal', undefined, { fallbackData: initialStatus });
 
-  return {
-    ...swrResponse,
-    open() {
+  return Object.assign(swrResponse, {
+    open: () => {
       swrResponse.mutate({ isOpened: true });
     },
-    close() {
+    close: () => {
       swrResponse.mutate({ isOpened: false });
     },
-  };
+  });
 };

--- a/packages/app/src/stores/modal.tsx
+++ b/packages/app/src/stores/modal.tsx
@@ -553,3 +553,31 @@ export const useHandsontableModal = (status?: HandsontableModalStatus): SWRRespo
     close,
   };
 };
+
+/*
+ * ConflictDiffModal
+ */
+type ConflictDiffModalStatus = {
+  isOpened: boolean,
+}
+
+type ConflictDiffModalUtils = {
+  open(): void,
+  close(): void,
+}
+
+export const useConflictDiffModal = (): SWRResponse<ConflictDiffModalStatus, Error> & ConflictDiffModalUtils => {
+
+  const initialStatus: ConflictDiffModalStatus = { isOpened: false };
+  const swrResponse = useStaticSWR<ConflictDiffModalStatus, Error>('conflictDiffModal', undefined, { fallbackData: initialStatus });
+
+  return {
+    ...swrResponse,
+    open() {
+      swrResponse.mutate({ isOpened: true });
+    },
+    close() {
+      swrResponse.mutate({ isOpened: false });
+    },
+  };
+};

--- a/packages/app/src/stores/remote-latest-page.ts
+++ b/packages/app/src/stores/remote-latest-page.ts
@@ -16,3 +16,7 @@ export const useRemoteRevisionBody = (initialData?: string): SWRResponse<string,
 export const useRemoteRevisionLastUpdatUser = (initialData?: IUser): SWRResponse<IUser, Error> => {
   return useStaticSWR<IUser, Error>('remoteRevisionLastUpdatUser', initialData);
 };
+
+export const useRemoteRevisionLastUpdatedAt = (initialData?: Date): SWRResponse<Date, Error> => {
+  return useStaticSWR<Date, Error>('remoteRevisionLastUpdatedAt', initialData);
+};


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/110607

## やったこと
- UpdatedPageAlertの「衝突を解消」ボタンを押すと、コンフリクト解消モーダルが表示されるようになる
- 手元で動作確認済みです

<img width="1909" alt="conflict_modal" src="https://user-images.githubusercontent.com/65263895/206410665-c4a2dc3e-3176-4618-b7f3-002ef68805ba.PNG">


## 備考
- 機能に関しては後続タスクでやります
- https://redmine.weseek.co.jp/issues/110608