### PR TITLE
fix: Color of the close icon in modal header

### DIFF
--- a/packages/app/src/styles/theme/_apply-colors.scss
+++ b/packages/app/src/styles/theme/_apply-colors.scss
@@ -350,6 +350,14 @@ ul.pagination {
   }
 }
 
+.grw-page-accessories-modal,.grw-descendants-page-list-modal {
+  .modal-header {
+    .close {
+      color: #{hsl.contrast(var(--bgcolor-global))};
+    }
+  }
+}
+
 .grw-custom-nav-tab {
   .nav-item {
     &:hover,


### PR DESCRIPTION
**Task**
[v6][CSS] PageAccessoriesModal.tsx の拡大マークと右上バツ印を修正する
┗[116363](https://redmine.weseek.co.jp/issues/116363)

**やったこと**
- modal.modal-headerに、modal-headerの背景色がprimaryとなる場合のアイコンの色のみ設定されており、背景色がbgcolor-globalの場合について考慮できていなかった
- apply-colorsに、grw-page-accessories-modalとgrw-descendants-page-list-modalに関する指定を追加