### PR TITLE
fix: WideView Setting on ShareLink mode is not reflected

### DIFF
--- a/packages/app/src/client/services/use-current-layout-class-name.ts
+++ b/packages/app/src/client/services/use-current-layout-class-name.ts
@@ -1,9 +1,10 @@
-import { useIsContainerFluid } from '~/stores/context';
+import { useIsContainerFluid, useShareLinkId } from '~/stores/context';
 import { useSWRxCurrentPage } from '~/stores/page';
 import { useEditorMode } from '~/stores/ui';
 
 export const useCurrentLayoutClassName = (): string => {
-  const { data: currentPage } = useSWRxCurrentPage();
+  const { data: shareLinkId } = useShareLinkId();
+  const { data: currentPage } = useSWRxCurrentPage(shareLinkId ?? undefined);
 
   const { data: dataIsContainerFluid } = useIsContainerFluid();
   const { getClassNamesByEditorMode } = useEditorMode();

--- a/packages/app/src/pages/share/[[...path]].page.tsx
+++ b/packages/app/src/pages/share/[[...path]].page.tsx
@@ -26,7 +26,6 @@ import {
   useShareLinkId, useIsSearchServiceConfigured, useIsSearchServiceReachable, useIsSearchScopeChildrenAsDefault, useDrawioUri, useIsContainerFluid,
 } from '~/stores/context';
 import { useDescendantsPageListModal } from '~/stores/modal';
-import { useSWRxCurrentPage } from '~/stores/page';
 import loggerFactory from '~/utils/logger';
 
 import {
@@ -54,7 +53,6 @@ const SharedPage: NextPage<Props> = (props: Props) => {
   useShareLinkId(props.shareLink?._id);
   useCurrentPageId(props.shareLink?.relatedPage._id);
   useCurrentUser(props.currentUser);
-  useSWRxCurrentPage(props.shareLink?._id); // store initial data
   useCurrentPathname(props.currentPathname);
   useRendererConfig(props.rendererConfig);
   useIsSearchServiceConfigured(props.isSearchServiceConfigured);

--- a/packages/app/src/pages/share/[[...path]].page.tsx
+++ b/packages/app/src/pages/share/[[...path]].page.tsx
@@ -26,6 +26,7 @@ import {
   useShareLinkId, useIsSearchServiceConfigured, useIsSearchServiceReachable, useIsSearchScopeChildrenAsDefault, useDrawioUri, useIsContainerFluid,
 } from '~/stores/context';
 import { useDescendantsPageListModal } from '~/stores/modal';
+import { useSWRxCurrentPage } from '~/stores/page';
 import loggerFactory from '~/utils/logger';
 
 import {
@@ -53,6 +54,7 @@ const SharedPage: NextPage<Props> = (props: Props) => {
   useShareLinkId(props.shareLink?._id);
   useCurrentPageId(props.shareLink?.relatedPage._id);
   useCurrentUser(props.currentUser);
+  useSWRxCurrentPage(props.shareLink?._id); // store initial data
   useCurrentPathname(props.currentPathname);
   useRendererConfig(props.rendererConfig);
   useIsSearchServiceConfigured(props.isSearchServiceConfigured);


### PR DESCRIPTION
## Task
[Next.js] sharelink先にページ個別のワイドビュー設定が反映されない
┗[111131](https://redmine.weseek.co.jp/issues/111131) 修正

## Description

https://github.com/weseek/growi/blob/imprv/get-layout-pattern/packages/app/src/client/services/use-current-layout-class-name.ts#L11-L13

ShareLink のページでは、currentPage がnull になっているため、管理画面のカスタマイズで設定された `isContainerFluidDefault (dataIsContainerFluid)` が適用されてしまっていることが原因でした。

## ScreenShots
### isContainerFluid: `false`
<img width="1774" alt="Screen Shot 2022-12-15 at 19 12 18" src="https://user-images.githubusercontent.com/59536731/207832803-1d1a386a-47cc-4a67-a815-86b57ffb140d.png">

<img width="1776" alt="Screen Shot 2022-12-15 at 19 12 26" src="https://user-images.githubusercontent.com/59536731/207832811-855de226-d8cf-4af2-9d02-0259afccd28d.png">


### isContainerFluid:  `true`
<img width="1790" alt="Screen Shot 2022-12-15 at 19 12 34" src="https://user-images.githubusercontent.com/59536731/207832815-2185d4bf-4768-4d9c-9832-6cdb8028d357.png">

<img width="1787" alt="Screen Shot 2022-12-15 at 19 12 49" src="https://user-images.githubusercontent.com/59536731/207832819-f1377933-8920-4a4a-bf08-608b296352d8.png">
