### PR TITLE
feat: Add Mermaid diagrams (/Sandbox/Diagrams)

### DIFF
--- a/apps/app/resource/locales/en_US/sandbox-diagrams.md
+++ b/apps/app/resource/locales/en_US/sandbox-diagrams.md
@@ -293,7 +293,7 @@ packetdiag {
 
 # :pencil: Mermaid
 
-## Pie chart diagrams
+## Pie chart diagram
 
 ```mermaid
 %%{init: {"pie": {"textPosition": 0.5}, "themeVariables": {"pieOuterStrokeWidth": "5px"}} }%%
@@ -305,7 +305,7 @@ pie showData
     "Iron" :  5
 ```
 
-## Gantt diagrams
+## Gantt diagram
 
 ```mermaid
 gantt
@@ -319,7 +319,7 @@ gantt
     another task      : 24d
 ```
 
-## Gitgraph Diagrams
+## Gitgraph diagram
 
 ```mermaid
 %%{init: { 'logLevel': 'debug', 'theme': 'base', 'gitGraph': {'rotateCommitLabel': true}} }%%
@@ -340,7 +340,7 @@ gitGraph
   commit
 ```
 
-## Mindmaps
+## Mindmap diagram
 
 ```mermaid
 mindmap

--- a/apps/app/resource/locales/en_US/sandbox-diagrams.md
+++ b/apps/app/resource/locales/en_US/sandbox-diagrams.md
@@ -290,3 +290,74 @@ packetdiag {
 :::
 
 </div>
+
+# :pencil: Mermaid
+
+## Pie chart diagrams
+
+```mermaid
+%%{init: {"pie": {"textPosition": 0.5}, "themeVariables": {"pieOuterStrokeWidth": "5px"}} }%%
+pie showData
+    title Key elements in Product X
+    "Calcium" : 42.96
+    "Potassium" : 50.05
+    "Magnesium" : 10.01
+    "Iron" :  5
+```
+
+## Gantt diagrams
+
+```mermaid
+gantt
+    title A Gantt Diagram
+    dateFormat  YYYY-MM-DD
+    section Section
+    A task           :a1, 2014-01-01, 30d
+    Another task     :after a1  , 20d
+    section Another
+    Task in sec      :2014-01-12  , 12d
+    another task      : 24d
+```
+
+## Gitgraph Diagrams
+
+```mermaid
+%%{init: { 'logLevel': 'debug', 'theme': 'base', 'gitGraph': {'rotateCommitLabel': true}} }%%
+gitGraph
+  commit id: "feat(api): ..."
+  commit id: "a"
+  commit id: "b"
+  commit id: "fix(client): .extra long label.."
+  branch c2
+  commit id: "feat(modules): ..."
+  commit id: "test(client): ..."
+  checkout main
+  commit id: "fix(api): ..."
+  commit id: "ci: ..."
+  branch b1
+  commit
+  branch b2
+  commit
+```
+
+## Mindmaps
+
+```mermaid
+mindmap
+  root((mindmap))
+    Origins
+      Long history
+      ::icon(fa fa-book)
+      Popularisation
+        British popular psychology author Tony Buzan
+    Research
+      On effectiveness<br/>and features
+      On Automatic creation
+        Uses
+            Creative techniques
+            Strategic planning
+            Argument mapping
+    Tools
+      Pen and paper
+      Mermaid
+```

--- a/apps/app/resource/locales/ja_JP/sandbox-diagrams.md
+++ b/apps/app/resource/locales/ja_JP/sandbox-diagrams.md
@@ -289,3 +289,74 @@ packetdiag {
 :::
 
 </div>
+
+# :pencil: Mermaid
+
+## 円グラフ
+
+```mermaid
+%%{init: {"pie": {"textPosition": 0.5}, "themeVariables": {"pieOuterStrokeWidth": "5px"}} }%%
+pie showData
+    title Key elements in Product X
+    "Calcium" : 42.96
+    "Potassium" : 50.05
+    "Magnesium" : 10.01
+    "Iron" :  5
+```
+
+## ガントチャート
+
+```mermaid
+gantt
+    title A Gantt Diagram
+    dateFormat  YYYY-MM-DD
+    section Section
+    A task           :a1, 2014-01-01, 30d
+    Another task     :after a1  , 20d
+    section Another
+    Task in sec      :2014-01-12  , 12d
+    another task      : 24d
+```
+
+## Git 樹形図
+
+```mermaid
+%%{init: { 'logLevel': 'debug', 'theme': 'base', 'gitGraph': {'rotateCommitLabel': true}} }%%
+gitGraph
+  commit id: "feat(api): ..."
+  commit id: "a"
+  commit id: "b"
+  commit id: "fix(client): .extra long label.."
+  branch c2
+  commit id: "feat(modules): ..."
+  commit id: "test(client): ..."
+  checkout main
+  commit id: "fix(api): ..."
+  commit id: "ci: ..."
+  branch b1
+  commit
+  branch b2
+  commit
+```
+
+## マインドマップ
+
+```mermaid
+mindmap
+  root((mindmap))
+    Origins
+      Long history
+      ::icon(fa fa-book)
+      Popularisation
+        British popular psychology author Tony Buzan
+    Research
+      On effectiveness<br/>and features
+      On Automatic creation
+        Uses
+            Creative techniques
+            Strategic planning
+            Argument mapping
+    Tools
+      Pen and paper
+      Mermaid
+```

--- a/apps/app/resource/locales/zh_CN/sandbox-diagrams.md
+++ b/apps/app/resource/locales/zh_CN/sandbox-diagrams.md
@@ -290,3 +290,75 @@ packetdiag {
 :::
 
 </div>
+
+
+# :pencil: Mermaid
+
+## Pie chart diagrams
+
+```mermaid
+%%{init: {"pie": {"textPosition": 0.5}, "themeVariables": {"pieOuterStrokeWidth": "5px"}} }%%
+pie showData
+    title Key elements in Product X
+    "Calcium" : 42.96
+    "Potassium" : 50.05
+    "Magnesium" : 10.01
+    "Iron" :  5
+```
+
+## Gantt diagrams
+
+```mermaid
+gantt
+    title A Gantt Diagram
+    dateFormat  YYYY-MM-DD
+    section Section
+    A task           :a1, 2014-01-01, 30d
+    Another task     :after a1  , 20d
+    section Another
+    Task in sec      :2014-01-12  , 12d
+    another task      : 24d
+```
+
+## Gitgraph Diagrams
+
+```mermaid
+%%{init: { 'logLevel': 'debug', 'theme': 'base', 'gitGraph': {'rotateCommitLabel': true}} }%%
+gitGraph
+  commit id: "feat(api): ..."
+  commit id: "a"
+  commit id: "b"
+  commit id: "fix(client): .extra long label.."
+  branch c2
+  commit id: "feat(modules): ..."
+  commit id: "test(client): ..."
+  checkout main
+  commit id: "fix(api): ..."
+  commit id: "ci: ..."
+  branch b1
+  commit
+  branch b2
+  commit
+```
+
+## Mindmaps
+
+```mermaid
+mindmap
+  root((mindmap))
+    Origins
+      Long history
+      ::icon(fa fa-book)
+      Popularisation
+        British popular psychology author Tony Buzan
+    Research
+      On effectiveness<br/>and features
+      On Automatic creation
+        Uses
+            Creative techniques
+            Strategic planning
+            Argument mapping
+    Tools
+      Pen and paper
+      Mermaid
+```

--- a/apps/app/resource/locales/zh_CN/sandbox-diagrams.md
+++ b/apps/app/resource/locales/zh_CN/sandbox-diagrams.md
@@ -294,7 +294,7 @@ packetdiag {
 
 # :pencil: Mermaid
 
-## Pie chart diagrams
+## Pie chart diagram
 
 ```mermaid
 %%{init: {"pie": {"textPosition": 0.5}, "themeVariables": {"pieOuterStrokeWidth": "5px"}} }%%
@@ -306,7 +306,7 @@ pie showData
     "Iron" :  5
 ```
 
-## Gantt diagrams
+## Gantt diagram
 
 ```mermaid
 gantt
@@ -320,7 +320,7 @@ gantt
     another task      : 24d
 ```
 
-## Gitgraph Diagrams
+## Gitgraph diagram
 
 ```mermaid
 %%{init: { 'logLevel': 'debug', 'theme': 'base', 'gitGraph': {'rotateCommitLabel': true}} }%%
@@ -341,7 +341,7 @@ gitGraph
   commit
 ```
 
-## Mindmaps
+## Mindmap diagram
 
 ```mermaid
 mindmap


### PR DESCRIPTION
## Task
[#121660](https://redmine.weseek.co.jp/issues/121660) [GROWI] mermaid 記法が利用できる
└ [#122347](https://redmine.weseek.co.jp/issues/122347) /Sandbox/Disagrams に mermaid 記法を追加

## Screenshot
![screencapture-localhost-3000-646351a9518ac18658f4ea41-2023-05-16-19_18_02](https://github.com/weseek/growi/assets/34241526/8d97e21e-6b74-4a86-9df9-b213111ba11d)
