### PR TITLE
fix: Show handsontable edit modal color in dark theme 

### DIFF
--- a/packages/app/src/styles/theme/_apply-colors-dark.scss
+++ b/packages/app/src/styles/theme/_apply-colors-dark.scss
@@ -504,6 +504,11 @@
   /*
   * GROWI HandsontableModal
   */
+
+  .handsontable td {
+    color: black;
+  }
+
   .grw-hot-modal-navbar {
     background-color: var(--dark);
   }


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/117499

## やったこと
- 6系で`future`などの暗いテーマの文字色の初期値が白になっており、Handsontableの編集モーダル内で文字が見えていなかったのを修正