### PR TITLE
fix: isEnabledLinebreaksInComments is not applied

### DIFF
--- a/packages/app/src/pages/[[...path]].page.tsx
+++ b/packages/app/src/pages/[[...path]].page.tsx
@@ -542,8 +542,6 @@ function injectServerConfigurations(context: GetServerSidePropsContext, props: P
   props.isAllReplyShown = configManager.getConfig('crowi', 'customize:isAllReplyShown');
   props.isContainerFluid = configManager.getConfig('crowi', 'customize:isContainerFluid');
   props.isEnabledStaleNotification = configManager.getConfig('crowi', 'customize:isEnabledStaleNotification');
-  // props.isEnabledLinebreaks = configManager.getConfig('markdown', 'markdown:isEnabledLinebreaks');
-  // props.isEnabledLinebreaksInComments = configManager.getConfig('markdown', 'markdown:isEnabledLinebreaksInComments');
   props.disableLinkSharing = configManager.getConfig('crowi', 'security:disableLinkSharing');
   props.editorConfig = {
     upload: {

--- a/packages/app/src/services/renderer/renderer.tsx
+++ b/packages/app/src/services/renderer/renderer.tsx
@@ -208,7 +208,12 @@ export const generateTocOptions = (config: RendererConfig, tocNode: HtmlElementN
   return options;
 };
 
-export const generateSimpleViewOptions = (config: RendererConfig, pagePath: string, highlightKeywords?: string | string[]): RendererOptions => {
+export const generateSimpleViewOptions = (
+    config: RendererConfig,
+    pagePath: string,
+    highlightKeywords?: string | string[],
+    overrideIsEnabledLinebreaks?: boolean,
+): RendererOptions => {
   const options = generateCommonOptions(pagePath);
 
   const { remarkPlugins, rehypePlugins, components } = options;
@@ -222,7 +227,10 @@ export const generateSimpleViewOptions = (config: RendererConfig, pagePath: stri
     lsxGrowiPlugin.remarkPlugin,
     table.remarkPlugin,
   );
-  if (config.isEnabledLinebreaks) {
+
+  const isEnabledLinebreaks = overrideIsEnabledLinebreaks ?? config.isEnabledLinebreaks;
+
+  if (isEnabledLinebreaks) {
     remarkPlugins.push(breaks);
   }
 

--- a/packages/app/src/stores/renderer.tsx
+++ b/packages/app/src/stores/renderer.tsx
@@ -92,9 +92,19 @@ export const useCommentForCurrentPageOptions = (): SWRResponse<RendererOptions, 
 
   return useSWRImmutable<RendererOptions, Error>(
     key,
-    (rendererId, rendererConfig, currentPagePath) => generateSimpleViewOptions(rendererConfig, currentPagePath),
+    (rendererId, rendererConfig, currentPagePath) => generateSimpleViewOptions(
+      rendererConfig,
+      currentPagePath,
+      undefined,
+      rendererConfig.isEnabledLinebreaksInComments,
+    ),
     {
-      fallbackData: isAllDataValid ? generateSimpleViewOptions(rendererConfig, currentPagePath) : undefined,
+      fallbackData: isAllDataValid ? generateSimpleViewOptions(
+        rendererConfig,
+        currentPagePath,
+        undefined,
+        rendererConfig.isEnabledLinebreaksInComments,
+      ) : undefined,
     },
   );
 };


### PR DESCRIPTION
## Task
[Next.js][Admin][Markdown][Line Break設定] 「Line Break を有効にする」が「コメント欄で Line Break を有効にする」に適用されてしまっている
┗[112128](https://redmine.weseek.co.jp/issues/112128) 修正

<img width="865" alt="Screen Shot 2022-12-26 at 23 14 44" src="https://user-images.githubusercontent.com/59536731/209557632-23b6b74b-0b59-4afe-b47d-d74e08300acf.png">


## Screenshots
### linebreak: `OFF`
<img width="392" alt="Screen Shot 2022-12-26 at 23 11 17" src="https://user-images.githubusercontent.com/59536731/209557336-1184ec54-8691-4924-97f5-30befe1d66d4.png">

### linebreak: `ON`
<img width="640" alt="Screen Shot 2022-12-26 at 23 11 34" src="https://user-images.githubusercontent.com/59536731/209557338-78df49a3-d0d6-4d3c-a944-69e8025225d5.png">


## Note
マージ先は `fix/renderers`