### PR TITLE
fix: Bug in Page Tree Selected Item Background Color

### DIFF
--- a/packages/app/src/components/Sidebar/PageTree/Item.tsx
+++ b/packages/app/src/components/Sidebar/PageTree/Item.tsx
@@ -55,6 +55,9 @@ const markTarget = (children: ItemNode[], targetPathOrId?: Nullable<string>): vo
     if (node.page._id === targetPathOrId || node.page.path === targetPathOrId) {
       node.page.isTarget = true;
     }
+    else {
+      node.page.isTarget = false;
+    }
     return node;
   });
 };


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/113669

- ページツリー内のアイテムがページ遷移しても背景色が変わらない不具合を修正