### PR TITLE
fix: Lsx filter and except option do not work when the path includes special characters

### DIFF
--- a/packages/remark-lsx/src/server/routes/lsx.js
+++ b/packages/remark-lsx/src/server/routes/lsx.js
@@ -1,3 +1,4 @@
+import escapeStringRegexp from 'escape-string-regexp';
 import createError, { isHttpError } from 'http-errors';
 
 const { pathUtils, pagePathUtils, customTagUtils } = require('@growi/core');
@@ -103,14 +104,16 @@ class Lsx {
       throw createError(400, 'filter option require value in regular expression.');
     }
 
+    const pagePathForRegexp = escapeStringRegexp(addTrailingSlash(pagePath));
+
     let filterPath = '';
     try {
       if (optionsFilter.charAt(0) === '^') {
         // move '^' to the first of path
-        filterPath = new RegExp(`^${addTrailingSlash(pagePath)}${optionsFilter.slice(1, optionsFilter.length)}`);
+        filterPath = new RegExp(`^${pagePathForRegexp}${optionsFilter.slice(1, optionsFilter.length)}`);
       }
       else {
-        filterPath = new RegExp(`^${addTrailingSlash(pagePath)}.*${optionsFilter}`);
+        filterPath = new RegExp(`^${pagePathForRegexp}.*${optionsFilter}`);
       }
     }
     catch (err) {


### PR DESCRIPTION
fix #7522 