### PR TITLE
fix: Responses 500 status code when invalid regular expressions are inputted to lsx's execpt option

### DIFF
--- a/packages/remark-lsx/src/server/routes/lsx.js
+++ b/packages/remark-lsx/src/server/routes/lsx.js
@@ -104,12 +104,17 @@ class Lsx {
     }
 
     let filterPath = '';
-    if (optionsFilter.charAt(0) === '^') {
-      // move '^' to the first of path
-      filterPath = new RegExp(`^${addTrailingSlash(pagePath)}${optionsFilter.slice(1, optionsFilter.length)}`);
+    try {
+      if (optionsFilter.charAt(0) === '^') {
+        // move '^' to the first of path
+        filterPath = new RegExp(`^${addTrailingSlash(pagePath)}${optionsFilter.slice(1, optionsFilter.length)}`);
+      }
+      else {
+        filterPath = new RegExp(`^${addTrailingSlash(pagePath)}.*${optionsFilter}`);
+      }
     }
-    else {
-      filterPath = new RegExp(`^${addTrailingSlash(pagePath)}.*${optionsFilter}`);
+    catch (err) {
+      throw createError(400, err);
     }
 
     if (isExceptFilter) {


### PR DESCRIPTION
task: https://redmine.weseek.co.jp/issues/116955