### PR TITLE
fix:  Toaster success after deleting user group

### DIFF
--- a/packages/app/src/components/Admin/UserGroup/UserGroupPage.tsx
+++ b/packages/app/src/components/Admin/UserGroup/UserGroupPage.tsx
@@ -126,7 +126,7 @@ export const UserGroupPage: FC = () => {
 
   const deleteUserGroupById = useCallback(async(deleteGroupId: string, actionName: string, transferToUserGroupId: string) => {
     try {
-      const res = await apiv3Delete(`/user-groups/${deleteGroupId}`, {
+      await apiv3Delete(`/user-groups/${deleteGroupId}`, {
         actionName,
         transferToUserGroupId,
       });
@@ -137,12 +137,12 @@ export const UserGroupPage: FC = () => {
       setSelectedUserGroup(undefined);
       setDeleteModalShown(false);
 
-      toastSuccess(`Deleted ${res.data.userGroups.length} groups.`);
+      toastSuccess(`Deleted ${selectedUserGroup?.name} group.`);
     }
     catch (err) {
       toastError(new Error('Unable to delete the groups'));
     }
-  }, [mutateUserGroups]);
+  }, [mutateUserGroups, selectedUserGroup]);
 
   return (
     <div data-testid="admin-user-groups">


### PR DESCRIPTION
## Task
[Next.js][Admin] /admin/user-groups で既存グループを歯車アイコンから削除すると 「Deleted undefined groups.」 のトーストサクセスが表示される
┗ [111878](https://redmine.weseek.co.jp/issues/111878) 修正

## Before
<img width="335" alt="Screen Shot 2022-12-26 at 16 09 19" src="https://user-images.githubusercontent.com/59536731/209516202-c0c18de2-1380-48c1-9403-faf7476d135d.png">


## After
<img width="328" alt="Screen Shot 2022-12-26 at 16 08 08" src="https://user-images.githubusercontent.com/59536731/209516082-c9b7158e-313d-433f-82db-4824aaabaf46.png">

