### PR TITLE
fix: Do not show author info in UsersHomePage

### DIFF
--- a/packages/app/src/components/Navbar/GrowiContextualSubNavigation.tsx
+++ b/packages/app/src/components/Navbar/GrowiContextualSubNavigation.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
 
-import { isPopulated, IUser } from '@growi/core';
+import { isPopulated, IUser, pagePathUtils } from '@growi/core';
 import { useTranslation } from 'next-i18next';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
@@ -43,6 +43,7 @@ import type { SubNavButtonsProps } from './SubNavButtons';
 import AuthorInfoStyles from './AuthorInfo.module.scss';
 import PageEditorModeManagerStyles from './PageEditorModeManager.module.scss';
 
+const { isUsersHomePage } = pagePathUtils;
 
 const AuthorInfoSkeleton = () => <Skeleton additionalClass={`${AuthorInfoStyles['grw-author-info-skeleton']} py-1`} />;
 
@@ -378,7 +379,7 @@ const GrowiContextualSubNavigation = (props: GrowiContextualSubNavigationProps):
               />
             )}
           </div>
-          { (isAbleToShowPageAuthors && !isCompactMode) && (
+          { (isAbleToShowPageAuthors && !isCompactMode && !isUsersHomePage(path ?? '')) && (
             <ul className={`${AuthorInfoStyles['grw-author-info']} text-nowrap border-left d-none d-lg-block d-edit-none py-2 pl-4 mb-0 ml-3`}>
               <li className="pb-1">
                 { currentPage != null


### PR DESCRIPTION
## Task
110221 [Next.js][Guest user]/user/hoge ページの navbar に AuthorInfo が表示されている
└ 110883 修正

## Screenshot

ログイン時
<img width="1440" alt="ScreenShot 2022-12-09 18 32 46" src="https://user-images.githubusercontent.com/34241526/206672052-56ad8178-ae15-43f7-b57a-2b70a5a82a2d.png">

ゲストモード時
<img width="1440" alt="ScreenShot 2022-12-09 18 33 12" src="https://user-images.githubusercontent.com/34241526/206672859-3d124943-a99f-4492-9705-a999d18d8974.png">



