### PR TITLE
feat: Initialize editor settings in server side

### DIFF
--- a/packages/app/src/pages/[[...path]].page.tsx
+++ b/packages/app/src/pages/[[...path]].page.tsx
@@ -40,7 +40,7 @@ import {
   useIsSlackConfigured, useRendererConfig,
   useEditorConfig, useIsAllReplyShown, useIsUploadableFile, useIsUploadableImage, useIsContainerFluid, useIsNotCreatable,
 } from '~/stores/context';
-import { useEditingMarkdown } from '~/stores/editor';
+import { useEditingMarkdown, useEditorSettings } from '~/stores/editor';
 import { useHasDraftOnHackmd, usePageIdOnHackmd, useRevisionIdHackmdSynced } from '~/stores/hackmd';
 import { useSWRxCurrentPage, useSWRxIsGrantNormalized } from '~/stores/page';
 import { useRedirectFrom } from '~/stores/page-redirect';
@@ -183,6 +183,8 @@ const Page: NextPageWithLayout<Props> = (props: Props) => {
   const router = useRouter();
 
   useCurrentUser(props.currentUser ?? null);
+
+  useEditorSettings(props.editorSettings);
 
   // commons
   useEditorConfig(props.editorConfig);

--- a/packages/app/src/pages/[[...path]].page.tsx
+++ b/packages/app/src/pages/[[...path]].page.tsx
@@ -184,6 +184,7 @@ const Page: NextPageWithLayout<Props> = (props: Props) => {
 
   useCurrentUser(props.currentUser ?? null);
 
+  // initialize editor setting
   useEditorSettings(props.editorSettings);
 
   // commons

--- a/packages/app/src/pages/utils/commons.ts
+++ b/packages/app/src/pages/utils/commons.ts
@@ -87,7 +87,7 @@ export const getServerSideCommonProps: GetServerSideProps<CommonProps> = async(c
   const EditorSettings = getModelSafely<EditorSettingsDocument>('EditorSettings');
   const editorSettings = user != null && EditorSettings != null
     ? await EditorSettings.findOne({ userId: user._id }).exec()
-    : {} as any; // TODO: typescriptize
+    : {} as any;
 
   const props: CommonProps = {
     namespacesRequired: ['translation'],

--- a/packages/app/src/stores/editor.tsx
+++ b/packages/app/src/stores/editor.tsx
@@ -30,7 +30,7 @@ type EditorSettingsOperation = {
 // TODO: Enable localStorageMiddleware
 //   - Unabling localStorageMiddleware occurrs a flickering problem when loading theme.
 //   - see: https://github.com/weseek/growi/pull/6781#discussion_r1000285786
-export const useEditorSettings = (initialData?: any): SWRResponseWithUtils<EditorSettingsOperation, IEditorSettings, Error> => {
+export const useEditorSettings = (initialData?: IEditorSettings): SWRResponseWithUtils<EditorSettingsOperation, IEditorSettings, Error> => {
   const { data: currentUser } = useCurrentUser();
   const { data: isGuestUser } = useIsGuestUser();
 

--- a/packages/app/src/stores/editor.tsx
+++ b/packages/app/src/stores/editor.tsx
@@ -38,7 +38,6 @@ export const useEditorSettings = (initialData?: any): SWRResponseWithUtils<Edito
     isGuestUser ? null : ['/personal-setting/editor-settings', currentUser?.username],
     ([endpoint]) => apiv3Get(endpoint).then(result => result.data),
     {
-      // use: [localStorageMiddleware], // store to localStorage for initialization fastly
       fallbackData: initialData,
     },
   );

--- a/packages/app/src/stores/editor.tsx
+++ b/packages/app/src/stores/editor.tsx
@@ -30,7 +30,7 @@ type EditorSettingsOperation = {
 // TODO: Enable localStorageMiddleware
 //   - Unabling localStorageMiddleware occurrs a flickering problem when loading theme.
 //   - see: https://github.com/weseek/growi/pull/6781#discussion_r1000285786
-export const useEditorSettings = (): SWRResponseWithUtils<EditorSettingsOperation, IEditorSettings, Error> => {
+export const useEditorSettings = (initialData?: any): SWRResponseWithUtils<EditorSettingsOperation, IEditorSettings, Error> => {
   const { data: currentUser } = useCurrentUser();
   const { data: isGuestUser } = useIsGuestUser();
 
@@ -39,7 +39,7 @@ export const useEditorSettings = (): SWRResponseWithUtils<EditorSettingsOperatio
     ([endpoint]) => apiv3Get(endpoint).then(result => result.data),
     {
       // use: [localStorageMiddleware], // store to localStorage for initialization fastly
-      // fallbackData: undefined,
+      fallbackData: initialData,
     },
   );
 


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/116120

## やったこと
- `useEditorSettings`をサーバーサイドで初期化

## 備考
ストーリーのコメントにあったように

> https://example.com/xxxxxxxxxxxx#edit にアクセスした時に、
> - CodeMirror の初期化(表示)が遅くなる
> - CodeMirror theme の flicker が起こる

flickeringは若干起こってますが、5系の製品版でも同じようにflickeringが起こっているので、無視しています。
今回はあくまで、`useEditorSettings`をサーバーサイドで初期化して、初期値に`undefined`が返るのを防いだだけです。