### PR TITLE
Feat/114424 116536 track guest user questionnaire answer status with local storage

### DIFF
--- a/packages/app/src/client/services/guest-questionnaire-answer-status.ts
+++ b/packages/app/src/client/services/guest-questionnaire-answer-status.ts
@@ -65,11 +65,12 @@ const setStatus = (questionnaireOrderId: string, status: StatusType): void => {
   if (storage != null) {
     storage[questionnaireOrderId] = guestQuestionnaireAnswerStatus;
     localStorage.setItem(storageKey, JSON.stringify(storage));
+    return;
   }
-  else {
-    const initialStorage: GuestQuestionnaireAnswerStatusStorage = { [questionnaireOrderId]: guestQuestionnaireAnswerStatus };
-    localStorage.setItem(storageKey, JSON.stringify(initialStorage));
-  }
+
+  const initialStorage: GuestQuestionnaireAnswerStatusStorage = { [questionnaireOrderId]: guestQuestionnaireAnswerStatus };
+  localStorage.setItem(storageKey, JSON.stringify(initialStorage));
+
 };
 
 export const GuestQuestionnaireAnswerStatusService = {

--- a/packages/app/src/client/services/guest-questionnaire-answer-status.ts
+++ b/packages/app/src/client/services/guest-questionnaire-answer-status.ts
@@ -13,40 +13,39 @@ interface GuestQuestionnaireAnswerStatusStorage {
 }
 
 const storageKey = 'guestQuestionnaireAnswerStatuses';
-const daysUntilExpiration = 30;
+const DAYS_UNTIL_EXPIRATION = 30;
 
 /**
  * Get all answer statuses stored in localStorage as GuestQuestionnaireAnswerStatusStorage,
  * and update outdated information.
  */
 const getStorage = (): GuestQuestionnaireAnswerStatusStorage | null => {
-  if (typeof window !== 'undefined') {
-    const currentStorage = localStorage.getItem(storageKey);
-    if (currentStorage != null) {
-      const storageJson: GuestQuestionnaireAnswerStatusStorage = JSON.parse(currentStorage);
+  if (typeof window === 'undefined') { return null }
 
-      // delete status if outdated to prevent localStorage overflow
-      // change skipped to not_answered if different date than when skipped
-      Object.keys(storageJson).forEach((key) => {
-        const answerStatus = storageJson[key];
-        const updatedDate = new Date(answerStatus.updatedDate);
-        const expirationDate = new Date(updatedDate.setDate(updatedDate.getDate() + daysUntilExpiration));
-        if (expirationDate < new Date()) {
-          delete storageJson[key];
-        }
-        else if (answerStatus.status === StatusType.skipped
-          && new Date().toDateString() !== answerStatus.updatedDate) {
-          storageJson[key] = {
-            status: StatusType.not_answered,
-            updatedDate: new Date().toDateString(),
-          };
-        }
-      });
+  const currentStorage = localStorage.getItem(storageKey);
 
-      return storageJson;
+  if (currentStorage == null) { return null }
+
+  const storageJson: GuestQuestionnaireAnswerStatusStorage = JSON.parse(currentStorage);
+  // delete status if outdated to prevent localStorage overflow
+  // change skipped to not_answered if different date than when skipped
+  Object.keys(storageJson).forEach((key) => {
+    const answerStatus = storageJson[key];
+    const updatedDate = new Date(answerStatus.updatedDate);
+    const expirationDate = new Date(updatedDate.setDate(updatedDate.getDate() + DAYS_UNTIL_EXPIRATION));
+    if (expirationDate < new Date()) {
+      delete storageJson[key];
     }
-  }
-  return null;
+    else if (answerStatus.status === StatusType.skipped
+          && new Date().toDateString() !== answerStatus.updatedDate) {
+      storageJson[key] = {
+        status: StatusType.not_answered,
+        updatedDate: new Date().toDateString(),
+      };
+    }
+  });
+
+  return storageJson;
 };
 
 /**
@@ -54,22 +53,22 @@ const getStorage = (): GuestQuestionnaireAnswerStatusStorage | null => {
  * and save it in localStorage.
  */
 const setStatus = (questionnaireOrderId: string, status: StatusType): void => {
-  if (typeof window !== 'undefined') {
-    const guestQuestionnaireAnswerStatus: GuestQuestionnaireAnswerStatus = {
-      status,
-      updatedDate: new Date().toDateString(),
-    };
+  if (typeof window === 'undefined') { return }
 
-    const storage = getStorage();
+  const guestQuestionnaireAnswerStatus: GuestQuestionnaireAnswerStatus = {
+    status,
+    updatedDate: new Date().toDateString(),
+  };
 
-    if (storage != null) {
-      storage[questionnaireOrderId] = guestQuestionnaireAnswerStatus;
-      localStorage.setItem(storageKey, JSON.stringify(storage));
-    }
-    else {
-      const initialStorage: GuestQuestionnaireAnswerStatusStorage = { [questionnaireOrderId]: guestQuestionnaireAnswerStatus };
-      localStorage.setItem(storageKey, JSON.stringify(initialStorage));
-    }
+  const storage = getStorage();
+
+  if (storage != null) {
+    storage[questionnaireOrderId] = guestQuestionnaireAnswerStatus;
+    localStorage.setItem(storageKey, JSON.stringify(storage));
+  }
+  else {
+    const initialStorage: GuestQuestionnaireAnswerStatusStorage = { [questionnaireOrderId]: guestQuestionnaireAnswerStatus };
+    localStorage.setItem(storageKey, JSON.stringify(initialStorage));
   }
 };
 

--- a/packages/app/src/client/services/guest-questionnaire-answer-status.ts
+++ b/packages/app/src/client/services/guest-questionnaire-answer-status.ts
@@ -25,7 +25,7 @@ const getStorage = (): GuestQuestionnaireAnswerStatusStorage | null => {
     if (currentStorage) {
       const storageJson: GuestQuestionnaireAnswerStatusStorage = JSON.parse(currentStorage);
 
-      // delete status if outdated
+      // delete status if outdated to prevent localStorage expansion
       // change skipped to not_answered if different date than when skipped
       Object.keys(storageJson).forEach((key) => {
         const answerStatus = storageJson[key];

--- a/packages/app/src/client/services/guest-questionnaire-answer-status.ts
+++ b/packages/app/src/client/services/guest-questionnaire-answer-status.ts
@@ -1,0 +1,79 @@
+// A service to manage questionnaire answer statuses for guest user.
+// Saves statuses in localStorage.
+
+import { StatusType } from '~/interfaces/questionnaire/questionnaire-answer-status';
+
+interface GuestQuestionnaireAnswerStatus {
+  status: StatusType
+  updatedDate: string
+}
+
+interface GuestQuestionnaireAnswerStatusStorage {
+  [key: string]: GuestQuestionnaireAnswerStatus
+}
+
+const storageKey = 'guestQuestionnaireAnswerStatuses';
+const daysUntilExpiration = 30;
+
+/**
+ * Get all answer statuses stored in localStorage as GuestQuestionnaireAnswerStatusStorage,
+ * and update outdated information.
+ */
+const getStorage = (): GuestQuestionnaireAnswerStatusStorage | null => {
+  if (typeof window !== 'undefined') {
+    const currentStorage = localStorage.getItem(storageKey);
+    if (currentStorage) {
+      const storageJson: GuestQuestionnaireAnswerStatusStorage = JSON.parse(currentStorage);
+
+      // delete status if outdated
+      // change skipped to not_answered if different date than when skipped
+      Object.keys(storageJson).forEach((key) => {
+        const answerStatus = storageJson[key];
+        const updatedDate = new Date(answerStatus.updatedDate);
+        const expirationDate = new Date(updatedDate.setDate(updatedDate.getDate() + daysUntilExpiration));
+        if (expirationDate < new Date()) {
+          delete storageJson[key];
+        }
+        else if (answerStatus.status === StatusType.skipped
+          && new Date().toDateString() !== answerStatus.updatedDate) {
+          storageJson[key] = {
+            status: StatusType.not_answered,
+            updatedDate: new Date().toDateString(),
+          };
+        }
+      });
+
+      return storageJson;
+    }
+  }
+  return null;
+};
+
+/**
+ * Set answer status for questionnaire order in GuestQuestionnaireAnswerStatusStorage,
+ * and save it in localStorage.
+ */
+const setStatus = (questionnaireOrderId: string, status: StatusType): void => {
+  if (typeof window !== 'undefined') {
+    const guestQuestionnaireAnswerStatus: GuestQuestionnaireAnswerStatus = {
+      status,
+      updatedDate: new Date().toDateString(),
+    };
+
+    const storage = getStorage();
+
+    if (storage) {
+      storage[questionnaireOrderId] = guestQuestionnaireAnswerStatus;
+      localStorage.setItem(storageKey, JSON.stringify(storage));
+    }
+    else {
+      const initialStorage: GuestQuestionnaireAnswerStatusStorage = { [questionnaireOrderId]: guestQuestionnaireAnswerStatus };
+      localStorage.setItem(storageKey, JSON.stringify(initialStorage));
+    }
+  }
+};
+
+export const GuestQuestionnaireAnswerStatusService = {
+  setStatus,
+  getStorage,
+};

--- a/packages/app/src/client/services/guest-questionnaire-answer-status.ts
+++ b/packages/app/src/client/services/guest-questionnaire-answer-status.ts
@@ -25,7 +25,7 @@ const getStorage = (): GuestQuestionnaireAnswerStatusStorage | null => {
     if (currentStorage) {
       const storageJson: GuestQuestionnaireAnswerStatusStorage = JSON.parse(currentStorage);
 
-      // delete status if outdated to prevent localStorage expansion
+      // delete status if outdated to prevent localStorage overflow
       // change skipped to not_answered if different date than when skipped
       Object.keys(storageJson).forEach((key) => {
         const answerStatus = storageJson[key];

--- a/packages/app/src/client/services/guest-questionnaire-answer-status.ts
+++ b/packages/app/src/client/services/guest-questionnaire-answer-status.ts
@@ -22,7 +22,7 @@ const daysUntilExpiration = 30;
 const getStorage = (): GuestQuestionnaireAnswerStatusStorage | null => {
   if (typeof window !== 'undefined') {
     const currentStorage = localStorage.getItem(storageKey);
-    if (currentStorage) {
+    if (currentStorage != null) {
       const storageJson: GuestQuestionnaireAnswerStatusStorage = JSON.parse(currentStorage);
 
       // delete status if outdated to prevent localStorage overflow
@@ -62,7 +62,7 @@ const setStatus = (questionnaireOrderId: string, status: StatusType): void => {
 
     const storage = getStorage();
 
-    if (storage) {
+    if (storage != null) {
       storage[questionnaireOrderId] = guestQuestionnaireAnswerStatus;
       localStorage.setItem(storageKey, JSON.stringify(storage));
     }

--- a/packages/app/src/components/Questionnaire/QuestionnaireModal.tsx
+++ b/packages/app/src/components/Questionnaire/QuestionnaireModal.tsx
@@ -3,6 +3,7 @@ import { useCallback } from 'react';
 import { useTranslation } from 'next-i18next';
 import { Modal, ModalBody } from 'reactstrap';
 
+import { GuestQuestionnaireAnswerStatusService } from '~/client/services/guest-questionnaire-answer-status';
 import { apiv3Put } from '~/client/util/apiv3-client';
 import { toastSuccess, toastError } from '~/client/util/toastr';
 import { IAnswer } from '~/interfaces/questionnaire/answer';
@@ -38,7 +39,7 @@ const QuestionnaireModal = ({ questionnaireOrder }: QuestionnaireModalProps): JS
         answers,
       });
       if (!currentUser) {
-        localStorage.setItem(questionnaireOrder._id, StatusType.answered);
+        GuestQuestionnaireAnswerStatusService.setStatus(questionnaireOrder._id, StatusType.answered);
       }
       toastSuccess(
         <>
@@ -77,7 +78,7 @@ const QuestionnaireModal = ({ questionnaireOrder }: QuestionnaireModalProps): JS
         questionnaireOrderId: questionnaireOrder._id,
       });
       if (!currentUser) {
-        localStorage.setItem(questionnaireOrder._id, StatusType.denied);
+        GuestQuestionnaireAnswerStatusService.setStatus(questionnaireOrder._id, StatusType.denied);
       }
       toastSuccess(t('questionnaire.denied'));
     }
@@ -97,7 +98,7 @@ const QuestionnaireModal = ({ questionnaireOrder }: QuestionnaireModalProps): JS
         questionnaireOrderId: questionnaireOrder._id,
       });
       if (!currentUser) {
-        localStorage.setItem(questionnaireOrder._id, StatusType.skipped);
+        GuestQuestionnaireAnswerStatusService.setStatus(questionnaireOrder._id, StatusType.skipped);
       }
     }
     catch (e) {

--- a/packages/app/src/components/Questionnaire/QuestionnaireModal.tsx
+++ b/packages/app/src/components/Questionnaire/QuestionnaireModal.tsx
@@ -38,7 +38,7 @@ const QuestionnaireModal = ({ questionnaireOrder }: QuestionnaireModalProps): JS
         questionnaireOrderId: questionnaireOrder._id,
         answers,
       });
-      if (!currentUser) {
+      if (currentUser == null) {
         GuestQuestionnaireAnswerStatusService.setStatus(questionnaireOrder._id, StatusType.answered);
       }
       toastSuccess(
@@ -77,7 +77,7 @@ const QuestionnaireModal = ({ questionnaireOrder }: QuestionnaireModalProps): JS
       apiv3Put('/questionnaire/deny', {
         questionnaireOrderId: questionnaireOrder._id,
       });
-      if (!currentUser) {
+      if (currentUser == null) {
         GuestQuestionnaireAnswerStatusService.setStatus(questionnaireOrder._id, StatusType.denied);
       }
       toastSuccess(t('questionnaire.denied'));
@@ -97,7 +97,7 @@ const QuestionnaireModal = ({ questionnaireOrder }: QuestionnaireModalProps): JS
       await apiv3Put('/questionnaire/skip', {
         questionnaireOrderId: questionnaireOrder._id,
       });
-      if (!currentUser) {
+      if (currentUser == null) {
         GuestQuestionnaireAnswerStatusService.setStatus(questionnaireOrder._id, StatusType.skipped);
       }
     }

--- a/packages/app/src/components/Questionnaire/QuestionnaireModalManager.tsx
+++ b/packages/app/src/components/Questionnaire/QuestionnaireModalManager.tsx
@@ -17,7 +17,7 @@ const QuestionnaireModalManager = ():JSX.Element => {
 
   const questionnaireOrdersToShow = useCallback((questionnaireOrders: IQuestionnaireOrderHasId[] | undefined) => {
     const guestQuestionnaireAnswerStorage = GuestQuestionnaireAnswerStatusService.getStorage();
-    if (currentUser || !guestQuestionnaireAnswerStorage) {
+    if (currentUser != null || guestQuestionnaireAnswerStorage == null) {
       return questionnaireOrders;
     }
 

--- a/packages/app/src/components/Questionnaire/QuestionnaireModalManager.tsx
+++ b/packages/app/src/components/Questionnaire/QuestionnaireModalManager.tsx
@@ -1,3 +1,6 @@
+import { StatusType } from '~/interfaces/questionnaire/questionnaire-answer-status';
+import { IQuestionnaireOrderHasId } from '~/interfaces/questionnaire/questionnaire-order';
+import { useCurrentUser } from '~/stores/context';
 import { useSWRxQuestionnaireOrders } from '~/stores/questionnaire';
 
 import QuestionnaireModal from './QuestionnaireModal';
@@ -7,6 +10,17 @@ import styles from './QuestionnaireModalManager.module.scss';
 
 const QuestionnaireModalManager = ():JSX.Element => {
   const { data: questionnaireOrders } = useSWRxQuestionnaireOrders();
+  const { data: currentUser } = useCurrentUser();
+
+  const questionnaireOrdersToShow = (questionnaireOrders: IQuestionnaireOrderHasId[] | undefined) => {
+    if (currentUser) {
+      return questionnaireOrders;
+    }
+    return questionnaireOrders?.filter((questionnaireOrder) => {
+      const localAnswerStatus = localStorage.getItem(questionnaireOrder._id);
+      return !localAnswerStatus || localAnswerStatus === StatusType.not_answered;
+    });
+  };
 
   return <>
     {questionnaireOrders?.map((questionnaireOrder) => {
@@ -15,7 +29,7 @@ const QuestionnaireModalManager = ():JSX.Element => {
         key={questionnaireOrder._id} />;
     })}
     <div className={styles['grw-questionnaire-toasts']}>
-      {questionnaireOrders?.map((questionnaireOrder) => {
+      {questionnaireOrdersToShow(questionnaireOrders)?.map((questionnaireOrder) => {
         return <QuestionnaireToast questionnaireOrder={questionnaireOrder} key={questionnaireOrder._id}/>;
       })}
     </div>

--- a/packages/app/src/components/Questionnaire/QuestionnaireModalManager.tsx
+++ b/packages/app/src/components/Questionnaire/QuestionnaireModalManager.tsx
@@ -23,7 +23,7 @@ const QuestionnaireModalManager = ():JSX.Element => {
 
     return questionnaireOrders?.filter((questionnaireOrder) => {
       const localAnswerStatus = guestQuestionnaireAnswerStorage[questionnaireOrder._id];
-      return !localAnswerStatus || localAnswerStatus.status === StatusType.not_answered;
+      return localAnswerStatus == null || localAnswerStatus.status === StatusType.not_answered;
     });
   }, [currentUser]);
 

--- a/packages/app/src/components/Questionnaire/QuestionnaireModalManager.tsx
+++ b/packages/app/src/components/Questionnaire/QuestionnaireModalManager.tsx
@@ -1,3 +1,4 @@
+import { GuestQuestionnaireAnswerStatusService } from '~/client/services/guest-questionnaire-answer-status';
 import { StatusType } from '~/interfaces/questionnaire/questionnaire-answer-status';
 import { IQuestionnaireOrderHasId } from '~/interfaces/questionnaire/questionnaire-order';
 import { useCurrentUser } from '~/stores/context';
@@ -13,12 +14,14 @@ const QuestionnaireModalManager = ():JSX.Element => {
   const { data: currentUser } = useCurrentUser();
 
   const questionnaireOrdersToShow = (questionnaireOrders: IQuestionnaireOrderHasId[] | undefined) => {
-    if (currentUser) {
+    const guestQuestionnaireAnswerStorage = GuestQuestionnaireAnswerStatusService.getStorage();
+    if (currentUser || !guestQuestionnaireAnswerStorage) {
       return questionnaireOrders;
     }
+
     return questionnaireOrders?.filter((questionnaireOrder) => {
-      const localAnswerStatus = localStorage.getItem(questionnaireOrder._id);
-      return !localAnswerStatus || localAnswerStatus === StatusType.not_answered;
+      const localAnswerStatus = guestQuestionnaireAnswerStorage[questionnaireOrder._id];
+      return !localAnswerStatus || localAnswerStatus.status === StatusType.not_answered;
     });
   };
 

--- a/packages/app/src/components/Questionnaire/QuestionnaireModalManager.tsx
+++ b/packages/app/src/components/Questionnaire/QuestionnaireModalManager.tsx
@@ -1,3 +1,5 @@
+import { useCallback } from 'react';
+
 import { GuestQuestionnaireAnswerStatusService } from '~/client/services/guest-questionnaire-answer-status';
 import { StatusType } from '~/interfaces/questionnaire/questionnaire-answer-status';
 import { IQuestionnaireOrderHasId } from '~/interfaces/questionnaire/questionnaire-order';
@@ -13,7 +15,7 @@ const QuestionnaireModalManager = ():JSX.Element => {
   const { data: questionnaireOrders } = useSWRxQuestionnaireOrders();
   const { data: currentUser } = useCurrentUser();
 
-  const questionnaireOrdersToShow = (questionnaireOrders: IQuestionnaireOrderHasId[] | undefined) => {
+  const questionnaireOrdersToShow = useCallback((questionnaireOrders: IQuestionnaireOrderHasId[] | undefined) => {
     const guestQuestionnaireAnswerStorage = GuestQuestionnaireAnswerStatusService.getStorage();
     if (currentUser || !guestQuestionnaireAnswerStorage) {
       return questionnaireOrders;
@@ -23,7 +25,7 @@ const QuestionnaireModalManager = ():JSX.Element => {
       const localAnswerStatus = guestQuestionnaireAnswerStorage[questionnaireOrder._id];
       return !localAnswerStatus || localAnswerStatus.status === StatusType.not_answered;
     });
-  };
+  }, [currentUser]);
 
   return <>
     {questionnaireOrders?.map((questionnaireOrder) => {

--- a/packages/app/src/components/Questionnaire/QuestionnaireToast.tsx
+++ b/packages/app/src/components/Questionnaire/QuestionnaireToast.tsx
@@ -38,7 +38,7 @@ const QuestionnaireToast = ({ questionnaireOrder }: QuestionnaireToastProps): JS
       await apiv3Put('/questionnaire/deny', {
         questionnaireOrderId: questionnaireOrder._id,
       });
-      if (!currentUser) {
+      if (currentUser == null) {
         GuestQuestionnaireAnswerStatusService.setStatus(questionnaireOrder._id, StatusType.denied);
       }
       toastSuccess(t('questionnaire.denied'));
@@ -56,7 +56,7 @@ const QuestionnaireToast = ({ questionnaireOrder }: QuestionnaireToastProps): JS
       await apiv3Put('/questionnaire/skip', {
         questionnaireOrderId: questionnaireOrder._id,
       });
-      if (!currentUser) {
+      if (currentUser == null) {
         GuestQuestionnaireAnswerStatusService.setStatus(questionnaireOrder._id, StatusType.skipped);
       }
     }

--- a/packages/app/src/components/Questionnaire/QuestionnaireToast.tsx
+++ b/packages/app/src/components/Questionnaire/QuestionnaireToast.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'next-i18next';
 
 import { apiv3Put } from '~/client/util/apiv3-client';
 import { toastSuccess } from '~/client/util/toastr';
+import { StatusType } from '~/interfaces/questionnaire/questionnaire-answer-status';
 import { IQuestionnaireOrderHasId } from '~/interfaces/questionnaire/questionnaire-order';
 import { useCurrentUser } from '~/stores/context';
 import { useQuestionnaireModal } from '~/stores/modal';
@@ -36,12 +37,15 @@ const QuestionnaireToast = ({ questionnaireOrder }: QuestionnaireToastProps): JS
       await apiv3Put('/questionnaire/deny', {
         questionnaireOrderId: questionnaireOrder._id,
       });
+      if (!currentUser) {
+        localStorage.setItem(questionnaireOrder._id, StatusType.denied);
+      }
       toastSuccess(t('questionnaire.denied'));
     }
     catch (e) {
       logger.error(e);
     }
-  }, [questionnaireOrder._id, t]);
+  }, [questionnaireOrder._id, t, currentUser]);
 
   // No showing toasts since not important
   const closeBtnClickHandler = useCallback(async() => {
@@ -51,11 +55,14 @@ const QuestionnaireToast = ({ questionnaireOrder }: QuestionnaireToastProps): JS
       await apiv3Put('/questionnaire/skip', {
         questionnaireOrderId: questionnaireOrder._id,
       });
+      if (!currentUser) {
+        localStorage.setItem(questionnaireOrder._id, StatusType.skipped);
+      }
     }
     catch (e) {
       logger.error(e);
     }
-  }, [questionnaireOrder._id]);
+  }, [questionnaireOrder._id, currentUser]);
 
   const questionnaireOrderShortTitle = lang === 'en_US' ? questionnaireOrder.shortTitle.en_US : questionnaireOrder.shortTitle.ja_JP;
 

--- a/packages/app/src/components/Questionnaire/QuestionnaireToast.tsx
+++ b/packages/app/src/components/Questionnaire/QuestionnaireToast.tsx
@@ -2,6 +2,7 @@ import { useCallback, useState } from 'react';
 
 import { useTranslation } from 'next-i18next';
 
+import { GuestQuestionnaireAnswerStatusService } from '~/client/services/guest-questionnaire-answer-status';
 import { apiv3Put } from '~/client/util/apiv3-client';
 import { toastSuccess } from '~/client/util/toastr';
 import { StatusType } from '~/interfaces/questionnaire/questionnaire-answer-status';
@@ -38,7 +39,7 @@ const QuestionnaireToast = ({ questionnaireOrder }: QuestionnaireToastProps): JS
         questionnaireOrderId: questionnaireOrder._id,
       });
       if (!currentUser) {
-        localStorage.setItem(questionnaireOrder._id, StatusType.denied);
+        GuestQuestionnaireAnswerStatusService.setStatus(questionnaireOrder._id, StatusType.denied);
       }
       toastSuccess(t('questionnaire.denied'));
     }
@@ -56,7 +57,7 @@ const QuestionnaireToast = ({ questionnaireOrder }: QuestionnaireToastProps): JS
         questionnaireOrderId: questionnaireOrder._id,
       });
       if (!currentUser) {
-        localStorage.setItem(questionnaireOrder._id, StatusType.skipped);
+        GuestQuestionnaireAnswerStatusService.setStatus(questionnaireOrder._id, StatusType.skipped);
       }
     }
     catch (e) {

--- a/packages/app/src/stores/modal.tsx
+++ b/packages/app/src/stores/modal.tsx
@@ -589,12 +589,12 @@ export const useConflictDiffModal = (): SWRResponse<ConflictDiffModalStatus, Err
 */
 type QuestionnaireModalStatuses = {
   openedQuestionnaireId: string | null,
-  closeToastor?: () => void | Promise<void>,
+  closeToast?: () => void | Promise<void>,
 }
 
 type QuestionnaireModalStatusUtils = {
-  open(string: string, closeToastor: () => void | Promise<void>): Promise<QuestionnaireModalStatuses | undefined>
-  close(shouldCloseToastor?: boolean): Promise<QuestionnaireModalStatuses | undefined>
+  open(string: string, closeToast: () => void | Promise<void>): Promise<QuestionnaireModalStatuses | undefined>
+  close(shouldCloseToast?: boolean): Promise<QuestionnaireModalStatuses | undefined>
 }
 
 export const useQuestionnaireModal = (status?: QuestionnaireModalStatuses): SWRResponse<QuestionnaireModalStatuses, Error> & QuestionnaireModalStatusUtils => {
@@ -603,14 +603,14 @@ export const useQuestionnaireModal = (status?: QuestionnaireModalStatuses): SWRR
 
   return {
     ...swrResponse,
-    open: (questionnaireOrderId: string, closeToastor: () => void | Promise<void>) => swrResponse.mutate({
+    open: (questionnaireOrderId: string, closeToast: () => void | Promise<void>) => swrResponse.mutate({
       openedQuestionnaireId: questionnaireOrderId,
-      closeToastor,
+      closeToast,
     }),
-    close: (shouldCloseToastor?: boolean) => {
-      if (shouldCloseToastor) {
-        swrResponse.data?.closeToastor?.();
-        if (swrResponse.data?.closeToastor === undefined) logger.debug('Tried to run `swrResponse.data?.closeToastor` but it was `undefined`');
+    close: (shouldCloseToast?: boolean) => {
+      if (shouldCloseToast) {
+        swrResponse.data?.closeToast?.();
+        if (swrResponse.data?.closeToast === undefined) logger.debug('Tried to run `swrResponse.data?.closeToast` but it was `undefined`');
       }
 
       return swrResponse.mutate({ openedQuestionnaireId: null });


### PR DESCRIPTION
## review task
https://redmine.weseek.co.jp/issues/117286

## 注目点
- skipped のステータスを not_answered に更新する
- 一定期間経過した際に localStorage から answer status を削除する

ために、回答状況と一緒に answer, skip, deny した時刻を保存するデータ構造を用意 (GuestQuestionnaireAnswerStatus)。

各回答状況を一つの object (GuestQuestionnaireAnswerStatusStorage) にまとめて、localStorage に格納する（でないと、localStorage 内の全ての回答状況の精査と更新ができない）。