### PR TITLE
feat: Replace tags and attr in recommended settings with config in rehype

### DIFF
--- a/packages/app/src/components/Admin/MarkdownSetting/XssForm.jsx
+++ b/packages/app/src/components/Admin/MarkdownSetting/XssForm.jsx
@@ -2,11 +2,11 @@ import React from 'react';
 
 import { useTranslation } from 'next-i18next';
 import PropTypes from 'prop-types';
+import { defaultSchema as sanitizeDefaultSchema } from 'rehype-sanitize';
 
 import AdminMarkDownContainer from '~/client/services/AdminMarkDownContainer';
 import { toastSuccess, toastError } from '~/client/util/apiNotification';
 import { RehypeSanitizeOption } from '~/interfaces/rehype';
-import { tags, attrs } from '~/services/xss/recommended-whitelist';
 import loggerFactory from '~/utils/logger';
 
 import { withUnstatedContainers } from '../../UnstatedUtils';
@@ -15,6 +15,9 @@ import AdminUpdateButtonRow from '../Common/AdminUpdateButtonRow';
 import WhiteListInput from './WhiteListInput';
 
 const logger = loggerFactory('growi:importer');
+
+const tags = sanitizeDefaultSchema.tagNames;
+const attrs = JSON.stringify(sanitizeDefaultSchema.attributes);
 
 class XssForm extends React.Component {
 


### PR DESCRIPTION
## Task
[#107872](https://redmine.weseek.co.jp/issues/107872) [Next化]XSS(Cross Site Scripting)対策設定 が機能していない
└ [#109715](https://redmine.weseek.co.jp/issues/109715) おすすめ設定の中身のタグと属性を書き換える

## Screenshot

before
<img width="326" alt="ScreenShot 2022-12-19 21 25 48" src="https://user-images.githubusercontent.com/34241526/208425783-cb48e2c3-cd83-4464-a412-c0fd9ea38f12.png">

after
<img width="328" alt="ScreenShot 2022-12-19 21 23 28" src="https://user-images.githubusercontent.com/34241526/208425418-657780ac-3b59-4be3-9b41-87933889d242.png">