### PR TITLE
imprv: UnsavedAlertDialog and page transition when next routing

### DIFF
--- a/packages/app/public/static/locales/en_US/translation.json
+++ b/packages/app/public/static/locales/en_US/translation.json
@@ -328,7 +328,7 @@
     "notice": {
       "conflict": "Couldn't save the changes you made because someone else was editing this page. Please re-edit the affected section after reloading the page."
     },
-    "changes_not_saved": "Changes you made may not be saved."
+    "changes_not_saved": "Changes you made may not be saved. Are you sure you want to move?"
   },
   "page_comment": {
     "display_the_page_when_posting_this_comment": "Display the page when posting this comment",

--- a/packages/app/public/static/locales/ja_JP/translation.json
+++ b/packages/app/public/static/locales/ja_JP/translation.json
@@ -328,7 +328,7 @@
     "notice": {
       "conflict": "すでに他の人がこのページを編集していたため保存できませんでした。ページを再読み込み後、自分の編集箇所のみ再度編集してください。"
     },
-    "changes_not_saved": "変更が保存されていない可能性があります。"
+    "changes_not_saved": "変更が保存されていない可能性があります。本当に移動しますか？"
   },
   "page_comment": {
     "display_the_page_when_posting_this_comment": "投稿時のページを表示する",

--- a/packages/app/public/static/locales/zh_CN/translation.json
+++ b/packages/app/public/static/locales/zh_CN/translation.json
@@ -318,7 +318,7 @@
 		"notice": {
 			"conflict": "无法保存您所做的更改，因为其他人正在编辑此页。请在重新加载页面后重新编辑受影响的部分。"
 		},
-    "changes_not_saved": "您所做的更改可能不会保存。"
+    "changes_not_saved": "您所做的更改可能不会保存。你真的想继续前进吗？"
   },
   "page_comment": {
     "display_the_page_when_posting_this_comment": "Display the page when posting this comment",

--- a/packages/app/src/components/UnsavedAlertDialog.tsx
+++ b/packages/app/src/components/UnsavedAlertDialog.tsx
@@ -23,9 +23,11 @@ const UnsavedAlertDialog = (): JSX.Element => {
 
   const alertUnsavedWarningByNextRouter = useCallback(() => {
     if (isEnabledUnsavedWarning) {
-    // eslint-disable-next-line no-alert
+      // eslint-disable-next-line no-alert
       window.alert(t('page_edit.changes_not_saved'));
 
+      // Execute only when window.alert is displayed
+      // Do not execute when the dialog is displayed
       mutateIsEnabledUnsavedWarning(false);
     }
     return;

--- a/packages/app/src/components/UnsavedAlertDialog.tsx
+++ b/packages/app/src/components/UnsavedAlertDialog.tsx
@@ -22,13 +22,19 @@ const UnsavedAlertDialog = (): JSX.Element => {
   }, [isEnabledUnsavedWarning]);
 
   const alertUnsavedWarningByNextRouter = useCallback(() => {
-    // eslint-disable-next-line no-alert
-    const answer = window.confirm(t('page_edit.changes_not_saved'));
-    if (!answer) {
+    if (isEnabledUnsavedWarning) {
+      // eslint-disable-next-line no-alert
+      const answer = window.confirm(t('page_edit.changes_not_saved'));
+      if (!answer) {
       // eslint-disable-next-line no-throw-literal
-      throw 'Abort route';
+        throw 'Abort route';
+      }
     }
-  }, [t]);
+  }, [isEnabledUnsavedWarning, t]);
+
+  const onRouterChangeComplete = useCallback(() => {
+    mutateIsEnabledUnsavedWarning(false);
+  }, [mutateIsEnabledUnsavedWarning]);
 
   /*
   * Route changes by Browser
@@ -52,6 +58,14 @@ const UnsavedAlertDialog = (): JSX.Element => {
       router.events.off('routeChangeStart', alertUnsavedWarningByNextRouter);
     };
   }, [alertUnsavedWarningByNextRouter, router.events]);
+
+
+  useEffect(() => {
+    router.events.on('routeChangeComplete', onRouterChangeComplete);
+    return () => {
+      router.events.off('routeChangeComplete', onRouterChangeComplete);
+    };
+  }, [onRouterChangeComplete, router.events]);
 
 
   return <></>;

--- a/packages/app/src/components/UnsavedAlertDialog.tsx
+++ b/packages/app/src/components/UnsavedAlertDialog.tsx
@@ -22,16 +22,13 @@ const UnsavedAlertDialog = (): JSX.Element => {
   }, [isEnabledUnsavedWarning]);
 
   const alertUnsavedWarningByNextRouter = useCallback(() => {
-    if (isEnabledUnsavedWarning) {
-      // eslint-disable-next-line no-alert
-      window.alert(t('page_edit.changes_not_saved'));
-
-      // Execute only when window.alert is displayed
-      // Do not execute when the dialog is displayed
-      mutateIsEnabledUnsavedWarning(false);
+    // eslint-disable-next-line no-alert
+    const answer = window.confirm(t('page_edit.changes_not_saved'));
+    if (!answer) {
+      // eslint-disable-next-line no-throw-literal
+      throw 'Abort route';
     }
-    return;
-  }, [isEnabledUnsavedWarning, mutateIsEnabledUnsavedWarning, t]);
+  }, [t]);
 
   /*
   * Route changes by Browser

--- a/packages/app/src/components/UnsavedAlertDialog.tsx
+++ b/packages/app/src/components/UnsavedAlertDialog.tsx
@@ -8,7 +8,7 @@ import { useIsEnabledUnsavedWarning } from '~/stores/editor';
 const UnsavedAlertDialog = (): JSX.Element => {
   const { t } = useTranslation();
   const router = useRouter();
-  const { data: isEnabledUnsavedWarning } = useIsEnabledUnsavedWarning();
+  const { data: isEnabledUnsavedWarning, mutate: mutateIsEnabledUnsavedWarning } = useIsEnabledUnsavedWarning();
 
   const alertUnsavedWarningByBrowser = useCallback((e) => {
     if (isEnabledUnsavedWarning) {
@@ -25,9 +25,11 @@ const UnsavedAlertDialog = (): JSX.Element => {
     if (isEnabledUnsavedWarning) {
     // eslint-disable-next-line no-alert
       window.alert(t('page_edit.changes_not_saved'));
+
+      mutateIsEnabledUnsavedWarning(false);
     }
     return;
-  }, [isEnabledUnsavedWarning, t]);
+  }, [isEnabledUnsavedWarning, mutateIsEnabledUnsavedWarning, t]);
 
   /*
   * Route changes by Browser

--- a/packages/app/src/components/UnsavedAlertDialog.tsx
+++ b/packages/app/src/components/UnsavedAlertDialog.tsx
@@ -23,6 +23,7 @@ const UnsavedAlertDialog = (): JSX.Element => {
 
   const alertUnsavedWarningByNextRouter = useCallback(() => {
     if (isEnabledUnsavedWarning) {
+      // see: https://zenn.dev/qaynam/articles/c4794537a163d2
       // eslint-disable-next-line no-alert
       const answer = window.confirm(t('page_edit.changes_not_saved'));
       if (!answer) {


### PR DESCRIPTION
## Task
[#115201](https://redmine.weseek.co.jp/issues/115201) [v6] ページを保存していない状態で別のページに遷移すると遷移の度「変更が保存されていない可能性があります」というアラートが表示される
└ [#115770](https://redmine.weseek.co.jp/issues/115770) 修正