### PR TITLE
fix: PageDeleteModal warns even if you have delete permission

### DIFF
--- a/packages/app/src/components/PageDeleteModal.tsx
+++ b/packages/app/src/components/PageDeleteModal.tsx
@@ -229,7 +229,7 @@ const PageDeleteModal: FC = () => {
       return pages.map(page => (
         <p key={page.data._id} className="mb-1">
           <code>{ page.data.path }</code>
-          { !page.meta?.isDeletable && <span className="ml-3 text-danger"><strong>(CAN NOT TO DELETE)</strong></span> }
+          { page.meta?.isDeletable != null && !page.meta?.isDeletable && <span className="ml-3 text-danger"><strong>(CAN NOT TO DELETE)</strong></span> }
         </p>
       ));
     }


### PR DESCRIPTION
## Task
[#116889](https://redmine.weseek.co.jp/issues/116889) PageDeleteModal で削除権限がある場合にでも警告 (CAN NOT TO DELETE) される