### PR TITLE
Imprv: Send new password email

### DIFF
--- a/apps/app/public/static/locales/en_US/admin.json
+++ b/apps/app/public/static/locales/en_US/admin.json
@@ -757,8 +757,7 @@
       "password_reset_message": "Let the user know the new password below and strongly recommend to change another one immediately.",
       "send_new_password": "Please send the new password to the user.",
       "target_user": "Target User",
-      "new_password": "New Password",
-      "mail_setting_link":"<i class='icon-settings mr-2'></i><a href='/admin/app'>Email settings</a>"
+      "new_password": "New Password"
     },
     "external_account": "External Account Management",
     "external_accounts":"External accounts",

--- a/apps/app/public/static/locales/en_US/admin.json
+++ b/apps/app/public/static/locales/en_US/admin.json
@@ -758,10 +758,7 @@
       "send_new_password": "Please send the new password to the user.",
       "target_user": "Target User",
       "new_password": "New Password",
-      "send_password_email": "Send the password to user",
-      "mail_setting_link":"<i class='icon-settings mr-2'></i><a href='/admin/app'>Email settings</a>",
-      "show_password": "Click to show password",
-      "hide_password": "hide"
+      "mail_setting_link":"<i class='icon-settings mr-2'></i><a href='/admin/app'>Email settings</a>"
     },
     "external_account": "External Account Management",
     "external_accounts":"External accounts",

--- a/apps/app/public/static/locales/ja_JP/admin.json
+++ b/apps/app/public/static/locales/ja_JP/admin.json
@@ -765,8 +765,7 @@
       "password_reset_message": "対象ユーザーに下記のパスワードを伝え、すぐに新しく別のパスワードを設定するよう伝えてください。",
       "send_new_password": "新規発行したパスワードを、対象ユーザーへ連絡してください。",
       "target_user": "対象ユーザー",
-      "new_password": "新しいパスワード",
-      "mail_setting_link": "<i class='icon-settings mr-2'></i><a href='/admin/app'>メールの設定</a>"
+      "new_password": "新しいパスワード"
     },
     "external_account": "外部アカウントの管理",
     "external_accounts": "外部アカウント",

--- a/apps/app/public/static/locales/ja_JP/admin.json
+++ b/apps/app/public/static/locales/ja_JP/admin.json
@@ -766,10 +766,7 @@
       "send_new_password": "新規発行したパスワードを、対象ユーザーへ連絡してください。",
       "target_user": "対象ユーザー",
       "new_password": "新しいパスワード",
-      "send_password_email": "メールを送信する",
-      "mail_setting_link": "<i class='icon-settings mr-2'></i><a href='/admin/app'>メールの設定</a>",
-      "show_password": "クリックしてパスワードを表示",
-      "hide_password": "非表示"
+      "mail_setting_link": "<i class='icon-settings mr-2'></i><a href='/admin/app'>メールの設定</a>"
     },
     "external_account": "外部アカウントの管理",
     "external_accounts": "外部アカウント",

--- a/apps/app/public/static/locales/zh_CN/admin.json
+++ b/apps/app/public/static/locales/zh_CN/admin.json
@@ -766,10 +766,7 @@
       "send_new_password": "Please send the new password to the user.",
       "target_user": "Target User",
       "new_password": "New Password",
-      "send_password_email": "Send the password to user",
-      "mail_setting_link":"<i class='icon-settings mr-2'></i><a href='/admin/app'>Email settings</a>",
-      "show_password": "Click to show password",
-      "hide_password": "hide"
+      "mail_setting_link":"<i class='icon-settings mr-2'></i><a href='/admin/app'>Email settings</a>"
     },
     "external_account": "外部账户管理",
     "external_accounts": "外部账户",

--- a/apps/app/public/static/locales/zh_CN/admin.json
+++ b/apps/app/public/static/locales/zh_CN/admin.json
@@ -765,8 +765,7 @@
       "password_reset_message": "Let the user know the new password below and strongly recommend to change another one immediately.",
       "send_new_password": "Please send the new password to the user.",
       "target_user": "Target User",
