### PR TITLE
imprv: Revive preLogin

### DIFF
--- a/packages/app/src/server/routes/login.js
+++ b/packages/app/src/server/routes/login.js
@@ -102,18 +102,18 @@ module.exports = function(crowi, app) {
 
   actions.preLogin = function(req, res, next) {
     // user has already logged in
-    // const { user } = req;
-    // if (user != null && user.status === User.STATUS_ACTIVE) {
-    //   const { redirectTo } = req.session;
-    //   // remove session.redirectTo
-    //   delete req.session.redirectTo;
-    //   return res.safeRedirect(redirectTo);
-    // }
+    const { user } = req;
+    if (user != null && user.status === User.STATUS_ACTIVE) {
+      const { redirectTo } = req.session;
+      // remove session.redirectTo
+      delete req.session.redirectTo;
+      return res.safeRedirect(redirectTo);
+    }
 
-    // // set referer to 'redirectTo'
-    // if (req.session.redirectTo == null && req.headers.referer != null) {
-    //   req.session.redirectTo = req.headers.referer;
-    // }
+    // set referer to 'redirectTo'
+    if (req.session.redirectTo == null && req.headers.referer != null) {
+      req.session.redirectTo = req.headers.referer;
+    }
 
     next();
   };


### PR DESCRIPTION
## Task
[Next.js] コメントアウトされている preLogin の中身の処理 を復活させる
┗[110715](https://redmine.weseek.co.jp/issues/110715) 修正

## Description
- register
- login
が正常動作することを確認しました。

## Note
https://github.com/weseek/growi/blob/dev/5.1.x/packages/app/src/server/routes/index.js#L74-L80

v5 までは、`preLogin` は、①「GET /register 」と ②「GET  /login」 で使われていましたが、
#7031 のPRによって 「GET /register」 は　v6から削除されています。