### PR TITLE
fix: Keep showing page restricted alert

### DIFF
--- a/packages/app/src/pages/[[...path]].page.tsx
+++ b/packages/app/src/pages/[[...path]].page.tsx
@@ -496,6 +496,7 @@ async function injectRoutingInformation(context: GetServerSidePropsContext, prop
   else {
     props.isNotFound = page.isEmpty;
     props.isNotCreatable = false;
+    props.isForbidden = false;
     // /62a88db47fed8b2d94f30000 ==> /path/to/page
     if (isPermalink && page.isEmpty) {
       props.currentPathname = page.path;


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/115319

# 起こっていたこと
- 権限がないページを表示した後にnext rouitngで画面遷移して、権限があるページに移動してもアラートが表示されたままになっていた。

# 原因
```
// check the page is forbidden or just does not exist.
const count = isPermalink ? await Page.count({ _id: pageId }) : await Page.count({ path: currentPathname });
props.isForbidden = count > 0;
```
`props.isForbidden`の初期化が`[[..path]].page.tsx`の上の部分しかなかったので、権限がないページに移動した後に権限があるページに移動しても、`props.isForbidden`が`undefined`になっており、`context`の初期化が行われていなかった。

# やったこと
`props.isForbidden`を`false`で初期化するようにした

