### PR TITLE
imprv: If the environment variable `FILE_UPLOAD` is set to "none" at the destination, do not transfer.

### DIFF
--- a/packages/app/src/server/service/g2g-transfer.ts
+++ b/packages/app/src/server/service/g2g-transfer.ts
@@ -62,6 +62,8 @@ export type IDataGROWIInfo = {
   attachmentInfo: {
     /** File storage type */
     type: string;
+    /** File storage type of env var */
+    typeOfEnv?: string
     /** Whether the storage is writable */
     writable: boolean;
     /** Bucket name (S3 and GCS only) */
@@ -271,6 +273,14 @@ export class G2GTransferPusherService implements Pusher {
         canTransfer: false,
         // TODO: i18n for reason
         reason: 'File upload is not configured for src GROWI.',
+      };
+    }
+
+    if (destGROWIInfo.attachmentInfo.typeOfEnv === 'none') {
+      return {
+        canTransfer: false,
+        // TODO: i18n for reason
+        reason: 'File upload is not configured for dest GROWI',
       };
     }
 
@@ -540,6 +550,7 @@ export class G2GTransferReceiverService implements Receiver {
 
     const attachmentInfo = {
       type: configManager.getConfig('crowi', 'app:fileUploadType'),
+      typeOfEnv: configManager.getConfigFromEnvVars('crowi', 'app:fileUploadType'),
       writable: isWritable,
       bucket: undefined,
       customEndpoint: undefined, // for S3


### PR DESCRIPTION
## Task
[#115308](https://redmine.weseek.co.jp/issues/115308) [v6][g2g] 移行先の GROWI に 環境変数 FILE_UPLOAD=none が設定されている場合は添付ファイルの移行をできなくする
└ [#115387](https://redmine.weseek.co.jp/issues/115387) 改善