### PR TITLE
imprv: Determine page grant considering wiki mode when creating a new page by uploading attachments (v5)

### DIFF
--- a/packages/app/src/server/routes/attachment.js
+++ b/packages/app/src/server/routes/attachment.js
@@ -458,7 +458,10 @@ module.exports = function(crowi, app) {
     if (pageId == null) {
       logger.debug('Create page before file upload');
 
-      page = await crowi.pageService.create(pagePath, `# ${pagePath}`, req.user, { grant: Page.GRANT_OWNER });
+      const isAclEnabled = crowi.aclService.isAclEnabled();
+      const grant = isAclEnabled ? Page.GRANT_OWNER : Page.GRANT_PUBLIC;
+
+      page = await crowi.pageService.create(pagePath, `# ${pagePath}`, req.user, { grant });
       pageCreated = true;
       pageId = page._id;
     }


### PR DESCRIPTION
## Task
[#116497](https://redmine.weseek.co.jp/issues/116497) [GROWI] 添付ファイルをアップロードしてページを新規作成する場合に wiki mode を考慮してページの grant を決定する
└ [#117961](https://redmine.weseek.co.jp/issues/117961) 改善 v5 