### PR TITLE
fix: Border-color in edit mode

### DIFF
--- a/packages/app/src/styles/theme/_apply-colors.scss
+++ b/packages/app/src/styles/theme/_apply-colors.scss
@@ -515,7 +515,6 @@ ul.pagination {
 }
 
 
-
 /*
  * Preview for editing /Sidebar
  */

--- a/packages/app/src/styles/theme/_apply-colors.scss
+++ b/packages/app/src/styles/theme/_apply-colors.scss
@@ -496,23 +496,25 @@ ul.pagination {
  * GROWI Editor
  */
 .layout-root.editing {
-  .main {
-    background-color: hsl.darken(var(--bgcolor-global),2%);
+  background-color: hsl.darken(var(--bgcolor-global),2%);
 
+  &.builtin-editor {
     .page-editor-editor-container {
       border-right-color: var(--border-color-theme);
-
-      .navbar-editor {
-        background-color: var(--bgcolor-global); // same color with active tab
-        border-bottom-color: var(--border-color-theme);
-      }
-    }
-
-    .page-editor-preview-container {
-      background-color: var(--bgcolor-global);
     }
   }
+
+  .navbar-editor {
+    background-color: var(--bgcolor-global); // same color with active tab
+    border-bottom-color: var(--border-color-theme);
+  }
+
+  .page-editor-preview-container {
+    background-color: var(--bgcolor-global);
+  }
 }
+
+
 
 /*
  * Preview for editing /Sidebar


### PR DESCRIPTION
**Task**
[Next.js]edit画面のボーダーが非表示になっている
┗[114860](https://redmine.weseek.co.jp/issues/114860)

**やったこと**
- apply-colorsの.layout-root.editingの記述を修正