### PR TITLE
fix: CodeBlock string is be `[object Object]` if searched

### DIFF
--- a/packages/app/src/components/ReactMarkdownComponents/CodeBlock.module.scss
+++ b/packages/app/src/components/ReactMarkdownComponents/CodeBlock.module.scss
@@ -13,3 +13,23 @@
   border-radius: bs.$border-radius;
   opacity: 0.8;
 }
+
+// Match react-syntax-highlighter library's oneDark style
+.code-block {
+  padding: 1em;
+  margin: 0.5em 0px;
+  overflow: auto;
+  // text-shadow: rgba(0, 0, 0, 0.3) 0px 1px; // Comment out because it stands out when highlighted.
+  font-family:'Fira Code', 'Fira Mono', Menlo, Consolas, 'DejaVu Sans Mono', monospace;
+  hyphens: none;
+  line-height: 1.5;
+  color: rgb(171, 178, 191);
+  text-align: left;
+  word-break: normal;
+  tab-size: 2;
+  white-space: pre;
+  background-color: rgb(40, 44, 52);
+  border-radius: 0.3em;
+  word-spacing: normal;
+  direction: ltr;
+}

--- a/packages/app/src/components/ReactMarkdownComponents/CodeBlock.module.scss
+++ b/packages/app/src/components/ReactMarkdownComponents/CodeBlock.module.scss
@@ -13,23 +13,3 @@
   border-radius: bs.$border-radius;
   opacity: 0.8;
 }
-
-// Match react-syntax-highlighter library's oneDark style
-.code-block {
-  padding: 1em;
-  margin: 0.5em 0px;
-  overflow: auto;
-  // text-shadow: rgba(0, 0, 0, 0.3) 0px 1px; // Comment out because it stands out when highlighted.
-  font-family:'Fira Code', 'Fira Mono', Menlo, Consolas, 'DejaVu Sans Mono', monospace;
-  hyphens: none;
-  line-height: 1.5;
-  color: rgb(171, 178, 191);
-  text-align: left;
-  word-break: normal;
-  tab-size: 2;
-  white-space: pre;
-  background-color: rgb(40, 44, 52);
-  border-radius: 0.3em;
-  word-spacing: normal;
-  direction: ltr;
-}

--- a/packages/app/src/components/ReactMarkdownComponents/CodeBlock.tsx
+++ b/packages/app/src/components/ReactMarkdownComponents/CodeBlock.tsx
@@ -1,9 +1,8 @@
-import type { CodeComponent } from 'react-markdown/lib/ast-to-react';
+import { CodeComponent } from 'react-markdown/lib/ast-to-react';
 import { PrismAsyncLight } from 'react-syntax-highlighter';
 import { oneDark } from 'react-syntax-highlighter/dist/cjs/styles/prism';
 
 import styles from './CodeBlock.module.scss';
-
 
 export const CodeBlock: CodeComponent = ({ inline, className, children }) => {
 
@@ -22,14 +21,24 @@ export const CodeBlock: CodeComponent = ({ inline, className, children }) => {
       {name != null && (
         <cite className={`code-highlighted-title ${styles['code-highlighted-title']}`}>{name}</cite>
       )}
-      <PrismAsyncLight
-        className="code-highlighted"
-        PreTag="div"
-        style={oneDark}
-        language={lang}
-      >
-        {String(children).replace(/\n$/, '')}
-      </PrismAsyncLight>
+      {typeof children[0] !== 'string'
+        ? (
+          // Attach custom codeblock style if highlighted code by Elasticsearch
+          <div className={`code-highlighted code-block ${styles['code-block']}`}>
+            <code className={'language-text'}>
+              {children}
+            </code>
+          </div>
+        ) : (
+          <PrismAsyncLight
+            className="code-highlighted"
+            PreTag="div"
+            style={oneDark}
+            language={lang}
+          >
+            {String(children).replace(/\n$/, '')}
+          </PrismAsyncLight>
+        )}
     </>
   );
 };

--- a/packages/app/src/components/ReactMarkdownComponents/CodeBlock.tsx
+++ b/packages/app/src/components/ReactMarkdownComponents/CodeBlock.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { ReactNode } from 'react';
 
 import type { CodeComponent } from 'react-markdown/lib/ast-to-react';
 import { PrismAsyncLight } from 'react-syntax-highlighter';
