### PR TITLE
fix: Author info and page path are not displayed on share link page

### DIFF
--- a/packages/app/src/components/Navbar/GrowiContextualSubNavigation.tsx
+++ b/packages/app/src/components/Navbar/GrowiContextualSubNavigation.tsx
@@ -188,7 +188,8 @@ const GrowiContextualSubNavigation = (props: GrowiContextualSubNavigationProps):
 
   const router = useRouter();
 
-  const { data: currentPage, mutate: mutateCurrentPage } = useSWRxCurrentPage();
+  const { data: shareLinkId } = useShareLinkId();
+  const { data: currentPage, mutate: mutateCurrentPage } = useSWRxCurrentPage(shareLinkId ?? undefined);
 
   const revision = currentPage?.revision;
   const revisionId = (revision != null && isPopulated(revision)) ? revision._id : undefined;
@@ -201,7 +202,6 @@ const GrowiContextualSubNavigation = (props: GrowiContextualSubNavigationProps):
   const { data: isNotFound } = useIsNotFound();
   const { data: isGuestUser } = useIsGuestUser();
   const { data: isSharedUser } = useIsSharedUser();
-  const { data: shareLinkId } = useShareLinkId();
   const { data: isContainerFluid } = useIsContainerFluid();
 
   const { data: isAbleToShowPageManagement } = useIsAbleToShowPageManagement();


### PR DESCRIPTION
## Task
[#111401](https://redmine.weseek.co.jp/issues/111401) [Next.js][ShareLink] Private wiki かつ 非ログインの状態だと AuthorInfo が表示されない
└ [#111404](https://redmine.weseek.co.jp/issues/111404) 修正

[#111400](https://redmine.weseek.co.jp/issues/111400) [Next.js][ShareLink] Private wiki かつ 非ログインの状態だとページパスが表示されない
└ [#111405](https://redmine.weseek.co.jp/issues/111405) 修正