### PR TITLE
fix: Unable to execute the migration of draw.io

### DIFF
--- a/bin/data-migrations/src/migrations/v60x/index.js
+++ b/bin/data-migrations/src/migrations/v60x/index.js
@@ -1,6 +1,7 @@
 const bracketlink = require('./bracketlink');
 const csv = require('./csv');
+const drawio = require('./drawio');
 const plantUML = require('./plantuml');
 const tsv = require('./tsv');
 
-module.exports = [...bracketlink, ...csv, ...plantUML, ...tsv];
+module.exports = [...bracketlink, ...csv, ...drawio, ...plantUML, ...tsv];


### PR DESCRIPTION
MIGRATION_MODULE に v60x を指定した時に draw.io のマイグレーションスクリプトが動作しなかった問題の修正