### PR TITLE
feat: disable remove leaf on move/rename recursively

### DIFF
--- a/packages/app/src/server/models/page.ts
+++ b/packages/app/src/server/models/page.ts
@@ -671,18 +671,55 @@ schema.statics.findTargetAndAncestorsByPathOrId = async function(pathOrId: strin
   return { targetAndAncestors, rootPage };
 };
 
+/*
+ * Utils from obsolete-page.js
+ */
+export async function pushRevision(pageData, newRevision, user) {
+  await newRevision.save();
+
+  pageData.revision = newRevision;
+  pageData.lastUpdateUser = user?._id ?? user;
+  pageData.updatedAt = Date.now();
+
+  return pageData.save();
+}
+
 /**
  * Create empty pages at paths at which no pages exist
  * @param paths Page paths
  * @param aggrPipelineForExistingPages AggregationPipeline object to find existing pages at paths
  */
-schema.statics.createEmptyPagesByPaths = async function(paths: string[], aggrPipelineForExistingPages: any[]): Promise<void> {
+schema.statics.createEmptyPagesByPaths = async function(paths: string[], aggrPipelineForExistingPages: any[], user?: IUserHasId): Promise<void> {
   const existingPages = await this.aggregate(aggrPipelineForExistingPages);
 
   const existingPagePaths = existingPages.map(page => page.path);
   const notExistingPagePaths = paths.filter(path => !existingPagePaths.includes(path));
+  if (user != null) {
+    const Revision = mongoose.model('Revision') as any;
+    // Create and save pages
+    const createPagesAndRevisions = notExistingPagePaths.map(async(path) => {
+      const page = await this.create({ path, isEmpty: false, descendantCount: 0 });
 
-  await this.insertMany(notExistingPagePaths.map(path => ({ path, isEmpty: true })));
+      // Get number of descendants
+      const descendantCount = await this.countDocuments({ path: { $regex: `^${path}/` } });
+
+      // Update descendantCount
+      page.descendantCount = descendantCount;
+      await page.save();
+
+      // Create revision and push it to the page
+      const newRevision = Revision.prepareRevision(page, '', null, user, { format: 'markdown' });
+      await pushRevision(page, newRevision, user);
+      await page.populateDataToShowRevision();
+
+      return page;
+    });
+
+    await Promise.all(createPagesAndRevisions);
+  }
+  else {
+    await this.insertMany(notExistingPagePaths.map(path => ({ path, isEmpty: true })));
+  }
 };
 
 /**
@@ -705,19 +742,6 @@ schema.statics.findParentByPath = async function(path: string): Promise<PageDocu
 
   return null;
 };
-
-/*
- * Utils from obsolete-page.js
- */
-export async function pushRevision(pageData, newRevision, user) {
-  await newRevision.save();
-
-  pageData.revision = newRevision;
-  pageData.lastUpdateUser = user?._id ?? user;
-  pageData.updatedAt = Date.now();
-
-  return pageData.save();
-}
 
 /**
  * add/subtract descendantCount of pages with provided paths by increment.

--- a/packages/app/src/server/service/page.ts
+++ b/packages/app/src/server/service/page.ts
@@ -561,12 +561,6 @@ class PageService {
     const nToIncrease = (renamedPage.isEmpty ? 0 : 1) + page.descendantCount;
     await this.updateDescendantCountOfAncestors(renamedPage._id, nToIncrease, false);
 
-    // Remove leaf empty pages if not moving to under the ex-target position
-    if (!this.isRenamingToUnderTarget(page.path, newPagePath)) {
-    // remove empty pages at leaf position
-      await Page.removeLeafEmptyPagesRecursively(page.parent);
-    }
-
     await PageOperation.findByIdAndDelete(pageOpId);
   }
 

--- a/packages/app/src/server/service/page.ts
+++ b/packages/app/src/server/service/page.ts
@@ -561,12 +561,6 @@ class PageService {
     const nToIncrease = (renamedPage.isEmpty ? 0 : 1) + page.descendantCount;
     await this.updateDescendantCountOfAncestors(renamedPage._id, nToIncrease, false);
 
-    // Remove leaf empty pages if not moving to under the ex-target position
-    if (!this.isRenamingToUnderTarget(page.path, newPagePath)) {
-      // remove empty pages at leaf position
-      await Page.removeLeafEmptyPagesRecursively(page.parent);
-    }
-
     await PageOperation.findByIdAndDelete(pageOpId);
   }
 
@@ -3347,7 +3341,8 @@ class PageService {
 
     // Fill ancestors
     const aggregationPipeline: any[] = await this.buildPipelineToCreateEmptyPagesByUser(user, ancestorPaths);
-    await Page.createEmptyPagesByPaths(ancestorPaths, aggregationPipeline, user);
+
+    await Page.createEmptyPagesByPaths(ancestorPaths, aggregationPipeline);
 
     // Connect ancestors
     await this.connectPageTree(path);

--- a/packages/app/src/server/service/page.ts
+++ b/packages/app/src/server/service/page.ts
@@ -561,6 +561,12 @@ class PageService {
     const nToIncrease = (renamedPage.isEmpty ? 0 : 1) + page.descendantCount;
     await this.updateDescendantCountOfAncestors(renamedPage._id, nToIncrease, false);
 
+    // Remove leaf empty pages if not moving to under the ex-target position
+    if (page.path !== newPagePath && !this.isRenamingToUnderTarget(page.path, newPagePath)) {
+      // remove empty pages at leaf position
+      await Page.removeLeafEmptyPagesRecursively(page.parent);
+    }
+
     await PageOperation.findByIdAndDelete(pageOpId);
   }
 

--- a/packages/app/src/server/service/page.ts
+++ b/packages/app/src/server/service/page.ts
@@ -561,6 +561,12 @@ class PageService {
     const nToIncrease = (renamedPage.isEmpty ? 0 : 1) + page.descendantCount;
     await this.updateDescendantCountOfAncestors(renamedPage._id, nToIncrease, false);
 
+    // Remove leaf empty pages if not moving to under the ex-target position
+    if (!this.isRenamingToUnderTarget(page.path, newPagePath)) {
+      // remove empty pages at leaf position
+      await Page.removeLeafEmptyPagesRecursively(page.parent);
+    }
+
     await PageOperation.findByIdAndDelete(pageOpId);
   }
 
@@ -3341,8 +3347,7 @@ class PageService {
 
     // Fill ancestors
     const aggregationPipeline: any[] = await this.buildPipelineToCreateEmptyPagesByUser(user, ancestorPaths);
-
-    await Page.createEmptyPagesByPaths(ancestorPaths, aggregationPipeline);
+    await Page.createEmptyPagesByPaths(ancestorPaths, aggregationPipeline, user);
 
     // Connect ancestors
     await this.connectPageTree(path);


### PR DESCRIPTION
https://youtrack.weseek.co.jp/issue/GW-7936
- disable removeLeafEmptyPagesRecursively on renameSubOperation

## Issue 
Empty pages under updated page will removed and broke the tree structure

## Solution
Disable /remove removeLeafEmptyPagesRecursively excecution on renameSubOperation method