### PR TITLE
fix: Custom logo not displayed on shared page

### DIFF
--- a/packages/app/src/server/middlewares/certify-shared-file.js
+++ b/packages/app/src/server/middlewares/certify-shared-file.js
@@ -1,4 +1,6 @@
+import { AttachmentType } from '~/server/interfaces/attachment';
 import loggerFactory from '~/utils/logger';
+
 
 const url = require('url');
 
@@ -29,6 +31,12 @@ module.exports = (crowi) => {
     const attachment = await Attachment.findOne({ _id: fileId });
 
     if (attachment == null) {
+      return next();
+    }
+
+    const isBlandLogo = attachment.attachmentType === AttachmentType.BRAND_LOGO;
+    if (isBlandLogo) {
+      req.isSharedPage = true;
       return next();
     }
 


### PR DESCRIPTION
## Task
[#112434](https://redmine.weseek.co.jp/issues/112434) [GROWI][Next.js] カスタムロゴ設定した状態で、任意のページのsharelink にアクセスすると、ロゴが表示されない
└ [#112474](https://redmine.weseek.co.jp/issues/112474) 修正