### PR TITLE
Fix/114143 114144 fix questionnaire cron test

### DIFF
--- a/packages/app/test/integration/service/questionnaire-cron.test.ts
+++ b/packages/app/test/integration/service/questionnaire-cron.test.ts
@@ -260,7 +260,7 @@ describe('QuestionnaireCronService', () => {
     crowi.questionnaireCronService.stopCron(); // jest will not finish until cronjob stops
   });
 
-  test('Job execution should save quesionnaire orders, delete outdated ones, and update skipped answer status', async() => {
+  test('Job execution should save(update) quesionnaire orders, delete outdated ones, and update skipped answer statuses', async() => {
     // testing the cronjob from schedule has untrivial overhead, so test job execution in place
     await crowi.questionnaireCronService.executeJob();
 

--- a/packages/app/test/integration/service/questionnaire-cron.test.ts
+++ b/packages/app/test/integration/service/questionnaire-cron.test.ts
@@ -3,23 +3,13 @@ import { getInstance } from '../setup-crowi';
 
 const axios = require('axios').default;
 
-const rand = require('../../../src/utils/rand');
-
 const spyAxiosGet = jest.spyOn<typeof axios, 'get'>(
   axios,
   'get',
 );
 
-const spyGetRandomIntInRange = jest.spyOn<typeof rand, 'getRandomIntInRange'>(
-  rand,
-  'getRandomIntInRange',
-);
-
 describe('QuestionnaireCronService', () => {
   let crowi;
-
-  const maxSecondsUntilRequest = 4 * 60 * 60 * 1000;
-  const secondsUntilRequest = rand.getRandomIntInRange(0, maxSecondsUntilRequest);
 
   const mockResponse = {
     data: {
@@ -134,9 +124,6 @@ describe('QuestionnaireCronService', () => {
   };
 
   beforeAll(async() => {
-    process.env.QUESTIONNAIRE_CRON_SCHEDULE = '0 22 * * *';
-    process.env.QUESTIONNAIRE_CRON_MAX_HOURS_UNTIL_REQUEST = '4';
-
     crowi = await getInstance();
     // reload
     await crowi.setupConfigManager();
@@ -242,33 +229,18 @@ describe('QuestionnaireCronService', () => {
       },
     ]);
 
-    // mock the date to 5 seconds before cronjob execution
-    const mockDate = new Date(2022, 0, 1, 21, 59, 55);
-    jest.useFakeTimers();
-    jest.setSystemTime(mockDate);
-
-    // must be after useFakeTimers for mockDate to be in effect
     crowi.setupCron();
 
     spyAxiosGet.mockResolvedValue(mockResponse);
-    spyGetRandomIntInRange.mockReturnValue(secondsUntilRequest); // static sleep time until request
   });
 
   afterAll(() => {
-    jest.useRealTimers();
     crowi.questionnaireCronService.stopCron();
   });
 
-  test('Should save quesionnaire orders and delete outdated ones', async() => {
-    jest.advanceTimersByTime(5 * 1000); // advance unitl cronjob execution
-    jest.advanceTimersByTime(secondsUntilRequest); // advance until request execution
-    jest.useRealTimers(); // after cronjob starts, undo timer mocks so mongoose can work properly
-
-    await new Promise((resolve) => {
-      // wait until cronjob execution finishes
-      // refs: https://github.com/node-cron/node-cron/blob/a0be3f4a7a5419af109cecf4a41071ea559b9b3d/src/task.js#L24
-      crowi.questionnaireCronService.cronJob._task.once('task-finished', resolve);
-    });
+  test('Job execution should save quesionnaire orders and delete outdated ones', async() => {
+    // testing the cronjob from schedule has untrivial overhead, so test job execution in place
+    await crowi.questionnaireCronService.executeJob();
 
     const savedOrders = await QuestionnaireOrder.find()
       .select('-condition._id -questions._id')


### PR DESCRIPTION
## review task
https://redmine.weseek.co.jp/issues/115576

## 概要
- [CI で落ちてしまう test](https://wsgrowi.slack.com/archives/C04C589BE7Q/p1674716686596599) の修正
    - test 内容: [アンケート情報更新処理](https://dev.growi.org/6385911e1632aa30f4dae6a4#mdcont-%E3%82%A2%E3%83%B3%E3%82%B1%E3%83%BC%E3%83%88%E6%83%85%E5%A0%B1%E6%9B%B4%E6%96%B0%E5%87%A6%E7%90%86) の test
    - 原因: cronjob のスケジュール設定から、スケジュールされた時間への到達 -> ランダムな実行時間までの待機 -> 実行 をテストしていたが、node-cron ごとテストしようとすると時間的オーバーヘッドが大きそう
    - 対処: スケジュールされた時間での実行をテストすることを諦め、その場で更新処理を実行し、その内容をテストする
    - 備考: feat/questionnaire に merge されるまで CI でのテスト実行を確認できないため、merge されたら CI の結果を[確認します](https://redmine.weseek.co.jp/issues/115577)
- リファクタリング
- アンケート情報更新処理での QuestionnaireAnswerStatus の更新が denied -> not_answered になっていたため、skipped -> not_answered に修正