### PR TITLE
imprv: Replaced by IAttachmentHasId

### DIFF
--- a/apps/app/src/components/PageAttachment.tsx
+++ b/apps/app/src/components/PageAttachment.tsx
@@ -2,7 +2,7 @@ import React, {
   useCallback, useMemo, useState,
 } from 'react';
 
-import { HasObjectId, IAttachment } from '@growi/core';
+import { IAttachmentHasId } from '@growi/core';
 
 import { useSWRxAttachments } from '~/stores/attachment';
 import { useIsGuestUser } from '~/stores/context';
@@ -28,7 +28,7 @@ const PageAttachment = (): JSX.Element => {
 
   // States
   const [pageNumber, setPageNumber] = useState(1);
-  const [attachmentToDelete, setAttachmentToDelete] = useState<(IAttachment & HasObjectId) | null>(null);
+  const [attachmentToDelete, setAttachmentToDelete] = useState<(IAttachmentHasId) | null>(null);
   const [deleting, setDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState('');
 
@@ -58,7 +58,7 @@ const PageAttachment = (): JSX.Element => {
     setAttachmentToDelete(attachment);
   }, []);
 
-  const onAttachmentDeleteClickedConfirmHandler = useCallback(async(attachment: IAttachment & HasObjectId) => {
+  const onAttachmentDeleteClickedConfirmHandler = useCallback(async(attachment: IAttachmentHasId) => {
     setDeleting(true);
 
     try {

--- a/apps/app/src/components/PageAttachment/DeleteAttachmentModal.tsx
+++ b/apps/app/src/components/PageAttachment/DeleteAttachmentModal.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/prop-types */
 import React, { useCallback } from 'react';
 
-import { HasObjectId, IAttachment } from '@growi/core';
+import { IAttachmentHasId } from '@growi/core';
 import { UserPicture } from '@growi/ui/dist/components/User/UserPicture';
 import {
   Button,
@@ -25,10 +25,10 @@ function iconNameByFormat(format: string): string {
 type Props = {
   isOpen: boolean,
   toggle: () => void,
-  attachmentToDelete: IAttachment & HasObjectId | null,
+  attachmentToDelete: IAttachmentHasId | null,
   deleting: boolean,
   deleteError: string,
-  onAttachmentDeleteClickedConfirm?: (attachment: IAttachment & HasObjectId) => Promise<void>,
+  onAttachmentDeleteClickedConfirm?: (attachment: IAttachmentHasId) => Promise<void>,
 }
 
 export const DeleteAttachmentModal = (props: Props): JSX.Element => {

--- a/apps/app/src/components/PageAttachment/PageAttachmentList.tsx
+++ b/apps/app/src/components/PageAttachment/PageAttachmentList.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 
-import { HasObjectId, IAttachment } from '@growi/core';
+import { IAttachmentHasId } from '@growi/core';
 import { Attachment } from '@growi/ui/dist/components/Attachment';
 import { useTranslation } from 'next-i18next';
 
 type Props = {
-  attachments: (IAttachment & HasObjectId)[],
+  attachments: (IAttachmentHasId)[],
   inUse: { [id: string]: boolean },
-  onAttachmentDeleteClicked?: (attachment: IAttachment & HasObjectId) => void,
+  onAttachmentDeleteClicked?: (attachment: IAttachmentHasId) => void,
   isUserLoggedIn?: boolean,
 }
 

--- a/apps/app/src/interfaces/attachment.ts
+++ b/apps/app/src/interfaces/attachment.ts
@@ -1,8 +1,8 @@
-import type { HasObjectId, IAttachment } from '@growi/core';
+import type { IAttachmentHasId } from '@growi/core';
 
 import type { PaginateResult } from './mongoose-utils';
 
 
 export type IResAttachmentList = {
-  paginateResult: PaginateResult<IAttachment & HasObjectId>
+  paginateResult: PaginateResult<IAttachmentHasId>
 };

--- a/apps/app/src/stores/attachment.tsx
+++ b/apps/app/src/stores/attachment.tsx
@@ -1,8 +1,7 @@
 import { useCallback } from 'react';
 
 import {
-  HasObjectId,
-  IAttachment, Nullable, type SWRResponseWithUtils, withUtils,
+  IAttachmentHasId, Nullable, type SWRResponseWithUtils, withUtils,
 } from '@growi/core';
 import useSWR from 'swr';
 
@@ -15,7 +14,7 @@ type Util = {
 };
 
 type IDataAttachmentList = {
-  attachments: (IAttachment & HasObjectId)[]
+  attachments: (IAttachmentHasId)[]
   totalAttachments: number
   limit: number
 };

--- a/packages/ui/src/components/Attachment.tsx
+++ b/packages/ui/src/components/Attachment.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 
-import { HasObjectId, IAttachment } from '@growi/core';
+import { IAttachmentHasId } from '@growi/core';
 
 import { UserPicture } from './User/UserPicture';
 
 type AttachmentProps = {
-  attachment: IAttachment & HasObjectId,
+  attachment: IAttachmentHasId,
   inUse: boolean,
-  onAttachmentDeleteClicked?: (attachment: IAttachment & HasObjectId) => void,
+  onAttachmentDeleteClicked?: (attachment: IAttachmentHasId) => void,
   isUserLoggedIn?: boolean,
 };
 


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/120922

# 概要
`IAttachment & HasObjectId` が使用されている箇所を `IAttachmentHasId` に置き換える。