### PR TITLE
feat: Manage guest sidebar mode with session

### DIFF
--- a/packages/app/src/client/services/user-ui-settings.ts
+++ b/packages/app/src/client/services/user-ui-settings.ts
@@ -1,11 +1,9 @@
 // eslint-disable-next-line no-restricted-imports
 import { AxiosResponse } from 'axios';
-
 import { debounce } from 'throttle-debounce';
 
 import { apiv3Put } from '~/client/util/apiv3-client';
 import { IUserUISettings } from '~/interfaces/user-ui-settings';
-import { useIsGuestUser } from '~/stores/context';
 
 let settingsForBulk: Partial<IUserUISettings> = {};
 const _putUserUISettingsInBulk = (): Promise<AxiosResponse<IUserUISettings>> => {
@@ -33,11 +31,8 @@ type UserUISettingsUtil = {
   scheduleToPut: ScheduleToPutFunction | (() => void),
 }
 export const useUserUISettings = (): UserUISettingsUtil => {
-  const { data: isGuestUser } = useIsGuestUser();
 
   return {
-    scheduleToPut: isGuestUser
-      ? () => {}
-      : scheduleToPut,
+    scheduleToPut,
   };
 };

--- a/packages/app/src/interfaces/crowi-request.ts
+++ b/packages/app/src/interfaces/crowi-request.ts
@@ -9,6 +9,8 @@ export interface CrowiRequest<U extends IUser = IUserHasId> extends Request {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   crowi: any,
 
+  session: any,
+
   // provided by csurf
   csrfToken: () => string,
 

--- a/packages/app/src/pages/[[...path]].page.tsx
+++ b/packages/app/src/pages/[[...path]].page.tsx
@@ -468,7 +468,7 @@ async function injectUserUISettings(context: GetServerSidePropsContext, props: P
 
   const userUISettings = user == null ? req.session.uiSettings : await UserUISettings.findOne({ user: user._id }).exec();
   if (userUISettings != null) {
-    props.userUISettings = userUISettings.toObject();
+    props.userUISettings = userUISettings.toObject?.() ?? userUISettings;
   }
 }
 

--- a/packages/app/src/pages/[[...path]].page.tsx
+++ b/packages/app/src/pages/[[...path]].page.tsx
@@ -466,7 +466,7 @@ async function injectUserUISettings(context: GetServerSidePropsContext, props: P
   const { user } = req;
   const UserUISettings = mongooseModel('UserUISettings') as UserUISettingsModel;
 
-  const userUISettings = user == null ? null : await UserUISettings.findOne({ user: user._id }).exec();
+  const userUISettings = user == null ? req.session.uiSettings : await UserUISettings.findOne({ user: user._id }).exec();
   if (userUISettings != null) {
     props.userUISettings = userUISettings.toObject();
   }

--- a/packages/app/src/server/routes/apiv3/user-ui-settings.ts
+++ b/packages/app/src/server/routes/apiv3/user-ui-settings.ts
@@ -38,7 +38,7 @@ module.exports = (crowi) => {
     };
 
     if (user == null) {
-      req.uiSettings = updateData;
+      req.session.uiSettings = updateData;
       return res.apiv3(updateData);
     }
 

--- a/packages/app/src/server/routes/apiv3/user-ui-settings.ts
+++ b/packages/app/src/server/routes/apiv3/user-ui-settings.ts
@@ -13,7 +13,6 @@ const logger = loggerFactory('growi:routes:apiv3:user-ui-settings');
 const router = express.Router();
 
 module.exports = (crowi) => {
-  const loginRequiredStrictly = require('../../middlewares/login-required')(crowi);
 
   const validatorForPut = [
     body('settings').exists().withMessage('The body param \'settings\' is required'),
@@ -25,7 +24,7 @@ module.exports = (crowi) => {
   ];
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  router.put('/', loginRequiredStrictly, validatorForPut, apiV3FormValidator, async(req: any, res: any) => {
+  router.put('/', validatorForPut, apiV3FormValidator, async(req: any, res: any) => {
     const { user } = req;
     const { settings } = req.body;
 

--- a/packages/app/src/server/routes/apiv3/user-ui-settings.ts
+++ b/packages/app/src/server/routes/apiv3/user-ui-settings.ts
@@ -36,6 +36,13 @@ module.exports = (crowi) => {
       preferDrawerModeByUser: settings.preferDrawerModeByUser,
       preferDrawerModeOnEditByUser: settings.preferDrawerModeOnEditByUser,
     };
+
+    if (user == null) {
+      req.uiSettings = updateData;
+      return res.apiv3(updateData);
+    }
+
+
     // remove the keys that have null value
     Object.keys(updateData).forEach((key) => {
       if (updateData[key] == null) {

--- a/packages/app/src/stores/ui.tsx
+++ b/packages/app/src/stores/ui.tsx
@@ -22,10 +22,9 @@ import type { UpdateDescCountData } from '~/interfaces/websocket';
 import loggerFactory from '~/utils/logger';
 
 import {
-  useCurrentPageId, useIsEditable, useIsGuestUser,
+  useCurrentPageId, useIsEditable,
   useIsSharedUser, useIsIdenticalPath, useCurrentUser, useShareLinkId, useIsNotFound,
 } from './context';
-import { localStorageMiddleware } from './middlewares/sync-to-storage';
 import { useCurrentPagePath, useIsTrashPage } from './page';
 import { useStaticSWR } from './use-static-swr';
 
@@ -235,18 +234,14 @@ type PreferDrawerModeByUserUtils = {
 }
 
 export const usePreferDrawerModeByUser = (initialData?: boolean): SWRResponseWithUtils<PreferDrawerModeByUserUtils, boolean> => {
-  const { data: isGuestUser } = useIsGuestUser();
   const { scheduleToPut } = useUserUISettings();
 
-  const swrResponse: SWRResponse<boolean, Error> = useStaticSWR('preferDrawerModeByUser', initialData, { use: isGuestUser ? [localStorageMiddleware] : [] });
+  const swrResponse: SWRResponse<boolean, Error> = useStaticSWR('preferDrawerModeByUser', initialData);
 
   const utils: PreferDrawerModeByUserUtils = {
     update: (preferDrawerMode: boolean) => {
       swrResponse.mutate(preferDrawerMode);
-
-      if (!isGuestUser) {
-        scheduleToPut({ preferDrawerModeByUser: preferDrawerMode });
-      }
+      scheduleToPut({ preferDrawerModeByUser: preferDrawerMode });
     },
   };
 


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/112566

# やったこと
- `userUISettings.preferDrawerModeByUser`を`session`で管理するようにし、ゲスト状態でも状態が保存されるようにした

# 備考
- 現状の実装でも、その他のUI設定をsessionで保持できるが、新しい設定をsessionに保存したときに既存の設定を上書いてしまうため、複数のUI設定をsessionで保持するには少しまだ実装が必要。
- 今回は`userUISettings.preferDrawerModeByUser`をsessionに保持することにとどめ、その他のUI設定は後続ストーリーで実装します。
- [後続ストーリー](https://redmine.weseek.co.jp/issues/115856)