### PR TITLE
feat: Transition to requested page after login

### DIFF
--- a/packages/app/src/components/LoginForm.tsx
+++ b/packages/app/src/components/LoginForm.tsx
@@ -34,13 +34,14 @@ type LoginFormProps = {
   objOfIsExternalAuthEnableds?: any,
   isMailerSetup?: boolean,
   externalAccountLoginError?: IExternalAccountLoginError,
+  redirectTo?: string,
 }
 export const LoginForm = (props: LoginFormProps): JSX.Element => {
   const { t } = useTranslation();
   const router = useRouter();
 
   const {
-    isLocalStrategySetup, isLdapStrategySetup, isLdapSetupFailed, isPasswordResetEnabled,
+    isLocalStrategySetup, isLdapStrategySetup, isLdapSetupFailed, isPasswordResetEnabled, redirectTo,
     isEmailAuthenticationEnabled, registrationMode, registrationWhiteList, isMailerSetup, objOfIsExternalAuthEnableds,
   } = props;
   const isLocalOrLdapStrategiesEnabled = isLocalStrategySetup || isLdapStrategySetup;
@@ -95,14 +96,18 @@ export const LoginForm = (props: LoginFormProps): JSX.Element => {
 
     try {
       const res = await apiv3Post('/login', { loginForm });
-      const { redirectTo, userStatus } = res.data;
+      const { userStatus } = res.data;
 
-      if (redirectTo != null) {
-        return router.push(redirectTo);
+      if (userStatus === USER_STATUS.INVITED) {
+        router.push('/invited');
       }
 
       if (userStatus !== USER_STATUS.ACTIVE) {
         window.location.href = '/';
+      }
+
+      if (redirectTo != null) {
+        return router.push(redirectTo);
       }
 
       return router.push('/');

--- a/packages/app/src/components/LoginForm.tsx
+++ b/packages/app/src/components/LoginForm.tsx
@@ -118,7 +118,7 @@ export const LoginForm = (props: LoginFormProps): JSX.Element => {
     }
     return;
 
-  }, [passwordForLogin, resetLoginErrors, router, usernameForLogin]);
+  }, [passwordForLogin, redirectTo, resetLoginErrors, router, usernameForLogin]);
 
   // separate errors based on error code
   const separateErrorsBasedOnErrorCode = useCallback((errors: IErrorV3[]) => {

--- a/packages/app/src/interfaces/crowi-request.ts
+++ b/packages/app/src/interfaces/crowi-request.ts
@@ -12,4 +12,7 @@ export interface CrowiRequest<U extends IUser = IUserHasId> extends Request {
   // provided by csurf
   csrfToken: () => string,
 
+  session?: {
+    redirectTo: string,
+  },
 }

--- a/packages/app/src/pages/login/index.page.tsx
+++ b/packages/app/src/pages/login/index.page.tsx
@@ -35,6 +35,7 @@ type Props = CommonProps & {
   isPasswordResetEnabled: boolean,
   isEmailAuthenticationEnabled: boolean,
   externalAccountLoginError?: IExternalAccountLoginError,
+  redirectTo?: string,
 };
 
 const LoginPage: NextPage<Props> = (props: Props) => {
@@ -65,6 +66,7 @@ const LoginPage: NextPage<Props> = (props: Props) => {
         isMailerSetup={props.isMailerSetup}
         registrationMode={props.registrationMode}
         externalAccountLoginError={props.externalAccountLoginError}
+        redirectTo={props.redirectTo}
       />
     </NoLoginLayout>
   );
@@ -108,6 +110,7 @@ async function injectServerConfigurations(context: GetServerSidePropsContext, pr
     passportService,
   } = crowi;
 
+  props.redirectTo = req.session?.redirectTo;
   props.isPasswordResetEnabled = crowi.configManager.getConfig('crowi', 'security:passport-local:isPasswordResetEnabled');
   props.isMailerSetup = mailService.isMailerSetup;
   props.isLocalStrategySetup = passportService.isLocalStrategySetup;

--- a/packages/app/src/server/routes/login-passport.js
+++ b/packages/app/src/server/routes/login-passport.js
@@ -124,13 +124,7 @@ module.exports = function(crowi, app) {
       return res.redirect('/');
     }
 
-    // check for redirection to '/invited'
-    const redirectTo = req.user.status === User.STATUS_INVITED ? '/invited' : req.session.redirectTo;
-
-    // remove session.redirectTo
-    delete req.session.redirectTo;
-
-    return res.apiv3({ redirectTo, userStatus: req.user.status });
+    return res.apiv3({ userStatus: req.user.status });
   };
 
   const isEnableLoginWithLocalOrLdap = (req, res, next) => {


### PR DESCRIPTION
## Task
[#115620](https://redmine.weseek.co.jp/issues/115620) [v6] 未ログイン状態でページURLにアクセスしてログインすると指定ページではなくホームが表示される
└ [#115621](https://redmine.weseek.co.jp/issues/115621) 修正

## やっていないこと
- Local, Ldap 以外の認証方法に関しては、XHR化されていないため未対応
https://github.com/weseek/growi/blob/8ed71bb4053abe4955c06d2a42795c04290ecafd/packages/app/src/components/LoginForm.tsx#L77-L81