### PR TITLE
imprv: Improve release parent group button

### DIFF
--- a/apps/app/src/components/Admin/UserGroup/UserGroupForm.tsx
+++ b/apps/app/src/components/Admin/UserGroup/UserGroupForm.tsx
@@ -45,6 +45,9 @@ export const UserGroupForm: FC<Props> = (props: Props) => {
 
   const isSelectableParentUserGroups = selectableParentUserGroups != null && selectableParentUserGroups.length > 0;
 
+  const isChildUserGroup = parentUserGroup !== undefined;
+  const messageAtReleaseParentGroup = isChildUserGroup ? t('user_group_management.release_parent_group') : t('user_group_management.select_parent_group');
+
   return (
     <form onSubmit={(e) => {
       e.preventDefault();
@@ -107,7 +110,7 @@ export const UserGroupForm: FC<Props> = (props: Props) => {
                 btn btn-outline-secondary dropdown-toggle mb-3 ${isSelectableParentUserGroups ? '' : 'disabled'}
               `}
             >
-              {selectedParent?.name ?? t('user_group_management.select_parent_group')}
+              {selectedParent?.name ?? messageAtReleaseParentGroup}
             </button>
             <div className="dropdown-menu" aria-labelledby="dropdownMenuButton">
               {


### PR DESCRIPTION
task: https://redmine.weseek.co.jp/issues/124924
### 概要
・任意のグループの選択画面で「親グループの解除」を選択したときの表示を変更しました。
### 詳細
・親グループを持つ子グループで「親グループの解除」を選択したときにラベルに「親グループの解除」と表示されるようにしました。
・親グループを持たないグループで「親グループの解除」を選択したときにはラベルに「親グループを選択」と表示されるようにしました。