### PR TITLE
fix: Deleted descendant pages do not appear in search results

### DIFF
--- a/apps/app/src/server/service/page.ts
+++ b/apps/app/src/server/service/page.ts
@@ -1468,6 +1468,9 @@ class PageService {
 
           throw err;
         }
+        finally {
+          this.pageEvent.emit('syncDescendantsUpdate', deletedPage, user);
+        }
       })();
     }
     else {


### PR DESCRIPTION
## Task
[#120476](https://redmine.weseek.co.jp/issues/120476) ゴミ箱に出し入れした際の全文検索のバグを修正する
└ [#120600](https://redmine.weseek.co.jp/issues/120600) 修正 (問題1)