### PR TITLE
fix: Show lsx page list in trash page correctly

### DIFF
--- a/packages/remark-lsx/src/server/routes/lsx.ts
+++ b/packages/remark-lsx/src/server/routes/lsx.ts
@@ -194,9 +194,6 @@ export const routesFactory = (crowi): any => {
     const builder = new Page.PageQueryBuilder(baseQuery);
     builder.addConditionToListOnlyDescendants(pagePath);
 
-    builder
-      .addConditionToExcludeTrashed();
-
     return Page.addConditionToFilteringByViewerForList(builder, user);
   }
 


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/120594

# やったこと
- lsxのページリストを取得する際に、ゴミ箱配下を除くコードを削除。ゴミ箱配下でもlsxのページリストが正常に表示されるようにした。

# 備考
- ゴミ箱配下でDescendantsPageListModal の PageList に /trash/foo/bar が表示されない。

上の不具合は再現しなかったので、無視しています。