### PR TITLE
fix: show empty page

### DIFF
--- a/packages/app/src/pages/[[...path]].page.tsx
+++ b/packages/app/src/pages/[[...path]].page.tsx
@@ -260,7 +260,7 @@ const GrowiPage: NextPage<Props> = (props: Props) => {
 
   useCurrentPageId(pageId ?? null);
   useRevisionIdHackmdSynced(pageWithMeta?.data.revisionHackmdSynced);
-  useRemoteRevisionId(pageWithMeta?.data.revision._id);
+  useRemoteRevisionId(pageWithMeta?.data.revision?._id);
   usePageIdOnHackmd(pageWithMeta?.data.pageIdOnHackmd);
   useHasDraftOnHackmd(pageWithMeta?.data.hasDraftOnHackmd ?? false);
   // useIsNotCreatable(props.isForbidden || !isCreatablePage(pagePath)); // TODO: need to include props.isIdentical


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/111635

# 起きていた問題
- 空ページを表示したときにエラーが出ていた

# やったこと
- `revision`の`id`を見ていた部分にオプショナルチェインを追加し、空ページに対応した