### PR TITLE
imprv: Fix user group settings

### DIFF
--- a/apps/app/public/static/locales/en_US/commons.json
+++ b/apps/app/public/static/locales/en_US/commons.json
@@ -22,7 +22,8 @@
   "alert": {
     "siteUrl_is_not_set": "'Site URL' is NOT set. Set it from the {{link}}",
     "please_enable_mailer": "Please setup mailer first.",
-    "password_reset_please_enable_mailer": "Please setup mailer first."
+    "password_reset_please_enable_mailer": "Please setup mailer first.",
+    "email_is_already_in_use": "The email address is already in use."
   },
   "headers": {
     "app_settings": "App Settings"

--- a/apps/app/public/static/locales/ja_JP/commons.json
+++ b/apps/app/public/static/locales/ja_JP/commons.json
@@ -21,7 +21,8 @@
   "alert": {
     "siteUrl_is_not_set": "'サイトURL' が設定されていません。{{link}} から設定してください。",
     "please_enable_mailer": "メール認証を有効にするには、メール設定を完了させてください。",
-    "password_reset_please_enable_mailer": "パスワード再設定を有効にするには、メール設定を完了させてください。"
+    "password_reset_please_enable_mailer": "パスワード再設定を有効にするには、メール設定を完了させてください。",
+    "email_is_already_in_use": "そのメールアドレスは既に使用されています。"
   },
   "headers": {
     "app_settings": "アプリ設定"

--- a/apps/app/public/static/locales/zh_CN/commons.json
+++ b/apps/app/public/static/locales/zh_CN/commons.json
@@ -22,7 +22,8 @@
   "alert": {
     "siteUrl_is_not_set": "主页URL未设置，通过 {{link}} 设置",
     "please_enable_mailer": "请先设置邮件程序。",
-    "password_reset_please_enable_mailer": "请先设置邮件程序。"
+    "password_reset_please_enable_mailer": "请先设置邮件程序。",
+    "email_is_already_in_use": "这个电子邮件地址已经在使用了。"
   },
   "headers": {
     "app_settings": "系统设置"

--- a/apps/app/src/components/Admin/UserGroup/UserGroupForm.tsx
+++ b/apps/app/src/components/Admin/UserGroup/UserGroupForm.tsx
@@ -4,6 +4,11 @@ import dateFnsFormat from 'date-fns/format';
 import { useTranslation } from 'next-i18next';
 
 import { IUserGroupHasId } from '~/interfaces/user';
+import { useSWRxUserGroup } from '~/stores/user-group';
+import loggerFactory from '~/utils/logger';
+
+const logger = loggerFactory('growi:stores:personal-settings');
+
 
 type Props = {
   userGroup: IUserGroupHasId,
@@ -18,14 +23,28 @@ export const UserGroupForm: FC<Props> = (props: Props) => {
 
   const {
     userGroup, selectableParentUserGroups, submitButtonLabel, onSubmit,
-  } = props;
+  } = props; // 受け取ったpropsを代入
 
+  const parentUserGroupId = userGroup?.parent;
+  const { data: parentUserGroup } = useSWRxUserGroup(parentUserGroupId as string);
+
+  logger.error('ここから先確認事項');
+  logger.error(parentUserGroupId);
+  logger.error(parentUserGroup);
+  logger.error(typeof parentUserGroup);
+  logger.error(parentUserGroup?.name);
+  console.dir(parentUserGroup);
   /*
    * State
    */
   const [currentName, setName] = useState(userGroup != null ? userGroup.name : '');
   const [currentDescription, setDescription] = useState(userGroup != null ? userGroup.description : '');
-  const [selectedParent, setSelectedParent] = useState<IUserGroupHasId | undefined>(userGroup?.parent as IUserGroupHasId);
+  const [selectedParent, setSelectedParent] = useState<IUserGroupHasId | undefined>(parentUserGroup as IUserGroupHasId);
+  // ここでステートを定義, userGroup?.parentはidであって、データ本体ではない。
+
+  logger.error(selectedParent);
+  logger.error(typeof selectedParent);
+  logger.error(selectedParent?.name);
 
   /*
    * Function
@@ -40,7 +59,7 @@ export const UserGroupForm: FC<Props> = (props: Props) => {
 
   const onChangeParerentButtonHandler = useCallback((userGroup: IUserGroupHasId) => {
     if (userGroup._id !== selectedParent?._id) {
-      setSelectedParent(userGroup);
+      setSelectedParent(userGroup); // ここでラベルが変更されたときにステートも変更している
     }
   }, [selectedParent, setSelectedParent]);
 
@@ -51,7 +70,7 @@ export const UserGroupForm: FC<Props> = (props: Props) => {
         name: currentName,
         description: currentDescription,
         parent: selectedParent,
-      });
+      }); // 送信するデータのまとめ
     }}
     >
 
@@ -106,7 +125,9 @@ export const UserGroupForm: FC<Props> = (props: Props) => {
                 btn btn-outline-secondary dropdown-toggle mb-3 ${selectableParentUserGroups != null && selectableParentUserGroups.length > 0 ? '' : 'disabled'}
               `}
             >
-              {selectedParent?.name ?? t('user_group_management.select_parent_group')}
+              {/* {selectedParent?.name ?? t('user_group_management.select_parent_group')} */}
+              {selectedParent?.name}
+              {/* selectedParent?.nameがnullなら、後者を、nullじゃないなら前者を表示 */}
             </button>
             <div className="dropdown-menu" aria-labelledby="dropdownMenuButton">
               {

--- a/apps/app/src/components/Admin/UserGroup/UserGroupForm.tsx
+++ b/apps/app/src/components/Admin/UserGroup/UserGroupForm.tsx
@@ -1,14 +1,12 @@
-import React, { FC, useCallback, useState } from 'react';
+import React, {
+  FC, useCallback, useState, useEffect,
+} from 'react';
 
 import dateFnsFormat from 'date-fns/format';
 import { useTranslation } from 'next-i18next';
 
 import { IUserGroupHasId } from '~/interfaces/user';
 import { useSWRxUserGroup } from '~/stores/user-group';
-import loggerFactory from '~/utils/logger';
-
-const logger = loggerFactory('growi:stores:personal-settings');
-
 
 type Props = {
   userGroup: IUserGroupHasId,
@@ -23,28 +21,20 @@ export const UserGroupForm: FC<Props> = (props: Props) => {
 
   const {
     userGroup, selectableParentUserGroups, submitButtonLabel, onSubmit,
-  } = props; // 受け取ったpropsを代入
+  } = props;
 
   const parentUserGroupId = userGroup?.parent;
   const { data: parentUserGroup } = useSWRxUserGroup(parentUserGroupId as string);
-
-  logger.error('ここから先確認事項');
-  logger.error(parentUserGroupId);
-  logger.error(parentUserGroup);
-  logger.error(typeof parentUserGroup);
-  logger.error(parentUserGroup?.name);
-  console.dir(parentUserGroup);
   /*
    * State
    */
   const [currentName, setName] = useState(userGroup != null ? userGroup.name : '');
   const [currentDescription, setDescription] = useState(userGroup != null ? userGroup.description : '');
-  const [selectedParent, setSelectedParent] = useState<IUserGroupHasId | undefined>(parentUserGroup as IUserGroupHasId);
-  // ここでステートを定義, userGroup?.parentはidであって、データ本体ではない。
+  const [selectedParent, setSelectedParent] = useState<IUserGroupHasId | undefined>();
 
-  logger.error(selectedParent);
-  logger.error(typeof selectedParent);
-  logger.error(selectedParent?.name);
+  useEffect(() => {
+    setSelectedParent(parentUserGroup);
+  }, [parentUserGroup]);
 
   /*
    * Function
@@ -59,7 +49,7 @@ export const UserGroupForm: FC<Props> = (props: Props) => {
 
   const onChangeParerentButtonHandler = useCallback((userGroup: IUserGroupHasId) => {
     if (userGroup._id !== selectedParent?._id) {
-      setSelectedParent(userGroup); // ここでラベルが変更されたときにステートも変更している
+      setSelectedParent(userGroup);
     }
   }, [selectedParent, setSelectedParent]);
 
@@ -70,7 +60,7 @@ export const UserGroupForm: FC<Props> = (props: Props) => {
         name: currentName,
         description: currentDescription,
         parent: selectedParent,
-      }); // 送信するデータのまとめ
+      });
     }}
     >
 
@@ -125,9 +115,7 @@ export const UserGroupForm: FC<Props> = (props: Props) => {
                 btn btn-outline-secondary dropdown-toggle mb-3 ${selectableParentUserGroups != null && selectableParentUserGroups.length > 0 ? '' : 'disabled'}
               `}
             >
-              {/* {selectedParent?.name ?? t('user_group_management.select_parent_group')} */}
-              {selectedParent?.name}
-              {/* selectedParent?.nameがnullなら、後者を、nullじゃないなら前者を表示 */}
+              {selectedParent?.name ?? t('user_group_management.select_parent_group')}
             </button>
             <div className="dropdown-menu" aria-labelledby="dropdownMenuButton">
               {

--- a/apps/app/src/components/Admin/UserGroupDetail/UserGroupDetailPage.tsx
+++ b/apps/app/src/components/Admin/UserGroupDetail/UserGroupDetailPage.tsx
@@ -53,12 +53,6 @@ const UserGroupDetailPage = (props: Props): JSX.Element => {
 
   const { data: currentUserGroup } = useSWRxUserGroup(currentUserGroupId);
 
-  logger.error('上手くいってる方の確認');
-  logger.error(currentUserGroupId);
-  logger.error(currentUserGroup);
-  logger.error(typeof currentUserGroup);
-  logger.error(currentUserGroup?.name);
-
   const [searchType, setSearchType] = useState<SearchType>(SearchTypes.PARTIAL);
   const [isAlsoMailSearched, setAlsoMailSearched] = useState<boolean>(false);
   const [isAlsoNameSearched, setAlsoNameSearched] = useState<boolean>(false);
@@ -147,9 +141,6 @@ const UserGroupDetailPage = (props: Props): JSX.Element => {
   );
 
   const onClickSubmitForm = useCallback(async(targetGroup: IUserGroupHasId, userGroupData: Partial<IUserGroupHasId>): Promise<void> => {
-    logger.error(userGroupData);
-    logger.error(userGroupData?.parent);
-    logger.error(typeof userGroupData?.parent);
     if (typeof userGroupData?.parent === 'string') {
       toastError(t('Something went wrong. Please try again.'));
       return;

--- a/apps/app/src/components/Admin/UserGroupDetail/UserGroupDetailPage.tsx
+++ b/apps/app/src/components/Admin/UserGroupDetail/UserGroupDetailPage.tsx
@@ -21,8 +21,12 @@ import {
   useSWRxUserGroupPages, useSWRxUserGroupRelationList, useSWRxChildUserGroupList, useSWRxUserGroup,
   useSWRxSelectableParentUserGroups, useSWRxSelectableChildUserGroups, useSWRxAncestorUserGroups, useSWRxUserGroupRelations,
 } from '~/stores/user-group';
+import loggerFactory from '~/utils/logger';
 
 import styles from './UserGroupDetailPage.module.scss';
+
+
+const logger = loggerFactory('growi:stores:personal-settings');
 
 const UserGroupPageList = dynamic(() => import('./UserGroupPageList'), { ssr: false });
 const UserGroupUserTable = dynamic(() => import('./UserGroupUserTable'), { ssr: false });
@@ -136,6 +140,8 @@ const UserGroupDetailPage = (props: Props): JSX.Element => {
   );
 
   const onClickSubmitForm = useCallback(async(targetGroup: IUserGroupHasId, userGroupData: Partial<IUserGroupHasId>): Promise<void> => {
+    logger.error(userGroupData?.parent);
+    logger.error(typeof userGroupData?.parent);
     if (typeof userGroupData?.parent === 'string') {
       toastError(t('Something went wrong. Please try again.'));
       return;

--- a/apps/app/src/components/Admin/UserGroupDetail/UserGroupDetailPage.tsx
+++ b/apps/app/src/components/Admin/UserGroupDetail/UserGroupDetailPage.tsx
@@ -140,6 +140,7 @@ const UserGroupDetailPage = (props: Props): JSX.Element => {
   );
 
   const onClickSubmitForm = useCallback(async(targetGroup: IUserGroupHasId, userGroupData: Partial<IUserGroupHasId>): Promise<void> => {
+    logger.error(userGroupData);
     logger.error(userGroupData?.parent);
     logger.error(typeof userGroupData?.parent);
     if (typeof userGroupData?.parent === 'string') {

--- a/apps/app/src/components/Admin/UserGroupDetail/UserGroupDetailPage.tsx
+++ b/apps/app/src/components/Admin/UserGroupDetail/UserGroupDetailPage.tsx
@@ -52,6 +52,13 @@ const UserGroupDetailPage = (props: Props): JSX.Element => {
   const { userGroupId: currentUserGroupId } = props;
 
   const { data: currentUserGroup } = useSWRxUserGroup(currentUserGroupId);
+
+  logger.error('上手くいってる方の確認');
+  logger.error(currentUserGroupId);
+  logger.error(currentUserGroup);
+  logger.error(typeof currentUserGroup);
+  logger.error(currentUserGroup?.name);
+
   const [searchType, setSearchType] = useState<SearchType>(SearchTypes.PARTIAL);
   const [isAlsoMailSearched, setAlsoMailSearched] = useState<boolean>(false);
   const [isAlsoNameSearched, setAlsoNameSearched] = useState<boolean>(false);

--- a/apps/app/src/components/Me/BasicInfoSettings.tsx
+++ b/apps/app/src/components/Me/BasicInfoSettings.tsx
@@ -26,7 +26,7 @@ export const BasicInfoSettings = (): JSX.Element => {
     }
     catch (err) {
       // toastError(err);
-      if (err.message === 'Failed to update personal data') {
+      if (err.message === 'User validation failed: email: Error, expected `email` to be unique. Value: `admin@example.com`') {
         toastError(t('alert.email_is_already_in_use', { ns: 'commons' }));
       }
       else {

--- a/apps/app/src/components/Me/BasicInfoSettings.tsx
+++ b/apps/app/src/components/Me/BasicInfoSettings.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { Logger } from 'browser-bunyan';
 import { useTranslation, i18n } from 'next-i18next';
 
 import { i18n as i18nConfig } from '^/config/next-i18next.config';
@@ -25,14 +26,14 @@ export const BasicInfoSettings = (): JSX.Element => {
       toastSuccess(t('toaster.update_successed', { target: t('Basic Info'), ns: 'commons' }));
     }
     catch (err) {
-      // toastError(err);
-      if (err.message === 'User validation failed: email: Error, expected `email` to be unique. Value: `admin@example.com`') {
+      const code = err.message;
+
+      if (code === 'The email is already in use') {
         toastError(t('alert.email_is_already_in_use', { ns: 'commons' }));
       }
       else {
-        toastError(err);
+        toastError(code);
       }
-
     }
   };
 

--- a/apps/app/src/components/Me/BasicInfoSettings.tsx
+++ b/apps/app/src/components/Me/BasicInfoSettings.tsx
@@ -25,7 +25,14 @@ export const BasicInfoSettings = (): JSX.Element => {
       toastSuccess(t('toaster.update_successed', { target: t('Basic Info'), ns: 'commons' }));
     }
     catch (err) {
-      toastError(err);
+      // toastError(err);
+      if (err.message === 'Failed to update personal data') {
+        toastError(t('alert.email_is_already_in_use', { ns: 'commons' }));
+      }
+      else {
+        toastError(err);
+      }
+
     }
   };
 

--- a/apps/app/src/server/models/user.js
+++ b/apps/app/src/server/models/user.js
@@ -149,10 +149,7 @@ module.exports = function(crowi) {
 
     const userData = await User.findOne({ email: this.email });
 
-    if (userData) {
-      if (this.username === userData.username) {
-        return true;
-      }
+    if (userData != null && this._id !== userData._id) {
       return false;
     }
     return true;

--- a/apps/app/src/server/models/user.js
+++ b/apps/app/src/server/models/user.js
@@ -144,6 +144,20 @@ module.exports = function(crowi) {
     return hasher.digest('base64');
   }
 
+  userSchema.methods.isUniqueEmail = async function() {
+    const User = this.model('User');
+
+    const userData = await User.findOne({ email: this.email });
+
+    if (userData) {
+      if (this.username === userData.username) {
+        return true;
+      }
+      return false;
+    }
+    return true;
+  };
+
   userSchema.methods.isPasswordSet = function() {
     if (this.password) {
       return true;

--- a/apps/app/src/server/routes/apiv3/personal-setting.js
+++ b/apps/app/src/server/routes/apiv3/personal-setting.js
@@ -238,6 +238,15 @@ module.exports = (crowi) => {
       user.isEmailPublished = req.body.isEmailPublished;
       user.slackMemberId = req.body.slackMemberId;
 
+      const isUniqueEmail = await user.isUniqueEmail();
+
+      if (isUniqueEmail) {
+        logger.error('email-is-unique');
+      }
+      else {
+        throw new Error('email-is-not-unique');
+      }
+
       const updatedUser = await user.save();
 
       const parameters = { action: SupportedAction.ACTION_USER_PERSONAL_SETTINGS_UPDATE };
@@ -247,7 +256,12 @@ module.exports = (crowi) => {
     }
     catch (err) {
       logger.error(err);
-      return res.apiv3Err(err);
+
+      if (err.message === 'email-is-not-unique') {
+        return res.apiv3Err('email-is-already-in-use');
+      }
+
+      return res.apiv3Err('update-personal-data-failed');
     }
 
   });

--- a/apps/app/src/server/routes/apiv3/personal-setting.js
+++ b/apps/app/src/server/routes/apiv3/personal-setting.js
@@ -240,12 +240,9 @@ module.exports = (crowi) => {
 
       const isUniqueEmail = await user.isUniqueEmail();
 
-      if (isUniqueEmail) {
-        logger.error('email-is-unique');
-      }
-      else {
+      if (!isUniqueEmail) {
         logger.error('email-is-not-unique');
-        throw new Error('email-is-not-unique');
+        return res.apiv3Err('email-is-already-in-use');
       }
 
       const updatedUser = await user.save();
@@ -257,11 +254,6 @@ module.exports = (crowi) => {
     }
     catch (err) {
       logger.error(err);
-
-      if (err.message === 'email-is-not-unique') {
-        return res.apiv3Err('email-is-already-in-use');
-      }
-
       return res.apiv3Err('update-personal-data-failed');
     }
 

--- a/apps/app/src/server/routes/apiv3/personal-setting.js
+++ b/apps/app/src/server/routes/apiv3/personal-setting.js
@@ -247,7 +247,8 @@ module.exports = (crowi) => {
     }
     catch (err) {
       logger.error(err);
-      return res.apiv3Err('update-personal-settings-failed');
+      // return res.apiv3Err('update-personal-settings-failed');
+      return res.apiv3Err(err);
     }
 
   });

--- a/apps/app/src/server/routes/apiv3/personal-setting.js
+++ b/apps/app/src/server/routes/apiv3/personal-setting.js
@@ -244,6 +244,7 @@ module.exports = (crowi) => {
         logger.error('email-is-unique');
       }
       else {
+        logger.error('email-is-not-unique');
         throw new Error('email-is-not-unique');
       }
 

--- a/apps/app/src/server/routes/apiv3/personal-setting.js
+++ b/apps/app/src/server/routes/apiv3/personal-setting.js
@@ -247,7 +247,6 @@ module.exports = (crowi) => {
     }
     catch (err) {
       logger.error(err);
-      // return res.apiv3Err('update-personal-settings-failed');
       return res.apiv3Err(err);
     }
 

--- a/apps/app/src/stores/personal-settings.tsx
+++ b/apps/app/src/stores/personal-settings.tsx
@@ -68,9 +68,9 @@ export const usePersonalSettings = (config?: SWRConfiguration): SWRResponse<IUse
     }
     catch (err) {
       logger.error(err);
-      const message = err[0].message;
+      const code = err[0].message;
 
-      if (message.includes('User validation failed: email: Error, expected `email` to be unique.')) {
+      if (code === 'email-is-already-in-use') {
         throw new Error('The email is already in use');
       }
 

--- a/apps/app/src/stores/personal-settings.tsx
+++ b/apps/app/src/stores/personal-settings.tsx
@@ -68,8 +68,13 @@ export const usePersonalSettings = (config?: SWRConfiguration): SWRResponse<IUse
     }
     catch (err) {
       logger.error(err);
-      // throw new Error('Failed to update personal data');
-      throw new Error(err[0].message);
+      const message = err[0].message;
+
+      if (message.includes('User validation failed: email: Error, expected `email` to be unique.')) {
+        throw new Error('The email is already in use');
+      }
+
+      throw new Error('Failed to update personal data');
     }
   };
 

--- a/apps/app/src/stores/personal-settings.tsx
+++ b/apps/app/src/stores/personal-settings.tsx
@@ -68,7 +68,8 @@ export const usePersonalSettings = (config?: SWRConfiguration): SWRResponse<IUse
     }
     catch (err) {
       logger.error(err);
-      throw new Error('Failed to update personal data');
+      // throw new Error('Failed to update personal data');
+      throw new Error(err[0].message);
     }
   };
 


### PR DESCRIPTION
task: https://redmine.weseek.co.jp/issues/120624
### 概要
・子グループの設定画面を開いた場合に、親グループが表示されるようにした。
・子グループの基本情報から名前編集するなどして更新した場合に、「Something went worng. ~省略」と表示され編集できないバグを修正した。

### 詳細
・selectedParentステートの初期値が、子グループの既に設定されている親グループになるようにした。