### PR TITLE
fix: Revision schema migration for v5 to v6

### DIFF
--- a/apps/app/src/migrations/20211227060705-revision-path-to-page-id-schema-migration--fixed-7549.js
+++ b/apps/app/src/migrations/20211227060705-revision-path-to-page-id-schema-migration--fixed-7549.js
@@ -9,7 +9,7 @@ import { getModelSafely, getMongoUri, mongoOptions } from '~/server/util/mongoos
 import loggerFactory from '~/utils/logger';
 
 
-const logger = loggerFactory('growi:migrate:revision-path-to-page-id-schema-migration');
+const logger = loggerFactory('growi:migrate:revision-path-to-page-id-schema-migration--fixed-7549');
 
 const LIMIT = 300;
 

--- a/turbo.json
+++ b/turbo.json
@@ -90,7 +90,7 @@
     },
     "@growi/app#dev:migrate": {
       "outputs": ["tmp/cache/migration-status.out"],
-      "inputs": ["src/migration/*.js"],
+      "inputs": ["src/migrations/*.js"],
       "outputMode": "new-only"
     },
     "@growi/app#dev:styles-prebuilt": {


### PR DESCRIPTION
- append `pageId` to all revisions that have `path: page.path`
- fix #7549
