### PR TITLE
support: Add test for View and Edit contents when saving

### DIFF
--- a/packages/app/test/cypress/integration/20-basic-features/20-basic-features--access-to-page.spec.ts
+++ b/packages/app/test/cypress/integration/20-basic-features/20-basic-features--access-to-page.spec.ts
@@ -113,8 +113,7 @@ context('Access to page', () => {
     cy.get('.grw-editor-navbar-bottom').should('be.visible');
 
     // check editing contents with shortcut key
-    cy.get('.CodeMirror-line').children().first().should(($elm) => {
-      const text = $elm.text()
+    cy.get('.CodeMirror-line').children().first().invoke('text').then((text) => {
       cy.get('.CodeMirror').type(body2);
       cy.get('.CodeMirror').contains(text+body2);
       cy.get('.page-editor-preview-body').contains(text+body2);

--- a/packages/app/test/cypress/integration/20-basic-features/20-basic-features--access-to-page.spec.ts
+++ b/packages/app/test/cypress/integration/20-basic-features/20-basic-features--access-to-page.spec.ts
@@ -68,6 +68,62 @@ context('Access to page', () => {
     cy.screenshot(`${ssPrefix}-Sandbox-edit-page`);
   })
 
+  it('View and Edit contents are successfully loaded', () => {
+    const body1 = 'hello';
+    cy.visit('/Sandbox/testForUseEditingMarkdown');
+
+    cy.get('#grw-page-editor-mode-manager').as('pageEditorModeManager').should('be.visible');
+    cy.waitUntil(() => {
+      // do
+      cy.get('@pageEditorModeManager').within(() => {
+        cy.get('button:nth-child(2)').click();
+      });
+      // until
+      return cy.get('.layout-root').then($elem => $elem.hasClass('editing'));
+    })
+
+    cy.get('.grw-editor-navbar-bottom').should('be.visible');
+
+    // check edited contents after save
+    cy.get('.CodeMirror').type(body1);
+    cy.get('.CodeMirror').contains(body1);
+    cy.get('.page-editor-preview-body').contains(body1);
+    cy.getByTestid('page-editor').should('be.visible');
+    cy.getByTestid('save-page-btn').click();
+    cy.get('.wiki').should('be.visible');
+    cy.get('.wiki').children().first().should('have.text', body1);
+  })
+
+  it('Editing contents are successfully loaded with shortcut key', () => {
+    const body2 = ' world!';
+    const savePageShortcutKey = '{ctrl+s}';
+
+    cy.visit('/Sandbox/testForUseEditingMarkdown');
+
+    cy.get('#grw-page-editor-mode-manager').as('pageEditorModeManager').should('be.visible');
+    cy.waitUntil(() => {
+      // do
+      cy.get('@pageEditorModeManager').within(() => {
+        cy.get('button:nth-child(2)').click();
+      });
+      // until
+      return cy.get('.layout-root').then($elem => $elem.hasClass('editing'));
+    })
+
+    cy.get('.grw-editor-navbar-bottom').should('be.visible');
+
+    // check editing contents with shortcut key
+    cy.get('. CodeMirror-line ').children().first().should(($elm) => {
+      const text = $elm.text()
+      cy.get('.CodeMirror').type(body2);
+      cy.get('.CodeMirror').contains(text+body2);
+      cy.get('.page-editor-preview-body').contains(text+body2);
+      cy.get('.CodeMirror').type(savePageShortcutKey);
+      cy.get('.CodeMirror').contains(text+body2);
+      cy.get('.page-editor-preview-body').contains(text+body2);
+    })
+  })
+
   it('/user/admin is successfully loaded', () => {
     cy.visit('/user/admin');
 

--- a/packages/app/test/cypress/integration/20-basic-features/20-basic-features--access-to-page.spec.ts
+++ b/packages/app/test/cypress/integration/20-basic-features/20-basic-features--access-to-page.spec.ts
@@ -113,7 +113,7 @@ context('Access to page', () => {
     cy.get('.grw-editor-navbar-bottom').should('be.visible');
 
     // check editing contents with shortcut key
-    cy.get('. CodeMirror-line ').children().first().should(($elm) => {
+    cy.get('.CodeMirror-line').children().first().should(($elm) => {
       const text = $elm.text()
       cy.get('.CodeMirror').type(body2);
       cy.get('.CodeMirror').contains(text+body2);


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/114087

# やったこと
以下のテストケースを追加
- 文を編集して更新ボタンで更新したときのEditとViewの文字列の一致を確認
- 文を編集してショートカットキーで更新したときにEdit内の文字列が変更されないか確認