### PR TITLE
imprv: Apply PageListMeta icon space mr-2

### DIFF
--- a/packages/ui/src/components/PagePath/PageListMeta.tsx
+++ b/packages/ui/src/components/PagePath/PageListMeta.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import { FC } from 'react';
 
 import assert from 'assert';
 
@@ -45,7 +45,7 @@ const SeenUsersCount = (props: SeenUsersCountProps): JSX.Element => {
   const strengthClass = `strength-${strengthLevel}`; // strength-{0, 1, 2, 3, 4}
 
   return (
-    <span className={`seen-users-count ${shouldSpaceOutIcon ? 'mr-3' : ''} ${strengthClass}`}>
+    <span className={`seen-users-count ${shouldSpaceOutIcon ? 'mr-2' : ''} ${strengthClass}`}>
       <i className="footstamp-icon"><FootstampIcon /></i>
       {count}
     </span>
@@ -69,33 +69,33 @@ export const PageListMeta: FC<PageListMetaProps> = (props: PageListMetaProps) =>
   // top check
   let topLabel;
   if (isTopPage(page.path)) {
-    topLabel = <span className={`badge badge-info ${shouldSpaceOutIcon ? 'mr-3' : ''} top-label`}>TOP</span>;
+    topLabel = <span className={`badge badge-info ${shouldSpaceOutIcon ? 'mr-2' : ''} top-label`}>TOP</span>;
   }
 
   // template check
   let templateLabel;
   if (checkTemplatePath(page.path)) {
-    templateLabel = <span className={`badge badge-info ${shouldSpaceOutIcon ? 'mr-3' : ''}`}>TMPL</span>;
+    templateLabel = <span className={`badge badge-info ${shouldSpaceOutIcon ? 'mr-2' : ''}`}>TMPL</span>;
   }
 
   let commentCount;
   if (page.commentCount > 0) {
-    commentCount = <span className={`${shouldSpaceOutIcon ? 'mr-3' : ''}`}><i className="icon-bubble" />{page.commentCount}</span>;
+    commentCount = <span className={`${shouldSpaceOutIcon ? 'mr-2' : ''}`}><i className="icon-bubble" />{page.commentCount}</span>;
   }
 
   let likerCount;
   if (props.likerCount != null && props.likerCount > 0) {
-    likerCount = <span className={`${shouldSpaceOutIcon ? 'mr-3' : ''}`}><i className="fa fa-heart-o" />{props.likerCount}</span>;
+    likerCount = <span className={`${shouldSpaceOutIcon ? 'mr-2' : ''}`}><i className="fa fa-heart-o" />{props.likerCount}</span>;
   }
 
   let locked;
   if (page.grant !== 1) {
-    locked = <span className={`${shouldSpaceOutIcon ? 'mr-3' : ''}`}><i className="icon-lock" /></span>;
+    locked = <span className={`${shouldSpaceOutIcon ? 'mr-2' : ''}`}><i className="icon-lock" /></span>;
   }
 
   let bookmarkCount;
   if (props.bookmarkCount != null && props.bookmarkCount > 0) {
-    bookmarkCount = <span className={`${shouldSpaceOutIcon ? 'mr-3' : ''}`}><i className="fa fa-bookmark-o" />{props.bookmarkCount}</span>;
+    bookmarkCount = <span className={`${shouldSpaceOutIcon ? 'mr-2' : ''}`}><i className="fa fa-bookmark-o" />{props.bookmarkCount}</span>;
   }
 
   return (


### PR DESCRIPTION
## task
- https://redmine.weseek.co.jp/issues/127218

## 概要
- `shouldSpaceOutIcon` が `true` なときの `PageListMeta` の icon の幅を `mr-3` から `mr-2` にしました。

## design 相談
- https://wsgrowi.slack.com/archives/C0111HG81GB/p1690340217030519

## Screenshot
### Before
![localhost_3000__search_q=test](https://github.com/weseek/growi/assets/68407388/0efb4f93-6de8-4f86-80c2-6e2440da21a0)

### After
![localhost_3000__search_q=test (2)](https://github.com/weseek/growi/assets/68407388/c711ed1c-c501-4119-8cc6-5032329532f1)
### PageListItemL を使っている箇所
![localhost_3000_trash](https://github.com/weseek/growi/assets/68407388/9690a571-c00b-4c30-a03f-4ebaa5a3f267)
![localhost_3000_trash (1)](https://github.com/weseek/growi/assets/68407388/3a4e673a-24b4-42de-995c-fe0a076d582b)
![localhost_3000_trash](https://github.com/weseek/growi/assets/68407388/e5224310-19fa-4f3d-8680-a7186651d190)
