### PR TITLE
imprv: Show spinner after create

### DIFF
--- a/apps/app/src/components/InstallerForm.tsx
+++ b/apps/app/src/components/InstallerForm.tsx
@@ -47,9 +47,6 @@ const InstallerForm = memo((): JSX.Element => {
     }
 
     setSubmittingDisabled(true);
-    setTimeout(() => {
-      setSubmittingDisabled(false);
-    }, 3000);
 
     if (e.target.elements == null) {
       return;
@@ -81,6 +78,7 @@ const InstallerForm = memo((): JSX.Element => {
     catch (errs) {
       const err = errs[0];
       const code = err.code;
+      setSubmittingDisabled(false);
 
       if (code === 'failed_to_login_after_install') {
         toastError(t('installer.failed_to_login_after_install'));
@@ -223,7 +221,7 @@ const InstallerForm = memo((): JSX.Element => {
               disabled={isSubmittingDisabled}
             >
               <div className="eff"></div>
-              <span className="btn-label"><i className="icon-user-follow" /></span>
+              <span className="btn-label"><i className={isSubmittingDisabled ? 'fa fa-spinner fa-pulse mr-1' : 'icon-user-follow'} /></span>
               <span className="btn-label-text">{ t('Create') }</span>
             </button>
           </div>

--- a/apps/app/src/components/InstallerForm.tsx
+++ b/apps/app/src/components/InstallerForm.tsx
@@ -44,10 +44,6 @@ const InstallerForm = memo((): JSX.Element => {
 
     setIsLoading(true);
 
-    if (e.target.elements == null) {
-      return;
-    }
-
     const formData = e.target.elements;
 
     const {

--- a/apps/app/src/components/InstallerForm.tsx
+++ b/apps/app/src/components/InstallerForm.tsx
@@ -19,7 +19,7 @@ const InstallerForm = memo((): JSX.Element => {
   const isSupportedLang = AllLang.includes(i18n.language as Lang);
 
   const [isValidUserName, setValidUserName] = useState(true);
-  const [isSubmittingDisabled, setSubmittingDisabled] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
   const [currentLocale, setCurrentLocale] = useState(isSupportedLang ? i18n.language : Lang.en_US);
 
   const checkUserName = useCallback(async(event) => {
@@ -42,11 +42,7 @@ const InstallerForm = memo((): JSX.Element => {
   const submitHandler: FormEventHandler = useCallback(async(e: any) => {
     e.preventDefault();
 
-    if (isSubmittingDisabled) {
-      return;
-    }
-
-    setSubmittingDisabled(true);
+    setIsLoading(true);
 
     if (e.target.elements == null) {
       return;
@@ -78,7 +74,7 @@ const InstallerForm = memo((): JSX.Element => {
     catch (errs) {
       const err = errs[0];
       const code = err.code;
-      setSubmittingDisabled(false);
+      setIsLoading(false);
 
       if (code === 'failed_to_login_after_install') {
         toastError(t('installer.failed_to_login_after_install'));
@@ -87,7 +83,7 @@ const InstallerForm = memo((): JSX.Element => {
 
       toastError(t('installer.failed_to_install'));
     }
-  }, [isSubmittingDisabled, currentLocale, router, t]);
+  }, [currentLocale, router, t]);
 
   const hasErrorClass = isValidUserName ? '' : ' has-error';
   const unavailableUserId = isValidUserName
@@ -218,10 +214,10 @@ const InstallerForm = memo((): JSX.Element => {
               type="submit"
               className="btn-fill btn btn-register"
               id="register"
-              disabled={isSubmittingDisabled}
+              disabled={isLoading}
             >
               <div className="eff"></div>
-              <span className="btn-label"><i className={isSubmittingDisabled ? 'fa fa-spinner fa-pulse mr-1' : 'icon-user-follow'} /></span>
+              <span className="btn-label"><i className={isLoading ? 'fa fa-spinner fa-pulse mr-1' : 'icon-user-follow'} /></span>
               <span className="btn-label-text">{ t('Create') }</span>
             </button>
           </div>

--- a/apps/app/src/components/InvitedForm.tsx
+++ b/apps/app/src/components/InvitedForm.tsx
@@ -18,7 +18,6 @@ export const InvitedForm = (props: InvitedFormProps): JSX.Element => {
   const { t } = useTranslation();
   const router = useRouter();
   const { data: user } = useCurrentUser();
-  const [isConnectSuccess, setIsConnectSuccess] = useState<boolean>(false);
   const [loginErrors, setLoginErrors] = useState<Error[]>([]);
   const [isLoading, setIsLoading] = useState(false);
 
@@ -44,7 +43,6 @@ export const InvitedForm = (props: InvitedFormProps): JSX.Element => {
 
     try {
       const res = await apiv3Post('/invited', { invitedForm });
-      setIsConnectSuccess(true);
       const { redirectTo } = res.data;
       router.push(redirectTo ?? '/');
     }
@@ -55,14 +53,6 @@ export const InvitedForm = (props: InvitedFormProps): JSX.Element => {
   }, [router]);
 
   const formNotification = useCallback(() => {
-
-    if (isConnectSuccess) {
-      return (
-        <p className="alert alert-success">
-          <strong>{ t('message.successfully_connected') }</strong><br></br>
-        </p>
-      );
-    }
 
     return (
       <>
@@ -80,7 +70,7 @@ export const InvitedForm = (props: InvitedFormProps): JSX.Element => {
         ) }
       </>
     );
-  }, [isConnectSuccess, loginErrors, t]);
+  }, [loginErrors, t]);
 
   if (user == null) {
     return <></>;

--- a/apps/app/src/components/InvitedForm.tsx
+++ b/apps/app/src/components/InvitedForm.tsx
@@ -20,11 +20,13 @@ export const InvitedForm = (props: InvitedFormProps): JSX.Element => {
   const { data: user } = useCurrentUser();
   const [isConnectSuccess, setIsConnectSuccess] = useState<boolean>(false);
   const [loginErrors, setLoginErrors] = useState<Error[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
 
   const { invitedFormUsername, invitedFormName } = props;
 
   const submitHandler = useCallback(async(e) => {
     e.preventDefault();
+    setIsLoading(true);
 
     const formData = e.target.elements;
 
@@ -48,6 +50,7 @@ export const InvitedForm = (props: InvitedFormProps): JSX.Element => {
     }
     catch (err) {
       setLoginErrors(err);
+      setIsLoading(false);
     }
   }, [router]);
 
@@ -154,9 +157,9 @@ export const InvitedForm = (props: InvitedFormProps): JSX.Element => {
         </div>
         {/* Create Button */}
         <div className="input-group justify-content-center d-flex mt-4">
-          <button type="submit" className="btn btn-fill" id="register">
+          <button type="submit" className="btn btn-fill" id="register" disabled={isLoading}>
             <div className="eff"></div>
-            <span className="btn-label"><i className="icon-user-follow"></i></span>
+            <span className="btn-label"><i className={isLoading ? 'fa fa-spinner fa-pulse mr-1' : 'icon-user-follow'} /></span>
             <span className="btn-label-text">{t('Create')}</span>
           </button>
         </div>


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/124844
/installer、/invitedページでCreateボタンを押すと、ボタンがdisabledになり、アイコンがスピナーに切り替わるようにしました。

installerフォームでは、
`setTimeout(() => {
      setSubmittingDisabled(false);
    }, 3000);`
で3秒経過後ボタンが有効になるように設定されていましたが、正常終了した場合はリダイレクトするまでdisabledのままで良いと思ったので、削除しました。


https://github.com/weseek/growi/assets/112812878/e8f3627f-3794-4094-af9e-569458eaf3f4

https://github.com/weseek/growi/assets/112812878/eab07a54-0576-4d91-977f-a973520b1822