@@ -6,12 +6,62 @@ import { oneDark } from 'react-syntax-highlighter/dist/cjs/styles/prism';
 
 import styles from './CodeBlock.module.scss';
 
-export const CodeBlock: CodeComponent = ({ inline, className, children }) => {
 
-  const isHighlightedByElasticsearch = useMemo((): boolean => {
-    const hasOnlyOneStringChild = children.length === 1 && typeof children[0] === 'string';
-    return !hasOnlyOneStringChild;
-  }, [children]);
+function extractChildrenToIgnoreReactNode(children: ReactNode): ReactNode {
+
+  if (children == null) {
+    return children;
+  }
+
+  // Single element array
+  if (Array.isArray(children) && children.length === 1) {
+    return extractChildrenToIgnoreReactNode(children[0]);
+  }
+
+  // Multiple element array
+  if (Array.isArray(children) && children.length > 1) {
+    return children.map(node => extractChildrenToIgnoreReactNode(node)).join('');
+  }
+
+  // object
+  if (typeof children === 'object') {
+    const grandChildren = (children as any).children ?? (children as any).props.children;
+    return extractChildrenToIgnoreReactNode(grandChildren);
+  }
+
+  return String(children).replace(/\n$/, '');
+}
+
+function CodeBlockSubstance({ lang, children }: { lang: string, children: ReactNode }): JSX.Element {
+  // return alternative element
+  //   in order to fix "CodeBlock string is be [object Object] if searched"
+  // see: https://github.com/weseek/growi/pull/7484
+  //
+  // Note: You can also remove this code if the user requests to see the code highlighted in Prism as-is.
+  const isSimpleString = Array.isArray(children) && children.length === 1 && typeof children[0] === 'string';
+  if (!isSimpleString) {
+    return (
+      <div className="code-highlighted" style={oneDark['pre[class*="language-"]']}>
+        <code className={`language-${lang}`} style={oneDark['code[class*="language-"]']}>
+          {children}
+        </code>
+      </div>
+    );
+  }
+
+  return (
+    <PrismAsyncLight
+      className="code-highlighted"
+      PreTag="div"
+      style={oneDark}
+      language={lang}
+    >
+      {extractChildrenToIgnoreReactNode(children)}
+    </PrismAsyncLight>
+  );
+}
+
+export const CodeBlock: CodeComponent = ({ inline, className, children }) => {
 
   if (inline) {
     return <code className={`code-inline ${className ?? ''}`}>{children}</code>;
@@ -28,22 +78,7 @@ export const CodeBlock: CodeComponent = ({ inline, className, children }) => {
       {name != null && (
         <cite className={`code-highlighted-title ${styles['code-highlighted-title']}`}>{name}</cite>
       )}
-      {isHighlightedByElasticsearch ? (
-        <div className="code-highlighted" style={oneDark['pre[class*="language-"]']}>
-          <code className={`language-${lang}`} style={oneDark['code[class*="language-"]']}>
-            {children}
-          </code>
-        </div>
-      ) : (
-        <PrismAsyncLight
-          className="code-highlighted"
-          PreTag="div"
-          style={oneDark}
-          language={lang}
-        >
-          {String(children).replace(/\n$/, '')}
-        </PrismAsyncLight>
-      )}
+      <CodeBlockSubstance lang={lang}>{children}</CodeBlockSubstance>
     </>
   );
 };

--- a/packages/app/src/components/ReactMarkdownComponents/CodeBlock.tsx
+++ b/packages/app/src/components/ReactMarkdownComponents/CodeBlock.tsx
@@ -1,10 +1,16 @@
-import { CodeComponent } from 'react-markdown/lib/ast-to-react';
+import { useMemo } from 'react';
+
+import type { CodeComponent } from 'react-markdown/lib/ast-to-react';
 import { PrismAsyncLight } from 'react-syntax-highlighter';
 import { oneDark } from 'react-syntax-highlighter/dist/cjs/styles/prism';
 
 import styles from './CodeBlock.module.scss';
 
 export const CodeBlock: CodeComponent = ({ inline, className, children }) => {
+
+  const isHighlightedByElasticsearch = useMemo((): boolean => {
+    return !(children.every(item => typeof item === 'string') && children.length === 1);
+  }, [children]);
 
   if (inline) {
     return <code className={`code-inline ${className ?? ''}`}>{children}</code>;
@@ -21,24 +27,22 @@ export const CodeBlock: CodeComponent = ({ inline, className, children }) => {
       {name != null && (
         <cite className={`code-highlighted-title ${styles['code-highlighted-title']}`}>{name}</cite>
       )}
-      {typeof children[0] !== 'string'
-        ? (
-          // Attach custom codeblock style if highlighted code by Elasticsearch
-          <div className={`code-highlighted code-block ${styles['code-block']}`}>
-            <code className={`language-${lang}`}>
-              {children}
-            </code>
-          </div>
-        ) : (
-          <PrismAsyncLight
-            className="code-highlighted"
-            PreTag="div"
-            style={oneDark}
-            language={lang}
-          >
-            {String(children).replace(/\n$/, '')}
-          </PrismAsyncLight>
-        )}
+      {isHighlightedByElasticsearch ? (
+        <div className="code-highlighted" style={oneDark['pre[class*="language-"]']}>
+          <code className={`language-${lang}`} style={oneDark['code[class*="language-"]']}>
+            {children}
+          </code>
+        </div>
+      ) : (
+        <PrismAsyncLight
+          className="code-highlighted"
+          PreTag="div"
+          style={oneDark}
+          language={lang}
+        >
+          {String(children).replace(/\n$/, '')}
+        </PrismAsyncLight>
+      )}
     </>
   );
 };

--- a/packages/app/src/components/ReactMarkdownComponents/CodeBlock.tsx
+++ b/packages/app/src/components/ReactMarkdownComponents/CodeBlock.tsx
@@ -9,7 +9,8 @@ import styles from './CodeBlock.module.scss';
 export const CodeBlock: CodeComponent = ({ inline, className, children }) => {
 
   const isHighlightedByElasticsearch = useMemo((): boolean => {
-    return !(children.every(item => typeof item === 'string') && children.length === 1);
+    const hasOnlyOneStringChild = children.length === 1 && typeof children[0] === 'string';
+    return !hasOnlyOneStringChild;
   }, [children]);
 
   if (inline) {

--- a/packages/app/src/components/ReactMarkdownComponents/CodeBlock.tsx
+++ b/packages/app/src/components/ReactMarkdownComponents/CodeBlock.tsx
@@ -25,7 +25,7 @@ export const CodeBlock: CodeComponent = ({ inline, className, children }) => {
         ? (
           // Attach custom codeblock style if highlighted code by Elasticsearch
           <div className={`code-highlighted code-block ${styles['code-block']}`}>
-            <code className={'language-text'}>
+            <code className={`language-${lang}`}>
               {children}
             </code>
           </div>


### PR DESCRIPTION
task: [117414](https://redmine.weseek.co.jp/issues/117414)

## 原因
- renderer.tsx で code タグを CodeBlock コンポーネントで置き換えている
- CodeBlock.tsx では children (ReactNode) を string にキャストしてから PrismAsyncLight コンポーネントで挟むことで codeblock 表示している
- 一方検索ワードに引っかかった文字列は highlight される仕様
- つまり対象のcodeが CodeBlock.tsx の children として渡ってくる時には `<span>` タグや `<em>` タグが付与されている
- HTML タグが付与されている children を string にキャストすると [Object Object]  と表示されていた

## 修正案
CodeBlock style を用意して、検索文字列が含まれるときはそれを使用するようにする。

## Screenshot
### 用意したコードブロック
![localhost_3000_64123ef261456f4064eb9f53](https://user-images.githubusercontent.com/68407388/225454106-d7bcbf9a-588a-4daa-a5ba-0209259e96de.png)

### Before (`[object Object]` になる)
![localhost_3000_64123ef261456f4064eb9f53 (1)](https://user-images.githubusercontent.com/68407388/225454131-7ce79420-c3d0-4e4e-a396-0be614031738.png)
![localhost_3000__search_q=hello (1)](https://user-images.githubusercontent.com/68407388/225456824-3eb2e819-806f-4b34-965d-9d3719796874.png)

### After
![localhost_3000_64123ef261456f4064eb9f53 (2)](https://user-images.githubusercontent.com/68407388/225454238-2cb82fd0-51e1-4849-9c6d-93001e326021.png)
![localhost_3000__search_q=hello](https://user-images.githubusercontent.com/68407388/225456844-0411b295-fb90-4246-9db7-636f34189a61.png)
