### PR TITLE
fix: PageStatusAlert does not disappear after loading latest revision

### DIFF
--- a/packages/app/src/pages/[[...path]].page.tsx
+++ b/packages/app/src/pages/[[...path]].page.tsx
@@ -234,8 +234,6 @@ const Page: NextPageWithLayout<Props> = (props: Props) => {
   const revisionBody = pageWithMeta?.data.revision?.body;
 
   useCurrentPageId(pageId ?? null);
-  useRevisionIdHackmdSynced(pageWithMeta?.data.revisionHackmdSynced);
-  useRemoteRevisionId(pageWithMeta?.data.revision?._id);
   usePageIdOnHackmd(pageWithMeta?.data.pageIdOnHackmd);
   useHasDraftOnHackmd(pageWithMeta?.data.hasDraftOnHackmd ?? false);
   useCurrentPathname(props.currentPathname);
@@ -246,6 +244,9 @@ const Page: NextPageWithLayout<Props> = (props: Props) => {
 
   const { data: grantData } = useSWRxIsGrantNormalized(pageId);
   const { mutate: mutateSelectedGrant } = useSelectedGrant();
+
+  const { mutate: mutateRemoteRevisionId } = useRemoteRevisionId();
+  const { mutate: mutateRevisionIdHackmdSynced } = useRevisionIdHackmdSynced();
 
   useSetupGlobalSocket();
   useSetupGlobalSocketForPage(pageId);
@@ -278,6 +279,11 @@ const Page: NextPageWithLayout<Props> = (props: Props) => {
       mutateEditingMarkdown(revisionBody);
     }
   }, [mutateEditingMarkdown, revisionBody, props.currentPathname]);
+
+  useEffect(() => {
+    mutateRemoteRevisionId(pageWithMeta?.data.revision?._id);
+    mutateRevisionIdHackmdSynced(pageWithMeta?.data.revisionHackmdSynced);
+  }, [mutateRemoteRevisionId, mutateRevisionIdHackmdSynced, pageWithMeta?.data.revision?._id, pageWithMeta?.data.revisionHackmdSynced]);
 
   const title = generateCustomTitleForPage(props, pagePath);
 


### PR DESCRIPTION
## Task
[#116134](https://redmine.weseek.co.jp/issues/116134) 最新版を読み込むで PageStatusAlert が消えない