### PR TITLE
fix: Refactor axios date serializer config

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -96,6 +96,7 @@
     "cookie-parser": "^1.4.5",
     "csurf": "^1.11.0",
     "csv-to-markdown-table": "^1.1.0",
+    "dayjs": "^1.11.7",
     "date-fns": "^2.23.0",
     "detect-indent": "^7.0.0",
     "diff": "^5.0.0",

--- a/packages/app/src/utils/axios.ts
+++ b/packages/app/src/utils/axios.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line no-restricted-imports
 import axios from 'axios';
-import parseISO from 'date-fns/parseISO';
-import isIsoDate from 'is-iso-date';
+import dayjs from 'dayjs';
+import qs from 'qs';
 
 const customAxios = axios.create({
   headers: {
@@ -10,26 +10,10 @@ const customAxios = axios.create({
   },
 });
 
-// add an interceptor to convert ISODate
-const convertDates = (body: any): void => {
-  if (body === null || body === undefined || typeof body !== 'object') {
-    return body;
-  }
-
-  for (const key of Object.keys(body)) {
-    const value = body[key];
-    if (isIsoDate(value)) {
-      body[key] = parseISO(value);
-    }
-    else if (typeof value === 'object') {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      convertDates(value);
-    }
-  }
-};
-customAxios.interceptors.response.use((response) => {
-  convertDates(response.data);
-  return response;
+// serialize Date config: https://github.com/axios/axios/issues/1548#issuecomment-548306666
+customAxios.interceptors.request.use((config) => {
+  config.paramsSerializer = params => qs.stringify(params, { serializeDate: (date: Date) => dayjs(date).format('YYYY-MM-DDTHH:mm:ssZ') });
+  return config;
 });
 
 export default customAxios;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7693,6 +7693,11 @@ dayjs@^1.10.4:
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.10.7.tgz#2cf5f91add28116748440866a0a1d26f3a6ce468"
   integrity sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig==
 
+dayjs@^1.11.7:
+  version "1.11.7"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.7.tgz#4b296922642f70999544d1144a2c25730fce63e2"
+  integrity sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ==
+
 dayjs@^1.8.19:
   version "1.10.6"
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.10.6.tgz#288b2aa82f2d8418a6c9d4df5898c0737ad02a63"


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/112598

# 起こっていたこと
- wikiの本文に日付が含まれていた場合、axiosのintercepterによって強制的に変換されてしまい、結果内容が`Invalid Date`になってしまい、表示されない

# やったこと
- 既存のaxiosの設定をリファクタ

# 備考
- 日付を含んだページが正常に表示されることを確認