### PR TITLE
fix: Deprecate Rendering Draw.io function

### DIFF
--- a/packages/app/src/components/PageEditor/OptionsSelector.tsx
+++ b/packages/app/src/components/PageEditor/OptionsSelector.tsx
@@ -199,30 +199,6 @@ const ConfigurationDropdown = memo(({ onConfirmEnableTextlint }: ConfigurationDr
     );
   }, [editorSettings, update, t]);
 
-  const renderRealtimeDrawioMenuItem = useCallback(() => {
-    if (editorSettings == null) {
-      return <></>;
-    }
-
-    const isActive = editorSettings.renderDrawioInRealtime;
-
-    const iconClasses = ['text-info'];
-    if (isActive) {
-      iconClasses.push('ti ti-check');
-    }
-    const iconClassName = iconClasses.join(' ');
-
-    return (
-      <DropdownItem toggle={false} onClick={() => update({ renderDrawioInRealtime: !isActive })}>
-        <div className="d-flex justify-content-between">
-          <span className="icon-container"><img src="/images/icons/fx.svg" width="14px" alt="fx"></img></span>
-          <span className="menuitem-label">draw.io Rendering</span>
-          <span className="icon-container"><i className={iconClassName}></i></span>
-        </div>
-      </DropdownItem>
-    );
-  }, [editorSettings, update]);
-
   const renderMarkdownTableAutoFormattingMenuItem = useCallback(() => {
     if (editorSettings == null) {
       return <></>;
@@ -300,7 +276,6 @@ const ConfigurationDropdown = memo(({ onConfirmEnableTextlint }: ConfigurationDr
 
         <DropdownMenu>
           {renderActiveLineMenuItem()}
-          {renderRealtimeDrawioMenuItem()}
           {renderMarkdownTableAutoFormattingMenuItem()}
           {renderIsTextlintEnabledMenuItem()}
           {/* <DropdownItem divider /> */}

--- a/packages/app/src/interfaces/editor-settings.ts
+++ b/packages/app/src/interfaces/editor-settings.ts
@@ -24,7 +24,6 @@ export interface IEditorSettings {
   theme: undefined | string,
   keymapMode: undefined | KeyMapMode,
   styleActiveLine: boolean,
-  renderDrawioInRealtime: boolean,
   autoFormatMarkdownTable: boolean,
   textlintSettings: undefined | ITextlintSettings;
 }

--- a/packages/app/src/server/models/editor-settings.ts
+++ b/packages/app/src/server/models/editor-settings.ts
@@ -26,7 +26,6 @@ const editorSettingsSchema = new Schema<EditorSettingsDocument, EditorSettingsMo
   theme: { type: String },
   keymapMode: { type: String },
   styleActiveLine: { type: Boolean, default: false },
-  renderDrawioInRealtime: { type: Boolean, default: true },
   autoFormatMarkdownTable: { type: Boolean, default: true },
   textlintSettings: textlintSettingsSchema,
 });

--- a/packages/app/src/server/routes/apiv3/personal-setting.js
+++ b/packages/app/src/server/routes/apiv3/personal-setting.js
@@ -117,7 +117,6 @@ module.exports = (crowi) => {
       body('theme').optional().isString(),
       body('keymapMode').optional().isString(),
       body('styleActiveLine').optional().isBoolean(),
-      body('renderDrawioInRealtime').optional().isBoolean(),
       body('autoFormatMarkdownTable').optional().isBoolean(),
       body('textlintSettings.neverAskBeforeDownloadLargeFiles').optional().isBoolean(),
       body('textlintSettings.textlintRules.*.name').optional().isString(),
@@ -539,12 +538,12 @@ module.exports = (crowi) => {
     const { body } = req;
 
     const {
-      theme, keymapMode, styleActiveLine, renderDrawioInRealtime, autoFormatMarkdownTable,
+      theme, keymapMode, styleActiveLine, autoFormatMarkdownTable,
       textlintSettings,
     } = body;
 
     const document = {
-      theme, keymapMode, styleActiveLine, renderDrawioInRealtime, autoFormatMarkdownTable,
+      theme, keymapMode, styleActiveLine, autoFormatMarkdownTable,
     };
 
     if (textlintSettings != null) {


### PR DESCRIPTION
## Task
[Next.js] 編集画面で draw.io rendering の ON/OFF 切り替えできる機能を廃止する
┗ [112047](https://redmine.weseek.co.jp/issues/112047) 修正

## Before
<img width="328" alt="Screen Shot 2022-12-23 at 23 14 06" src="https://user-images.githubusercontent.com/59536731/209349854-1fbdf652-66f6-4481-8249-cf89c756db5c.png">

## After
<img width="323" alt="Screen Shot 2022-12-23 at 23 13 40" src="https://user-images.githubusercontent.com/59536731/209349865-62a6c286-59cb-4a1c-bd58-fb52d42beb06.png">

