### PR TITLE
imprv: Include anyone with the link page in the deletion target

### DIFF
--- a/packages/app/src/server/models/page.ts
+++ b/packages/app/src/server/models/page.ts
@@ -553,11 +553,13 @@ schema.statics.replaceTargetWithPage = async function(exPage, pageToReplaceWith?
 /*
  * Find pages by ID and viewer.
  */
-schema.statics.findByIdsAndViewer = async function(pageIds: string[], user, userGroups?, includeEmpty?: boolean): Promise<PageDocument[]> {
+schema.statics.findByIdsAndViewer = async function(
+    pageIds: string[], user, userGroups?, includeEmpty?: boolean, includeAnyoneWithTheLink?: boolean,
+): Promise<PageDocument[]> {
   const baseQuery = this.find({ _id: { $in: pageIds } });
   const queryBuilder = new PageQueryBuilder(baseQuery, includeEmpty);
 
-  await queryBuilder.addViewerCondition(user, userGroups);
+  await queryBuilder.addViewerCondition(user, userGroups, includeAnyoneWithTheLink);
 
   return queryBuilder.query.exec();
 };

--- a/packages/app/src/server/models/page.ts
+++ b/packages/app/src/server/models/page.ts
@@ -57,7 +57,7 @@ type PaginatedPages = {
 export type CreateMethod = (path: string, body: string, user, options: PageCreateOptions) => Promise<PageDocument & { _id: any }>
 export interface PageModel extends Model<PageDocument> {
   [x: string]: any; // for obsolete static methods
-  findByIdsAndViewer(pageIds: ObjectIdLike[], user, userGroups?, includeEmpty?: boolean): Promise<PageDocument[]>
+  findByIdsAndViewer(pageIds: ObjectIdLike[], user, userGroups?, includeEmpty?: boolean, includeAnyoneWithTheLink?: boolean): Promise<PageDocument[]>
   findByPathAndViewer(path: string | null, user, userGroups?, useFindOne?: true, includeEmpty?: boolean): Promise<PageDocument & HasObjectId | null>
   findByPathAndViewer(path: string | null, user, userGroups?, useFindOne?: false, includeEmpty?: boolean): Promise<(PageDocument & HasObjectId)[]>
   countByPathAndViewer(path: string | null, user, userGroups?, includeEmpty?:boolean): Promise<number>

--- a/packages/app/src/server/routes/apiv3/pages.js
+++ b/packages/app/src/server/routes/apiv3/pages.js
@@ -860,7 +860,7 @@ module.exports = (crowi) => {
       return res.apiv3Err(new ErrorV3('Failed to find pages to delete.'));
     }
     if (isAnyoneWithTheLink && pagesToDelete[0].grant !== PageGrant.GRANT_RESTRICTED) {
-      return res.apiv3Err(new ErrorV3('The page you tried to delete is not a restricted page'), 400);
+      return res.apiv3Err(new ErrorV3('The grant of the retrieved page is not restricted'), 500);
     }
 
     let pagesCanBeDeleted;

--- a/packages/app/src/server/routes/apiv3/pages.js
+++ b/packages/app/src/server/routes/apiv3/pages.js
@@ -842,8 +842,9 @@ module.exports = (crowi) => {
     }
 
     let pagesToDelete;
+    const includeAnyoneWithTheLink = pageIds.length === 1;
     try {
-      pagesToDelete = await Page.findByIdsAndViewer(pageIds, req.user, null, true);
+      pagesToDelete = await Page.findByIdsAndViewer(pageIds, req.user, null, true, includeAnyoneWithTheLink);
     }
     catch (err) {
       logger.error('Failed to find pages to delete.', err);


### PR DESCRIPTION
## Task
[#107497](https://redmine.weseek.co.jp/issues/107497) [v6] /_api/v3/pages/delete での「リンクを知っている人のみ (anyone with the link)」設定のページ削除に対応する
└ [#116613](https://redmine.weseek.co.jp/issues/116613) 改善