### PR TITLE
fix: Language selection dropdown in installer does not reflect browser language setting

### DIFF
--- a/packages/app/src/components/InstallerForm.tsx
+++ b/packages/app/src/components/InstallerForm.tsx
@@ -2,6 +2,7 @@ import {
   FormEventHandler, memo, useCallback, useState,
 } from 'react';
 
+import { Lang, AllLang } from '@growi/core';
 import { useTranslation } from 'next-i18next';
 import { useRouter } from 'next/router';
 
@@ -15,9 +16,11 @@ const InstallerForm = memo((): JSX.Element => {
 
   const router = useRouter();
 
+  const isSupportedLang = AllLang.includes(i18n.language as Lang);
+
   const [isValidUserName, setValidUserName] = useState(true);
   const [isSubmittingDisabled, setSubmittingDisabled] = useState(false);
-  const [currentLocale, setCurrentLocale] = useState(i18n.language);
+  const [currentLocale, setCurrentLocale] = useState(isSupportedLang ? i18n.language : Lang.en_US);
 
   const checkUserName = useCallback(async(event) => {
     const axios = require('axios').create({

--- a/packages/app/src/components/InstallerForm.tsx
+++ b/packages/app/src/components/InstallerForm.tsx
@@ -17,7 +17,7 @@ const InstallerForm = memo((): JSX.Element => {
 
   const [isValidUserName, setValidUserName] = useState(true);
   const [isSubmittingDisabled, setSubmittingDisabled] = useState(false);
-  const [currentLocale, setCurrentLocale] = useState('en_US');
+  const [currentLocale, setCurrentLocale] = useState(i18n.language);
 
   const checkUserName = useCallback(async(event) => {
     const axios = require('axios').create({


### PR DESCRIPTION
## Task
[#118099](https://redmine.weseek.co.jp/issues/118099) [GROWI] インストール画面で言語選択ドロップダウンを操作しないと言語反映されない
└ [#118315](https://redmine.weseek.co.jp/issues/118315) 修正