### PR TITLE
fix: migration script for plantuml

### DIFF
--- a/bin/data-migrations/src/migrations/v60x/plantuml.js
+++ b/bin/data-migrations/src/migrations/v60x/plantuml.js
@@ -7,7 +7,7 @@ module.exports = [
    * @type {MigrationModule}
    */
   (body) => {
-    const oldDrawioRegExp = /:::\s?drawio\n(.+?)\n:::/g; // drawio old format
-    return body.replace(oldDrawioRegExp, '``` drawio\n$1\n```');
+    const oldPlantUmlRegExp = /@startuml\n([\s\S]*?)\n@enduml/g; // plantUML old format
+    return body.replace(oldPlantUmlRegExp, '``` plantuml\n$1\n```');
   },
 ];


### PR DESCRIPTION
PlantUML用のマイグレーションスクリプトの内容がdrawio用のものと同様になっていて期待通りのマイグレーションが実施できていなかったため、 #7694 適用前のprocessor.jsを参考に修正しました。
