### PR TITLE
feat: Checkable attachment type

### DIFF
--- a/apps/app/src/components/ReactMarkdownComponents/RichAttachment.tsx
+++ b/apps/app/src/components/ReactMarkdownComponents/RichAttachment.tsx
@@ -36,6 +36,7 @@ export const RichAttachment: React.FC<{
     creator,
     createdAt,
     fileSize,
+    fileFormat,
   } = attachment;
 
   // Guard here because attachment properties might be deleted in turn when an attachment is removed
@@ -45,8 +46,15 @@ export const RichAttachment: React.FC<{
     || creator == null
     || createdAt == null
     || fileSize == null
+    || fileFormat == null
   ) {
     return <span className='text-muted'>{t('rich_attachment.attachment_not_be_found')}</span>;
+  }
+
+  if (fileFormat === 'application/pdf') {
+    // TODO: Show pdf preview
+    // https://redmine.weseek.co.jp/issues/125416
+    return <>This is PDF file</>;
   }
 
   return (

--- a/apps/app/src/services/renderer/remark-plugins/attachment.ts
+++ b/apps/app/src/services/renderer/remark-plugins/attachment.ts
@@ -15,22 +15,23 @@ const isAttachmentLink = (url: string) => {
 
 const rewriteNode = (node: Node) => {
   const attachmentId = path.basename(node.url as string);
-  const data = node.data ?? (node.data = {});
-  data.hName = 'attachment';
-  data.hProperties = {
-    attachmentId,
-    url: node.url,
-    attachmentName: (node.children as any)[0]?.value,
+
+  node.data = {
+    ...(node.data ?? {}),
+    hName: 'attachment',
+    hProperties: {
+      attachmentId,
+      url: node.url,
+      attachmentName: (node.children as any)[0]?.value,
+    },
   };
 };
 
 export const remarkPlugin: Plugin = () => {
   return (tree) => {
-    visit(tree, (node) => {
-      if (node.type === 'link') {
-        if (isAttachmentLink(node.url as string)) {
-          rewriteNode(node);
-        }
+    visit(tree, 'link', (node: Node) => {
+      if (isAttachmentLink(node.url as string)) {
+        rewriteNode(node);
       }
     });
   };


### PR DESCRIPTION
task: https://redmine.weseek.co.jp/issues/125414

## 概要
- attachment type を判別できるようにする
- まずは PDF を判別できるようにする
- zip ファイルなどの判別は icon を用意してもらう必要があるので、fumiya-s さんとデザイン相談してから進めていきます。Slack を参考に attachment type によって icon 表示を変える方針です。

## 手順
- attachment ドキュメント attachment type を格納している fileFormat プロパティがあったのでそこから取得するようにしました。
- 少しリファクタリングを行いました。