### PR TITLE
fix: MongoStore.js "Unable to find the session to touch" error

### DIFF
--- a/apps/app/src/components/LoginForm.tsx
+++ b/apps/app/src/components/LoginForm.tsx
@@ -94,7 +94,6 @@ export const LoginForm = (props: LoginFormProps): JSX.Element => {
   const handleLoginWithLocalSubmit = useCallback(async(e) => {
     e.preventDefault();
     resetLoginErrors();
-    setIsLoading(true);
 
     const loginForm = {
       username: usernameForLogin,
@@ -103,6 +102,11 @@ export const LoginForm = (props: LoginFormProps): JSX.Element => {
 
     try {
       const res = await apiv3Post('/login', { loginForm });
+
+      // !! - EXECUTE setIsLoading() AFTER POST - !! -- 7.12 ryoji-s
+      // Because occurs MongoStore.js "Unable to find the session to touch" error
+      setIsLoading(true);
+
       const { redirectTo } = res.data;
 
       if (redirectTo != null) {

--- a/apps/app/src/components/LoginForm.tsx
+++ b/apps/app/src/components/LoginForm.tsx
@@ -49,7 +49,6 @@ export const LoginForm = (props: LoginFormProps): JSX.Element => {
   // states
   const [isRegistering, setIsRegistering] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
-  const [isSubmitted, setIsSubmitted] = useState(false);
   // For Login
   const [usernameForLogin, setUsernameForLogin] = useState('');
   const [passwordForLogin, setPasswordForLogin] = useState('');
@@ -95,10 +94,7 @@ export const LoginForm = (props: LoginFormProps): JSX.Element => {
   const handleLoginWithLocalSubmit = useCallback(async(e) => {
     e.preventDefault();
     resetLoginErrors();
-
-    // !! - DO NOT USE setIsLoading() INSTEAD - !! -- 7.12 ryoji-s
-    // Because occurs MongoStore.js "Unable to find the session to touch" error
-    setIsSubmitted(true);
+    setIsLoading(true);
 
     const loginForm = {
       username: usernameForLogin,
@@ -107,11 +103,6 @@ export const LoginForm = (props: LoginFormProps): JSX.Element => {
 
     try {
       const res = await apiv3Post('/login', { loginForm });
-
-      // !! - EXECUTE setIsLoading() AFTER POST - !! -- 7.12 ryoji-s
-      // Because occurs MongoStore.js "Unable to find the session to touch" error
-      setIsLoading(true);
-
       const { redirectTo } = res.data;
 
       if (redirectTo != null) {
@@ -123,7 +114,6 @@ export const LoginForm = (props: LoginFormProps): JSX.Element => {
     catch (err) {
       const errs = toArrayIfNot(err);
       setLoginErrors(errs);
-      setIsSubmitted(false);
       setIsLoading(false);
     }
     return;
@@ -189,6 +179,12 @@ export const LoginForm = (props: LoginFormProps): JSX.Element => {
 
     return (
       <>
+        {/* !! - DO NOT DELETE HIDDEN ELEMENT - !! -- 7.12 ryoji-s */}
+        {/* Import font-awesome to prevent MongoStore.js "Unable to find the session to touch" error */}
+        <div className='sr-only'>
+          <i className="fa fa-spinner fa-pulse" />
+        </div>
+        {/* !! - END OF HIDDEN ELEMENT - !! */}
         {isLdapSetupFailed && (
           <div className="alert alert-warning small">
             <strong><i className="icon-fw icon-info"></i>{t('login.enabled_ldap_has_configuration_problem')}</strong><br/>
@@ -232,7 +228,7 @@ export const LoginForm = (props: LoginFormProps): JSX.Element => {
               id="login"
               className="btn btn-fill rounded-0 login mx-auto"
               data-testid="btnSubmitForLogin"
-              disabled={isSubmitted || isLoading}
+              disabled={isLoading}
             >
               <div className="eff"></div>
               <span className="btn-label">
@@ -253,7 +249,6 @@ export const LoginForm = (props: LoginFormProps): JSX.Element => {
     isLdapSetupFailed,
     t,
     handleLoginWithLocalSubmit,
-    isSubmitted,
     isLoading,
   ]);
 

--- a/apps/app/src/components/LoginForm.tsx
+++ b/apps/app/src/components/LoginForm.tsx
@@ -49,7 +49,7 @@ export const LoginForm = (props: LoginFormProps): JSX.Element => {
   // states
   const [isRegistering, setIsRegistering] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
-  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isSubmitted, setIsSubmitted] = useState(false);
   // For Login
   const [usernameForLogin, setUsernameForLogin] = useState('');
   const [passwordForLogin, setPasswordForLogin] = useState('');
@@ -98,7 +98,7 @@ export const LoginForm = (props: LoginFormProps): JSX.Element => {
 
     // !! - DO NOT USE setIsLoading() INSTEAD - !! -- 7.12 ryoji-s
     // Because occurs MongoStore.js "Unable to find the session to touch" error
-    setIsSubmitting(true);
+    setIsSubmitted(true);
 
     const loginForm = {
       username: usernameForLogin,
@@ -123,7 +123,7 @@ export const LoginForm = (props: LoginFormProps): JSX.Element => {
     catch (err) {
       const errs = toArrayIfNot(err);
       setLoginErrors(errs);
-      setIsSubmitting(false);
+      setIsSubmitted(false);
       setIsLoading(false);
     }
     return;
@@ -232,7 +232,7 @@ export const LoginForm = (props: LoginFormProps): JSX.Element => {
               id="login"
               className="btn btn-fill rounded-0 login mx-auto"
               data-testid="btnSubmitForLogin"
-              disabled={isSubmitting || isLoading}
+              disabled={isSubmitted || isLoading}
             >
               <div className="eff"></div>
               <span className="btn-label">
@@ -253,7 +253,7 @@ export const LoginForm = (props: LoginFormProps): JSX.Element => {
     isLdapSetupFailed,
     t,
     handleLoginWithLocalSubmit,
-    isSubmitting,
+    isSubmitted,
     isLoading,
   ]);
 

--- a/apps/app/src/components/LoginForm.tsx
+++ b/apps/app/src/components/LoginForm.tsx
@@ -49,7 +49,7 @@ export const LoginForm = (props: LoginFormProps): JSX.Element => {
   // states
   const [isRegistering, setIsRegistering] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
-  const [isPosting, setIsPosting] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
   // For Login
   const [usernameForLogin, setUsernameForLogin] = useState('');
   const [passwordForLogin, setPasswordForLogin] = useState('');
@@ -98,7 +98,7 @@ export const LoginForm = (props: LoginFormProps): JSX.Element => {
 
     // !! - DO NOT USE setIsLoading() INSTEAD - !! -- 7.12 ryoji-s
     // Because occurs MongoStore.js "Unable to find the session to touch" error
-    setIsPosting(true);
+    setIsSubmitting(true);
 
     const loginForm = {
       username: usernameForLogin,
@@ -123,7 +123,7 @@ export const LoginForm = (props: LoginFormProps): JSX.Element => {
     catch (err) {
       const errs = toArrayIfNot(err);
       setLoginErrors(errs);
-      setIsPosting(false);
+      setIsSubmitting(false);
       setIsLoading(false);
     }
     return;
@@ -227,7 +227,13 @@ export const LoginForm = (props: LoginFormProps): JSX.Element => {
           </div>
 
           <div className="input-group my-4">
-            <button type="submit" id="login" className="btn btn-fill rounded-0 login mx-auto" data-testid="btnSubmitForLogin" disabled={isPosting || isLoading}>
+            <button
+              type="submit"
+              id="login"
+              className="btn btn-fill rounded-0 login mx-auto"
+              data-testid="btnSubmitForLogin"
+              disabled={isSubmitting || isLoading}
+            >
               <div className="eff"></div>
               <span className="btn-label">
                 <i className={isLoading ? 'fa fa-spinner fa-pulse mr-1' : 'icon-login'} />
@@ -247,7 +253,7 @@ export const LoginForm = (props: LoginFormProps): JSX.Element => {
     isLdapSetupFailed,
     t,
     handleLoginWithLocalSubmit,
-    isPosting,
+    isSubmitting,
     isLoading,
   ]);
 

--- a/apps/app/src/components/LoginForm.tsx
+++ b/apps/app/src/components/LoginForm.tsx
@@ -49,6 +49,7 @@ export const LoginForm = (props: LoginFormProps): JSX.Element => {
   // states
   const [isRegistering, setIsRegistering] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
+  const [isPosting, setIsPosting] = useState(false);
   // For Login
   const [usernameForLogin, setUsernameForLogin] = useState('');
   const [passwordForLogin, setPasswordForLogin] = useState('');
@@ -95,6 +96,10 @@ export const LoginForm = (props: LoginFormProps): JSX.Element => {
     e.preventDefault();
     resetLoginErrors();
 
+    // !! - DO NOT USE setIsLoading() INSTEAD - !! -- 7.12 ryoji-s
+    // Because occurs MongoStore.js "Unable to find the session to touch" error
+    setIsPosting(true);
+
     const loginForm = {
       username: usernameForLogin,
       password: passwordForLogin,
@@ -118,6 +123,7 @@ export const LoginForm = (props: LoginFormProps): JSX.Element => {
     catch (err) {
       const errs = toArrayIfNot(err);
       setLoginErrors(errs);
+      setIsPosting(false);
       setIsLoading(false);
     }
     return;
@@ -221,7 +227,7 @@ export const LoginForm = (props: LoginFormProps): JSX.Element => {
           </div>
 
           <div className="input-group my-4">
-            <button type="submit" id="login" className="btn btn-fill rounded-0 login mx-auto" data-testid="btnSubmitForLogin" disabled={isLoading}>
+            <button type="submit" id="login" className="btn btn-fill rounded-0 login mx-auto" data-testid="btnSubmitForLogin" disabled={isPosting || isLoading}>
               <div className="eff"></div>
               <span className="btn-label">
                 <i className={isLoading ? 'fa fa-spinner fa-pulse mr-1' : 'icon-login'} />
@@ -232,8 +238,19 @@ export const LoginForm = (props: LoginFormProps): JSX.Element => {
         </form>
       </>
     );
-  }, [generateDangerouslySetErrors, generateSafelySetErrors, handleLoginWithLocalSubmit,
-      isLdapSetupFailed, loginErrors, props, separateErrorsBasedOnErrorCode, isLoading, t]);
+  }, [
+    props,
+    separateErrorsBasedOnErrorCode,
+    loginErrors,
+    generateDangerouslySetErrors,
+    generateSafelySetErrors,
+    isLdapSetupFailed,
+    t,
+    handleLoginWithLocalSubmit,
+    isPosting,
+    isLoading,
+  ]);
+
 
   const renderExternalAuthInput = useCallback((auth) => {
     const authIconNames = {


### PR DESCRIPTION
- https://redmine.weseek.co.jp/issues/126000

## 現状
- https://github.com/weseek/growi/pull/7823 で CI E2E テスト 20, 23, 30, 50 でエラーが発生した。
- [VRT](https://growi-vrt-snapshots.s3.amazonaws.com/b73e184748946da036f24636eeb386791d7a6806/index.html?id=new-20-basic-features--access-to-pagelist.cy.ts/Access%20to%20pagelist%20--%20Page%20list%20modal%20is%20successfully%20opened%20--%20before%20each%20hook%20(failed).png) より login できていなかった。
- ログを確認すると以下のエラーが発生していた。
```
Error: Unable to find the session to touch
    at /home/runner/work/growi/growi/node_modules/connect-mongo/build/main/lib/MongoStore.js:326:37
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```
- `Unable to find the session to touch` は https://github.com/jdesboeufs/connect-mongo/blob/d52dc41996909e3f3d98ce4a194a16a6afde246c/src/lib/MongoStore.ts#L446-L447 で throw していた

## 原因
- ログイン POST
```
POST /_api/v3/login HTTP/1.1 200 44 http://localhost:3000/login
```
後に
```
GET /_next/static/media/fontawesome-webfont.e9955780.woff2 HTTP/1.1 200 77160 http://localhost:3000/_next/static/css/bde0048c8ce14047.css 
```
が走ることで発生

- この
```
GET /_next/static/media/fontawesome-webfont.e9955780.woff2 HTTP/1.1 200 77160 http://localhost:3000/_next/static/css/bde0048c8ce14047.css 
```
は、loading 表示のために `fa fa-spinner fa-pulse` 表示するために必要な font をインポートしている。

## 解決案
- POST 実行後に `setIsLoading(true)` をして `fa fa-spinner fa-pulse` を表示する
- これだと連続で複数回 POST できてしまうので `setIsSubmitted()` という useState を新たに用意し POST 前に `setIsSubmitted(true)` を実行する

## その他
- CI 確認用 PR https://github.com/weseek/growi/pull/7874