### PR TITLE
fix: CodeBlock string is be `[object Object]` if searched

### DIFF
--- a/packages/app/src/components/ReactMarkdownComponents/CodeBlock.module.scss
+++ b/packages/app/src/components/ReactMarkdownComponents/CodeBlock.module.scss
@@ -13,3 +13,23 @@
   border-radius: bs.$border-radius;
   opacity: 0.8;
 }
+
+// Match react-syntax-highlighter library's oneDark style
+.code-block {
+  padding: 1em;
+  margin: 0.5em 0px;
+  overflow: auto;
+  // text-shadow: rgba(0, 0, 0, 0.3) 0px 1px; // Comment out because it stands out when highlighted.
+  font-family:'Fira Code', 'Fira Mono', Menlo, Consolas, 'DejaVu Sans Mono', monospace;
+  hyphens: none;
+  line-height: 1.5;
+  color: rgb(171, 178, 191);
+  text-align: left;
+  word-break: normal;
+  tab-size: 2;
+  white-space: pre;
+  background-color: rgb(40, 44, 52);
+  border-radius: 0.3em;
+  word-spacing: normal;
+  direction: ltr;
+}

--- a/packages/app/src/components/ReactMarkdownComponents/CodeBlock.tsx
+++ b/packages/app/src/components/ReactMarkdownComponents/CodeBlock.tsx
@@ -1,11 +1,24 @@
+import { useMemo } from 'react';
+
+import * as ReactDOMServer from 'react-dom/server';
 import type { CodeComponent } from 'react-markdown/lib/ast-to-react';
 import { PrismAsyncLight } from 'react-syntax-highlighter';
 import { oneDark } from 'react-syntax-highlighter/dist/cjs/styles/prism';
 
 import styles from './CodeBlock.module.scss';
 
-
 export const CodeBlock: CodeComponent = ({ inline, className, children }) => {
+
+  const removeHtmlTags = (text: string) => text.replace(/<[^>]*>/g, '');
+
+  const formattedCode = useMemo(() => {
+    if (typeof children[0] === 'string') {
+      return String(children).replace(/\n$/, '');
+    }
+    // Remove tags if highlighted by Elasticsearch
+    const staticMarkup = ReactDOMServer.renderToStaticMarkup(children);
+    return removeHtmlTags(staticMarkup);
+  }, [children]);
 
   if (inline) {
     return <code className={`code-inline ${className ?? ''}`}>{children}</code>;
@@ -28,7 +41,7 @@ export const CodeBlock: CodeComponent = ({ inline, className, children }) => {
         style={oneDark}
         language={lang}
       >
-        {String(children).replace(/\n$/, '')}
+        {formattedCode}
       </PrismAsyncLight>
     </>
   );

--- a/packages/app/src/components/ReactMarkdownComponents/CodeBlock.tsx
+++ b/packages/app/src/components/ReactMarkdownComponents/CodeBlock.tsx
@@ -1,24 +1,10 @@
-import { useMemo } from 'react';
-
-import * as ReactDOMServer from 'react-dom/server';
-import type { CodeComponent } from 'react-markdown/lib/ast-to-react';
+import { CodeComponent } from 'react-markdown/lib/ast-to-react';
 import { PrismAsyncLight } from 'react-syntax-highlighter';
 import { oneDark } from 'react-syntax-highlighter/dist/cjs/styles/prism';
 
 import styles from './CodeBlock.module.scss';
 
 export const CodeBlock: CodeComponent = ({ inline, className, children }) => {
-
-  const removeHtmlTags = (text: string) => text.replace(/<[^>]*>/g, '');
-
-  const formattedCode = useMemo(() => {
-    if (typeof children[0] === 'string') {
-      return String(children).replace(/\n$/, '');
-    }
-    // Remove tags if highlighted by Elasticsearch
-    const staticMarkup = ReactDOMServer.renderToStaticMarkup(children);
-    return removeHtmlTags(staticMarkup);
-  }, [children]);
 
   if (inline) {
     return <code className={`code-inline ${className ?? ''}`}>{children}</code>;
@@ -35,14 +21,24 @@ export const CodeBlock: CodeComponent = ({ inline, className, children }) => {
       {name != null && (
         <cite className={`code-highlighted-title ${styles['code-highlighted-title']}`}>{name}</cite>
       )}
-      <PrismAsyncLight
-        className="code-highlighted"
-        PreTag="div"
-        style={oneDark}
-        language={lang}
-      >
-        {formattedCode}
-      </PrismAsyncLight>
+      {typeof children[0] !== 'string'
+        ? (
+          // Attach custom codeblock style if highlighted code by Elasticsearch
+          <div className={`code-highlighted code-block ${styles['code-block']}`}>
+            <code className={'language-text'}>
+              {children}
+            </code>
+          </div>
+        ) : (
+          <PrismAsyncLight
+            className="code-highlighted"
+            PreTag="div"
+            style={oneDark}
+            language={lang}
+          >
+            {String(children).replace(/\n$/, '')}
+          </PrismAsyncLight>
+        )}
     </>
   );
 };


### PR DESCRIPTION
task: [117414](https://redmine.weseek.co.jp/issues/117414)

## 原因
- renderer.tsx で code タグを CodeBlock コンポーネントで置き換えている
- CodeBlock.tsx では children (ReactNode) を string にキャストしてから PrismAsyncLight コンポーネントで挟むことで codeblock 表示している
- 一方検索ワードに引っかかった文字列は highlight される仕様
- つまり対象のcodeが CodeBlock.tsx の children として渡ってくる時には `<span>` タグや `<em>` タグが付与されている
- HTML タグが付与されている children を string にキャストすると [Object Object]  と表示されていた

## 修正案
- CodeBlock 表示と Elasticsearch で付与される highlighted の両立はできないので妥協案を考える
- CodeBlock.tsx で highlighted された children が渡ってきた場合は付与されている HTML tag とクラスを排除し、[objcet Object] と表示されないようにする. highlighted はしない.

## Screenshot
### before
![image](https://user-images.githubusercontent.com/68407388/225177756-e37335a7-e4df-4ac0-a0fd-4af076c00841.png)
### after
![image](https://user-images.githubusercontent.com/68407388/225177817-1eabc814-9924-4280-9f15-36e40a8c55db.png)
