### PR TITLE
imprv: search page layout fix

### DIFF
--- a/packages/app/src/components/Layout/SearchResultLayout.tsx
+++ b/packages/app/src/components/Layout/SearchResultLayout.tsx
@@ -11,14 +11,12 @@ type Props = {
 const SearchResultLayout = ({ children }: Props): JSX.Element => {
 
   return (
-    <div className={`on-search ${commonStyles['on-search']}`}>
-      <BasicLayout>
-        <div id="grw-fav-sticky-trigger" className="sticky-top"></div>
-        <div id="main" className="main search-page mt-0">
-          { children }
-        </div>
-      </BasicLayout>
-    </div>
+    <BasicLayout className={`on-search ${commonStyles['on-search']}`}>
+      <div id="grw-fav-sticky-trigger" className="sticky-top"></div>
+      <div id="main" className="main search-page mt-0">
+        { children }
+      </div>
+    </BasicLayout>
   );
 };
 

--- a/packages/app/src/pages/_search.page.tsx
+++ b/packages/app/src/pages/_search.page.tsx
@@ -5,6 +5,7 @@ import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import dynamic from 'next/dynamic';
 import Head from 'next/head';
 
+import SearchResultLayout from '~/components/Layout/SearchResultLayout';
 import { DrawioViewerScript } from '~/components/Script/DrawioViewerScript';
 import type { CrowiRequest } from '~/interfaces/crowi-request';
 import type { RendererConfig } from '~/interfaces/services/renderer';
@@ -23,12 +24,11 @@ import {
 
 import { SearchPage } from '../components/SearchPage';
 
+import { NextPageWithLayout } from './_app.page';
 import {
   CommonProps, getNextI18NextConfig, getServerSideCommonProps, generateCustomTitle,
 } from './utils/commons';
-import { NextPageWithLayout } from './_app.page';
 
-const SearchResultLayout = dynamic(() => import('~/components/Layout/SearchResultLayout'), { ssr: false });
 
 type Props = CommonProps & {
   currentUser: IUser,


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/112246
検索結果ページを他ページとの遷移に対応化
- Layout が dynamic import されていた件の修正
- Layoutの階層構造の共通化（差分検出処理を考慮）