### PR TITLE
fix : gw7938 fix search by username in comments

### DIFF
--- a/packages/app/src/components/PageEditor/CodeMirrorEditor.jsx
+++ b/packages/app/src/components/PageEditor/CodeMirrorEditor.jsx
@@ -40,6 +40,7 @@ import styles from './CodeMirrorEditor.module.scss';
 window.JSHINT = JSHINT;
 window.kuromojin = { dicPath: '/static/dict' };
 
+require('codemirror/addon/hint/show-hint.css'); // Import from CodeMirrorEditor.module.scss not working
 require('codemirror/addon/display/placeholder');
 require('codemirror/addon/edit/matchbrackets');
 require('codemirror/addon/edit/matchtags');

--- a/packages/app/src/components/PageEditor/CodeMirrorEditor.jsx
+++ b/packages/app/src/components/PageEditor/CodeMirrorEditor.jsx
@@ -5,6 +5,7 @@ import { commands } from 'codemirror';
 import { JSHINT } from 'jshint';
 import * as loadCssSync from 'load-css-file';
 import PropTypes from 'prop-types';
+import { useTranslation } from 'react-i18next';
 import { Button } from 'reactstrap';
 import * as loadScript from 'simple-load-script';
 import { throttle, debounce } from 'throttle-debounce';
