### PR TITLE
fix:  Search results are not highlighted when searching for quoteted words (PageListItemL)

### DIFF
--- a/packages/app/src/interfaces/search.ts
+++ b/packages/app/src/interfaces/search.ts
@@ -5,7 +5,6 @@ export type IPageSearchMeta = {
   elasticSearchResult?: {
     snippet?: string | null;
     highlightedPath?: string | null;
-    isHtmlInPath: boolean;
   };
 }
 

--- a/packages/app/src/server/service/search.ts
+++ b/packages/app/src/server/service/search.ts
@@ -450,7 +450,7 @@ class SearchService implements SearchQueryParser, SearchResolver {
       const highlightData = data._highlight;
       if (highlightData != null) {
         const snippet = this.canShowSnippet(pageData, user, userGroups)
-          ? highlightData['body.en'] || highlightData['body.ja'] || highlightData['comments.en'] || highlightData['comments.ja']
+          ? highlightData.body || highlightData['body.en'] || highlightData['body.ja'] || highlightData['comments.en'] || highlightData['comments.ja']
           : null;
         const pathMatch = highlightData['path.en'] || highlightData['path.ja'];
         const isHtmlInPath = highlightData['path.en'] != null || highlightData['path.ja'] != null;

--- a/packages/app/src/server/service/search.ts
+++ b/packages/app/src/server/service/search.ts
@@ -454,12 +454,10 @@ class SearchService implements SearchQueryParser, SearchResolver {
           ? highlightData.body || highlightData['body.en'] || highlightData['body.ja'] || highlightData.comments || highlightData['comments.en'] || highlightData['comments.ja']
           : null;
         const pathMatch = highlightData['path.en'] || highlightData['path.ja'];
-        const isHtmlInPath = highlightData['path.en'] != null || highlightData['path.ja'] != null;
 
         elasticSearchResult = {
           snippet: snippet != null && typeof snippet[0] === 'string' ? filterXss.process(snippet) : null,
           highlightedPath: pathMatch != null && typeof pathMatch[0] === 'string' ? filterXss.process(pathMatch) : null,
-          isHtmlInPath,
         };
       }
 

--- a/packages/app/src/server/service/search.ts
+++ b/packages/app/src/server/service/search.ts
@@ -450,7 +450,8 @@ class SearchService implements SearchQueryParser, SearchResolver {
       const highlightData = data._highlight;
       if (highlightData != null) {
         const snippet = this.canShowSnippet(pageData, user, userGroups)
-          ? highlightData.body || highlightData['body.en'] || highlightData['body.ja'] || highlightData['comments.en'] || highlightData['comments.ja']
+          // eslint-disable-next-line max-len
+          ? highlightData.body || highlightData['body.en'] || highlightData['body.ja'] || highlightData.comments || highlightData['comments.en'] || highlightData['comments.ja']
           : null;
         const pathMatch = highlightData['path.en'] || highlightData['path.ja'];
         const isHtmlInPath = highlightData['path.en'] != null || highlightData['path.ja'] != null;


### PR DESCRIPTION
## Task
[#115501](https://redmine.weseek.co.jp/issues/115501) [v6] ダブルクォーテーション検索した時に検索結果ページで対象のキーワードがハイライトされない
└ [#117050](https://redmine.weseek.co.jp/issues/117050) 修正 (PageListItemL)