### PR TITLE
imprv: Determine page grant considering wiki mode when creating a new page by uploading attachments

### DIFF
--- a/packages/app/src/server/routes/attachment.js
+++ b/packages/app/src/server/routes/attachment.js
@@ -468,7 +468,10 @@ module.exports = function(crowi, app) {
     if (pageId == null) {
       logger.debug('Create page before file upload');
 
-      page = await crowi.pageService.create(pagePath, `# ${pagePath}`, req.user, { grant: Page.GRANT_OWNER });
+      const wikiMode = crowi.configManager.getConfig('crowi', 'security:wikiMode');
+      const grant = wikiMode === 'public' ? Page.GRANT_PUBLIC : Page.GRANT_OWNER;
+
+      page = await crowi.pageService.create(pagePath, `# ${pagePath}`, req.user, { grant });
       pageCreated = true;
       pageId = page._id;
     }

--- a/packages/app/src/server/routes/attachment.js
+++ b/packages/app/src/server/routes/attachment.js
@@ -468,8 +468,8 @@ module.exports = function(crowi, app) {
     if (pageId == null) {
       logger.debug('Create page before file upload');
 
-      const wikiMode = crowi.configManager.getConfig('crowi', 'security:wikiMode');
-      const grant = wikiMode === 'public' ? Page.GRANT_PUBLIC : Page.GRANT_OWNER;
+      const isAclEnabled = crowi.aclService.isAclEnabled();
+      const grant = isAclEnabled ? Page.GRANT_OWNER : Page.GRANT_PUBLIC;
 
       page = await crowi.pageService.create(pagePath, `# ${pagePath}`, req.user, { grant });
       pageCreated = true;


### PR DESCRIPTION
## Task
[#116497](https://redmine.weseek.co.jp/issues/116497) [v6] 添付ファイルをアップロードしてページを新規作成する場合に wiki mode を考慮してページの grant を決定する
└ [#116499](https://redmine.weseek.co.jp/issues/116499) 改善