### PR TITLE
fix: GrowiContextualSubNavigation style is broken

### DIFF
--- a/packages/app/src/components/Navbar/GrowiSubNavigationSwitcher.tsx
+++ b/packages/app/src/components/Navbar/GrowiSubNavigationSwitcher.tsx
@@ -38,9 +38,11 @@ export const GrowiSubNavigationSwitcher = (props: GrowiSubNavigationSwitcherProp
   // use more specific type HTMLDivElement for avoid assertion error.
   // see: https://developer.mozilla.org/en-US/docs/Web/API/HTMLDivElement
   const fixedContainerRef = useRef<HTMLDivElement>(null);
+  const clientWidth = fixedContainerRef.current?.parentElement?.clientWidth;
 
+  // Do not use clientWidth as useCallback deps, resizing events will not work in production builds.
   const initWidth = useCallback(() => {
-    if (fixedContainerRef.current && fixedContainerRef.current.parentElement) {
+    if (fixedContainerRef.current != null && fixedContainerRef.current.parentElement != null) {
       // get parent elements width
       const { clientWidth } = fixedContainerRef.current.parentElement;
       setWidth(clientWidth);
@@ -84,10 +86,14 @@ export const GrowiSubNavigationSwitcher = (props: GrowiSubNavigationSwitcherProp
     }
   }, [isSidebarCollapsed, initWidth]);
 
-  // initialize width
+  /*
+   * initialize width.
+   * Since width is not recalculated at production build first rendering,
+   * make initWidth execution dependent on clientWidth.
+   */
   useEffect(() => {
-    initWidth();
-  }, [initWidth]);
+    if (clientWidth != null) initWidth();
+  }, [initWidth, clientWidth]);
 
   if (currentPage == null) {
     return <></>;


### PR DESCRIPTION
task: https://redmine.weseek.co.jp/issues/114013

## 事象
ストーリー説明欄を確認: https://redmine.weseek.co.jp/issues/114011

## How
### 原因
- GrowiContextualSubNaviagtion の幅 (width) が 初期値の 0のまま更新されていなかった

### 解決案
- width は親 dom の `const clientWidth = fixedContainerRef.current?.parentElement?.clientWidth` から取得する.
- clientWidth を deps に入れることで, clientWidth を取得した後に initWidth() が実行されるようにした.
- `fixedContainerRef` `current` `parentElement` を deps にしても動作しないので `const clientWidth = fixedContainerRef.current?.parentElement?.clientWidth` を外で呼び出し依存させた.
- initWidth 関数も clientWidth を使用するが、useCallbackの依存配列に clientWidth を加えると, 今度は resize events が起こらなくなった. -> 依存させずに既存のままとしている

## 確認事項
### 環境：
- cloud demo 環境 or 手元のプロダクションビルド
- Windows
  - Chrome
  - Firefox
- Mac
  - Chrome
  - Firefox
  - Safari

### 確認すること：
- 画面リサイズ
- collapseSidebar: 直接と設定から
- ブラウザリロード
- ブラウザフォワード・バック