### PR TITLE
fix: Do not show global search bar on share link page

### DIFF
--- a/packages/app/src/components/Layout/ShareLinkLayout.tsx
+++ b/packages/app/src/components/Layout/ShareLinkLayout.tsx
@@ -30,7 +30,7 @@ export const ShareLinkLayout = ({
 
   return (
     <RawLayout title={title} className={myClassName}>
-      <GrowiNavbar />
+      <GrowiNavbar isGlobalSearchHidden={true} />
 
       <div className="page-wrapper d-flex d-print-block">
         <div className="flex-fill mw-0" style={{ position: 'relative' }}>


### PR DESCRIPTION
https://github.com/weseek/growi/pull/7099 の引き継ぎ