### PR TITLE
fix: H6 line-height

### DIFF
--- a/packages/app/src/styles/bootstrap/_override.scss
+++ b/packages/app/src/styles/bootstrap/_override.scss
@@ -45,7 +45,7 @@ h5 {
 
 h6 {
   font-size: 12px;
-  line-height: 14px;
+  line-height: 18px;
 }
 
 // Navs


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/119602

# やったこと
<img width="460" alt="スクリーンショット 2023-04-06 14 39 14" src="https://user-images.githubusercontent.com/65263895/230281882-eb405d11-fd88-4b2d-af97-b006fa88bcb5.png">

- _override.scss
- _wiki.scss

2つのファイルのh6に対するスタイル定義が競合していたので、`_override.scss`ファイル内の`line-height`を`14px`から`18px`に変更。今までと同じフォントのサイズで`line-height`を大きくすることで複数行になっても文字が重ならないようにしました。
