### PR TITLE
fix: Comment form background

### DIFF
--- a/packages/app/src/styles/theme/_apply-colors-dark.scss
+++ b/packages/app/src/styles/theme/_apply-colors-dark.scss
@@ -519,8 +519,10 @@
     }
   }
 
-  .page-comments-row {
-    background: var(--bgcolor-subnav);
+  .page-comment-form .comment-form-main {
+    &:before {
+      border-right-color: var(--bgcolor-global);
+    }
   }
 
   /*

--- a/packages/app/src/styles/theme/_apply-colors-light.scss
+++ b/packages/app/src/styles/theme/_apply-colors-light.scss
@@ -400,8 +400,10 @@
     }
   }
 
-  .page-comments-row {
-    background: var(--bgcolor-subnav);
+  .page-comment-form .comment-form-main {
+    &:before {
+      border-right-color: var(--bgcolor-global);
+    }
   }
 
   /*

--- a/packages/app/src/styles/theme/_apply-colors.scss
+++ b/packages/app/src/styles/theme/_apply-colors.scss
@@ -567,14 +567,11 @@ ul.pagination {
 /*
  * GROWI comment form
  */
-.page-comments {
+.page-comments-row {
+  background: var(--bgcolor-subnav);
   .page-comment .page-comment-main,
   .page-comment-form .comment-form-main {
     background-color: var(--bgcolor-global);
-
-    &:before {
-      border-right-color: var(--bgcolor-global);
-    }
 
     .nav.nav-tabs {
       > li > a.active {


### PR DESCRIPTION
**Task**
[Next.js]コメント部分の背景が適用されていない
┗[115294](https://redmine.weseek.co.jp/issues/115294)

**やったこと**
- apply-colors.scss
  - .page-comments から .page-comments-rowに変更
- apply-colors-dark & light.scss
  - .page-comments-rowの中で、dark と lightで設定が共通だった部分をapply-colorsに移動
  - 代わりに、apply-colorsだと色が上手く反映されなかった &:before 部分をdark と lightに移動