### PR TITLE
fix: Redirect does not work after delething page on production environment

### DIFF
--- a/packages/app/src/components/Navbar/GrowiContextualSubNavigation.tsx
+++ b/packages/app/src/components/Navbar/GrowiContextualSubNavigation.tsx
@@ -304,7 +304,9 @@ const GrowiContextualSubNavigation = (props: GrowiContextualSubNavigationProps):
         router.push(path);
       }
       else {
-        reload();
+        // Do not use "router.push(`/${pageId}`)" to avoid `Error: Invariant: attempted to hard navigate to the same URL`
+        // See: https://github.com/weseek/growi/pull/7061
+        router.reload();
       }
     };
     openDeleteModal([pageWithMeta], { onDeleted: deletedHandler });

--- a/packages/app/src/components/Navbar/GrowiContextualSubNavigation.tsx
+++ b/packages/app/src/components/Navbar/GrowiContextualSubNavigation.tsx
@@ -304,13 +304,13 @@ const GrowiContextualSubNavigation = (props: GrowiContextualSubNavigationProps):
         router.push(path);
       }
       else {
-        // Do not use "router.push(`/${pageId}`)" to avoid `Error: Invariant: attempted to hard navigate to the same URL`
+        // Do not use "router.push(currentPathname)" to avoid `Error: Invariant: attempted to hard navigate to the same URL`
         // See: https://github.com/weseek/growi/pull/7061
         router.reload();
       }
     };
     openDeleteModal([pageWithMeta], { onDeleted: deletedHandler });
-  }, [openDeleteModal, reload, router]);
+  }, [openDeleteModal, router]);
 
   const switchContentWidthHandler = useCallback(async(pageId: string, value: boolean) => {
     await updateContentWidth(pageId, value);

--- a/packages/app/src/components/PageAlert/TrashPageAlert.tsx
+++ b/packages/app/src/components/PageAlert/TrashPageAlert.tsx
@@ -43,7 +43,7 @@ export const TrashPageAlert = (): JSX.Element => {
       return;
     }
     const putBackedHandler = () => {
-      // Do not use "router.push(path)" to avoid Err"
+      // Do not use "router.push(`/${pageId}`)" to avoid Err"
       // See: https://github.com/weseek/growi/pull/7054
       router.reload();
     };

--- a/packages/app/src/components/PageAlert/TrashPageAlert.tsx
+++ b/packages/app/src/components/PageAlert/TrashPageAlert.tsx
@@ -43,6 +43,7 @@ export const TrashPageAlert = (): JSX.Element => {
       return;
     }
     const putBackedHandler = () => {
+      // Do not use "router.push(path)" to avoid Err"
       router.reload();
     };
     openPutBackPageModal({ pageId, path: pagePath }, { onPutBacked: putBackedHandler });

--- a/packages/app/src/components/PageAlert/TrashPageAlert.tsx
+++ b/packages/app/src/components/PageAlert/TrashPageAlert.tsx
@@ -44,6 +44,7 @@ export const TrashPageAlert = (): JSX.Element => {
     }
     const putBackedHandler = () => {
       // Do not use "router.push(path)" to avoid Err"
+      // See: https://github.com/weseek/growi/pull/7054
       router.reload();
     };
     openPutBackPageModal({ pageId, path: pagePath }, { onPutBacked: putBackedHandler });

--- a/packages/app/src/components/PageAlert/TrashPageAlert.tsx
+++ b/packages/app/src/components/PageAlert/TrashPageAlert.tsx
@@ -43,7 +43,7 @@ export const TrashPageAlert = (): JSX.Element => {
       return;
     }
     const putBackedHandler = () => {
-      // Do not use "router.push(`/${pageId}`)" to avoid Err"
+      // Do not use "router.push(`/${pageId}`)" to avoid `Error: Invariant: attempted to hard navigate to the same URL`
       // See: https://github.com/weseek/growi/pull/7054
       router.reload();
     };


### PR DESCRIPTION
## Task
[Next.js][/trash] /hoge ページ削除時に /trash/hoge にリダイレクトされない (ローカル環境では発生しない)
┗[110183](https://redmine.weseek.co.jp/issues/110183)

## Description
原因は https://github.com/weseek/growi/pull/7054 と同じなので参照してください。

## Before(dev wiki: 6.0.0-RC.11)
https://user-images.githubusercontent.com/59536731/206671680-67ba7bfd-2eb9-4cb7-92a9-5eec65202a02.mov


## After (local)
https://user-images.githubusercontent.com/59536731/206671864-b1df06e8-435e-4b17-8451-e5d79073f0b2.mov



