### PR TITLE
fix: Can't controll slack notification button in comment editor

### DIFF
--- a/packages/app/src/components/PageComment/CommentEditor.tsx
+++ b/packages/app/src/components/PageComment/CommentEditor.tsx
@@ -85,12 +85,16 @@ export const CommentEditor = (props: CommentEditorProps): JSX.Element => {
     setActiveTab(activeTab);
   }, []);
 
+  // DO NOT dependent on slackChannelsData directly: https://github.com/weseek/growi/pull/7332
+  const slackChannelsDataString = slackChannelsData?.toString();
+  const initializeSlackEnabled = useCallback(() => {
+    setSlackChannels(slackChannelsDataString ?? '');
+    mutateIsSlackEnabled(false);
+  }, [mutateIsSlackEnabled, slackChannelsDataString]);
+
   useEffect(() => {
-    if (slackChannelsData != null) {
-      setSlackChannels(slackChannelsData.toString());
-      mutateIsSlackEnabled(false);
-    }
-  }, [mutateIsSlackEnabled, slackChannelsData]);
+    initializeSlackEnabled();
+  }, [initializeSlackEnabled]);
 
   const isSlackEnabledToggleHandler = (isSlackEnabled: boolean) => {
     mutateIsSlackEnabled(isSlackEnabled, false);
@@ -104,10 +108,11 @@ export const CommentEditor = (props: CommentEditorProps): JSX.Element => {
     setComment('');
     setActiveTab('comment_editor');
     setError(undefined);
+    initializeSlackEnabled();
     // reset value
     if (editorRef.current == null) { return }
     editorRef.current.setValue('');
-  }, []);
+  }, [initializeSlackEnabled]);
 
   const cancelButtonClickedHandler = useCallback(() => {
     // change state to not ready


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/114864

# やったこと
- コメントエディターのslack通知ボタンが正常に動作するようにした。

# 
- https://github.com/weseek/growi/pull/7332
- 上記PRで`PageEditor`に対して行った修正を`CommentEditor`にも適用しただけです。
- コメント投稿後にslackの通知がOFFになってほしかったので、初期化の処理をメソッドに切り出し、`initializeEditor`の中でも呼んでいます。
