### PR TITLE
Imprv/114261 114277 allow users to check sample questionnaire answer json

### DIFF
--- a/packages/app/src/components/Admin/App/QuestionnaireSettings.tsx
+++ b/packages/app/src/components/Admin/App/QuestionnaireSettings.tsx
@@ -54,16 +54,14 @@ const QuestionnaireSettings = (): JSX.Element => {
   return (
     <div id="questionnaire-settings" className="mb-5">
       <p className="card well">
-        システム全体でアンケート機能を有効/無効にします。また、ユーザーは設定画面から個別にアンケート機能を有効/無効にできます。
-        <br />
-        <br />
+        <div className="mb-4">システム全体でアンケート機能を有効/無効にします。また、ユーザーは設定画面から個別にアンケート機能を有効/無効にできます。</div>
         <span>
-          <span className="text-info mr-2"><i className="icon-info icon-fw"></i>送信される情報について</span>
-          {/* eslint-disable-next-line max-len */}
-          <a href="https://docs.growi.org/ja/admin-guide/management-cookbook/app-settings.html#%E3%82%A2%E3%83%B3%E3%82%B1%E3%83%BC%E3%83%88%E8%A8%AD%E5%AE%9A" rel="noreferrer" target="_blank" className="d-inline">詳細<i className="icon-share-alt"></i></a>
-          <br />
-          アンケートの回答と合わせて、GROWI の改善に必要な最小限の情報を合わせて収集します。<br />
-          収集されるデータにユーザーの個人情報は含まれません。<br />
+          <div className="mb-2">
+            <span className="text-info mr-2"><i className="icon-info icon-fw"></i>送信される情報について</span>
+            {/* eslint-disable-next-line max-len */}
+            <a href="https://docs.growi.org/ja/admin-guide/management-cookbook/app-settings.html#%E3%82%A2%E3%83%B3%E3%82%B1%E3%83%BC%E3%83%88%E8%A8%AD%E5%AE%9A" rel="noreferrer" target="_blank" className="d-inline">詳細<i className="icon-share-alt"></i></a>
+          </div>
+          アンケートの回答と合わせて、GROWI の改善に必要な情報を収集します。収集されるデータにユーザーの個人情報は含まれません。<br />
           私たちはそれらを活用し、最大限ユーザーの体験を向上させるよう努めます。
         </span>
       </p>

--- a/packages/app/src/components/Admin/App/QuestionnaireSettings.tsx
+++ b/packages/app/src/components/Admin/App/QuestionnaireSettings.tsx
@@ -60,7 +60,7 @@ const QuestionnaireSettings = (): JSX.Element => {
         <span>
           <span className="text-info mr-2"><i className="icon-info icon-fw"></i>送信される情報について</span>
           {/* eslint-disable-next-line max-len */}
-          <a href="https://docs.growi.org/ja/admin-guide/management-cookbook/app-settings.html#%E3%82%A2%E3%83%B3%E3%82%B1%E3%83%BC%E3%83%88%E8%A8%AD%E5%AE%9A" rel="noreferrer" target="_blank" className="d-inline">詳細情報<i className="icon-share-alt"></i></a>
+          <a href="https://docs.growi.org/ja/admin-guide/management-cookbook/app-settings.html#%E3%82%A2%E3%83%B3%E3%82%B1%E3%83%BC%E3%83%88%E8%A8%AD%E5%AE%9A" rel="noreferrer" target="_blank" className="d-inline">詳細<i className="icon-share-alt"></i></a>
           <br />
           アンケートの回答と合わせて、GROWI の改善に必要な最小限の情報を合わせて収集します。<br />
           収集されるデータにユーザーの個人情報は含まれません。<br />

--- a/packages/app/src/components/Admin/App/QuestionnaireSettings.tsx
+++ b/packages/app/src/components/Admin/App/QuestionnaireSettings.tsx
@@ -58,7 +58,7 @@ const QuestionnaireSettings = (): JSX.Element => {
         <br />
         <br />
         <span>
-          <span className="text-info mr-2"><i className="icon-info icon-fw"></i>送信されるデータについて</span>
+          <span className="text-info mr-2"><i className="icon-info icon-fw"></i>送信される情報について</span>
           {/* eslint-disable-next-line max-len */}
           <a href="https://docs.growi.org/ja/admin-guide/management-cookbook/app-settings.html#%E3%82%A2%E3%83%B3%E3%82%B1%E3%83%BC%E3%83%88%E8%A8%AD%E5%AE%9A" rel="noreferrer" target="_blank" className="d-inline">詳細情報<i className="icon-share-alt"></i></a>
           <br />

--- a/packages/app/src/components/Admin/App/QuestionnaireSettings.tsx
+++ b/packages/app/src/components/Admin/App/QuestionnaireSettings.tsx
@@ -54,14 +54,18 @@ const QuestionnaireSettings = (): JSX.Element => {
   return (
     <div id="questionnaire-settings" className="mb-5">
       <p className="card well">
-        システム全体でアンケート機能を有効/無効にします。また、ユーザーは設定画面から個別にアンケート機能を有効/無効にできます。<br />
-        送信されるデータにユーザーの個人情報は一切含まれません。
-        <div>
-          {/* eslint-disable-next-line max-len */}
-          詳しくは<a href="https://docs.growi.org/ja/admin-guide/management-cookbook/app-settings.html" rel="noreferrer" target="_blank" className="d-inline"> GROWI Docs &quot;アンケート設定&quot; <i className="icon-share-alt"></i></a>を参照ください。
-        </div>
+        システム全体でアンケート機能を有効/無効にします。また、ユーザーは設定画面から個別にアンケート機能を有効/無効にできます。
         <br />
-        GROWI の改善にご協力お願いします。
+        <br />
+        <span>
+          <span className="text-info mr-2"><i className="icon-info icon-fw"></i>送信されるデータについて</span>
+          {/* eslint-disable-next-line max-len */}
+          <a href="https://docs.growi.org/ja/admin-guide/management-cookbook/app-settings.html#%E3%82%A2%E3%83%B3%E3%82%B1%E3%83%BC%E3%83%88%E8%A8%AD%E5%AE%9A" rel="noreferrer" target="_blank" className="d-inline">詳細情報<i className="icon-share-alt"></i></a>
+          <br />
+          アンケートの回答と合わせて、GROWI の改善に必要な最小限の情報を合わせて収集します。<br />
+          収集されるデータにユーザーの個人情報は含まれません。<br />
+          私たちはそれらを活用し、最大限ユーザーの体験を向上させるよう努めます。
+        </span>
       </p>
 
       {isLoading && <div className="text-muted text-center mb-5">

--- a/packages/app/src/components/Admin/App/QuestionnaireSettings.tsx
+++ b/packages/app/src/components/Admin/App/QuestionnaireSettings.tsx
@@ -54,7 +54,7 @@ const QuestionnaireSettings = (): JSX.Element => {
   return (
     <div id="questionnaire-settings" className="mb-5">
       <p className="card well">
-        <div className="mb-4">システム全体でアンケート機能を有効/無効にします。また、ユーザーは設定画面から個別にアンケート機能を有効/無効にできます。</div>
+        <div className="mb-4">システム全体でアンケート機能を有効/無効にします。有効の場合、各ユーザーはユーザー設定ページの「その他の設定」から個別にアンケート機能を有効/無効にできます。</div>
         <span>
           <div className="mb-2">
             <span className="text-info mr-2"><i className="icon-info icon-fw"></i>送信される情報について</span>

--- a/packages/app/src/components/Admin/App/QuestionnaireSettings.tsx
+++ b/packages/app/src/components/Admin/App/QuestionnaireSettings.tsx
@@ -61,7 +61,7 @@ const QuestionnaireSettings = (): JSX.Element => {
             {/* eslint-disable-next-line max-len */}
             <a href="https://docs.growi.org/ja/admin-guide/management-cookbook/app-settings.html#%E3%82%A2%E3%83%B3%E3%82%B1%E3%83%BC%E3%83%88%E8%A8%AD%E5%AE%9A" rel="noreferrer" target="_blank" className="d-inline">詳細<i className="icon-share-alt"></i></a>
           </div>
-          アンケートの回答と合わせて、GROWI の改善に必要な情報を収集します。収集されるデータにユーザーの個人情報は含まれません。<br />
+          アンケートの回答と合わせて、GROWI の改善に必要な情報を送信します。送信されるデータにユーザーの個人情報は含まれません。<br />
           私たちはそれらを活用し、最大限ユーザーの体験を向上させるよう努めます。
         </span>
       </p>


### PR DESCRIPTION
## review task
https://redmine.weseek.co.jp/issues/115567

## 概要
- firefox のデータ収集についてのユーザ周知（↓）を参考に、既存の文言と見た目を若干改善（既存の画面でも特に問題なかったっぽいですが、実装しちゃったのでせっかくなので見ていただけると幸いです）
![Screenshot 2023-02-10 at 18 12 48](https://user-images.githubusercontent.com/32846231/218051384-0495d56d-9862-4f61-ae8c-719bc530cf09.png)
- docs へのリンクが「アンケート設定」への欄を直接表示してくれなかったため、ハッシュをリンクに追加。


### before
![Screenshot 2023-02-10 at 16 40 15](https://user-images.githubusercontent.com/32846231/218049122-ae7d29c7-7e5f-4209-8c1b-a2801cb844de.png)

### after
![Screenshot 2023-02-11 at 0 25 47](https://user-images.githubusercontent.com/32846231/218129550-9c9d644b-eaa4-4323-a6c7-298916654206.png)


## 備考
i18n は https://redmine.weseek.co.jp/issues/114445 で行います。