### PR TITLE
fix: 110743 tooltip for guest

### DIFF
--- a/packages/app/src/components/BookmarkButtons.tsx
+++ b/packages/app/src/components/BookmarkButtons.tsx
@@ -42,14 +42,14 @@ const BookmarkButtons: FC<Props> = (props: Props) => {
 
   const getTooltipMessage = useCallback(() => {
     if (isGuestUser) {
-      return 'Not available for guest';
+      return t('Not available for guest');
     }
 
     if (isBookmarked) {
       return 'tooltip.cancel_bookmark';
     }
     return 'tooltip.bookmark';
-  }, [isGuestUser, isBookmarked]);
+  }, [isGuestUser, isBookmarked, t]);
 
   return (
     <div className={`btn-group btn-group-bookmark ${styles['btn-group-bookmark']}`} role="group" aria-label="Bookmark buttons">

--- a/packages/app/src/components/BookmarkButtons.tsx
+++ b/packages/app/src/components/BookmarkButtons.tsx
@@ -41,15 +41,12 @@ const BookmarkButtons: FC<Props> = (props: Props) => {
   };
 
   const getTooltipMessage = useCallback(() => {
-    if (isGuestUser) {
-      return t('Not available for guest');
-    }
 
     if (isBookmarked) {
       return 'tooltip.cancel_bookmark';
     }
     return 'tooltip.bookmark';
-  }, [isGuestUser, isBookmarked, t]);
+  }, [isBookmarked]);
 
   return (
     <div className={`btn-group btn-group-bookmark ${styles['btn-group-bookmark']}`} role="group" aria-label="Bookmark buttons">

--- a/packages/app/src/components/LikeButtons.tsx
+++ b/packages/app/src/components/LikeButtons.tsx
@@ -35,14 +35,14 @@ const LikeButtons: FC<LikeButtonsProps> = (props: LikeButtonsProps) => {
 
   const getTooltipMessage = useCallback(() => {
     if (isGuestUser) {
-      return 'Not available for guest';
+      return t('Not available for guest');
     }
 
     if (isLiked) {
       return 'tooltip.cancel_like';
     }
     return 'tooltip.like';
-  }, [isGuestUser, isLiked]);
+  }, [isGuestUser, isLiked, t]);
 
   return (
     <div className={`btn-group btn-group-like ${styles['btn-group-like']}`} role="group" aria-label="Like buttons">

--- a/packages/app/src/components/LikeButtons.tsx
+++ b/packages/app/src/components/LikeButtons.tsx
@@ -34,15 +34,12 @@ const LikeButtons: FC<LikeButtonsProps> = (props: LikeButtonsProps) => {
   } = props;
 
   const getTooltipMessage = useCallback(() => {
-    if (isGuestUser) {
-      return t('Not available for guest');
-    }
 
     if (isLiked) {
       return 'tooltip.cancel_like';
     }
     return 'tooltip.like';
-  }, [isGuestUser, isLiked, t]);
+  }, [isLiked]);
 
   return (
     <div className={`btn-group btn-group-like ${styles['btn-group-like']}`} role="group" aria-label="Like buttons">

--- a/packages/app/src/components/Navbar/PageEditorModeManager.jsx
+++ b/packages/app/src/components/Navbar/PageEditorModeManager.jsx
@@ -110,11 +110,6 @@ function PageEditorModeManager(props) {
           </>
         )}
       </div>
-      {isBtnDisabled && (
-        <UncontrolledTooltip placement="top" target="grw-page-editor-mode-manager" fade={false}>
-          {t('Not available for guest')}
-        </UncontrolledTooltip>
-      )}
     </>
   );
 

--- a/packages/app/src/components/NotAvailableForGuest.jsx
+++ b/packages/app/src/components/NotAvailableForGuest.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { useTranslation } from 'next-i18next';
 import PropTypes from 'prop-types';
 import { UncontrolledTooltip } from 'reactstrap';
 
