### PR TITLE
fix: Refactor uri decoding in getServerSideProps

### DIFF
--- a/packages/app/src/pages/utils/commons.ts
+++ b/packages/app/src/pages/utils/commons.ts
@@ -36,7 +36,7 @@ export const getServerSideCommonProps: GetServerSideProps<CommonProps> = async(c
   } = crowi;
 
   const url = new URL(context.resolvedUrl, 'http://example.com');
-  const currentPathname = decodeURI(url.pathname);
+  const currentPathname = decodeURIComponent(url.pathname);
 
   const isMaintenanceMode = appService.isMaintenanceMode();
 


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/113678

# 起こっている問題
- コロンなどの特殊な文字をパスに含めると、`isCreatablePage`メソッドではじかれて作成できない

# やったこと
- コロンは`decodeURI`ではデコードできなかったので、`decodeURIComponent`を使用