### PR TITLE
fix: Redirect to root page when moving to a shared page with no id

### DIFF
--- a/packages/app/src/server/routes/index.js
+++ b/packages/app/src/server/routes/index.js
@@ -197,6 +197,7 @@ module.exports = function(crowi, app) {
     .get('/:token', applicationInstalled, injectUserRegistrationOrderByTokenMiddleware, userActivation.renderUserActivationPage(crowi))
     .use(userActivation.tokenErrorHandlerMiddeware(crowi)));
 
+  app.get('/share$', (req, res) => res.redirect('/'));
   app.get('/share/:linkId', next.delegateToNext);
 
   app.use('/ogp', express.Router().get('/:pageId([0-9a-z]{0,})', loginRequired, ogp.pageIdRequired, ogp.ogpValidator, ogp.renderOgp));


### PR DESCRIPTION
## Task
[#110223](https://redmine.weseek.co.jp/issues/110223) [Next.js] /share ページが Page is not found となる
└ [#110506](https://redmine.weseek.co.jp/issues/110506) 修正