### PR TITLE
fix: Remove obsoleted link from cheat sheet

### DIFF
--- a/packages/app/src/components/PageEditor/Cheatsheet.tsx
+++ b/packages/app/src/components/PageEditor/Cheatsheet.tsx
@@ -17,7 +17,7 @@ export const Cheatsheet = (): JSX.Element => {
   const codeBlockStr = 'text\n\ntext';
   const lineBlockStr = 'text\ntext';
   const typographyStr = `*${t('sandbox.italics')}*\n**${t('sandbox.bold')}**\n***${t('sandbox.italic_bold')}***\n~~${t('sandbox.strikethrough')}~~`;
-  const linkStr = '[Google](https://www.google.co.jp/)\n[/Page1/ChildPage1]';
+  const linkStr = '[Google](https://www.google.co.jp/)';
   const codeHighlightStr = '```javascript:index.js\nwriteCode();\n```';
 
   // Right Side


### PR DESCRIPTION
## Task
[Next.js]マークダウンヘルプのモーダルのデザインがおかしい
┗[111513](https://redmine.weseek.co.jp/issues/111513) [/Page1/ChildPage1] の記法を削除する

## Before
<img width="259" alt="Screen Shot 2022-12-19 at 18 38 34" src="https://user-images.githubusercontent.com/59536731/208395319-f46ed546-8b1a-483e-8bf5-b1d5f6f93de2.png">

## After
<img width="237" alt="Screen Shot 2022-12-19 at 18 38 04" src="https://user-images.githubusercontent.com/59536731/208395313-cda153af-24a4-4a8c-8a04-efc66c27ccc3.png">
