### PR TITLE
imprv: Show spinner after signin

### DIFF
--- a/apps/app/src/components/LoginForm.tsx
+++ b/apps/app/src/components/LoginForm.tsx
@@ -220,11 +220,7 @@ export const LoginForm = (props: LoginFormProps): JSX.Element => {
             <button type="submit" id="login" className="btn btn-fill rounded-0 login mx-auto" data-testid="btnSubmitForLogin" disabled={isLoading}>
               <div className="eff"></div>
               <span className="btn-label">
-                {isLoading ? (
-                  <i className="fa fa-spinner fa-pulse mr-1"></i>
-                ) : (
-                  <i className="icon-login"></i>
-                )}
+                <i className={isLoading ? 'fa fa-spinner fa-pulse mr-1' : 'icon-login'} />
               </span>
               <span className="btn-label-text">{t('Sign in')}</span>
             </button>

--- a/apps/app/src/components/LoginForm.tsx
+++ b/apps/app/src/components/LoginForm.tsx
@@ -233,7 +233,7 @@ export const LoginForm = (props: LoginFormProps): JSX.Element => {
       </>
     );
   }, [generateDangerouslySetErrors, generateSafelySetErrors, handleLoginWithLocalSubmit,
-      isLdapSetupFailed, loginErrors, props, separateErrorsBasedOnErrorCode, t]);
+      isLdapSetupFailed, loginErrors, props, separateErrorsBasedOnErrorCode, isLoading, t]);
 
   const renderExternalAuthInput = useCallback((auth) => {
     const authIconNames = {

--- a/apps/app/src/components/LoginForm.tsx
+++ b/apps/app/src/components/LoginForm.tsx
@@ -48,6 +48,7 @@ export const LoginForm = (props: LoginFormProps): JSX.Element => {
 
   // states
   const [isRegistering, setIsRegistering] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
   // For Login
   const [usernameForLogin, setUsernameForLogin] = useState('');
   const [passwordForLogin, setPasswordForLogin] = useState('');
@@ -93,6 +94,7 @@ export const LoginForm = (props: LoginFormProps): JSX.Element => {
   const handleLoginWithLocalSubmit = useCallback(async(e) => {
     e.preventDefault();
     resetLoginErrors();
+    setIsLoading(true);
 
     const loginForm = {
       username: usernameForLogin,
@@ -112,6 +114,7 @@ export const LoginForm = (props: LoginFormProps): JSX.Element => {
     catch (err) {
       const errs = toArrayIfNot(err);
       setLoginErrors(errs);
+      setIsLoading(false);
     }
     return;
 
@@ -214,9 +217,12 @@ export const LoginForm = (props: LoginFormProps): JSX.Element => {
           </div>
 
           <div className="input-group my-4">
-            <button type="submit" id="login" className="btn btn-fill rounded-0 login mx-auto" data-testid="btnSubmitForLogin">
+            <button type="submit" id="login" className="btn btn-fill rounded-0 login mx-auto" data-testid="btnSubmitForLogin"disabled={isLoading}>
               <div className="eff"></div>
               <span className="btn-label">
+                {isLoading && (
+                  <i className="fa fa-spinner fa-pulse mr-1"></i>
+                )}
                 <i className="icon-login"></i>
               </span>
               <span className="btn-label-text">{t('Sign in')}</span>

--- a/apps/app/src/components/LoginForm.tsx
+++ b/apps/app/src/components/LoginForm.tsx
@@ -217,13 +217,14 @@ export const LoginForm = (props: LoginFormProps): JSX.Element => {
           </div>
 
           <div className="input-group my-4">
-            <button type="submit" id="login" className="btn btn-fill rounded-0 login mx-auto" data-testid="btnSubmitForLogin"disabled={isLoading}>
+            <button type="submit" id="login" className="btn btn-fill rounded-0 login mx-auto" data-testid="btnSubmitForLogin" disabled={isLoading}>
               <div className="eff"></div>
               <span className="btn-label">
-                {isLoading && (
+                {isLoading ? (
                   <i className="fa fa-spinner fa-pulse mr-1"></i>
+                ) : (
+                  <i className="icon-login"></i>
                 )}
-                <i className="icon-login"></i>
               </span>
               <span className="btn-label-text">{t('Sign in')}</span>
             </button>


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/124539
ログイン画面でsign inボタンを押すと、ボタンが無効化され、ログインアイコンがスピナーに切り替わるようにしました。
また、ログインに失敗した場合はボタンを有効化するようにしています。

現状、loading中にswitchFormできてしまい、ログインボタンを押した後に新規登録ボタンも押せてしまう仕様になっています。ご確認お願いします

https://github.com/weseek/growi/assets/112812878/eaeac43f-740f-47af-9606-55ff04d3d005

https://github.com/weseek/growi/assets/112812878/1b36bead-0a77-45f8-ab5b-7f7049a515c6



