### PR TITLE
refs 114284: fix modal input error

### DIFF
--- a/packages/app/src/components/Questionnaire/Question.tsx
+++ b/packages/app/src/components/Questionnaire/Question.tsx
@@ -21,7 +21,7 @@ const Question = ({ question, inputNamePrefix }: QuestionProps): JSX.Element => 
     <div className="col-6 d-flex align-items-center pl-0">
       <div className="btn-group btn-group-toggle flex-fill grw-questionnaire-btn-group" data-toggle="buttons">
         <label className="btn btn-outline-primary active mr-3 rounded">
-          <input type="radio" name={`${inputNamePrefix + question._id}`} id={`${question._id}-noAnswer`} value='0' checked/> -
+          <input type="radio" name={`${inputNamePrefix + question._id}`} id={`${question._id}-noAnswer`} value='0' defaultChecked/> -
         </label>
         <label className="btn btn-outline-primary rounded-left">
           <input type="radio" name={`${inputNamePrefix + question._id}`} id={`${question._id}-option1`} value='1'/> 1


### PR DESCRIPTION
## 概要
modal を開いた際、

```
Warning: findDOMNode is deprecated in StrictMode. findDOMNode was passed an instance of Transition which is inside StrictMode. Instead, add a ref directly to the element you want to reference.
```

```
You provided a `checked` prop to a form field without an `onChange` handler
```

のエラーが出ており、前者は他の Modal を使っている箇所でも出ているようなので、一旦無視。
後者を修正

## review task
https://redmine.weseek.co.jp/issues/114286