-      "new_password": "New Password",
-      "mail_setting_link":"<i class='icon-settings mr-2'></i><a href='/admin/app'>Email settings</a>"
+      "new_password": "New Password"
     },
     "external_account": "外部账户管理",
     "external_accounts": "外部账户",

--- a/apps/app/src/components/Admin/Users/PasswordResetModal.jsx
+++ b/apps/app/src/components/Admin/Users/PasswordResetModal.jsx
@@ -21,7 +21,6 @@ class PasswordResetModal extends React.Component {
       temporaryPassword: [],
       isPasswordResetDone: false,
       sendEmail: false,
-      isCreateUserButtonPushed: false,
     };
 
     this.resetPassword = this.resetPassword.bind(this);
@@ -38,6 +37,21 @@ class PasswordResetModal extends React.Component {
     catch (err) {
       toastError(err);
     }
+  }
+
+  renderButtons() {
+    const { t, isMailerSetup } = this.props;
+
+    return (
+      <>
+        <button type="submit" className="btn btn-primary" onClick={this.onClickSendNewPasswordButton} disabled={!isMailerSetup}>
+          {t('Send')}
+        </button>
+        <button type="submit" className="btn btn-danger" onClick={this.props.onClose}>
+          {t('Close')}
+        </button>
+      </>
+    );
   }
 
   renderModalBodyBeforeReset() {
@@ -89,16 +103,7 @@ class PasswordResetModal extends React.Component {
           <div>
             <label className="form-text text-muted" dangerouslySetInnerHTML={{ __html: t('admin:mailer_setup_required') }} />
           </div>
-          <div>
-            <button type="submit" className="btn btn-primary" onClick={this.onClickSendNewPasswordButton} disabled={!isMailerSetup}>
-              {t('Send')}
-            </button>
-          </div>
-          <div>
-            <button type="submit" className="btn btn-danger" onClick={this.props.onClose}>
-              {t('Close')}
-            </button>
-          </div>
+          {this.renderButtons()}
         </>
       );
     }
@@ -109,16 +114,7 @@ class PasswordResetModal extends React.Component {
           <p className="mb-0">{userForPasswordResetModal.username}</p>
           <p className="mb-0">{userForPasswordResetModal.email}</p>
         </div>
-        <div>
-          <button type="submit" className="btn btn-primary" onClick={this.onClickSendNewPasswordButton} disabled={!isMailerSetup}>
-            {t('Send')}
-          </button>
-        </div>
-        <div>
-          <button type="submit" className="btn btn-danger" onClick={this.props.onClose}>
-            {t('Close')}
-          </button>
-        </div>
+        {this.renderButtons()}
       </>
     );
   }
