### PR TITLE
fix: When uploading an attachment file to a new page and pressing the update button, an error occurs

### DIFF
--- a/apps/app/src/components/PageEditor.tsx
+++ b/apps/app/src/components/PageEditor.tsx
@@ -82,7 +82,7 @@ const PageEditor = React.memo((): JSX.Element => {
   const { data: currentPagePath } = useCurrentPagePath();
   const { data: currentPathname } = useCurrentPathname();
   const { data: currentPage } = useSWRxCurrentPage();
-  const { trigger: mutateCurrentPage } = useSWRMUTxCurrentPage();
+  const { data: mutatedCurrenPage, trigger: mutateCurrentPage } = useSWRMUTxCurrentPage();
   const { data: grantData, mutate: mutateGrant } = useSelectedGrant();
   const { data: pageTags, sync: syncTagsInfoForEditor } = usePageTagsForEditors(pageId);
   const { mutate: mutateTagsInfo } = useSWRxTagsInfo(pageId);
@@ -110,7 +110,7 @@ const PageEditor = React.memo((): JSX.Element => {
 
   const updateStateAfterSave = useUpdateStateAfterSave(pageId, { supressEditingMarkdownMutation: true });
 
-  const currentRevisionId = currentPage?.revision?._id;
+  const currentRevisionId = currentPage?.revision?._id || mutatedCurrenPage?.revision?._id;
 
   const initialValue = useMemo(() => {
     if (!isNotFound) {


### PR DESCRIPTION
## Task
[#125923](https://redmine.weseek.co.jp/issues/125923) 新規ページに画像を添付して更新ボタンを押すと “cannot process create”  エラーが出る
└ [#125924](https://redmine.weseek.co.jp/issues/125924) 修正