### PR TITLE
feat: Save prevent xss custom settings in new format

### DIFF
--- a/packages/app/src/client/services/AdminMarkDownContainer.js
+++ b/packages/app/src/client/services/AdminMarkDownContainer.js
@@ -29,7 +29,7 @@ export default class AdminMarkDownContainer extends Container {
       isEnabledXss: false,
       xssOption: '',
       tagWhiteList: '',
-      attrWhiteList: '',
+      attrWhiteString: '',
     };
 
     this.switchEnableXss = this.switchEnableXss.bind(this);
@@ -60,7 +60,7 @@ export default class AdminMarkDownContainer extends Container {
       isEnabledXss: markdownParams.isEnabledXss,
       xssOption: markdownParams.xssOption,
       tagWhiteList: markdownParams.tagWhiteList || '',
-      attrWhiteList: markdownParams.attrWhiteList || '',
+      attrWhiteString: markdownParams.attrWhiteString || '',
     });
   }
 
@@ -120,13 +120,13 @@ export default class AdminMarkDownContainer extends Container {
    */
   async updateXssSetting() {
     let { tagWhiteList } = this.state;
-    const { attrWhiteList } = this.state;
+    const { attrWhiteString } = this.state;
 
     tagWhiteList = Array.isArray(tagWhiteList) ? tagWhiteList : tagWhiteList.split(',');
 
     try {
       // Check if parsing is possible
-      JSON.parse(attrWhiteList);
+      JSON.parse(attrWhiteString);
     }
     catch (err) {
       throw Error(err);
@@ -136,7 +136,7 @@ export default class AdminMarkDownContainer extends Container {
       isEnabledXss: this.state.isEnabledXss,
       xssOption: this.state.xssOption,
       tagWhiteList,
-      attrWhiteList,
+      attrWhiteString,
     });
   }
 

--- a/packages/app/src/client/services/AdminMarkDownContainer.js
+++ b/packages/app/src/client/services/AdminMarkDownContainer.js
@@ -29,7 +29,7 @@ export default class AdminMarkDownContainer extends Container {
       isEnabledXss: false,
       xssOption: '',
       tagWhiteList: '',
-      attrWhiteList: '',
+      attrWhiteList: '{}',
     };
 
     this.switchEnableXss = this.switchEnableXss.bind(this);
@@ -136,7 +136,7 @@ export default class AdminMarkDownContainer extends Container {
       isEnabledXss: this.state.isEnabledXss,
       xssOption: this.state.xssOption,
       tagWhiteList,
-      attrWhiteList,
+      attrWhiteList: attrWhiteList ?? '{}',
     });
   }
 

