### PR TITLE
fix: List only files in the namespace in GCS

### DIFF
--- a/apps/app/src/server/service/file-uploader/gcs.js
+++ b/apps/app/src/server/service/file-uploader/gcs.js
@@ -201,7 +201,9 @@ module.exports = function(crowi) {
 
     const gcs = getGcsInstance();
     const bucket = gcs.bucket(getGcsBucket());
-    const [files] = await bucket.getFiles();
+    const [files] = await bucket.getFiles({
+      prefix: configManager.getConfig('crowi', 'gcs:uploadNamespace'),
+    });
 
     return files.map(({ name, metadata: { size } }) => {
       return { name, size };


### PR DESCRIPTION
g2g transferで移行先のGCS bucketに既あるファイルと同名ファイルを移行対象から除外する機能があるが、移行対象から除外するファイルを使用中のnamespace内のファイルに限定する

https://redmine.weseek.co.jp/issues/120654