### PR TITLE
imprv: Customize user page deleteable

### DIFF
--- a/packages/app/src/client/services/AdminGeneralSecurityContainer.js
+++ b/packages/app/src/client/services/AdminGeneralSecurityContainer.js
@@ -38,6 +38,7 @@ export default class AdminGeneralSecurityContainer extends Container {
       expandOtherOptionsForCompleteDeletion: false,
       isShowRestrictedByOwner: false,
       isShowRestrictedByGroup: false,
+      isUserPageDeleteEnabled: false,
       isLocalEnabled: false,
       isLdapEnabled: false,
       isSamlEnabled: false,
@@ -73,6 +74,7 @@ export default class AdminGeneralSecurityContainer extends Container {
       currentPageRecursiveCompleteDeletionAuthority: generalSetting.pageRecursiveCompleteDeletionAuthority,
       isShowRestrictedByOwner: !generalSetting.hideRestrictedByOwner,
       isShowRestrictedByGroup: !generalSetting.hideRestrictedByGroup,
+      isUserPageDeleteEnabled: generalSetting.isUserPageDeleteEnabled,
       sessionMaxAge: generalSetting.sessionMaxAge,
       wikiMode: generalSetting.wikiMode,
       disableLinkSharing: shareLinkSetting.disableLinkSharing,
@@ -191,6 +193,13 @@ export default class AdminGeneralSecurityContainer extends Container {
    */
   switchIsShowRestrictedByGroup() {
     this.setState({ isShowRestrictedByGroup:  !this.state.isShowRestrictedByGroup });
+  }
+
+  /**
+   * Switch userPageDelete enabled
+   */
+  switchIsUserPageDeleteEnabled() {
+    this.setState({ isUserPageDeleteEnabled: !this.state.isUserPageDeleteEnabled });
   }
 
   /**

--- a/packages/app/src/client/services/AdminGeneralSecurityContainer.js
+++ b/packages/app/src/client/services/AdminGeneralSecurityContainer.js
@@ -196,7 +196,7 @@ export default class AdminGeneralSecurityContainer extends Container {
   }
 
   /**
-   * Switch userPageDelete enabled
+   * Switch isUserPageDeleteEnabled
    */
   switchIsUserPageDeleteEnabled() {
     this.setState({ isUserPageDeleteEnabled: !this.state.isUserPageDeleteEnabled });

--- a/packages/app/src/client/services/AdminGeneralSecurityContainer.js
+++ b/packages/app/src/client/services/AdminGeneralSecurityContainer.js
@@ -38,7 +38,7 @@ export default class AdminGeneralSecurityContainer extends Container {
       expandOtherOptionsForCompleteDeletion: false,
       isShowRestrictedByOwner: false,
       isShowRestrictedByGroup: false,
-      isUserPageDeleteEnabled: false,
+      isUserPageDeletionEnabled: false,
       isLocalEnabled: false,
       isLdapEnabled: false,
       isSamlEnabled: false,
@@ -74,7 +74,7 @@ export default class AdminGeneralSecurityContainer extends Container {
       currentPageRecursiveCompleteDeletionAuthority: generalSetting.pageRecursiveCompleteDeletionAuthority,
       isShowRestrictedByOwner: !generalSetting.hideRestrictedByOwner,
       isShowRestrictedByGroup: !generalSetting.hideRestrictedByGroup,
-      isUserPageDeleteEnabled: generalSetting.isUserPageDeleteEnabled,
+      isUserPageDeletionEnabled: generalSetting.isUserPageDeletionEnabled,
       sessionMaxAge: generalSetting.sessionMaxAge,
       wikiMode: generalSetting.wikiMode,
       disableLinkSharing: shareLinkSetting.disableLinkSharing,
@@ -196,10 +196,10 @@ export default class AdminGeneralSecurityContainer extends Container {
   }
 
   /**
-   * Switch isUserPageDeleteEnabled
+   * Switch isUserPageDeletionEnabled
    */
-  switchIsUserPageDeleteEnabled() {
-    this.setState({ isUserPageDeleteEnabled: !this.state.isUserPageDeleteEnabled });
+  switchisUserPageDeletionEnabled() {
+    this.setState({ isUserPageDeletionEnabled: !this.state.isUserPageDeletionEnabled });
   }
 
   /**

--- a/packages/app/src/components/Admin/Security/SecuritySetting.jsx
+++ b/packages/app/src/components/Admin/Security/SecuritySetting.jsx
@@ -453,6 +453,25 @@ class SecuritySetting extends React.Component {
           ].map(arr => this.renderPageDeletePermission(arr[0], arr[1], arr[2], arr[3]))
         }
 
+        <h4>ユーザーページの削除</h4>
+        <div className="row mb-4">
+          <div className="col-6 offset-3">
+            <div className="custom-control custom-switch custom-checkbox-success">
+              <input
+                type="checkbox"
+                className="custom-control-input"
+                id="isUserPageDeleteEnabled"
+                checked={adminGeneralSecurityContainer.state.isUserPageDeleteEnabled}
+                onChange={() => { adminGeneralSecurityContainer.switchIsUserPageDeleteEnabled() }}
+              />
+              <label className="custom-control-label" htmlFor="isUserPageDeleteEnabled">
+                無効化 / 有効化
+              </label>
+            </div>
+            <p className="form-text text-muted small" dangerouslySetInnerHTML={{ __html: 'ユーザー削除時にユーザーページも削除します。' }} />
+          </div>
+        </div>
+
         <h4>{t('security_settings.session')}</h4>
         <div className="form-group row">
           <label className="text-left text-md-right col-md-3 col-form-label">{t('security_settings.max_age')}</label>

--- a/packages/app/src/components/Admin/Security/SecuritySetting.jsx
+++ b/packages/app/src/components/Admin/Security/SecuritySetting.jsx
@@ -460,11 +460,11 @@ class SecuritySetting extends React.Component {
               <input
                 type="checkbox"
                 className="custom-control-input"
-                id="isUserPageDeleteEnabled"
-                checked={adminGeneralSecurityContainer.state.isUserPageDeleteEnabled}
-                onChange={() => { adminGeneralSecurityContainer.switchIsUserPageDeleteEnabled() }}
+                id="is-user-page-deletion-enabled"
+                checked={adminGeneralSecurityContainer.state.isUserPageDeletionEnabled}
+                onChange={() => { adminGeneralSecurityContainer.switchisUserPageDeletionEnabled() }}
               />
-              <label className="custom-control-label" htmlFor="isUserPageDeleteEnabled">
+              <label className="custom-control-label" htmlFor="is-user-page-deletion-enabled">
                 無効化 / 有効化
               </label>
             </div>


### PR DESCRIPTION
### 対象タスク
- 管理画面でユーザ削除時に HP を残すか削除するか設定できる
task: [114659](https://redmine.weseek.co.jp/issues/114659)

### 概要
- ユーザーページの削除 を追加
- i18n, 有効化時のユーザー削除時の処理, 無効化時のユーザー削除時の処理 は後続タスク

### Screenshot
![image](https://user-images.githubusercontent.com/68407388/216174581-8a93fcec-d956-4087-aee6-1bb1535ae325.png)
