### PR TITLE
fix: Make collapse work for anchor tags

### DIFF
--- a/packages/app/src/components/ReactMarkdownComponents/NextLink.tsx
+++ b/packages/app/src/components/ReactMarkdownComponents/NextLink.tsx
@@ -26,10 +26,11 @@ type Props = Omit<LinkProps, 'href'> & {
   children: React.ReactNode,
   href?: string,
   className?: string,
+  'data-toggle'?: string
 };
 
 export const NextLink = ({
-  href, children, className, ...props
+  href, children, className, 'data-toggle': dataToggle, ...props
 }: Props): JSX.Element => {
 
   const { data: siteUrl } = useSiteUrl();
@@ -41,7 +42,7 @@ export const NextLink = ({
   // when href is an anchor link
   if (isAnchorLink(href)) {
     return (
-      <a href={href} className={className}>{children}</a>
+      <a href={href} className={className} data-toggle={dataToggle}>{children}</a>
     );
   }
 

--- a/packages/app/src/components/ReactMarkdownComponents/NextLink.tsx
+++ b/packages/app/src/components/ReactMarkdownComponents/NextLink.tsx
@@ -26,12 +26,12 @@ type Props = Omit<LinkProps, 'href'> & {
   children: React.ReactNode,
   href?: string,
   className?: string,
-  'data-toggle'?: string
 };
 
-export const NextLink = ({
-  href, children, className, 'data-toggle': dataToggle, ...props
-}: Props): JSX.Element => {
+export const NextLink = (props: Props): JSX.Element => {
+  const {
+    href, children, className, ...rest
+  } = props;
 
   const { data: siteUrl } = useSiteUrl();
 
@@ -39,24 +39,29 @@ export const NextLink = ({
     return <a className={className}>{children}</a>;
   }
 
+  // extract 'data-*' props
+  const dataAttributes = Object.fromEntries(
+    Object.entries(rest).filter(([key]) => key.startsWith('data-')),
+  );
+
   // when href is an anchor link
   if (isAnchorLink(href)) {
     return (
-      <a href={href} className={className} data-toggle={dataToggle}>{children}</a>
+      <a href={href} className={className} {...dataAttributes}>{children}</a>
     );
   }
 
   if (isExternalLink(href, siteUrl)) {
     return (
-      <a href={href} className={className} target="_blank" rel="noopener noreferrer">
+      <a href={href} className={className} target="_blank" rel="noopener noreferrer" {...dataAttributes}>
         {children}&nbsp;<i className='icon-share-alt small'></i>
       </a>
     );
   }
 
   return (
-    <Link {...props} href={href} prefetch={false}>
-      <a href={href} className={className}>{children}</a>
+    <Link {...rest} href={href} prefetch={false}>
+      <a href={href} className={className} {...dataAttributes}>{children}</a>
     </Link>
   );
 };

--- a/packages/app/src/services/renderer/renderer.tsx
+++ b/packages/app/src/services/renderer/renderer.tsx
@@ -71,7 +71,9 @@ const baseSanitizeSchema = {
   tagNames: ['iframe'],
   attributes: {
     iframe: ['allow', 'referrerpolicy', 'sandbox', 'src', 'srcdoc'],
-    '*': ['class', 'className', 'style'],
+    // The special value 'data*' as a property name can be used to allow all data properties.
+    // see: https://github.com/syntax-tree/hast-util-sanitize/
+    '*': ['class', 'className', 'style', 'data*'],
   },
 };
 

--- a/packages/app/src/services/renderer/renderer.tsx
+++ b/packages/app/src/services/renderer/renderer.tsx
@@ -87,7 +87,7 @@ let isInjectedCustomSanitaizeOption = false;
 
 const injectCustomSanitizeOption = (config: RendererConfig) => {
   if (!isInjectedCustomSanitaizeOption && config.isEnabledXssPrevention && config.xssOption === RehypeSanitizeOption.CUSTOM) {
-    commonSanitizeOption.tagNames = deepmerge(baseSanitizeSchema.tagNames, config.tagWhiteList ?? []);
+    commonSanitizeOption.tagNames = baseSanitizeSchema.tagNames.concat(config.tagWhiteList ?? []);
     commonSanitizeOption.attributes = deepmerge(baseSanitizeSchema.attributes, config.attrWhiteList ?? {});
     isInjectedCustomSanitaizeOption = true;
   }


### PR DESCRIPTION
task: https://redmine.weseek.co.jp/issues/115071

## 解決したいこと
- collapse を a タグで work させる

## work しなかった原因
- 編集画面で a タグに data-toggle を設定しても View に DOM 生成されなかった。
  - a タグは `generateCommonOptions` で `NextLink`コンポーネントに置き換えられており、data-toggle attr が JSX まで渡せていなかった
- v6 では id attr の値の先頭に "mdcont-" が付く仕様。

## 解決案
- Anchor link の id 属性の場合は `NextLink` までわたってきた `data-toggle` も反映して返すようにする。

## ユーザ側の対策
- カスタムホワイトリストに "a":["href","dataToggle"] を加える or xss設定を無効にする
- id 指定時は href="#mdcont-*" の形式にしてもらう

## Note
- mdcont- が必要なことをどうやってユーザーに周知すべきだろうか
  - docs に書いておくか
  - collapse 使ってくれるようなユーザーはわかってくれるかな