### PR TITLE
imprv: Do no get tags on share link page

### DIFF
--- a/packages/app/src/components/Page.tsx
+++ b/packages/app/src/components/Page.tsx
@@ -5,6 +5,7 @@ import React, {
 
 import EventEmitter from 'events';
 
+import { pagePathUtils } from '@growi/core';
 import { DrawioEditByViewerProps } from '@growi/remark-drawio';
 import { useTranslation } from 'next-i18next';
 import dynamic from 'next/dynamic';
@@ -15,7 +16,7 @@ import { useSaveOrUpdate } from '~/client/services/page-operation';
 import { toastSuccess, toastError } from '~/client/util/apiNotification';
 import { OptionsToSave } from '~/interfaces/page-operation';
 import {
-  useIsGuestUser, useShareLinkId,
+  useIsGuestUser, useShareLinkId, useCurrentPathname,
 } from '~/stores/context';
 import { useEditingMarkdown } from '~/stores/editor';
 import { useDrawioModal, useHandsontableModal } from '~/stores/modal';
@@ -59,10 +60,13 @@ export const Page = (props) => {
     tocRef.current = toc;
   }, []);
 
+  const { data: currentPathname } = useCurrentPathname();
+  const isSharedPage = pagePathUtils.isSharedPage(currentPathname ?? '');
+
   const { data: shareLinkId } = useShareLinkId();
   const { data: currentPage, mutate: mutateCurrentPage } = useSWRxCurrentPage(shareLinkId ?? undefined);
   const { mutate: mutateEditingMarkdown } = useEditingMarkdown();
-  const { data: tagsInfo } = useSWRxTagsInfo(currentPage?._id);
+  const { data: tagsInfo } = useSWRxTagsInfo(!isSharedPage ? currentPage?._id : undefined);
   const { data: isGuestUser } = useIsGuestUser();
   const { data: isMobile } = useIsMobile();
   const { data: rendererOptions, mutate: mutateRendererOptions } = useViewOptions(storeTocNodeHandler);

--- a/packages/app/src/stores/page.tsx
+++ b/packages/app/src/stores/page.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 
 import type {
-  IPageInfoForEntity, IPagePopulatedToShowRevision,
+  IPageInfoForEntity, IPagePopulatedToShowRevision, Nullable,
 } from '@growi/core';
 import { isClient, pagePathUtils } from '@growi/core';
 import useSWR, { Key, SWRResponse } from 'swr';
@@ -80,11 +80,11 @@ export const useSWRxCurrentPage = (
 };
 
 
-export const useSWRxTagsInfo = (pageId?: string): SWRResponse<IPageTagsInfo | undefined, Error> => {
+export const useSWRxTagsInfo = (pageId: Nullable<string>): SWRResponse<IPageTagsInfo | undefined, Error> => {
   const endpoint = `/pages.getPageTag?pageId=${pageId}`;
   const key = pageId != null ? [endpoint, pageId] : null;
 
-  const fetcher = async(endpoint: string, pageId?: string) => {
+  const fetcher = async(endpoint: string, pageId: Nullable<string>) => {
     let tags: string[] = [];
     // when the page exists
     if (pageId != null) {

--- a/packages/app/src/stores/page.tsx
+++ b/packages/app/src/stores/page.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 
 import type {
-  IPageInfoForEntity, IPagePopulatedToShowRevision, Nullable,
+  IPageInfoForEntity, IPagePopulatedToShowRevision,
 } from '@growi/core';
 import { isClient, pagePathUtils } from '@growi/core';
 import useSWR, { Key, SWRResponse } from 'swr';
@@ -80,11 +80,11 @@ export const useSWRxCurrentPage = (
 };
 
 
-export const useSWRxTagsInfo = (pageId: Nullable<string>): SWRResponse<IPageTagsInfo | undefined, Error> => {
+export const useSWRxTagsInfo = (pageId?: string): SWRResponse<IPageTagsInfo | undefined, Error> => {
   const endpoint = `/pages.getPageTag?pageId=${pageId}`;
   const key = pageId != null ? [endpoint, pageId] : null;
 
-  const fetcher = async(endpoint: string, pageId: Nullable<string>) => {
+  const fetcher = async(endpoint: string, pageId?: string) => {
     let tags: string[] = [];
     // when the page exists
     if (pageId != null) {

--- a/packages/app/src/stores/page.tsx
+++ b/packages/app/src/stores/page.tsx
@@ -81,9 +81,8 @@ export const useSWRxCurrentPage = (
 
 
 export const useSWRxTagsInfo = (pageId: Nullable<string>): SWRResponse<IPageTagsInfo | undefined, Error> => {
-
   const endpoint = `/pages.getPageTag?pageId=${pageId}`;
-  const key = [endpoint, pageId];
+  const key = pageId != null ? [endpoint, pageId] : null;
 
   const fetcher = async(endpoint: string, pageId: Nullable<string>) => {
     let tags: string[] = [];

--- a/packages/app/src/stores/page.tsx
+++ b/packages/app/src/stores/page.tsx
@@ -81,8 +81,9 @@ export const useSWRxCurrentPage = (
 
 
 export const useSWRxTagsInfo = (pageId: Nullable<string>): SWRResponse<IPageTagsInfo | undefined, Error> => {
+
   const endpoint = `/pages.getPageTag?pageId=${pageId}`;
-  const key = pageId != null ? [endpoint, pageId] : null;
+  const key = [endpoint, pageId];
 
   const fetcher = async(endpoint: string, pageId: Nullable<string>) => {
     let tags: string[] = [];


### PR DESCRIPTION
## Task
[#111302](https://redmine.weseek.co.jp/issues/111302) [Next.js] Share link ページでは /_api/pages.getPageTag へリクエストをさせないようにする
└ [#111303](https://redmine.weseek.co.jp/issues/111303) 改善

## Memo
Basic認証が適用されている GROWI において、share link ページに遷移すると express の loginRequired middleware が効いてしまい '/login' へリダイレクトさせようとするため Basic認証 を要求してくる
