### PR TITLE
fix: Delete updated contents when save with shortcut

### DIFF
--- a/packages/app/src/pages/[[...path]].page.tsx
+++ b/packages/app/src/pages/[[...path]].page.tsx
@@ -285,7 +285,7 @@ const Page: NextPageWithLayout<Props> = (props: Props) => {
 
   useSWRxCurrentPage(pageWithMeta?.data ?? null); // store initial data
 
-  useEditingMarkdown(pageWithMeta?.data.revision?.body);
+  const { mutate: mutateEditingMarkdown } = useEditingMarkdown();
 
   const { data: grantData } = useSWRxIsGrantNormalized(pageId);
   const { mutate: mutateSelectedGrant } = useSelectedGrant();
@@ -313,6 +313,10 @@ const Page: NextPageWithLayout<Props> = (props: Props) => {
       router.replace(`${props.currentPathname}${search}${hash}`, undefined, { shallow: true });
     }
   }, [props.currentPathname, router]);
+
+  useEffect(() => {
+    mutateEditingMarkdown(pageWithMeta?.data.revision?.body);
+  }, [mutateEditingMarkdown, pageWithMeta?.data.revision?.body]);
 
   const isTopPagePath = isTopPage(pageWithMeta?.data.path ?? '');
 

--- a/packages/app/src/pages/[[...path]].page.tsx
+++ b/packages/app/src/pages/[[...path]].page.tsx
@@ -314,6 +314,7 @@ const Page: NextPageWithLayout<Props> = (props: Props) => {
     }
   }, [props.currentPathname, router]);
 
+  // initialize mutateEditingMarkdown only once per page
   useEffect(() => {
     mutateEditingMarkdown(pageWithMeta?.data.revision?.body);
   }, [mutateEditingMarkdown, pageWithMeta?.data.revision?.body]);

--- a/packages/app/src/stores/editor.tsx
+++ b/packages/app/src/stores/editor.tsx
@@ -10,15 +10,17 @@ import { IEditorSettings } from '~/interfaces/editor-settings';
 import { SlackChannels } from '~/interfaces/user-trigger-notification';
 
 import {
+  useCurrentPathname,
   useCurrentUser, useDefaultIndentSize, useIsGuestUser,
 } from './context';
 // import { localStorageMiddleware } from './middlewares/sync-to-storage';
-import { useCurrentPagePath, useSWRxTagsInfo } from './page';
+import { useSWRxTagsInfo } from './page';
 import { useStaticSWR } from './use-static-swr';
 
 
 export const useEditingMarkdown = (initialData?: string): SWRResponse<string, Error> => {
-  const { data: currentPagePath } = useCurrentPagePath();
+  const { data: currentPagePath } = useCurrentPathname();
+
   return useStaticSWR(['editingMarkdown', currentPagePath], initialData);
 };
 

--- a/packages/app/src/stores/editor.tsx
+++ b/packages/app/src/stores/editor.tsx
@@ -19,6 +19,8 @@ import { useStaticSWR } from './use-static-swr';
 
 
 export const useEditingMarkdown = (initialData?: string): SWRResponse<string, Error> => {
+  // need to include useCurrentPathname not useCurrentPagePath
+  // https://github.com/weseek/growi/pull/7301
   const { data: currentPagePath } = useCurrentPathname();
 
   return useStaticSWR(['editingMarkdown', currentPagePath], initialData);

--- a/packages/app/src/stores/page.tsx
+++ b/packages/app/src/stores/page.tsx
@@ -179,6 +179,8 @@ export const useCurrentPagePath = (): SWRResponse<string | undefined, Error> => 
   const { data: currentPage } = useSWRxCurrentPage();
   const { data: currentPathname } = useCurrentPathname();
 
+  const fallbackData = (currentPathname != null && !_isPermalink(currentPathname)) ? currentPathname : undefined;
+
   return useSWRImmutable(
     ['currentPagePath', currentPage?.path, currentPathname],
     (key: Key, pagePath: string|undefined, pathname: string|undefined) => {
@@ -190,8 +192,7 @@ export const useCurrentPagePath = (): SWRResponse<string | undefined, Error> => 
       }
       return undefined;
     },
-    // TODO: set fallbackData
-    // { fallbackData:  }
+    { fallbackData },
   );
 };
 

--- a/packages/app/src/stores/page.tsx
+++ b/packages/app/src/stores/page.tsx
@@ -179,8 +179,6 @@ export const useCurrentPagePath = (): SWRResponse<string | undefined, Error> => 
   const { data: currentPage } = useSWRxCurrentPage();
   const { data: currentPathname } = useCurrentPathname();
 
-  const fallbackData = (currentPathname != null && !_isPermalink(currentPathname)) ? currentPathname : undefined;
-
   return useSWRImmutable(
     ['currentPagePath', currentPage?.path, currentPathname],
     (key: Key, pagePath: string|undefined, pathname: string|undefined) => {
@@ -192,7 +190,8 @@ export const useCurrentPagePath = (): SWRResponse<string | undefined, Error> => 
       }
       return undefined;
     },
-    { fallbackData },
+    // TODO: set fallbackData
+    // { fallbackData:  },
   );
 };
 

--- a/packages/app/src/stores/page.tsx
+++ b/packages/app/src/stores/page.tsx
@@ -191,7 +191,7 @@ export const useCurrentPagePath = (): SWRResponse<string | undefined, Error> => 
       return undefined;
     },
     // TODO: set fallbackData
-    // { fallbackData:  },
+    // { fallbackData:  }
   );
 };
 


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/114058

# やったこと
- ページの更新時に再度`useEditingMarkdown`が`pageWithMeta?.data.revision?.body`で初期化されてしまうのを防ぐために、useEffectの中で初期化
- `useCurrentPagePath`は最初の値がundefinedである可能性があるので、`currentPathname`をkeyに含むように変更

# 備考
- cypressテストの作成は後続タスクでやります
- https://redmine.weseek.co.jp/issues/114087