### PR TITLE
fix: Reverted descendant pages do not appear in search results

### DIFF
--- a/apps/app/src/server/service/page.ts
+++ b/apps/app/src/server/service/page.ts
@@ -478,7 +478,7 @@ class PageService {
         throw err;
       }
       if (!isGrantNormalized) {
-        throw Error(`revertDeletedPage to "${newPagePath}" since the selected grant or grantedGroup is not assignable to this page.`);
+        throw Error(`This page cannot be renamed to "${newPagePath}" since the selected grant or grantedGroup is not assignable to this page.`);
       }
     }
 

--- a/apps/app/src/server/service/page.ts
+++ b/apps/app/src/server/service/page.ts
@@ -478,7 +478,7 @@ class PageService {
         throw err;
       }
       if (!isGrantNormalized) {
-        throw Error(`This page cannot be renamed to "${newPagePath}" since the selected grant or grantedGroup is not assignable to this page.`);
+        throw Error(`revertDeletedPage to "${newPagePath}" since the selected grant or grantedGroup is not assignable to this page.`);
       }
     }
 
@@ -2064,6 +2064,7 @@ class PageService {
     await PageTagRelation.updateMany({ relatedPage: page._id }, { $set: { isPageTrashed: false } });
 
     this.pageEvent.emit('revert', page, user);
+    this.pageEvent.emit('create', updatedPage, user);
 
     if (!isRecursively) {
       await this.updateDescendantCountOfAncestors(parent._id, 1, true);
@@ -2100,6 +2101,9 @@ class PageService {
           await PageOperation.deleteOne({ _id: pageOp._id });
 
           throw err;
+        }
+        finally {
+          this.pageEvent.emit('syncDescendantsUpdate', updatedPage, user);
         }
       })();
     }

--- a/apps/app/src/server/service/page.ts
+++ b/apps/app/src/server/service/page.ts
@@ -2093,6 +2093,7 @@ class PageService {
       (async() => {
         try {
           await this.revertRecursivelyMainOperation(page, user, options, pageOp._id, activity);
+          this.pageEvent.emit('syncDescendantsUpdate', updatedPage, user);
         }
         catch (err) {
           logger.error('Error occurred while running revertRecursivelyMainOperation.', err);
@@ -2101,9 +2102,6 @@ class PageService {
           await PageOperation.deleteOne({ _id: pageOp._id });
 
           throw err;
-        }
-        finally {
-          this.pageEvent.emit('syncDescendantsUpdate', updatedPage, user);
         }
       })();
     }

--- a/apps/app/src/server/service/page.ts
+++ b/apps/app/src/server/service/page.ts
@@ -1501,8 +1501,7 @@ class PageService {
         throw err;
       }
     }
-    this.pageEvent.emit('delete', page, user);
-    this.pageEvent.emit('create', deletedPage, user);
+    this.pageEvent.emit('delete', page, deletedPage, user);
 
     return deletedPage;
   }
@@ -1558,8 +1557,7 @@ class PageService {
       }
     }
 
-    this.pageEvent.emit('delete', page, user);
-    this.pageEvent.emit('create', deletedPage, user);
+    this.pageEvent.emit('delete', page, deletedPage, user);
 
     return deletedPage;
   }
@@ -2063,8 +2061,7 @@ class PageService {
 
     await PageTagRelation.updateMany({ relatedPage: page._id }, { $set: { isPageTrashed: false } });
 
-    this.pageEvent.emit('revert', page, user);
-    this.pageEvent.emit('create', updatedPage, user);
+    this.pageEvent.emit('revert', page, updatedPage, user);
 
     if (!isRecursively) {
       await this.updateDescendantCountOfAncestors(parent._id, 1, true);
@@ -2182,7 +2179,7 @@ class PageService {
     }, { new: true });
     await PageTagRelation.updateMany({ relatedPage: page._id }, { $set: { isPageTrashed: false } });
 
-    this.pageEvent.emit('revert', page, user);
+    this.pageEvent.emit('revert', page, updatedPage, user);
 
     return updatedPage;
   }

--- a/apps/app/src/server/service/search.ts
+++ b/apps/app/src/server/service/search.ts
@@ -140,8 +140,14 @@ class SearchService implements SearchQueryParser, SearchResolver {
     const pageEvent = this.crowi.event('page');
     pageEvent.on('create', this.fullTextSearchDelegator.syncPageUpdated.bind(this.fullTextSearchDelegator));
     pageEvent.on('update', this.fullTextSearchDelegator.syncPageUpdated.bind(this.fullTextSearchDelegator));
-    pageEvent.on('delete', this.fullTextSearchDelegator.syncPageDeleted.bind(this.fullTextSearchDelegator));
-    pageEvent.on('revert', this.fullTextSearchDelegator.syncPageDeleted.bind(this.fullTextSearchDelegator));
+    pageEvent.on('delete', (targetPage, deletedPage, user) => {
+      this.fullTextSearchDelegator.syncPageDeleted.bind(this.fullTextSearchDelegator)(targetPage, user);
+      this.fullTextSearchDelegator.syncPageUpdated.bind(this.fullTextSearchDelegator)(deletedPage, user);
+    });
+    pageEvent.on('revert', (targetPage, revertedPage, user) => {
+      this.fullTextSearchDelegator.syncPageDeleted.bind(this.fullTextSearchDelegator)(targetPage, user);
+      this.fullTextSearchDelegator.syncPageUpdated.bind(this.fullTextSearchDelegator)(revertedPage, user);
+    });
     pageEvent.on('deleteCompletely', this.fullTextSearchDelegator.syncPageDeleted.bind(this.fullTextSearchDelegator));
     pageEvent.on('syncDescendantsDelete', this.fullTextSearchDelegator.syncDescendantsPagesDeleted.bind(this.fullTextSearchDelegator));
     pageEvent.on('updateMany', this.fullTextSearchDelegator.syncPagesUpdated.bind(this.fullTextSearchDelegator));

--- a/apps/app/test/integration/service/page.test.js
+++ b/apps/app/test/integration/service/page.test.js
@@ -666,8 +666,7 @@ describe('PageService', () => {
       expect(resultPage.updatedAt).toEqual(parentForDelete1.updatedAt);
       expect(resultPage.lastUpdateUser).toEqual(testUser1._id);
 
-      expect(pageEventSpy).toHaveBeenCalledWith('delete', parentForDelete1, testUser2);
-      expect(pageEventSpy).toHaveBeenCalledWith('create', resultPage, testUser2);
+      expect(pageEventSpy).toHaveBeenCalledWith('delete', parentForDelete1, resultPage, testUser2);
     });
 
     test('delete page with isRecursively', async() => {
@@ -686,8 +685,7 @@ describe('PageService', () => {
       expect(resultPage.updatedAt).toEqual(parentForDelete2.updatedAt);
       expect(resultPage.lastUpdateUser).toEqual(testUser1._id);
 
-      expect(pageEventSpy).toHaveBeenCalledWith('delete', parentForDelete2, testUser2);
-      expect(pageEventSpy).toHaveBeenCalledWith('create', resultPage, testUser2);
+      expect(pageEventSpy).toHaveBeenCalledWith('delete', parentForDelete2, resultPage, testUser2);
     });
 
 


### PR DESCRIPTION
## Task
[#120476](https://redmine.weseek.co.jp/issues/120476) ゴミ箱に出し入れした際の全文検索のバグを修正する
└ [#120723](https://redmine.weseek.co.jp/issues/120723) 修正 (問題2)