### PR TITLE
fix: Not display page list count badge in trash page

### DIFF
--- a/apps/app/src/components/PageSideContents.tsx
+++ b/apps/app/src/components/PageSideContents.tsx
@@ -14,7 +14,7 @@ import TableOfContents from './TableOfContents';
 import styles from './PageSideContents.module.scss';
 
 
-const { isTopPage, isUsersHomePage } = pagePathUtils;
+const { isTopPage, isUsersHomePage, isTrashPage } = pagePathUtils;
 
 
 export type PageSideContentsProps = {
@@ -32,6 +32,7 @@ export const PageSideContents = (props: PageSideContentsProps): JSX.Element => {
   const pagePath = page.path;
   const isTopPagePath = isTopPage(pagePath);
   const isUsersHomePagePath = isUsersHomePage(pagePath);
+  const isTrash = isTrashPage(pagePath);
 
   return (
     <>
@@ -48,7 +49,9 @@ export const PageSideContents = (props: PageSideContentsProps): JSX.Element => {
               <PageListIcon />
             </div>
             {t('page_list')}
-            <CountBadge count={page?.descendantCount} offset={1} />
+
+            {/* Do not display CountBadge if '/trash/*' */}
+            { !isTrash ? <CountBadge count={page?.descendantCount} offset={1} /> : <div className='px-2'></div>}
           </button>
         )}
       </div>


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/120917

# やったこと
- ゴミ箱配下のページにはページリストのカウントバッジを表示しない仕様に変更