### PR TITLE
fix: downloaded attachment file name

### DIFF
--- a/apps/app/src/components/ReactMarkdownComponents/NextLink.tsx
+++ b/apps/app/src/components/ReactMarkdownComponents/NextLink.tsx
@@ -41,27 +41,27 @@ export const NextLink = (props: Props): JSX.Element => {
   const [contentType, setContentType] = useState<string | null>(null);
   const { data: siteUrl } = useSiteUrl();
 
-  if (href == null) {
-    return <a className={className}>{children}</a>;
-  }
-
   // Fetch and set contentType by given href
   useEffect(() => {
     const fetchContentType = async() => {
       try {
-        const response = await fetch(href);
-        const contentType = response.headers.get('content-type');
-        setContentType(contentType);
+        if (href != null) {
+          const response = await fetch(href);
+          const contentType = response.headers.get('content-type');
+          setContentType(contentType);
+        }
       }
       catch (error) {
         console.error('Failed to fetch content type', error);
       }
     };
 
-    if (href != null) {
-      fetchContentType();
-    }
+    fetchContentType();
   }, [href]);
+
+  if (href == null) {
+    return <a className={className}>{children}</a>;
+  }
 
   // extract 'data-*' props
   const dataAttributes = Object.fromEntries(

--- a/apps/app/src/components/ReactMarkdownComponents/NextLink.tsx
+++ b/apps/app/src/components/ReactMarkdownComponents/NextLink.tsx
@@ -47,18 +47,18 @@ export const NextLink = (props: Props): JSX.Element => {
 
   // Fetch and set contentType by given href
   useEffect(() => {
-    if (href != null) {
-      const fetchContentType = async() => {
-        try {
-          const response = await fetch(href);
-          const contentType = response.headers.get('content-type');
-          setContentType(contentType);
-        }
-        catch (error) {
-          console.error('Failed to fetch content type', error);
-        }
-      };
+    const fetchContentType = async() => {
+      try {
+        const response = await fetch(href);
+        const contentType = response.headers.get('content-type');
+        setContentType(contentType);
+      }
+      catch (error) {
+        console.error('Failed to fetch content type', error);
+      }
+    };
 
+    if (href != null) {
       fetchContentType();
     }
   }, [href]);

--- a/apps/app/src/components/ReactMarkdownComponents/NextLink.tsx
+++ b/apps/app/src/components/ReactMarkdownComponents/NextLink.tsx
@@ -69,7 +69,7 @@ export const NextLink = (props: Props): JSX.Element => {
     const dlhref = href.replace('/attachment/', '/download/');
     return (
       <span>
-        <a id={id} href={href} className={className} target="_blank" rel="noopener noreferrer" {...dataAttributes}>
+        <a id={id} href={dlhref} className={className} target="_blank" rel="noopener noreferrer" download {...dataAttributes}>
           {children}
         </a>&nbsp;
         <a href={dlhref} className="attachment-download"><i className='icon-cloud-download'></i></a>

--- a/apps/app/src/components/ReactMarkdownComponents/NextLink.tsx
+++ b/apps/app/src/components/ReactMarkdownComponents/NextLink.tsx
@@ -47,18 +47,20 @@ export const NextLink = (props: Props): JSX.Element => {
 
   // Fetch and set contentType by given href
   useEffect(() => {
-    const fetchContentType = async () => {
-      if (href != null) {
+    if (href != null) {
+      const fetchContentType = async() => {
         try {
           const response = await fetch(href);
           const contentType = response.headers.get('content-type');
           setContentType(contentType);
-        } catch (error) {
+        }
+        catch (error) {
           console.error('Failed to fetch content type', error);
         }
       };
-    };
-    fetchContentType();
+
+      fetchContentType();
+    }
   }, [href]);
 
   // extract 'data-*' props
@@ -85,7 +87,7 @@ export const NextLink = (props: Props): JSX.Element => {
   if (isAttached(href)) {
     const dlhref = href.replace('/attachment/', '/download/');
     // Conditional href and downloadable status by contentType
-    const isPdf = contentType === 'application/pdf'
+    const isPdf = contentType === 'application/pdf';
     const linkHref = isPdf ? href : dlhref;
     const isDownloadAble = !isPdf;
     return (


### PR DESCRIPTION
### Issue
https://youtrack.weseek.co.jp/issue/GW-7962
- The filename downloaded by clicking the link on the file name will be hashed instead of the original file name

### Fix
- Fix href value of file name link
- Added download attribute to fix security prompt on browser

### Test
![test-attachment](https://github.com/weseek/growi/assets/92426728/cf07410a-1706-4f69-82ba-23816bf41708)
