### PR TITLE
fix: disable tooltip for logged in user

### DIFF
--- a/packages/app/src/components/NotAvailableForGuest.tsx
+++ b/packages/app/src/components/NotAvailableForGuest.tsx
@@ -16,6 +16,10 @@ export const NotAvailableForGuest = ({ children }: NotAvailableForGuestProps): J
   const { data: isGuestUser } = useIsGuestUser();
   const isDisabled = !!isGuestUser;
 
+  if (!isGuestUser) {
+    return children;
+  }
+
   const id = `grw-not-available-for-guest-${Math.random().toString(32).substring(2)}`;
 
   return (


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/111311

# やったこと
- NotAvailableForGuestコンポーネント内部のログインユーザーに対する条件分岐が抜けていたので、修正