### PR TITLE
fix: PageStatusAlert is displayed on unnecessary pages

### DIFF
--- a/packages/app/src/client/services/side-effects/page-updated.ts
+++ b/packages/app/src/client/services/side-effects/page-updated.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect } from 'react';
 
 import { SocketEventName } from '~/interfaces/websocket';
+import { useCurrentPageId } from '~/stores/context';
 import { useSetRemoteLatestPageData } from '~/stores/remote-latest-page';
 import { useGlobalSocket } from '~/stores/websocket';
 
@@ -9,6 +10,7 @@ export const usePageUpdatedEffect = (): void => {
   const { setRemoteLatestPageData } = useSetRemoteLatestPageData();
 
   const { data: socket } = useGlobalSocket();
+  const { data: currentPageId } = useCurrentPageId();
 
   const setLatestRemotePageData = useCallback((data) => {
     const { s2cMessagePageUpdated } = data;
@@ -21,8 +23,12 @@ export const usePageUpdatedEffect = (): void => {
       revisionIdHackmdSynced: s2cMessagePageUpdated.revisionIdHackmdSynced,
       hasDraftOnHackmd: s2cMessagePageUpdated.hasDraftOnHackmd,
     };
-    setRemoteLatestPageData(remoteData);
-  }, [setRemoteLatestPageData]);
+
+    if (currentPageId != null && currentPageId === s2cMessagePageUpdated.pageId) {
+      setRemoteLatestPageData(remoteData);
+    }
+
+  }, [currentPageId, setRemoteLatestPageData]);
 
   // listen socket for someone updating this page
   useEffect(() => {

--- a/packages/app/src/pages/[[...path]].page.tsx
+++ b/packages/app/src/pages/[[...path]].page.tsx
@@ -242,7 +242,6 @@ const Page: NextPageWithLayout<Props> = (props: Props) => {
 
   const { mutate: mutateEditingMarkdown } = useEditingMarkdown();
 
-
   const { data: grantData } = useSWRxIsGrantNormalized(pageId);
   const { mutate: mutateSelectedGrant } = useSelectedGrant();
 

--- a/packages/app/src/pages/[[...path]].page.tsx
+++ b/packages/app/src/pages/[[...path]].page.tsx
@@ -233,7 +233,6 @@ const Page: NextPageWithLayout<Props> = (props: Props) => {
   const pagePath = pageWithMeta?.data.path ?? props.currentPathname;
   const revisionBody = pageWithMeta?.data.revision?.body;
 
-  useCurrentPageId(pageId ?? null);
   usePageIdOnHackmd(pageWithMeta?.data.pageIdOnHackmd);
   useHasDraftOnHackmd(pageWithMeta?.data.hasDraftOnHackmd ?? false);
   useCurrentPathname(props.currentPathname);
@@ -241,6 +240,8 @@ const Page: NextPageWithLayout<Props> = (props: Props) => {
   useSWRxCurrentPage(pageWithMeta?.data ?? null); // store initial data
 
   const { mutate: mutateEditingMarkdown } = useEditingMarkdown();
+
+  const { mutate: mutatePageId } = useCurrentPageId(pageId ?? null);
 
   const { data: grantData } = useSWRxIsGrantNormalized(pageId);
   const { mutate: mutateSelectedGrant } = useSelectedGrant();
@@ -284,6 +285,10 @@ const Page: NextPageWithLayout<Props> = (props: Props) => {
     mutateRemoteRevisionId(pageWithMeta?.data.revision?._id);
     mutateRevisionIdHackmdSynced(pageWithMeta?.data.revisionHackmdSynced);
   }, [mutateRemoteRevisionId, mutateRevisionIdHackmdSynced, pageWithMeta?.data.revision?._id, pageWithMeta?.data.revisionHackmdSynced]);
+
+  useEffect(() => {
+    mutatePageId(pageId ?? null);
+  }, [mutatePageId, pageId]);
 
   const title = generateCustomTitleForPage(props, pagePath);
 

--- a/packages/app/src/pages/[[...path]].page.tsx
+++ b/packages/app/src/pages/[[...path]].page.tsx
@@ -233,6 +233,7 @@ const Page: NextPageWithLayout<Props> = (props: Props) => {
   const pagePath = pageWithMeta?.data.path ?? props.currentPathname;
   const revisionBody = pageWithMeta?.data.revision?.body;
 
+  useCurrentPageId(pageId ?? null);
   usePageIdOnHackmd(pageWithMeta?.data.pageIdOnHackmd);
   useHasDraftOnHackmd(pageWithMeta?.data.hasDraftOnHackmd ?? false);
   useCurrentPathname(props.currentPathname);
@@ -241,7 +242,6 @@ const Page: NextPageWithLayout<Props> = (props: Props) => {
 
   const { mutate: mutateEditingMarkdown } = useEditingMarkdown();
 
-  const { mutate: mutatePageId } = useCurrentPageId(pageId ?? null);
 
   const { data: grantData } = useSWRxIsGrantNormalized(pageId);
   const { mutate: mutateSelectedGrant } = useSelectedGrant();
@@ -285,10 +285,6 @@ const Page: NextPageWithLayout<Props> = (props: Props) => {
     mutateRemoteRevisionId(pageWithMeta?.data.revision?._id);
     mutateRevisionIdHackmdSynced(pageWithMeta?.data.revisionHackmdSynced);
   }, [mutateRemoteRevisionId, mutateRevisionIdHackmdSynced, pageWithMeta?.data.revision?._id, pageWithMeta?.data.revisionHackmdSynced]);
-
-  useEffect(() => {
-    mutatePageId(pageId ?? null);
-  }, [mutatePageId, pageId]);
 
   const title = generateCustomTitleForPage(props, pagePath);
 


### PR DESCRIPTION
## Task
[#115279](https://redmine.weseek.co.jp/issues/115279) [v6] PageStatusAlert が不要な個所に表示される
└ [#116112](https://redmine.weseek.co.jp/issues/116112) 修正