### PR TITLE
imprv: Save the correct page body when uploading the attachment

### DIFF
--- a/packages/app/src/components/PageEditor.tsx
+++ b/packages/app/src/components/PageEditor.tsx
@@ -318,16 +318,6 @@ const PageEditor = React.memo((): JSX.Element => {
       const attachment = res.attachment;
       const fileName = attachment.originalName;
 
-      // when if created newly
-      if (res.pageCreated) {
-        logger.info('Page is created', res.page._id);
-        globalEmitter.emit('resetInitializedHackMdStatus');
-        mutateGrant(res.page.grant);
-
-        mutateIsEnabledUnsavedWarning(false);
-        await router.push(`/${res.page._id}#edit`);
-      }
-
       let insertText = `[${fileName}](${attachment.filePathProxied})`;
       // when image
       if (attachment.fileFormat.startsWith('image/')) {
@@ -335,6 +325,13 @@ const PageEditor = React.memo((): JSX.Element => {
         insertText = `!${insertText}`;
       }
       editorRef.current.insertText(insertText);
+
+      // when if created newly
+      if (res.pageCreated) {
+        logger.info('Page is created', res.page._id);
+        globalEmitter.emit('resetInitializedHackMdStatus');
+        mutateGrant(res.page.grant);
+      }
     }
     catch (e) {
       logger.error('failed to upload', e);
@@ -343,7 +340,7 @@ const PageEditor = React.memo((): JSX.Element => {
     finally {
       editorRef.current.terminateUploadingState();
     }
-  }, [currentPagePath, mutateGrant, pageId, router]);
+  }, [currentPagePath, mutateGrant, pageId]);
 
 
   const scrollPreviewByEditorLine = useCallback((line: number) => {

--- a/packages/app/src/components/PageEditor.tsx
+++ b/packages/app/src/components/PageEditor.tsx
@@ -318,6 +318,16 @@ const PageEditor = React.memo((): JSX.Element => {
       const attachment = res.attachment;
       const fileName = attachment.originalName;
 
+      // when if created newly
+      if (res.pageCreated) {
+        logger.info('Page is created', res.page._id);
+        globalEmitter.emit('resetInitializedHackMdStatus');
+        mutateGrant(res.page.grant);
+        
+        mutateIsEnabledUnsavedWarning(false);
+        await router.push(`/${res.page._id}#edit`);
+      }
+
       let insertText = `[${fileName}](${attachment.filePathProxied})`;
       // when image
       if (attachment.fileFormat.startsWith('image/')) {
@@ -325,13 +335,6 @@ const PageEditor = React.memo((): JSX.Element => {
         insertText = `!${insertText}`;
       }
       editorRef.current.insertText(insertText);
-
-      // when if created newly
-      if (res.pageCreated) {
-        logger.info('Page is created', res.page._id);
-        globalEmitter.emit('resetInitializedHackMdStatus');
-        mutateGrant(res.page.grant);
-      }
     }
     catch (e) {
       logger.error('failed to upload', e);
@@ -340,7 +343,7 @@ const PageEditor = React.memo((): JSX.Element => {
     finally {
       editorRef.current.terminateUploadingState();
     }
-  }, [currentPagePath, mutateGrant, pageId]);
+  }, [currentPagePath, mutateGrant, pageId, router]);
 
 
   const scrollPreviewByEditorLine = useCallback((line: number) => {

--- a/packages/app/src/components/PageEditor.tsx
+++ b/packages/app/src/components/PageEditor.tsx
@@ -310,6 +310,9 @@ const PageEditor = React.memo((): JSX.Element => {
       if (pageId != null) {
         formData.append('page_id', pageId);
       }
+      if (markdownToSave.current != null) {
+        formData.append('page_body', markdownToSave.current);
+      }
 
       res = await apiPostForm('/attachments.add', formData);
       const attachment = res.attachment;

--- a/packages/app/src/components/PageEditor.tsx
+++ b/packages/app/src/components/PageEditor.tsx
@@ -310,7 +310,7 @@ const PageEditor = React.memo((): JSX.Element => {
       if (pageId != null) {
         formData.append('page_id', pageId);
       }
-      if (markdownToSave.current != null) {
+      if (pageId == null && markdownToSave.current != null) {
         formData.append('page_body', markdownToSave.current);
       }
 

--- a/packages/app/src/components/PageEditor.tsx
+++ b/packages/app/src/components/PageEditor.tsx
@@ -323,7 +323,7 @@ const PageEditor = React.memo((): JSX.Element => {
         logger.info('Page is created', res.page._id);
         globalEmitter.emit('resetInitializedHackMdStatus');
         mutateGrant(res.page.grant);
-        
+
         mutateIsEnabledUnsavedWarning(false);
         await router.push(`/${res.page._id}#edit`);
       }

--- a/packages/app/src/server/routes/attachment.js
+++ b/packages/app/src/server/routes/attachment.js
@@ -1,5 +1,3 @@
-import { pathUtils } from '@growi/core';
-
 import { SupportedAction } from '~/interfaces/activity';
 import { AttachmentType } from '~/server/interfaces/attachment';
 import loggerFactory from '~/utils/logger';
@@ -470,12 +468,10 @@ module.exports = function(crowi, app) {
     if (pageId == null) {
       logger.debug('Create page before file upload');
 
-      const fixedPageBody = pageBody ?? pathUtils.attachTitleHeader(pagePath);
-
       const isAclEnabled = crowi.aclService.isAclEnabled();
       const grant = isAclEnabled ? Page.GRANT_OWNER : Page.GRANT_PUBLIC;
 
-      page = await crowi.pageService.create(pagePath, fixedPageBody, req.user, { grant });
+      page = await crowi.pageService.create(pagePath, pageBody ?? '', req.user, { grant });
       pageCreated = true;
       pageId = page._id;
     }

--- a/packages/app/src/server/routes/attachment.js
+++ b/packages/app/src/server/routes/attachment.js
@@ -1,3 +1,4 @@
+import { pathUtils } from '@growi/core';
 
 import { SupportedAction } from '~/interfaces/activity';
 import { AttachmentType } from '~/server/interfaces/attachment';
@@ -452,6 +453,7 @@ module.exports = function(crowi, app) {
   api.add = async function(req, res) {
     let pageId = req.body.page_id || null;
     const pagePath = req.body.path || null;
+    const pageBody = req.body.page_body || null;
     let pageCreated = false;
 
     // check params
@@ -468,10 +470,12 @@ module.exports = function(crowi, app) {
     if (pageId == null) {
       logger.debug('Create page before file upload');
 
+      const fixedPageBody = pageBody ?? pathUtils.attachTitleHeader(pagePath);
+
       const isAclEnabled = crowi.aclService.isAclEnabled();
       const grant = isAclEnabled ? Page.GRANT_OWNER : Page.GRANT_PUBLIC;
 
-      page = await crowi.pageService.create(pagePath, `# ${pagePath}`, req.user, { grant });
+      page = await crowi.pageService.create(pagePath, fixedPageBody, req.user, { grant });
       pageCreated = true;
       pageId = page._id;
     }


### PR DESCRIPTION
## Task
[#116583](https://redmine.weseek.co.jp/issues/116583) [v6] 添付ファイルをアップロードしてページを新規作成する場合に保存されるページの page body を添付ファイルアップロード時点に入力していた markdown にする
└ [#116585](https://redmine.weseek.co.jp/issues/116585) 改善