@@ -131,7 +127,7 @@ class PasswordResetModal extends React.Component {
 
 
     try {
-      const res = await apiv3Put('/users/reset-password-email', { id: userForPasswordResetModal._id });
+      const res = await apiv3Put('/users/reset-password-email', { id: userForPasswordResetModal._id, newPassword: this.state.temporaryPassword });
       const { failedToSendEmail } = res.data;
       if (failedToSendEmail == null) {
         const msg = `Email has been sent ${userForPasswordResetModal.email}`;
@@ -144,9 +140,6 @@ class PasswordResetModal extends React.Component {
     }
     catch (err) {
       toastError(err);
-    }
-    finally {
-      this.setState({ isCreateUserButtonPushed: false });
     }
   }
 

--- a/apps/app/src/components/Admin/Users/PasswordResetModal.jsx
+++ b/apps/app/src/components/Admin/Users/PasswordResetModal.jsx
@@ -26,6 +26,7 @@ class PasswordResetModal extends React.Component {
     this.onClickSendNewPasswordButton = this.onClickSendNewPasswordButton.bind(this);
   }
 
+  // Reset Password
   async resetPassword() {
     const { t, userForPasswordResetModal } = this.props;
     try {

--- a/apps/app/src/components/Admin/Users/PasswordResetModal.jsx
+++ b/apps/app/src/components/Admin/Users/PasswordResetModal.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { useTranslation } from 'next-i18next';
 import PropTypes from 'prop-types';
 import {
-  Modal, ModalHeader, ModalBody, ModalFooter, Collapse,
+  Modal, ModalHeader, ModalBody, ModalFooter,
 } from 'reactstrap';
 
 import AdminUsersContainer from '~/client/services/AdminUsersContainer';
@@ -22,12 +22,10 @@ class PasswordResetModal extends React.Component {
       isPasswordResetDone: false,
       sendEmail: false,
       isCreateUserButtonPushed: false,
-      collapse: false,
     };
 
     this.resetPassword = this.resetPassword.bind(this);
     this.onClickSendNewPasswordButton = this.onClickSendNewPasswordButton.bind(this);
-    this.toggle = this.toggle.bind(this);
   }
 
   async resetPassword() {
@@ -40,10 +38,6 @@ class PasswordResetModal extends React.Component {
     catch (err) {
       toastError(err);
     }
-  }
-
-  toggle() {
-    this.setState({ collapse: !this.state.collapse });
   }
 
   renderModalBodyBeforeReset() {

--- a/apps/app/src/components/Admin/Users/PasswordResetModal.jsx
+++ b/apps/app/src/components/Admin/Users/PasswordResetModal.jsx
@@ -137,12 +137,7 @@ class PasswordResetModal extends React.Component {
 
 
     try {
-      const res = await apiv3Put('/users/reset-password-email', { id: userForPasswordResetModal._id, newPassword: this.state.temporaryPassword });
-      const { failedToSendEmail } = res.data;
-      if (failedToSendEmail !== undefined) {
-        const msg = `reason: ${failedToSendEmail}`;
-        toastError(msg);
-      }
+      await apiv3Put('/users/reset-password-email', { id: userForPasswordResetModal._id, newPassword: this.state.temporaryPassword });
     }
     catch (err) {
       toastError(err);

--- a/apps/app/src/components/Admin/Users/PasswordResetModal.jsx
+++ b/apps/app/src/components/Admin/Users/PasswordResetModal.jsx
@@ -8,8 +8,8 @@ import {
 
 import AdminUsersContainer from '~/client/services/AdminUsersContainer';
 import { apiv3Put } from '~/client/util/apiv3-client';
-import { toastError } from '~/client/util/toastr';
-
+import { toastSuccess, toastError } from '~/client/util/toastr';
+import { useIsMailerSetup } from '~/stores/context';
 
 class PasswordResetModal extends React.Component {
 
@@ -175,7 +175,8 @@ class PasswordResetModal extends React.Component {
 
 const PasswordResetModalWrapperFC = (props) => {
   const { t } = useTranslation('admin');
-  return <PasswordResetModal t={t} {...props} />;
+  const { data: isMailerSetup } = useIsMailerSetup();
+  return <PasswordResetModal t={t} isMailerSetup={isMailerSetup ?? false} {...props} />;
 };
 
 /**

--- a/apps/app/src/components/Admin/Users/PasswordResetModal.jsx
+++ b/apps/app/src/components/Admin/Users/PasswordResetModal.jsx
@@ -26,7 +26,6 @@ class PasswordResetModal extends React.Component {
     this.onClickSendNewPasswordButton = this.onClickSendNewPasswordButton.bind(this);
   }
 
-  // Reset Password
   async resetPassword() {
     const { t, userForPasswordResetModal } = this.props;
     try {

--- a/apps/app/src/components/Admin/Users/PasswordResetModal.jsx
+++ b/apps/app/src/components/Admin/Users/PasswordResetModal.jsx
@@ -139,12 +139,8 @@ class PasswordResetModal extends React.Component {
     try {
       const res = await apiv3Put('/users/reset-password-email', { id: userForPasswordResetModal._id, newPassword: this.state.temporaryPassword });
       const { failedToSendEmail } = res.data;
-      if (failedToSendEmail == null) {
-        const msg = `Email has been sent ${userForPasswordResetModal.email}`;
-        toastSuccess(msg);
-      }
-      else {
-        const msg = { message: `email: ${failedToSendEmail.email} reason: ${failedToSendEmail.reason}` };
+      if (failedToSendEmail !== undefined) {
+        const msg = `reason: ${failedToSendEmail}`;
         toastError(msg);
       }
     }

--- a/apps/app/src/components/Admin/Users/PasswordResetModal.jsx
+++ b/apps/app/src/components/Admin/Users/PasswordResetModal.jsx
@@ -8,7 +8,7 @@ import {
 
 import AdminUsersContainer from '~/client/services/AdminUsersContainer';
 import { apiv3Put } from '~/client/util/apiv3-client';
-import { toastSuccess, toastError } from '~/client/util/toastr';
+import { toastError } from '~/client/util/toastr';
 import { useIsMailerSetup } from '~/stores/context';
 
 class PasswordResetModal extends React.Component {
@@ -19,7 +19,6 @@ class PasswordResetModal extends React.Component {
     this.state = {
       temporaryPassword: [],
       isPasswordResetDone: false,
-      sendEmail: false,
     };
 
     this.resetPassword = this.resetPassword.bind(this);

--- a/apps/app/src/components/Admin/Users/PasswordResetModal.jsx
+++ b/apps/app/src/components/Admin/Users/PasswordResetModal.jsx
@@ -144,7 +144,7 @@ class PasswordResetModal extends React.Component {
         toastSuccess(msg);
       }
       else {
-        const msg = { message: `email: ${failedToSendEmail.email}<br>reason: ${failedToSendEmail.reason}` };
+        const msg = { message: `email: ${failedToSendEmail.email} reason: ${failedToSendEmail.reason}` };
         toastError(msg);
       }
     }

--- a/apps/app/src/server/routes/apiv3/users.js
+++ b/apps/app/src/server/routes/apiv3/users.js
@@ -185,7 +185,7 @@ module.exports = (crowi) => {
   const sendEmailByUser = async(user) => {
     const { appService, mailService } = crowi;
     const appTitle = appService.getAppTitle();
-    const failedToSendNewPasswordEmail = { email: user.email, reazon: '' };
+    const failedToSendNewPasswordEmail = { email: user.email, reason: '' };
 
     try {
       await mailService.send({
@@ -202,7 +202,7 @@ module.exports = (crowi) => {
     }
     catch (err) {
       logger.error(err);
-      failedToSendNewPasswordEmail.reazon = err.message;
+      failedToSendNewPasswordEmail.reason = err.message;
     }
 
     return { failedToSendNewPasswordEmail };
@@ -1024,7 +1024,6 @@ module.exports = (crowi) => {
    *                      type: object
    *                      description: email and reasons for new password email sending failure
    */
-
   router.put('/reset-password-email', loginRequiredStrictly, adminRequired, addActivity, async(req, res) => {
     const { id } = req.body;
 
@@ -1040,7 +1039,7 @@ module.exports = (crowi) => {
 
       const sendEmail = await sendEmailByUser(userInfo);
 
-      return res.apiv3({ user, failedToSendEmail: sendEmail.failedToSendNewPasswordEmail[0] });
+      return res.apiv3({ user, failedToSendEmail: sendEmail.failedToSendNewPasswordEmail });
     }
     catch (err) {
       logger.error('Error', err);

--- a/apps/app/src/server/routes/apiv3/users.js
+++ b/apps/app/src/server/routes/apiv3/users.js
@@ -1004,16 +1004,6 @@ module.exports = (crowi) => {
    *                  user:
    *                    type: string
    *                    description: user id for send new password email
-   *        responses:
-   *          200:
-   *            description: success send new password email
-   *            content:
-   *              application/json:
-   *                schema:
-   *                  properties:
-   *                    failedToSendEmail:
-   *                      type: object
-   *                      description: email and reasons for new password email sending failure
    */
   router.put('/reset-password-email', loginRequiredStrictly, adminRequired, addActivity, async(req, res) => {
     const { id } = req.body;
@@ -1029,7 +1019,6 @@ module.exports = (crowi) => {
       };
 
       await sendEmailByUser(userInfo);
-      return res.apiv3({ user });
     }
     catch (err) {
       const msg = err.message;

--- a/apps/app/src/server/routes/apiv3/users.js
+++ b/apps/app/src/server/routes/apiv3/users.js
@@ -185,10 +185,9 @@ module.exports = (crowi) => {
   const sendEmailByUser = async(user) => {
     const { appService, mailService } = crowi;
     const appTitle = appService.getAppTitle();
-    const failedToSendEmailList = [];
+    const failedToSendNewPasswordEmail = [];
 
     try {
-      // eslint-disable-next-line no-await-in-loop
       await mailService.send({
         to: user.email,
         subject: `New password for ${appTitle}`,
@@ -203,13 +202,13 @@ module.exports = (crowi) => {
     }
     catch (err) {
       logger.error(err);
-      failedToSendEmailList.push({
+      failedToSendNewPasswordEmail.push({
         email: user.email,
         reason: err.message,
       });
     }
 
-    return { failedToSendEmailList };
+    return { failedToSendNewPasswordEmail };
   };
 
   /**
@@ -978,7 +977,7 @@ module.exports = (crowi) => {
    *                    description: user id for reset password
    *        responses:
    *          200:
-   *            description: success resrt password
+   *            description: success reset password
    */
   router.put('/reset-password', loginRequiredStrictly, adminRequired, addActivity, async(req, res) => {
     const { id } = req.body;
@@ -997,6 +996,38 @@ module.exports = (crowi) => {
     }
   });
 
+  /**
+   * @swagger
+   *
+   *  paths:
+   *    /users/reset-password-email:
+   *      put:
+   *        tags: [Users]
+   *        operationId: resetPassword
+   *        summary: /users/reset-password-email
+   *        description: send new password email
+   *        requestBody:
+   *          content:
+   *            application/json:
+   *              schema:
+   *                properties:
+   *                  newPassword:
+   *                    type: string
+   *                  user:
+   *                    type: string
+   *                    description: user id for send new password email
+   *        responses:
+   *          200:
+   *            description: success send new password email
+   *            content:
+   *              application/json:
+   *                schema:
+   *                  properties:
+   *                    failedToSendEmail:
+   *                      type: object
+   *                      description: email and reasons for new password email sending failure
+   */
+
   router.put('/reset-password-email', loginRequiredStrictly, adminRequired, addActivity, async(req, res) => {
     const { id } = req.body;
 
@@ -1012,7 +1043,7 @@ module.exports = (crowi) => {
 
       const sendEmail = await sendEmailByUser(userInfo);
 
-      return res.apiv3({ user, failedToSendEmail: sendEmail.failedToSendEmailList[0] });
+      return res.apiv3({ user, failedToSendEmail: sendEmail.failedToSendNewPasswordEmail[0] });
     }
     catch (err) {
       logger.error('Error', err);

--- a/apps/app/src/server/routes/apiv3/users.js
+++ b/apps/app/src/server/routes/apiv3/users.js
@@ -181,7 +181,6 @@ module.exports = (crowi) => {
     return { failedToSendEmailList };
   };
 
-
   const sendEmailByUser = async(user) => {
     const { appService, mailService } = crowi;
     const appTitle = appService.getAppTitle();
@@ -1004,6 +1003,9 @@ module.exports = (crowi) => {
    *                  user:
    *                    type: string
    *                    description: user id for send new password email
+   *        responses:
+   *          200:
+   *            description: success send new password email
    */
   router.put('/reset-password-email', loginRequiredStrictly, adminRequired, addActivity, async(req, res) => {
     const { id } = req.body;
@@ -1019,6 +1021,7 @@ module.exports = (crowi) => {
       };
 
       await sendEmailByUser(userInfo);
+      return res.apiv3({ user });
     }
     catch (err) {
       const msg = err.message;

--- a/apps/app/src/server/routes/apiv3/users.js
+++ b/apps/app/src/server/routes/apiv3/users.js
@@ -999,19 +999,17 @@ module.exports = (crowi) => {
 
   router.put('/reset-password-email', loginRequiredStrictly, adminRequired, addActivity, async(req, res) => {
     const { id } = req.body;
-    const user = await User.findById(id);
-    const newPassword = await User.resetPasswordByRandomString(id);
 
     try {
+      const user = await User.findById(id);
       const userInfo = {
         email: user.email,
-        password: newPassword,
-        user: { id },
+        password: req.body.newPassword,
       };
 
       const sendEmail = await sendEmailByUser(userInfo);
 
-      return res.apiv3({ newPassword, user, failedToSendEmail: sendEmail.failedToSendEmailList[0] });
+      return res.apiv3({ user, failedToSendEmail: sendEmail.failedToSendEmailList[0] });
     }
     catch (err) {
       logger.error('Error', err);

--- a/apps/app/src/server/routes/apiv3/users.js
+++ b/apps/app/src/server/routes/apiv3/users.js
@@ -1003,7 +1003,7 @@ module.exports = (crowi) => {
    *    /users/reset-password-email:
    *      put:
    *        tags: [Users]
-   *        operationId: resetPassword
+   *        operationId: resetPasswordEmail
    *        summary: /users/reset-password-email
    *        description: send new password email
    *        requestBody:

--- a/apps/app/src/server/routes/apiv3/users.js
+++ b/apps/app/src/server/routes/apiv3/users.js
@@ -1021,7 +1021,6 @@ module.exports = (crowi) => {
       };
 
       await sendEmailByUser(userInfo);
-      return res.apiv3({ user });
     }
     catch (err) {
       const msg = err.message;

--- a/apps/app/src/server/routes/apiv3/users.js
+++ b/apps/app/src/server/routes/apiv3/users.js
@@ -185,7 +185,6 @@ module.exports = (crowi) => {
   const sendEmailByUser = async(user) => {
     const { appService, mailService } = crowi;
     const appTitle = appService.getAppTitle();
-    const failedToSendNewPasswordEmail = { email: user.email, reason: '' };
 
     try {
       await mailService.send({
@@ -201,11 +200,10 @@ module.exports = (crowi) => {
       });
     }
     catch (err) {
+      const failedToSendNewPasswordEmail = { email: user.email, reason: err.message };
       logger.error(err);
-      failedToSendNewPasswordEmail.reason = err.message;
+      return { failedToSendNewPasswordEmail };
     }
-
-    return { failedToSendNewPasswordEmail };
   };
 
   /**

--- a/apps/app/src/server/routes/apiv3/users.js
+++ b/apps/app/src/server/routes/apiv3/users.js
@@ -1002,6 +1002,9 @@ module.exports = (crowi) => {
 
     try {
       const user = await User.findById(id);
+      if (user == null) {
+        throw new Error('User not found');
+      }
       const userInfo = {
         email: user.email,
         password: req.body.newPassword,

--- a/apps/app/src/server/routes/apiv3/users.js
+++ b/apps/app/src/server/routes/apiv3/users.js
@@ -185,27 +185,18 @@ module.exports = (crowi) => {
   const sendEmailByUser = async(user) => {
     const { appService, mailService } = crowi;
     const appTitle = appService.getAppTitle();
-    let failedToSendNewPasswordEmail = null;
 
-    try {
-      await mailService.send({
-        to: user.email,
-        subject: `New password for ${appTitle}`,
-        template: path.join(crowi.localeDir, 'en_US/admin/userResetPassword.txt'),
-        vars: {
-          email: user.email,
-          password: user.password,
-          url: crowi.appService.getSiteUrl(),
-          appTitle,
-        },
-      });
-    }
-    catch (err) {
-      logger.error(err);
-      failedToSendNewPasswordEmail = { email: user.email, reason: err.message };
-    }
-
-    return { failedToSendNewPasswordEmail };
+    await mailService.send({
+      to: user.email,
+      subject: `New password for ${appTitle}`,
+      template: path.join(crowi.localeDir, 'en_US/admin/userResetPassword.txt'),
+      vars: {
+        email: user.email,
+        password: user.password,
+        url: crowi.appService.getSiteUrl(),
+        appTitle,
+      },
+    });
   };
 
   /**
@@ -1037,13 +1028,13 @@ module.exports = (crowi) => {
         password: req.body.newPassword,
       };
 
-      const sendEmail = await sendEmailByUser(userInfo);
-
-      return res.apiv3({ user, failedToSendEmail: sendEmail.failedToSendNewPasswordEmail });
+      await sendEmailByUser(userInfo);
+      return res.apiv3({});
     }
     catch (err) {
+      const msg = err.message;
       logger.error('Error', err);
-      return res.apiv3Err(new ErrorV3(err));
+      return res.apiv3Err(new ErrorV3(msg));
     }
   });
 

--- a/apps/app/src/server/routes/apiv3/users.js
+++ b/apps/app/src/server/routes/apiv3/users.js
@@ -1029,7 +1029,7 @@ module.exports = (crowi) => {
       };
 
       await sendEmailByUser(userInfo);
-      return res.apiv3({});
+      return res.apiv3({ user });
     }
     catch (err) {
       const msg = err.message;

--- a/apps/app/src/server/routes/apiv3/users.js
+++ b/apps/app/src/server/routes/apiv3/users.js
@@ -185,6 +185,7 @@ module.exports = (crowi) => {
   const sendEmailByUser = async(user) => {
     const { appService, mailService } = crowi;
     const appTitle = appService.getAppTitle();
+    let failedToSendNewPasswordEmail = null;
 
     try {
       await mailService.send({
@@ -200,10 +201,11 @@ module.exports = (crowi) => {
       });
     }
     catch (err) {
-      const failedToSendNewPasswordEmail = { email: user.email, reason: err.message };
       logger.error(err);
-      return { failedToSendNewPasswordEmail };
+      failedToSendNewPasswordEmail = { email: user.email, reason: err.message };
     }
+
+    return { failedToSendNewPasswordEmail };
   };
 
   /**

--- a/apps/app/src/server/routes/apiv3/users.js
+++ b/apps/app/src/server/routes/apiv3/users.js
@@ -185,7 +185,7 @@ module.exports = (crowi) => {
   const sendEmailByUser = async(user) => {
     const { appService, mailService } = crowi;
     const appTitle = appService.getAppTitle();
-    const failedToSendNewPasswordEmail = [];
+    const failedToSendNewPasswordEmail = { email: user.email, reazon: '' };
 
     try {
       await mailService.send({
@@ -202,10 +202,7 @@ module.exports = (crowi) => {
     }
     catch (err) {
       logger.error(err);
-      failedToSendNewPasswordEmail.push({
-        email: user.email,
-        reason: err.message,
-      });
+      failedToSendNewPasswordEmail.reazon = err.message;
     }
 
     return { failedToSendNewPasswordEmail };


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/123395
パスワードリセット後、メール設定がされていればメールが送信できるようにしました。
Sendボタン横に宛先を表示しましたが、メールアドレスが長い場合を想定し、usernameとemailを上下に分けました。

<img width="497" alt="スクリーンショット 2023-06-01 16 16 08" src="https://github.com/weseek/growi/assets/112812878/22f76e12-237e-4256-8f43-c134868b600b">
<img width="498" alt="スクリーンショット 2023-06-01 16 16 48" src="https://github.com/weseek/growi/assets/112812878/d819e2c2-77e4-4319-a582-9e5aaa9cb13a">
