### PR TITLE
fix: Add lookahead assertion for search by Safari

### DIFF
--- a/packages/core/src/models/devided-page-path.js
+++ b/packages/core/src/models/devided-page-path.js
@@ -32,7 +32,7 @@ export class DevidedPagePath {
       }
     }
 
-    let PATTERN_DEFAULT = /^((.*)\/)?(.+)$/; // this will not ignore html end tags https://regex101.com/r/jpZwIe/1
+    let PATTERN_DEFAULT = /^((.*)\/(?!em>))?(.+)$/; // this will ignore em's end tags
     try { // for non-chrome browsers
       // eslint-disable-next-line regex/invalid
       PATTERN_DEFAULT = new RegExp('^((.*)(?<!<)\\/)?(.+)$'); // https://regex101.com/r/HJNvMW/1


### PR DESCRIPTION
#6766 のバグを解消するため、関連する正規表現を微修正しました。  
- MacとiOSのSafariで"em>"を含まない正常な検索結果が表示されます。

## 6766の原因と解決策
- elasticsearch が挿入する```</em>```タグをパス区切りのスラッシュ(/)と区別するために、Chrome等のブラウザでは"<"の否定後読みが用いられています。Lookbehind assertionがサポートされているブラウザでは問題は発生しません。
- Safariが現時点最新版(16.3)でも後読みをサポートしていないために閉じタグを区別できず、パス名に検索語が含まれる場合に検索結果の表示がバグってしまいます。
- 後読み非対応ブラウザで"em>"を否定先読みして"/em>"をパス区切りと認識しないように修正しました。
- [Lookaheadは全ブラウザでサポートされているそうです。](https://caniuse.com/sr_js-regexp-lookahead)
## 備考
- [Safariの次のバージョン(16.4)ではLookbehindがサポートされるようです。](https://developer.apple.com/documentation/safari-release-notes/safari-16_4-release-notes)
- v6.0.10に対して修正を行いましたが、devided-page-path.jsはv5.0.0から変更がないのでv5.xにも全く同じ修正が有効なはずです。