@@ -181,6 +182,7 @@ class CodeMirrorEditor extends AbstractEditor {
   }
 
   componentDidMount() {
+    const { t } = this.props;
     // ensure to be able to resolve 'this' to use 'codemirror.commands.save'
     this.getCodeMirror().codeMirrorEditor = this;
 
@@ -192,7 +194,7 @@ class CodeMirrorEditor extends AbstractEditor {
 
     // initialize commentMentionHelper if comment editor is opened
     if (this.props.isComment) {
-      this.commentMentionHelper = new CommentMentionHelper(this.getCodeMirror());
+      this.commentMentionHelper = new CommentMentionHelper(this.getCodeMirror(), t);
     }
     this.emojiPickerHelper = new EmojiPickerHelper(this.getCodeMirror());
 
@@ -1181,6 +1183,8 @@ const CodeMirrorEditorMemoized = memo(CodeMirrorEditor);
 
 
 const CodeMirrorEditorFc = React.forwardRef((props, ref) => {
+  const { t } = useTranslation();
+
   const { open: openDrawioModal } = useDrawioModal();
   const { open: openHandsontableModal } = useHandsontableModal();
   const { open: openTemplateModal } = useTemplateModal();
@@ -1203,6 +1207,7 @@ const CodeMirrorEditorFc = React.forwardRef((props, ref) => {
       onClickDrawioBtn={openDrawioModalHandler}
       onClickTableBtn={openTableModalHandler}
       onClickTemplateBtn={openTemplateModalHandler}
+      t={t}
       {...props}
     />
   );

--- a/packages/app/src/components/PageEditor/CodeMirrorEditor.jsx
+++ b/packages/app/src/components/PageEditor/CodeMirrorEditor.jsx
@@ -5,7 +5,6 @@ import { commands } from 'codemirror';
 import { JSHINT } from 'jshint';
 import * as loadCssSync from 'load-css-file';
 import PropTypes from 'prop-types';
-import { useTranslation } from 'react-i18next';
 import { Button } from 'reactstrap';
 import * as loadScript from 'simple-load-script';
 import { throttle, debounce } from 'throttle-debounce';
@@ -182,7 +181,6 @@ class CodeMirrorEditor extends AbstractEditor {
   }
 
   componentDidMount() {
-    const { t } = this.props;
     // ensure to be able to resolve 'this' to use 'codemirror.commands.save'
     this.getCodeMirror().codeMirrorEditor = this;
 
@@ -194,7 +192,7 @@ class CodeMirrorEditor extends AbstractEditor {
 
     // initialize commentMentionHelper if comment editor is opened
     if (this.props.isComment) {
-      this.commentMentionHelper = new CommentMentionHelper(this.getCodeMirror(), t);
+      this.commentMentionHelper = new CommentMentionHelper(this.getCodeMirror());
     }
     this.emojiPickerHelper = new EmojiPickerHelper(this.getCodeMirror());
 
@@ -1183,8 +1181,6 @@ const CodeMirrorEditorMemoized = memo(CodeMirrorEditor);
 
 
 const CodeMirrorEditorFc = React.forwardRef((props, ref) => {
-  const { t } = useTranslation();
-
   const { open: openDrawioModal } = useDrawioModal();
   const { open: openHandsontableModal } = useHandsontableModal();
   const { open: openTemplateModal } = useTemplateModal();
@@ -1207,7 +1203,6 @@ const CodeMirrorEditorFc = React.forwardRef((props, ref) => {
       onClickDrawioBtn={openDrawioModalHandler}
       onClickTableBtn={openTableModalHandler}
       onClickTemplateBtn={openTemplateModalHandler}
-      t={t}
       {...props}
     />
   );

--- a/packages/app/src/components/PageEditor/CodeMirrorEditor.module.scss
+++ b/packages/app/src/components/PageEditor/CodeMirrorEditor.module.scss
@@ -4,7 +4,6 @@
   @import '~codemirror/lib/codemirror';
 
   // addons
-  @import '~codemirror/addon/hint/show-hint';
   @import '~codemirror/addon/fold/foldgutter';
   @import '~codemirror/addon/lint/lint';
 

--- a/packages/app/src/components/PageEditor/CommentMentionHelper.ts
+++ b/packages/app/src/components/PageEditor/CommentMentionHelper.ts
@@ -1,20 +1,25 @@
-import i18n from 'i18next';
+import { Editor } from 'codemirror';
 import { debounce } from 'throttle-debounce';
 
 import { apiv3Get } from '~/client/util/apiv3-client';
 
+
+type UsersListForHints = {
+  text: string
+  displayText: string
+}
 export default class CommentMentionHelper {
 
-  editor;
+  editor: Editor;
 
-  pattern: RegExp;
+  t;
 
-
-  constructor(editor) {
+  constructor(editor: Editor, t) {
     this.editor = editor;
+    this.t = t;
   }
 
-  getUsernamHint = () => {
+  getUsenameHint = (): void => {
     // Get word that contains `@` character at the begining
     const currentPos = this.editor.getCursor();
     const wordStart = this.editor.findWordAt(currentPos).anchor.ch - 1;
@@ -32,14 +37,14 @@ export default class CommentMentionHelper {
     }
 
     // Get username after `@` character and search username
-    const mention = searchMention.substr(1);
+    const mention = searchMention.slice(1);
     this.editor.showHint({
       completeSingle: false,
       hint: async() => {
         if (mention.length > 0) {
           const users = await this.getUsersList(mention);
           return {
-            list: users.length > 0 ? users : [{ text: '', displayText: i18n.t('page_comment.no_user_found') }],
+            list: users.length > 0 ? users : [{ text: '', displayText: this.t('page_comment.no_user_found') }],
             from: searchFrom,
             to: searchTo,
           };
@@ -48,15 +53,15 @@ export default class CommentMentionHelper {
     });
   };
 
-  getUsersList = async(q: string) => {
+  getUsersList = async(q: string): Promise<UsersListForHints[]> => {
     const limit = 20;
     const { data } = await apiv3Get('/users/usernames', { q, limit });
-    return data.activeUser.usernames.map(username => ({
+    return data.activeUser.usernames.map((username: string) => ({
       text: `@${username} `,
       displayText: username,
     }));
   };
 
-  showUsernameHint = debounce(800, () => this.getUsernamHint());
+  showUsernameHint = debounce(800, () => this.getUsenameHint());
 
 }

--- a/packages/app/src/components/PageEditor/CommentMentionHelper.ts
+++ b/packages/app/src/components/PageEditor/CommentMentionHelper.ts
@@ -1,4 +1,5 @@
 import { Editor } from 'codemirror';
+import { i18n } from 'next-i18next';
 import { debounce } from 'throttle-debounce';
 
 import { apiv3Get } from '~/client/util/apiv3-client';
@@ -12,11 +13,8 @@ export default class CommentMentionHelper {
 
   editor: Editor;
 
-  t;
-
-  constructor(editor: Editor, t) {
+  constructor(editor: Editor) {
     this.editor = editor;
-    this.t = t;
   }
 
   getUsenameHint = (): void => {
@@ -44,7 +42,7 @@ export default class CommentMentionHelper {
         if (mention.length > 0) {
           const users = await this.getUsersList(mention);
           return {
-            list: users.length > 0 ? users : [{ text: '', displayText: this.t('page_comment.no_user_found') }],
+            list: users.length > 0 ? users : [{ text: '', displayText: i18n?.t('page_comment.no_user_found') }],
             from: searchFrom,
             to: searchTo,
           };


### PR DESCRIPTION
https://youtrack.weseek.co.jp/issue/GW-7938

## Issue
- Search `@{username}` not showing in comment
- Translation doesn't work when user not found

## Solution
- Move `show-hint.css` to `CodeMirrorEditor` component
- Pass t function to `CommentMentionHelper`

## Test Result

https://user-images.githubusercontent.com/92426728/226527161-86d49926-b449-4a1b-8ac2-8c77445b8c02.mp4

