### PR TITLE
imprv: Page body to markdown when uploading attachments

### DIFF
--- a/packages/app/src/components/PageEditor.tsx
+++ b/packages/app/src/components/PageEditor.tsx
@@ -310,6 +310,9 @@ const PageEditor = React.memo((): JSX.Element => {
       if (pageId != null) {
         formData.append('page_id', pageId);
       }
+      if (markdownToSave.current != null) {
+        formData.append('page_body', markdownToSave.current);
+      }
 
       res = await apiPostForm('/attachments.add', formData);
       const attachment = res.attachment;

--- a/packages/app/src/server/routes/attachment.js
+++ b/packages/app/src/server/routes/attachment.js
@@ -1,3 +1,4 @@
+import { pathUtils } from '@growi/core';
 
 import { SupportedAction } from '~/interfaces/activity';
 import { AttachmentType } from '~/server/interfaces/attachment';
@@ -452,6 +453,7 @@ module.exports = function(crowi, app) {
   api.add = async function(req, res) {
     let pageId = req.body.page_id || null;
     const pagePath = req.body.path || null;
+    const pageBody = req.body.page_body || null;
     let pageCreated = false;
 
     // check params
@@ -468,10 +470,12 @@ module.exports = function(crowi, app) {
     if (pageId == null) {
       logger.debug('Create page before file upload');
 
+      const fixedPageBody = pageBody ?? pathUtils.attachTitleHeader(pagePath);
+
       const isAclEnabled = crowi.aclService.isAclEnabled();
       const grant = isAclEnabled ? Page.GRANT_OWNER : Page.GRANT_PUBLIC;
 
-      page = await crowi.pageService.create(pagePath, `# ${pagePath}`, req.user, { grant });
+      page = await crowi.pageService.create(pagePath, fixedPageBody, req.user, { grant });
       pageCreated = true;
       pageId = page._id;
     }


### PR DESCRIPTION
## Task
[#116583](https://redmine.weseek.co.jp/issues/116583) [v6] 添付ファイルをアップロードしてページを新規作成する場合に保存されるページの page body を添付ファイルアップロード時点に入力していた markdown にする
└ [#116585](https://redmine.weseek.co.jp/issues/116585) 改善