--- a/packages/app/src/client/services/AdminMarkDownContainer.js
+++ b/packages/app/src/client/services/AdminMarkDownContainer.js
@@ -119,19 +119,25 @@ export default class AdminMarkDownContainer extends Container {
    * Update Xss Setting
    */
   async updateXssSetting() {
-    let { tagWhiteList, attrWhiteList } = this.state;
+    let { tagWhiteList } = this.state;
+    const { attrWhiteList } = this.state;
 
     tagWhiteList = Array.isArray(tagWhiteList) ? tagWhiteList : tagWhiteList.split(',');
-    attrWhiteList = Array.isArray(attrWhiteList) ? attrWhiteList : attrWhiteList.split(',');
 
-    const response = await apiv3Put('/markdown-setting/xss', {
+    try {
+      // Check if parsing is possible
+      JSON.parse(attrWhiteList);
+    }
+    catch (err) {
+      throw Error(err);
+    }
+
+    await apiv3Put('/markdown-setting/xss', {
       isEnabledXss: this.state.isEnabledXss,
       xssOption: this.state.xssOption,
       tagWhiteList,
       attrWhiteList,
     });
-
-    return response;
   }
 
   /**

--- a/packages/app/src/client/services/AdminMarkDownContainer.js
+++ b/packages/app/src/client/services/AdminMarkDownContainer.js
@@ -29,7 +29,7 @@ export default class AdminMarkDownContainer extends Container {
       isEnabledXss: false,
       xssOption: '',
       tagWhiteList: '',
-      attrWhiteString: '',
+      attrWhiteList: '',
     };
 
     this.switchEnableXss = this.switchEnableXss.bind(this);
@@ -60,7 +60,7 @@ export default class AdminMarkDownContainer extends Container {
       isEnabledXss: markdownParams.isEnabledXss,
       xssOption: markdownParams.xssOption,
       tagWhiteList: markdownParams.tagWhiteList || '',
-      attrWhiteString: markdownParams.attrWhiteString || '',
+      attrWhiteList: markdownParams.attrWhiteList || '',
     });
   }
 
@@ -120,13 +120,13 @@ export default class AdminMarkDownContainer extends Container {
    */
   async updateXssSetting() {
     let { tagWhiteList } = this.state;
-    const { attrWhiteString } = this.state;
+    const { attrWhiteList } = this.state;
 
     tagWhiteList = Array.isArray(tagWhiteList) ? tagWhiteList : tagWhiteList.split(',');
 
     try {
       // Check if parsing is possible
-      JSON.parse(attrWhiteString);
+      JSON.parse(attrWhiteList);
     }
     catch (err) {
       throw Error(err);
@@ -136,7 +136,7 @@ export default class AdminMarkDownContainer extends Container {
       isEnabledXss: this.state.isEnabledXss,
       xssOption: this.state.xssOption,
       tagWhiteList,
-      attrWhiteString,
+      attrWhiteList,
     });
   }
 

--- a/packages/app/src/components/Admin/MarkdownSetting/WhiteListInput.jsx
+++ b/packages/app/src/components/Admin/MarkdownSetting/WhiteListInput.jsx
@@ -14,7 +14,7 @@ class WhiteListInput extends React.Component {
     super(props);
 
     this.tagWhiteList = React.createRef();
-    this.attrWhiteString = React.createRef();
+    this.attrWhiteList = React.createRef();
 
     this.onClickRecommendTagButton = this.onClickRecommendTagButton.bind(this);
     this.onClickRecommendAttrButton = this.onClickRecommendAttrButton.bind(this);
@@ -26,8 +26,8 @@ class WhiteListInput extends React.Component {
   }
 
   onClickRecommendAttrButton() {
-    this.attrWhiteString.current.value = attrs;
-    this.props.adminMarkDownContainer.setState({ attrWhiteString: attrs });
+    this.attrWhiteList.current.value = attrs;
+    this.props.adminMarkDownContainer.setState({ attrWhiteList: attrs });
   }
 
   render() {
@@ -64,9 +64,9 @@ class WhiteListInput extends React.Component {
             name="recommendedAttrs"
             rows="6"
             cols="40"
-            ref={this.attrWhiteString}
-            defaultValue={adminMarkDownContainer.state.attrWhiteString}
-            onChange={(e) => { adminMarkDownContainer.setState({ attrWhiteString: e.target.value }) }}
+            ref={this.attrWhiteList}
+            defaultValue={adminMarkDownContainer.state.attrWhiteList}
+            onChange={(e) => { adminMarkDownContainer.setState({ attrWhiteList: e.target.value }) }}
           />
         </div>
       </>

--- a/packages/app/src/components/Admin/MarkdownSetting/WhiteListInput.jsx
+++ b/packages/app/src/components/Admin/MarkdownSetting/WhiteListInput.jsx
@@ -14,7 +14,7 @@ class WhiteListInput extends React.Component {
     super(props);
 
     this.tagWhiteList = React.createRef();
-    this.attrWhiteList = React.createRef();
+    this.attrWhiteString = React.createRef();
 
     this.onClickRecommendTagButton = this.onClickRecommendTagButton.bind(this);
     this.onClickRecommendAttrButton = this.onClickRecommendAttrButton.bind(this);
@@ -26,8 +26,8 @@ class WhiteListInput extends React.Component {
   }
 
   onClickRecommendAttrButton() {
-    this.attrWhiteList.current.value = attrs;
-    this.props.adminMarkDownContainer.setState({ attrWhiteList: attrs });
+    this.attrWhiteString.current.value = attrs;
+    this.props.adminMarkDownContainer.setState({ attrWhiteString: attrs });
   }
 
   render() {
@@ -64,9 +64,9 @@ class WhiteListInput extends React.Component {
             name="recommendedAttrs"
             rows="6"
             cols="40"
-            ref={this.attrWhiteList}
-            defaultValue={adminMarkDownContainer.state.attrWhiteList}
-            onChange={(e) => { adminMarkDownContainer.setState({ attrWhiteList: e.target.value }) }}
+            ref={this.attrWhiteString}
+            defaultValue={adminMarkDownContainer.state.attrWhiteString}
+            onChange={(e) => { adminMarkDownContainer.setState({ attrWhiteString: e.target.value }) }}
           />
         </div>
       </>

--- a/packages/app/src/server/models/config.ts
+++ b/packages/app/src/server/models/config.ts
@@ -148,7 +148,7 @@ export const defaultCrowiConfigs: { [key: string]: any } = {
 
 export const defaultMarkdownConfigs: { [key: string]: any } = {
   'markdown:xss:tagWhiteList': [],
-  'markdown:xss:attrWhiteList': [],
+  'markdown:xss:attrWhiteList': '{}',
   'markdown:rehypeSanitize:isEnabledPrevention': true,
   'markdown:rehypeSanitize:option': RehypeSanitizeOption.RECOMMENDED,
   'markdown:rehypeSanitize:tagNames': [],

--- a/packages/app/src/server/models/config.ts
+++ b/packages/app/src/server/models/config.ts
@@ -147,12 +147,14 @@ export const defaultCrowiConfigs: { [key: string]: any } = {
 };
 
 export const defaultMarkdownConfigs: { [key: string]: any } = {
+  // don't use it, but won't turn it off
   'markdown:xss:tagWhiteList': [],
-  'markdown:xss:attrWhiteList': '{}',
+  'markdown:xss:attrWhiteList': [],
+
   'markdown:rehypeSanitize:isEnabledPrevention': true,
   'markdown:rehypeSanitize:option': RehypeSanitizeOption.RECOMMENDED,
   'markdown:rehypeSanitize:tagNames': [],
-  'markdown:rehypeSanitize:attributes': {},
+  'markdown:rehypeSanitize:attributes': '{}',
   'markdown:isEnabledLinebreaks': false,
   'markdown:isEnabledLinebreaksInComments': true,
   'markdown:adminPreferredIndentSize': 4,

--- a/packages/app/src/server/routes/apiv3/markdown-setting.js
+++ b/packages/app/src/server/routes/apiv3/markdown-setting.js
@@ -292,10 +292,20 @@ module.exports = (crowi) => {
       return res.apiv3Err(new ErrorV3('xss option is required'));
     }
 
+    let parsedAttrWhiteList = {};
+    try {
+      parsedAttrWhiteList = JSON.parse(req.body.attrWhiteList);
+    }
+    catch (err) {
+      const msg = 'Error occurred in updating xss';
+      logger.error('Error', err);
+      return res.apiv3Err(new ErrorV3(msg, 'update-xss-failed'));
+    }
+
     const reqestXssParams = {
       'markdown:rehypeSanitize:isEnabledPrevention': req.body.isEnabledXss,
       'markdown:rehypeSanitize:option': req.body.xssOption,
-      'markdown:xss:tagWhiteList': req.body.tagWhiteList, // Todo: need to be changed at https://redmine.weseek.co.jp/issues/109763
+      'markdown:xss:tagWhiteList': parsedAttrWhiteList, // Todo: need to be changed at https://redmine.weseek.co.jp/issues/109763
       'markdown:xss:attrWhiteList': req.body.attrWhiteList, // Todo: need to be changed at https://redmine.weseek.co.jp/issues/109763
     };
 

--- a/packages/app/src/server/routes/apiv3/markdown-setting.js
+++ b/packages/app/src/server/routes/apiv3/markdown-setting.js
@@ -30,7 +30,7 @@ const validator = {
   xssSetting: [
     body('isEnabledXss').isBoolean(),
     body('tagWhiteList').isArray(),
-    body('attrWhiteList').isString(),
+    body('attrWhiteString').isString(),
   ],
 };
 
@@ -82,8 +82,8 @@ const validator = {
  *            items:
  *              type: string
  *              description: tag whitelist
- *          attrWhiteList:
- *            type: array
+ *          attrWhiteString:
+ *            type: string
  *            description: array of attr whiteList
  *            items:
  *              type: string
@@ -128,7 +128,7 @@ module.exports = (crowi) => {
       isEnabledXss: await crowi.configManager.getConfig('markdown', 'markdown:rehypeSanitize:isEnabledPrevention'),
       xssOption: await crowi.configManager.getConfig('markdown', 'markdown:rehypeSanitize:option'),
       tagWhiteList: await crowi.configManager.getConfig('markdown', 'markdown:xss:tagWhiteList'),
-      attrWhiteList: await crowi.configManager.getConfig('markdown', 'markdown:xss:attrWhiteList'),
+      attrWhiteString: await crowi.configManager.getConfig('markdown', 'markdown:xss:attrWhiteString'),
     };
 
     return res.apiv3({ markdownParams });
@@ -296,7 +296,7 @@ module.exports = (crowi) => {
       'markdown:rehypeSanitize:isEnabledPrevention': req.body.isEnabledXss,
       'markdown:rehypeSanitize:option': req.body.xssOption,
       'markdown:xss:tagWhiteList': req.body.tagWhiteList, // Todo: need to be changed at https://redmine.weseek.co.jp/issues/109763
-      'markdown:xss:attrWhiteList': req.body.attrWhiteList, // Todo: need to be changed at https://redmine.weseek.co.jp/issues/109763
+      'markdown:xss:attrWhiteString': req.body.attrWhiteString, // Todo: need to be changed at https://redmine.weseek.co.jp/issues/109763
     };
 
     try {
@@ -305,7 +305,7 @@ module.exports = (crowi) => {
         isEnabledXss: await crowi.configManager.getConfig('markdown', 'markdown:rehypeSanitize:isEnabledPrevention'),
         xssOption: await crowi.configManager.getConfig('markdown', 'markdown:rehypeSanitize:option'),
         tagWhiteList: await crowi.configManager.getConfig('markdown', 'markdown:xss:tagWhiteList'),
-        attrWhiteList: await crowi.configManager.getConfig('markdown', 'markdown:xss:attrWhiteList'),
+        attrWhiteString: await crowi.configManager.getConfig('markdown', 'markdown:xss:attrWhiteString'),
       };
 
       const parameters = { action: SupportedAction.ACTION_ADMIN_MARKDOWN_XSS_UPDATE };

--- a/packages/app/src/server/routes/apiv3/markdown-setting.js
+++ b/packages/app/src/server/routes/apiv3/markdown-setting.js
@@ -30,7 +30,7 @@ const validator = {
   xssSetting: [
     body('isEnabledXss').isBoolean(),
     body('tagWhiteList').isArray(),
-    body('attrWhiteList').isArray(),
+    body('attrWhiteList').isString(),
   ],
 };
 

--- a/packages/app/src/server/routes/apiv3/markdown-setting.js
+++ b/packages/app/src/server/routes/apiv3/markdown-setting.js
@@ -30,7 +30,7 @@ const validator = {
   xssSetting: [
     body('isEnabledXss').isBoolean(),
     body('tagWhiteList').isArray(),
-    body('attrWhiteString').isString(),
+    body('attrWhiteList').isString(),
   ],
 };
 
@@ -82,8 +82,8 @@ const validator = {
  *            items:
  *              type: string
  *              description: tag whitelist
- *          attrWhiteString:
- *            type: string
+ *          attrWhiteList:
+ *            type: array
  *            description: array of attr whiteList
  *            items:
  *              type: string
@@ -128,7 +128,7 @@ module.exports = (crowi) => {
       isEnabledXss: await crowi.configManager.getConfig('markdown', 'markdown:rehypeSanitize:isEnabledPrevention'),
       xssOption: await crowi.configManager.getConfig('markdown', 'markdown:rehypeSanitize:option'),
       tagWhiteList: await crowi.configManager.getConfig('markdown', 'markdown:xss:tagWhiteList'),
-      attrWhiteString: await crowi.configManager.getConfig('markdown', 'markdown:xss:attrWhiteString'),
+      attrWhiteList: await crowi.configManager.getConfig('markdown', 'markdown:xss:attrWhiteList'),
     };
 
     return res.apiv3({ markdownParams });
@@ -296,7 +296,7 @@ module.exports = (crowi) => {
       'markdown:rehypeSanitize:isEnabledPrevention': req.body.isEnabledXss,
       'markdown:rehypeSanitize:option': req.body.xssOption,
       'markdown:xss:tagWhiteList': req.body.tagWhiteList, // Todo: need to be changed at https://redmine.weseek.co.jp/issues/109763
-      'markdown:xss:attrWhiteString': req.body.attrWhiteString, // Todo: need to be changed at https://redmine.weseek.co.jp/issues/109763
+      'markdown:xss:attrWhiteList': req.body.attrWhiteList, // Todo: need to be changed at https://redmine.weseek.co.jp/issues/109763
     };
 
     try {
@@ -305,7 +305,7 @@ module.exports = (crowi) => {
         isEnabledXss: await crowi.configManager.getConfig('markdown', 'markdown:rehypeSanitize:isEnabledPrevention'),
         xssOption: await crowi.configManager.getConfig('markdown', 'markdown:rehypeSanitize:option'),
         tagWhiteList: await crowi.configManager.getConfig('markdown', 'markdown:xss:tagWhiteList'),
-        attrWhiteString: await crowi.configManager.getConfig('markdown', 'markdown:xss:attrWhiteString'),
+        attrWhiteList: await crowi.configManager.getConfig('markdown', 'markdown:xss:attrWhiteList'),
       };
 
       const parameters = { action: SupportedAction.ACTION_ADMIN_MARKDOWN_XSS_UPDATE };

--- a/packages/app/src/server/routes/apiv3/markdown-setting.js
+++ b/packages/app/src/server/routes/apiv3/markdown-setting.js
@@ -127,8 +127,8 @@ module.exports = (crowi) => {
       pageBreakCustomSeparator: await crowi.configManager.getConfig('markdown', 'markdown:presentation:pageBreakCustomSeparator'),
       isEnabledXss: await crowi.configManager.getConfig('markdown', 'markdown:rehypeSanitize:isEnabledPrevention'),
       xssOption: await crowi.configManager.getConfig('markdown', 'markdown:rehypeSanitize:option'),
-      tagWhiteList: await crowi.configManager.getConfig('markdown', 'markdown:xss:tagWhiteList'),
-      attrWhiteList: await crowi.configManager.getConfig('markdown', 'markdown:xss:attrWhiteList'),
+      tagWhiteList: await crowi.configManager.getConfig('markdown', 'markdown:rehypeSanitize:tagNames'),
+      attrWhiteList: await crowi.configManager.getConfig('markdown', 'markdown:rehypeSanitize:attributes'),
     };
 
     return res.apiv3({ markdownParams });
@@ -292,9 +292,8 @@ module.exports = (crowi) => {
       return res.apiv3Err(new ErrorV3('xss option is required'));
     }
 
-    let parsedAttrWhiteList = {};
     try {
-      parsedAttrWhiteList = JSON.parse(req.body.attrWhiteList);
+      JSON.parse(req.body.attrWhiteList);
     }
     catch (err) {
       const msg = 'Error occurred in updating xss';
@@ -305,8 +304,8 @@ module.exports = (crowi) => {
     const reqestXssParams = {
       'markdown:rehypeSanitize:isEnabledPrevention': req.body.isEnabledXss,
       'markdown:rehypeSanitize:option': req.body.xssOption,
-      'markdown:xss:tagWhiteList': parsedAttrWhiteList, // Todo: need to be changed at https://redmine.weseek.co.jp/issues/109763
-      'markdown:xss:attrWhiteList': req.body.attrWhiteList, // Todo: need to be changed at https://redmine.weseek.co.jp/issues/109763
+      'markdown:rehypeSanitize:tagNames': req.body.tagWhiteList,
+      'markdown:rehypeSanitize:attributes': req.body.attrWhiteList,
     };
 
     try {
@@ -314,8 +313,8 @@ module.exports = (crowi) => {
       const xssParams = {
         isEnabledXss: await crowi.configManager.getConfig('markdown', 'markdown:rehypeSanitize:isEnabledPrevention'),
         xssOption: await crowi.configManager.getConfig('markdown', 'markdown:rehypeSanitize:option'),
-        tagWhiteList: await crowi.configManager.getConfig('markdown', 'markdown:xss:tagWhiteList'),
-        attrWhiteList: await crowi.configManager.getConfig('markdown', 'markdown:xss:attrWhiteList'),
+        tagWhiteList: await crowi.configManager.getConfig('markdown', 'markdown:rehypeSanitize:tagNames'),
+        attrWhiteList: await crowi.configManager.getConfig('markdown', 'markdown:rehypeSanitize:attributes'),
       };
 
       const parameters = { action: SupportedAction.ACTION_ADMIN_MARKDOWN_XSS_UPDATE };


### PR DESCRIPTION
## Task
[#107872](https://redmine.weseek.co.jp/issues/107872) [Next化]XSS(Cross Site Scripting)対策設定 が機能していない
└ [#109763](https://redmine.weseek.co.jp/issues/109763) custom 設定を保存できる
└ [#109547](https://redmine.weseek.co.jp/issues/109547) custom 用のvalidate機能追加

## ScreenRecord
https://user-images.githubusercontent.com/34241526/208649125-f46f48f8-7302-4da7-8eab-dd7e2d3cf916.mov
