### PR TITLE
fix: Supress `activeTab` prop type error

### DIFF
--- a/packages/app/src/components/PageAccessoriesModal.tsx
+++ b/packages/app/src/components/PageAccessoriesModal.tsx
@@ -114,7 +114,7 @@ const PageAccessoriesModal = (): JSX.Element => {
     </div>
   ), [close, isWindowExpanded]);
 
-  if (status == null) {
+  if (status == null || activeTab == null) {
     return <></>;
   }
 


### PR DESCRIPTION
task: https://redmine.weseek.co.jp/issues/118278

不具合の再現もしなくなっていたので以下の browser console warning を出ないように修正しました.

![image](https://user-images.githubusercontent.com/68407388/227442624-2cc916e2-ac42-42b4-b8ca-961517eb651d.png)
