### PR TITLE
imprv: improve sidebar components and skeleton

### DIFF
--- a/packages/app/src/components/Sidebar.tsx
+++ b/packages/app/src/components/Sidebar.tsx
@@ -22,6 +22,10 @@ import { StickyStretchableScrollerProps } from './StickyStretchableScroller';
 
 import styles from './Sidebar.module.scss';
 
+const StickyStretchableScroller = dynamic<StickyStretchableScrollerProps>(() => import('./StickyStretchableScroller')
+  .then(mod => mod.StickyStretchableScroller), { ssr: false });
+const SidebarContents = dynamic(() => import('./Sidebar/SidebarContents')
+  .then(mod => mod.SidebarContents), { ssr: false, loading: () => <SidebarSkeleton /> });
 
 const sidebarMinWidth = 240;
 const sidebarMinimizeWidth = 20;
@@ -57,10 +61,6 @@ const GlobalNavigation = () => {
 };
 
 const SidebarContentsWrapper = () => {
-  const StickyStretchableScroller = dynamic<StickyStretchableScrollerProps>(() => import('./StickyStretchableScroller')
-    .then(mod => mod.StickyStretchableScroller), { ssr: false, loading: () => <SidebarSkeleton /> });
-  const SidebarContents = dynamic(() => import('./Sidebar/SidebarContents')
-    .then(mod => mod.SidebarContents), { ssr: false, loading: () => <SidebarSkeleton /> });
   const { mutate: mutateSidebarScroller } = useSidebarScrollerRef();
 
   const calcViewHeight = useCallback(() => {

--- a/packages/app/src/components/Sidebar.tsx
+++ b/packages/app/src/components/Sidebar.tsx
@@ -1,5 +1,5 @@
 import React, {
-  useCallback, useEffect, useRef, useState,
+  memo, useCallback, useEffect, useRef, useState,
 } from 'react';
 
 import dynamic from 'next/dynamic';
@@ -31,7 +31,7 @@ const sidebarMinWidth = 240;
 const sidebarMinimizeWidth = 20;
 const sidebarFixedWidthInDrawerMode = 320;
 
-const GlobalNavigation = () => {
+const GlobalNavigation = memo(() => {
   const { data: isDrawerMode } = useDrawerMode();
   const { data: currentContents } = useCurrentSidebarContents();
   const { data: isCollapsed, mutate: mutateSidebarCollapsed } = useSidebarCollapsed();
@@ -58,9 +58,10 @@ const GlobalNavigation = () => {
 
   return <SidebarNav onItemSelected={itemSelectedHandler} />;
 
-};
+});
+GlobalNavigation.displayName = 'GlobalNavigation';
 
-const SidebarContentsWrapper = () => {
+const SidebarContentsWrapper = memo(() => {
   const { mutate: mutateSidebarScroller } = useSidebarScrollerRef();
 
   const calcViewHeight = useCallback(() => {
@@ -85,10 +86,11 @@ const SidebarContentsWrapper = () => {
       <DrawerToggler iconClass="icon-arrow-left" />
     </>
   );
-};
+});
+SidebarContentsWrapper.displayName = 'SidebarContentsWrapper';
 
 
-const Sidebar = (): JSX.Element => {
+const Sidebar = memo((): JSX.Element => {
 
   const { data: isDrawerMode } = useDrawerMode();
   const { data: isDrawerOpened, mutate: mutateDrawerOpened } = useDrawerOpened();
@@ -354,6 +356,7 @@ const Sidebar = (): JSX.Element => {
     </>
   );
 
-};
+});
+Sidebar.displayName = 'Sidebar';
 
 export default Sidebar;

--- a/packages/app/src/components/Sidebar/RecentChanges.module.scss
+++ b/packages/app/src/components/Sidebar/RecentChanges.module.scss
@@ -29,7 +29,7 @@
 
   .grw-recent-changes-skeleton-date {
     @include grw-skeleton-text($font-size:10px, $line-height:12px);
-    width: 90px;
+    width: 80px;
   }
 
   .grw-recent-changes-item-lower {

--- a/packages/app/src/components/Sidebar/SidebarContents.tsx
+++ b/packages/app/src/components/Sidebar/SidebarContents.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { memo } from 'react';
 
 import { SidebarContentsType } from '~/interfaces/ui';
 import { useCurrentSidebarContents } from '~/stores/ui';
@@ -8,7 +8,7 @@ import PageTree from './PageTree';
 import RecentChanges from './RecentChanges';
 import Tag from './Tag';
 
-export const SidebarContents = (): JSX.Element => {
+export const SidebarContents = memo(() => {
   const { data: currentSidebarContents } = useCurrentSidebarContents();
 
   let Contents;
@@ -29,5 +29,5 @@ export const SidebarContents = (): JSX.Element => {
   return (
     <Contents />
   );
-
-};
+});
+SidebarContents.displayName = 'SidebarContents';

--- a/packages/app/src/components/Sidebar/Skeleton/SidebarSkeleton.tsx
+++ b/packages/app/src/components/Sidebar/Skeleton/SidebarSkeleton.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
-import { Skeleton } from '~/components/Skeleton';
+import { useTranslation } from 'next-i18next';
+
 import { SidebarContentsType } from '~/interfaces/ui';
 import { useCurrentSidebarContents } from '~/stores/ui';
 
@@ -9,42 +10,39 @@ import PageTreeContentSkeleton from './PageTreeContentSkeleton';
 import RecentChangesContentSkeleton from './RecentChangesContentSkeleton';
 import TagContentSkeleton from './TagContentSkeleton';
 
-import styles from './SidebarSkeleton.module.scss';
-
-export const SidebarHeaderSkeleton = (): JSX.Element => {
-  return (
-    <div className="grw-sidebar-content-header py-3">
-      <Skeleton additionalClass={styles['grw-sidebar-content-header-skeleton']} />
-    </div>
-  );
-};
-
 export const SidebarSkeleton = (): JSX.Element => {
-
+  const { t } = useTranslation();
   const { data: currentSidebarContents } = useCurrentSidebarContents();
 
-  let SidebarContentSkeleton: () => JSX.Element;
+  let Contents: () => JSX.Element;
+  let title: string;
   switch (currentSidebarContents) {
 
-    case SidebarContentsType.TAG:
-      SidebarContentSkeleton = TagContentSkeleton;
-      break;
     case SidebarContentsType.RECENT:
-      SidebarContentSkeleton = RecentChangesContentSkeleton;
+      Contents = RecentChangesContentSkeleton;
+      title = t('Recent Changes');
       break;
     case SidebarContentsType.CUSTOM:
-      SidebarContentSkeleton = CustomSidebarContentSkeleton;
+      Contents = CustomSidebarContentSkeleton;
+      title = t('CustomSidebar');
+      break;
+    case SidebarContentsType.TAG:
+      Contents = TagContentSkeleton;
+      title = t('Tags');
       break;
     case SidebarContentsType.TREE:
     default:
-      SidebarContentSkeleton = PageTreeContentSkeleton;
+      Contents = PageTreeContentSkeleton;
+      title = t('Page Tree');
       break;
   }
 
   return (
     <div className={currentSidebarContents === SidebarContentsType.TAG ? 'px-4' : 'px-3'}>
-      <SidebarHeaderSkeleton />
-      <SidebarContentSkeleton />
+      <div className="grw-sidebar-content-header py-3">
+        <h3 className="mb-0">{title}</h3>
+      </div>
+      <Contents />
     </div>
   );
 };

--- a/packages/app/src/components/Sidebar/Skeleton/SidebarSkeleton.tsx
+++ b/packages/app/src/components/Sidebar/Skeleton/SidebarSkeleton.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { memo } from 'react';
 
 import { useTranslation } from 'next-i18next';
 
@@ -10,7 +10,7 @@ import PageTreeContentSkeleton from './PageTreeContentSkeleton';
 import RecentChangesContentSkeleton from './RecentChangesContentSkeleton';
 import TagContentSkeleton from './TagContentSkeleton';
 
-export const SidebarSkeleton = (): JSX.Element => {
+export const SidebarSkeleton = memo(() => {
   const { t } = useTranslation();
   const { data: currentSidebarContents } = useCurrentSidebarContents();
 
@@ -45,4 +45,5 @@ export const SidebarSkeleton = (): JSX.Element => {
       <Contents />
     </div>
   );
-};
+});
+SidebarSkeleton.displayName = 'SidebarSkeleton';

--- a/packages/app/src/components/Sidebar/Skeleton/TagContentSkeleton.tsx
+++ b/packages/app/src/components/Sidebar/Skeleton/TagContentSkeleton.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { useTranslation } from 'next-i18next';
+
 import { Skeleton } from '~/components/Skeleton';
 
 import styles from '../Tag.module.scss';
@@ -11,10 +13,11 @@ export const TagListSkeleton = (): JSX.Element => {
 };
 
 const TagContentSkeleton = (): JSX.Element => {
+  const { t } = useTranslation('');
 
   return (
     <>
-      <Skeleton additionalClass={`${styles['grw-tag-skeleton-h3']} my-3`} />
+      <h3 className="my-3">{t('tag_list')}</h3>
       <TagListSkeleton />
     </>
   );

--- a/packages/app/src/components/Sidebar/Tag.module.scss
+++ b/packages/app/src/components/Sidebar/Tag.module.scss
@@ -1,10 +1,5 @@
 @use '~/styles/mixins' as *;
 
-.grw-tag-skeleton-h3 {
-  @include grw-skeleton-h3;
-  max-width: 120px;
-}
-
 .grw-tag-list-skeleton {
   height: 90px;
 }


### PR DESCRIPTION
[#111542](https://redmine.weseek.co.jp/issues/111542): [Next.js] 初回ロード時のSidebarにおけるflickeringの確認・解消
- [#111790](https://redmine.weseek.co.jp/issues/111790): Sidebarのdynamic importの位置を修正 1e7d682e9702d29dfdc406d4e2023e6a68cec03b
- [#111805](https://redmine.weseek.co.jp/issues/111805): スケルトンでサイドバーのタイトルを表示する d6d515269ec51fb2a5bdab79467b222eb2b4d337 140b08babd7ed8b373ac93a579ff3432c33949ef
- [#111806](https://redmine.weseek.co.jp/issues/111806): 一部コンポーネントのメモ化 8f19d72ff68f91d381c639fd3914a48a1a8e70ba

[#100878](https://redmine.weseek.co.jp/issues/100878): [Next.js] Sidebar の再レンダリングを可能な限り抑制する →メモ化 8f19d72ff68f91d381c639fd3914a48a1a8e70ba と同時に改善
- [#107386](https://redmine.weseek.co.jp/issues/107386): ToC 内のリンクをクリックした時に再レンダリングされないようにする
- [#104239](https://redmine.weseek.co.jp/issues/104239): ページ切り替えの度にサイドバーを再レンダリングしないようにする

## やったこと
- 何故かコンポーネント内にあったDynamic Importをグローバルスコープに移動、同時に\<StickyStretchableScroller /\>のloadingでのスケルトン表示を削除
  - 無駄なレンダリングの削減、hydration errorの予防
  - 結果的にスケルトン表示がcurrentSidebarContents取得後になるので、最初からずっと目的のタブに対応する物が表示されるように
- これにに伴いSidebarのタイトル部分の文字をスケルトンにせず最初から表示するよう変更
  - 最近の変更タブのスケルトンも微調整
- Sidebar関係でPropsの無いコンポーネントをメモ化
  - 完全ではない([参照](https://wsgrowi.slack.com/archives/C03LCBW00H3/p1671697054127429))が、可能な範囲における無駄なレンダリングはほぼ解消。