### PR TITLE
fix: Can't controll slack notification switch in editor

### DIFF
--- a/packages/app/src/components/PageEditor/EditorNavbarBottom.tsx
+++ b/packages/app/src/components/PageEditor/EditorNavbarBottom.tsx
@@ -36,8 +36,8 @@ const EditorNavbarBottom = (): JSX.Element => {
 
   const [slackChannelsStr, setSlackChannelsStr] = useState<string>('');
 
+  // DO NOT dependent on slackChannelsData directly: https://github.com/weseek/growi/pull/7332
   const slackChannelsDataString = slackChannelsData?.toString();
-
   useEffect(() => {
     if (slackChannelsDataString != null) {
       setSlackChannelsStr(slackChannelsDataString);

--- a/packages/app/src/components/PageEditor/EditorNavbarBottom.tsx
+++ b/packages/app/src/components/PageEditor/EditorNavbarBottom.tsx
@@ -36,12 +36,14 @@ const EditorNavbarBottom = (): JSX.Element => {
 
   const [slackChannelsStr, setSlackChannelsStr] = useState<string>('');
 
+  const slackChannelsDataString = slackChannelsData?.toString();
+
   useEffect(() => {
-    if (slackChannelsData != null) {
-      setSlackChannelsStr(slackChannelsData.toString());
+    if (slackChannelsDataString != null) {
+      setSlackChannelsStr(slackChannelsDataString);
       mutateIsSlackEnabled(false);
     }
-  }, [mutateIsSlackEnabled, slackChannelsData]);
+  }, [mutateIsSlackEnabled, slackChannelsDataString]);
 
   const isSlackEnabledToggleHandler = (bool: boolean) => {
     mutateIsSlackEnabled(bool, false);

--- a/packages/app/src/components/PageEditor/EditorNavbarBottom.tsx
+++ b/packages/app/src/components/PageEditor/EditorNavbarBottom.tsx
@@ -39,11 +39,11 @@ const EditorNavbarBottom = (): JSX.Element => {
   // DO NOT dependent on slackChannelsData directly: https://github.com/weseek/growi/pull/7332
   const slackChannelsDataString = slackChannelsData?.toString();
   useEffect(() => {
-    if (slackChannelsDataString != null) {
-      setSlackChannelsStr(slackChannelsDataString);
+    if (editorMode === 'editor') {
+      setSlackChannelsStr(slackChannelsDataString ?? '');
       mutateIsSlackEnabled(false);
     }
-  }, [mutateIsSlackEnabled, slackChannelsDataString]);
+  }, [editorMode, mutateIsSlackEnabled, slackChannelsDataString]);
 
   const isSlackEnabledToggleHandler = (bool: boolean) => {
     mutateIsSlackEnabled(bool, false);


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/114615

# やったこと
- Editorのslack通知の部分が正常に動作するように改修した