@@ -7,6 +8,7 @@ import { useIsGuestUser } from '~/stores/context';
 
 const NotAvailableForGuest = (props) => {
   const { children } = props;
+  const { t } = useTranslation();
 
   const { data: isGuestUser } = useIsGuestUser();
 
@@ -26,7 +28,7 @@ const NotAvailableForGuest = (props) => {
   return (
     <>
       { clonedChild }
-      <UncontrolledTooltip placement="top" target={id}>Not available for guest</UncontrolledTooltip>
+      <UncontrolledTooltip placement="top" target={id}>{t('Not available for guest')}</UncontrolledTooltip>
     </>
   );
 

--- a/packages/app/src/components/Page/RenderTagLabels.tsx
+++ b/packages/app/src/components/Page/RenderTagLabels.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import { useTranslation } from 'next-i18next';
-import { UncontrolledTooltip } from 'reactstrap';
 
 import NotAvailableForGuest from '../NotAvailableForGuest';
 

--- a/packages/app/src/components/Page/RenderTagLabels.tsx
+++ b/packages/app/src/components/Page/RenderTagLabels.tsx
@@ -3,6 +3,8 @@ import React from 'react';
 import { useTranslation } from 'next-i18next';
 import { UncontrolledTooltip } from 'reactstrap';
 
+import NotAvailableForGuest from '../NotAvailableForGuest';
+
 type RenderTagLabelsProps = {
   tags: string[],
   isGuestUser: boolean,
@@ -23,7 +25,7 @@ const RenderTagLabels = React.memo((props: RenderTagLabelsProps) => {
   const isTagsEmpty = tags.length === 0;
 
   return (
-    <>
+    <NotAvailableForGuest>
       {tags.map((tag) => {
         return (
           <a key={tag} href={`/_search?q=tag:${tag}`} className="grw-tag-label badge badge-secondary mr-2">
@@ -40,12 +42,7 @@ const RenderTagLabels = React.memo((props: RenderTagLabelsProps) => {
           <i className={`icon-plus ${isTagsEmpty && 'ml-1'}`}/>
         </a>
       </div>
-      {isGuestUser && (
-        <UncontrolledTooltip placement="top" target="edit-tags-btn-wrapper-for-tooltip" fade={false}>
-          {t('Not available for guest')}
-        </UncontrolledTooltip>
-      )}
-    </>
+    </NotAvailableForGuest>
   );
 
 });

--- a/packages/app/src/components/Page/RenderTagLabels.tsx
+++ b/packages/app/src/components/Page/RenderTagLabels.tsx
@@ -24,7 +24,7 @@ const RenderTagLabels = React.memo((props: RenderTagLabelsProps) => {
   const isTagsEmpty = tags.length === 0;
 
   return (
-    <NotAvailableForGuest>
+    <>
       {tags.map((tag) => {
         return (
           <a key={tag} href={`/_search?q=tag:${tag}`} className="grw-tag-label badge badge-secondary mr-2">
@@ -32,16 +32,19 @@ const RenderTagLabels = React.memo((props: RenderTagLabelsProps) => {
           </a>
         );
       })}
-      <div id="edit-tags-btn-wrapper-for-tooltip">
-        <a
-          className={`btn btn-link btn-edit-tags text-muted p-0 d-flex align-items-center ${isTagsEmpty && 'no-tags'} ${isGuestUser && 'disabled'}`}
-          onClick={openEditorHandler}
-        >
-          { isTagsEmpty && <>{ t('Add tags for this page') }</>}
-          <i className={`icon-plus ${isTagsEmpty && 'ml-1'}`}/>
-        </a>
-      </div>
-    </NotAvailableForGuest>
+      <NotAvailableForGuest>
+        <div id="edit-tags-btn-wrapper-for-tooltip">
+          <a
+            className={`btn btn-link btn-edit-tags text-muted p-0 d-flex align-items-center ${isTagsEmpty && 'no-tags'} ${isGuestUser && 'disabled'}`}
+            onClick={openEditorHandler}
+          >
+            { isTagsEmpty && <>{ t('Add tags for this page') }</>}
+            <i className={`icon-plus ${isTagsEmpty && 'ml-1'}`}/>
+          </a>
+        </div>
+      </NotAvailableForGuest>
+    </>
+
   );
 
 });

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -483,40 +483,39 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
           </div>
         )}
         <div className="grw-pagetree-control d-flex">
-          <NotAvailableForGuest>
-            <div id='option-button-in-page-tree'>
-              <PageItemControl
-                pageId={page._id}
-                isEnableActions={isEnableActions}
-                onClickBookmarkMenuItem={bookmarkMenuItemClickHandler}
-                onClickDuplicateMenuItem={duplicateMenuItemClickHandler}
-                onClickRenameMenuItem={renameMenuItemClickHandler}
-                onClickDeleteMenuItem={deleteMenuItemClickHandler}
-                onClickPathRecoveryMenuItem={pathRecoveryMenuItemClickHandler}
-                isInstantRename
-                // Todo: It is wanted to find a better way to pass operationProcessData to PageItemControl
-                operationProcessData={page.processData}
-              >
-                {/* pass the color property to reactstrap dropdownToggle props. https://6-4-0--reactstrap.netlify.app/components/dropdowns/  */}
-                <DropdownToggle color="transparent" className="border-0 rounded btn-page-item-control p-0 grw-visible-on-hover mr-1">
-                  <i className="icon-options fa fa-rotate-90 p-1"></i>
-                </DropdownToggle>
-              </PageItemControl>
-            </div>
-          </NotAvailableForGuest>
-          {!pagePathUtils.isUsersTopPage(page.path ?? '') && (
-            <NotAvailableForGuest>
-              <button
-                id='page-create-button-in-page-tree'
-                type="button"
-                className="border-0 rounded btn btn-page-item-control p-0 grw-visible-on-hover"
-                onClick={onClickPlusButton}
-              >
-                <i className="icon-plus d-block p-0" />
-              </button>
-            </NotAvailableForGuest>
-          )}
+          <PageItemControl
+            pageId={page._id}
+            isEnableActions={isEnableActions}
+            onClickBookmarkMenuItem={bookmarkMenuItemClickHandler}
+            onClickDuplicateMenuItem={duplicateMenuItemClickHandler}
+            onClickRenameMenuItem={renameMenuItemClickHandler}
+            onClickDeleteMenuItem={deleteMenuItemClickHandler}
+            onClickPathRecoveryMenuItem={pathRecoveryMenuItemClickHandler}
+            isInstantRename
+            // Todo: It is wanted to find a better way to pass operationProcessData to PageItemControl
+            operationProcessData={page.processData}
+          >
+            {/* pass the color property to reactstrap dropdownToggle props. https://6-4-0--reactstrap.netlify.app/components/dropdowns/  */}
+            <DropdownToggle color="transparent" className="border-0 rounded btn-page-item-control p-0 grw-visible-on-hover mr-1">
+              <NotAvailableForGuest>
+                <i id='option-button-in-page-tree' className="icon-options fa fa-rotate-90 p-1"></i>
+              </NotAvailableForGuest>
+            </DropdownToggle>
+          </PageItemControl>
         </div>
+
+        {!pagePathUtils.isUsersTopPage(page.path ?? '') && (
+          <NotAvailableForGuest>
+            <button
+              id='page-create-button-in-page-tree'
+              type="button"
+              className="border-0 rounded btn btn-page-item-control p-0 grw-visible-on-hover"
+              onClick={onClickPlusButton}
+            >
+              <i className="icon-plus d-block p-0" />
+            </button>
+          </NotAvailableForGuest>
+        )}
       </li>
 
       {isEnableActions && isNewPageInputShown && (

--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -14,6 +14,7 @@ import { bookmark, unbookmark, resumeRenameOperation } from '~/client/services/p
 import { toastWarning, toastError, toastSuccess } from '~/client/util/apiNotification';
 import { apiv3Put, apiv3Post } from '~/client/util/apiv3-client';
 import TriangleIcon from '~/components/Icons/TriangleIcon';
+import NotAvailableForGuest from '~/components/NotAvailableForGuest';
 import {
   IPageHasId, IPageInfoAll, IPageToDeleteWithMeta,
 } from '~/interfaces/page';
@@ -482,31 +483,38 @@ const Item: FC<ItemProps> = (props: ItemProps) => {
           </div>
         )}
         <div className="grw-pagetree-control d-flex">
-          <PageItemControl
-            pageId={page._id}
-            isEnableActions={isEnableActions}
-            onClickBookmarkMenuItem={bookmarkMenuItemClickHandler}
-            onClickDuplicateMenuItem={duplicateMenuItemClickHandler}
-            onClickRenameMenuItem={renameMenuItemClickHandler}
-            onClickDeleteMenuItem={deleteMenuItemClickHandler}
-            onClickPathRecoveryMenuItem={pathRecoveryMenuItemClickHandler}
-            isInstantRename
-            // Todo: It is wanted to find a better way to pass operationProcessData to PageItemControl
-            operationProcessData={page.processData}
-          >
-            {/* pass the color property to reactstrap dropdownToggle props. https://6-4-0--reactstrap.netlify.app/components/dropdowns/  */}
-            <DropdownToggle color="transparent" className="border-0 rounded btn-page-item-control p-0 grw-visible-on-hover mr-1">
-              <i className="icon-options fa fa-rotate-90 p-1"></i>
-            </DropdownToggle>
-          </PageItemControl>
+          <NotAvailableForGuest>
+            <div id='option-button-in-page-tree'>
+              <PageItemControl
+                pageId={page._id}
+                isEnableActions={isEnableActions}
+                onClickBookmarkMenuItem={bookmarkMenuItemClickHandler}
+                onClickDuplicateMenuItem={duplicateMenuItemClickHandler}
+                onClickRenameMenuItem={renameMenuItemClickHandler}
+                onClickDeleteMenuItem={deleteMenuItemClickHandler}
+                onClickPathRecoveryMenuItem={pathRecoveryMenuItemClickHandler}
+                isInstantRename
+                // Todo: It is wanted to find a better way to pass operationProcessData to PageItemControl
+                operationProcessData={page.processData}
+              >
+                {/* pass the color property to reactstrap dropdownToggle props. https://6-4-0--reactstrap.netlify.app/components/dropdowns/  */}
+                <DropdownToggle color="transparent" className="border-0 rounded btn-page-item-control p-0 grw-visible-on-hover mr-1">
+                  <i className="icon-options fa fa-rotate-90 p-1"></i>
+                </DropdownToggle>
+              </PageItemControl>
+            </div>
+          </NotAvailableForGuest>
           {!pagePathUtils.isUsersTopPage(page.path ?? '') && (
-            <button
-              type="button"
-              className="border-0 rounded btn btn-page-item-control p-0 grw-visible-on-hover"
-              onClick={onClickPlusButton}
-            >
-              <i className="icon-plus d-block p-0" />
-            </button>
+            <NotAvailableForGuest>
+              <button
+                id='page-create-button-in-page-tree'
+                type="button"
+                className="border-0 rounded btn btn-page-item-control p-0 grw-visible-on-hover"
+                onClick={onClickPlusButton}
+              >
+                <i className="icon-plus d-block p-0" />
+              </button>
+            </NotAvailableForGuest>
           )}
         </div>
       </li>

--- a/packages/app/src/components/SubscribeButton.tsx
+++ b/packages/app/src/components/SubscribeButton.tsx
@@ -20,15 +20,12 @@ const SubscribeButton: FC<Props> = (props: Props) => {
   const isSubscribing = status === SubscriptionStatusType.SUBSCRIBE;
 
   const getTooltipMessage = useCallback(() => {
-    if (isGuestUser) {
-      return t('Not available for guest');
-    }
 
     if (isSubscribing) {
       return 'tooltip.stop_notification';
     }
     return 'tooltip.receive_notifications';
-  }, [isGuestUser, isSubscribing, t]);
+  }, [isSubscribing]);
 
   return (
     <>

--- a/packages/app/src/components/SubscribeButton.tsx
+++ b/packages/app/src/components/SubscribeButton.tsx
@@ -21,14 +21,14 @@ const SubscribeButton: FC<Props> = (props: Props) => {
 
   const getTooltipMessage = useCallback(() => {
     if (isGuestUser) {
-      return 'Not available for guest';
+      return t('Not available for guest');
     }
 
     if (isSubscribing) {
       return 'tooltip.stop_notification';
     }
     return 'tooltip.receive_notifications';
-  }, [isGuestUser, isSubscribing]);
+  }, [isGuestUser, isSubscribing, t]);
 
   return (
     <>


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/110150

# やったこと
- サイドバーのページ作成ボタン
- サイドバーの三点ボタン

にゲストは使えない旨のツールチップを追加

- 既存のツールチップコンポーネントをi18n対応

# 備考
以下のコンポーネントはゲストには表示されない仕様になっていたので削除
- ブックマークボタン
- サブスクライブボタン
- いいねボタン
- PageModeManagerの3つのボタン

以下のコンポーネントで未ログイン状態でホバーすると正常にツールチップが出ることを確認
- サイドバーのページ作成ボタン
- サイドバーの三点ボタン
- タグボタン
