### PR TITLE
fix: show editor navbar

### DIFF
--- a/packages/app/src/components/PageEditor/Editor.tsx
+++ b/packages/app/src/components/PageEditor/Editor.tsx
@@ -73,13 +73,6 @@ const Editor: ForwardRefRenderFunction<IEditorMethods, EditorPropsType> = (props
   const cmEditorRef = useRef<AbstractEditor<any>>(null);
   const taEditorRef = useRef<TextAreaEditor>(null);
 
-  useEffect(() => {
-    if (cmEditorRef.current != null) {
-      const editorNavBarItems = cmEditorRef.current.getNavbarItems() ?? [];
-      setNavBarItems(editorNavBarItems);
-    }
-  }, []);
-
   const editorSubstance = useCallback(() => {
     return isMobile ? taEditorRef.current : cmEditorRef.current;
   }, [isMobile]);
@@ -266,6 +259,13 @@ const Editor: ForwardRefRenderFunction<IEditorMethods, EditorPropsType> = (props
       </Modal>
     );
   }, [isCheatsheetModalShown]);
+
+  useEffect(() => {
+    if (editorSubstance != null && editorSettings != null) {
+      const editorNavBarItems = editorSubstance()?.getNavbarItems() ?? [];
+      setNavBarItems(editorNavBarItems);
+    }
+  }, [editorSettings, editorSubstance]);
 
   if (editorSettings == null) {
     return <></>;

--- a/packages/app/src/components/PageEditor/Editor.tsx
+++ b/packages/app/src/components/PageEditor/Editor.tsx
@@ -263,6 +263,7 @@ const Editor: ForwardRefRenderFunction<IEditorMethods, EditorPropsType> = (props
   const isReadyToRenderEditor = editorSettings != null;
   const editorRef = editorSubstance();
 
+  // https://redmine.weseek.co.jp/issues/111731
   useEffect(() => {
     if (isReadyToRenderEditor && editorRef != null) {
       const editorNavBarItems = editorRef.getNavbarItems() ?? [];

--- a/packages/app/src/components/PageEditor/Editor.tsx
+++ b/packages/app/src/components/PageEditor/Editor.tsx
@@ -260,14 +260,17 @@ const Editor: ForwardRefRenderFunction<IEditorMethods, EditorPropsType> = (props
     );
   }, [isCheatsheetModalShown]);
 
+  const isReadyToRenderEditor = editorSettings != null;
+  const editorRef = editorSubstance();
+
   useEffect(() => {
-    if (editorSubstance != null && editorSettings != null) {
-      const editorNavBarItems = editorSubstance()?.getNavbarItems() ?? [];
+    if (isReadyToRenderEditor && editorRef != null) {
+      const editorNavBarItems = editorRef.getNavbarItems() ?? [];
       setNavBarItems(editorNavBarItems);
     }
-  }, [editorSettings, editorSubstance]);
+  }, [editorRef, isReadyToRenderEditor]);
 
-  if (editorSettings == null) {
+  if (!isReadyToRenderEditor) {
     return <></>;
   }
 

--- a/packages/app/src/components/PageEditor/Editor.tsx
+++ b/packages/app/src/components/PageEditor/Editor.tsx
@@ -1,6 +1,7 @@
 import React, {
   useState, useRef, useImperativeHandle, useCallback, ForwardRefRenderFunction, forwardRef,
   memo,
+  useEffect,
 } from 'react';
 
 import Dropzone from 'react-dropzone';
@@ -60,6 +61,8 @@ const Editor: ForwardRefRenderFunction<IEditorMethods, EditorPropsType> = (props
   const [isUploading, setIsUploading] = useState(false);
   const [isCheatsheetModalShown, setIsCheatsheetModalShown] = useState(false);
 
+  const [navBarItems, setNavBarItems] = useState<JSX.Element[]>([]);
+
   const { t } = useTranslation();
   const { data: editorSettings } = useEditorSettings();
   const { data: defaultIndentSize } = useDefaultIndentSize();
@@ -69,6 +72,13 @@ const Editor: ForwardRefRenderFunction<IEditorMethods, EditorPropsType> = (props
   // CodeMirrorEditor ref
   const cmEditorRef = useRef<AbstractEditor<any>>(null);
   const taEditorRef = useRef<TextAreaEditor>(null);
+
+  useEffect(() => {
+    if (cmEditorRef.current != null) {
+      const editorNavBarItems = cmEditorRef.current.getNavbarItems() ?? [];
+      setNavBarItems(editorNavBarItems);
+    }
+  }, []);
 
   const editorSubstance = useCallback(() => {
     return isMobile ? taEditorRef.current : cmEditorRef.current;
@@ -231,7 +241,7 @@ const Editor: ForwardRefRenderFunction<IEditorMethods, EditorPropsType> = (props
     return (
       <div className="m-0 navbar navbar-default navbar-editor" data-testid="navbar-editor" style={{ minHeight: 'unset' }}>
         <ul className="pl-2 nav nav-navbar">
-          { (editorSubstance()?.getNavbarItems() ?? []).map((item, idx) => {
+          { navBarItems.map((item, idx) => {
             // eslint-disable-next-line react/no-array-index-key
             return <li key={`navbarItem-${idx}`}>{item}</li>;
           }) }


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/112339
https://redmine.weseek.co.jp/issues/112233

# やったこと
- useEffectを利用して、refに値が入ってから必要なコンポーネントをレンダリングするようにした

# 備考
- 主には`Editor`の`NavBar`が表示されない不具合の修正ですが、2回レンダリングされるようにしたので、結果としてエディタのテーマが適用されない不具合も治っています
- 手元で`production build`をして、正常に動作することを確認しています