### PR TITLE
fix: Show load latest revision button when update drawio or table from view

### DIFF
--- a/packages/app/src/client/services/side-effects/drawio-modal-launcher-for-view.ts
+++ b/packages/app/src/client/services/side-effects/drawio-modal-launcher-for-view.ts
@@ -23,7 +23,7 @@ declare global {
 
 
 export const useDrawioModalLauncherForView = (opts?: {
-  onSaveSuccess?: (newMarkdown: string) => void,
+  onSaveSuccess?: () => void,
   onSaveError?: (error: any) => void,
 }): void => {
 
@@ -61,7 +61,7 @@ export const useDrawioModalLauncherForView = (opts?: {
         optionsToSave,
       );
 
-      opts?.onSaveSuccess?.(newMarkdown);
+      opts?.onSaveSuccess?.();
     }
     catch (error) {
       logger.error('failed to save', error);

--- a/packages/app/src/client/services/side-effects/handsontable-modal-launcher-for-view.ts
+++ b/packages/app/src/client/services/side-effects/handsontable-modal-launcher-for-view.ts
@@ -22,7 +22,7 @@ declare global {
 
 
 export const useHandsontableModalLauncherForView = (opts?: {
-  onSaveSuccess?: (newMarkdown: string) => void,
+  onSaveSuccess?: () => void,
   onSaveError?: (error: any) => void,
 }): void => {
 
@@ -60,7 +60,7 @@ export const useHandsontableModalLauncherForView = (opts?: {
         optionsToSave,
       );
 
-      opts?.onSaveSuccess?.(newMarkdown);
+      opts?.onSaveSuccess?.();
     }
     catch (error) {
       logger.error('failed to save', error);

--- a/packages/app/src/components/Page/PageContents.tsx
+++ b/packages/app/src/components/Page/PageContents.tsx
@@ -4,6 +4,7 @@ import { pagePathUtils } from '@growi/core';
 import { useTranslation } from 'next-i18next';
 import type { HtmlElementNode } from 'rehype-toc';
 
+import { useUpdateStateAfterSave } from '~/client/services/page-operation';
 import { useDrawioModalLauncherForView } from '~/client/services/side-effects/drawio-modal-launcher-for-view';
 import { useHandsontableModalLauncherForView } from '~/client/services/side-effects/handsontable-modal-launcher-for-view';
 import { toastSuccess, toastError } from '~/client/util/toastr';
@@ -30,6 +31,7 @@ export const PageContents = (): JSX.Element => {
   const { data: currentPage, mutate: mutateCurrentPage } = useSWRxCurrentPage();
   const { mutate: mutateEditingMarkdown } = useEditingMarkdown();
   const { mutate: mutateCurrentPageTocNode } = useCurrentPageTocNode();
+  const updateStateAfterSave = useUpdateStateAfterSave(currentPage?._id);
 
   const { data: rendererOptions, mutate: mutateRendererOptions } = useViewOptions((toc: HtmlElementNode) => {
     mutateCurrentPageTocNode(toc);
@@ -50,11 +52,7 @@ export const PageContents = (): JSX.Element => {
     onSaveSuccess: (newMarkdown) => {
       toastSuccess(t('toaster.save_succeeded'));
 
-      // rerender
-      if (!isSharedPage) {
-        mutateCurrentPage();
-      }
-      mutateEditingMarkdown(newMarkdown);
+      updateStateAfterSave?.();
     },
     onSaveError: (error) => {
       toastError(error);
@@ -65,11 +63,7 @@ export const PageContents = (): JSX.Element => {
     onSaveSuccess: (newMarkdown) => {
       toastSuccess(t('toaster.save_succeeded'));
 
-      // rerender
-      if (!isSharedPage) {
-        mutateCurrentPage();
-      }
-      mutateEditingMarkdown(newMarkdown);
+      updateStateAfterSave?.();
     },
     onSaveError: (error) => {
       toastError(error);

--- a/packages/app/src/components/Page/PageContents.tsx
+++ b/packages/app/src/components/Page/PageContents.tsx
@@ -49,7 +49,7 @@ export const PageContents = (): JSX.Element => {
   }, [mutateRendererOptions]);
 
   useHandsontableModalLauncherForView({
-    onSaveSuccess: (newMarkdown) => {
+    onSaveSuccess: () => {
       toastSuccess(t('toaster.save_succeeded'));
 
       updateStateAfterSave?.();
@@ -60,7 +60,7 @@ export const PageContents = (): JSX.Element => {
   });
 
   useDrawioModalLauncherForView({
-    onSaveSuccess: (newMarkdown) => {
+    onSaveSuccess: () => {
       toastSuccess(t('toaster.save_succeeded'));
 
       updateStateAfterSave?.();


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/114470

# 起こっていたこと
- テーブルや、drawioをViewモードから更新したとき、remote revisionを更新する処理がなかったため、現在表示しているrevisionとの差が生まれてしまい、`○○がページを更新しました`のラベルが出てしまっていた

# やったこと
- テーブルや、drawioをViewモードから更新した後の処理に、remoterevisionDataを更新する処理を追加した
- これにより、今表示しているrevisionとdbのrevisionの差がなくなり、`○○がページを更新しました`のラベルが出ないようになった