### PR TITLE
fix: mono-blue subnavigation color

### DIFF
--- a/packages/preset-themes/src/styles/mono-blue.scss
+++ b/packages/preset-themes/src/styles/mono-blue.scss
@@ -91,6 +91,11 @@
   // Sidebar list group
   // --bgcolor-sidebar-list-group: #; // optional
 
+  // Subnavigation
+  --bgcolor-subnav: hsl(var(--bgcolor-subnav-hs),var(--bgcolor-subnav-l));
+  --bgcolor-subnav-hs: var(--bgcolor-global-hs);
+  --bgcolor-subnav-l: calc(var(--bgcolor-global-l) - 3%);
+
   // Icon colors
   --color-editor-icons: var(--color-global);
 


### PR DESCRIPTION
**やったこと**
- mono-blue.scss のライトテーマに bgcolor-subnavの色指定を追加