### PR TITLE
fix: Other people's bookmarks are displayed in your bookmark tree

### DIFF
--- a/apps/app/src/server/models/bookmark-folder.ts
+++ b/apps/app/src/server/models/bookmark-folder.ts
@@ -199,6 +199,7 @@ bookmarkFolderSchema.statics.findUserRootBookmarksItem = async function(userId: 
   const bookmarkIdsInFolders = await this.distinct('bookmarks', { owner: userId });
   const userRootBookmarks: MyBookmarkList = await Bookmark.find({
     _id: { $nin: bookmarkIdsInFolders },
+    user: userId,
   }).populate({
     path: 'page',
     model: 'Page',


### PR DESCRIPTION
## Task
[#122357](https://redmine.weseek.co.jp/issues/122357) [GROWI] 別ユーザーの bookmark がページツリーに表示される
└ [#122362](https://redmine.weseek.co.jp/issues/122362) 修正