### PR TITLE
fix: Error when transitioning to a user home page where creator does not exist

### DIFF
--- a/packages/app/src/components/Page/PageView.tsx
+++ b/packages/app/src/components/Page/PageView.tsx
@@ -158,7 +158,7 @@ export const PageView = (props: Props): JSX.Element => {
       { specialContents }
       { specialContents == null && (
         <>
-          { isUsersHomePagePath && <UserInfo author={page?.creator} /> }
+          { (isUsersHomePagePath && page?.creator != null) && <UserInfo author={page.creator} /> }
           <div className={`mb-5 ${isMobile ? `page-mobile ${styles['page-mobile']}` : ''}`}>
             <Contents />
           </div>

--- a/packages/app/src/components/Page/PageView.tsx
+++ b/packages/app/src/components/Page/PageView.tsx
@@ -124,7 +124,7 @@ export const PageView = (props: Props): JSX.Element => {
         <div id="comments-container" ref={commentsContainerRef}>
           <Comments pageId={page._id} pagePath={pagePath} revision={page.revision} onLoaded={() => setCommentsLoaded(true)} />
         </div>
-        { isUsersHomePagePath && (
+        { (isUsersHomePagePath && page.creator != null) && (
           <UsersHomePageFooter creatorId={page.creator._id}/>
         ) }
         <PageContentFooter page={page} />

--- a/packages/core/src/interfaces/page.ts
+++ b/packages/core/src/interfaces/page.ts
@@ -40,7 +40,7 @@ export type IPagePopulatedToList = Omit<IPageHasId, 'lastUpdateUser'> & {
 
 export type IPagePopulatedToShowRevision = Omit<IPageHasId, 'lastUpdateUser'|'creator'|'deleteUser'|'grantedGroup'|'revision'|'author'> & {
   lastUpdateUser: IUserHasId,
-  creator: IUserHasId,
+  creator: IUserHasId | null,
   deleteUser: IUserHasId,
   grantedGroup: IUserGroupHasId,
   revision: IRevisionHasId,


### PR DESCRIPTION
## Task
[#118605](https://redmine.weseek.co.jp/issues/118605) [GROWI] creator が存在しない UserHomePage に遷移すると 500 エラーが返却されページが正しく表示されない
└ [#118606](https://redmine.weseek.co.jp/issues/118606) 修正