### PR TITLE
fix: Email is not sent to Admin user when the user is created at user registration restricted

### DIFF
--- a/packages/app/src/server/routes/login.js
+++ b/packages/app/src/server/routes/login.js
@@ -28,8 +28,8 @@ module.exports = function(crowi, app) {
         subject: `[${appTitle}:admin] A New User Created and Waiting for Activation`,
         template: path.join(crowi.localeDir, 'en_US/admin/userWaitingActivation.txt'),
         vars: {
+          adminUser: admin,
           createdUser: userData,
-          admin,
           url: appService.getSiteUrl(),
           appTitle,
         },


### PR DESCRIPTION
## Task
[#117324](https://redmine.weseek.co.jp/issues/117324) [GROWI] ユーザー登録制限時にユーザーを作成した時に Admin ユーザーに対してメールが送信されない
└ [#117332](https://redmine.weseek.co.jp/issues/117332) 修正