### PR TITLE
fix: Revert dynamic import.

### DIFF
--- a/apps/app/src/components/SearchPage/SearchPageBase.tsx
+++ b/apps/app/src/components/SearchPage/SearchPageBase.tsx
@@ -17,6 +17,7 @@ import { mutatePageTree } from '~/stores/page-listing';
 
 import { ForceHideMenuItems } from '../Common/Dropdown/PageItemControl';
 
+// TODO: use dynamic import. refs: https://redmine.weseek.co.jp/issues/127500
 import { SearchResultList } from './SearchResultList';
 
 import styles from './SearchPageBase.module.scss';
@@ -43,7 +44,7 @@ type Props = {
   searchPager: React.ReactNode,
 }
 
-
+// TODO: use dynamic import. refs: https://redmine.weseek.co.jp/issues/127500
 // const SearchResultList = dynamic(() => import('./SearchResultList').then(mod => mod.SearchResultList), { ssr: false });
 const SearchResultContent = dynamic(() => import('./SearchResultContent').then(mod => mod.SearchResultContent), {
   ssr: false,

--- a/apps/app/src/components/SearchPage/SearchPageBase.tsx
+++ b/apps/app/src/components/SearchPage/SearchPageBase.tsx
@@ -17,6 +17,8 @@ import { mutatePageTree } from '~/stores/page-listing';
 
 import { ForceHideMenuItems } from '../Common/Dropdown/PageItemControl';
 
+import { SearchResultList } from './SearchResultList';
+
 import styles from './SearchPageBase.module.scss';
 
 // https://regex101.com/r/brrkBu/1
@@ -42,7 +44,7 @@ type Props = {
 }
 
 
-const SearchResultList = dynamic(() => import('./SearchResultList').then(mod => mod.SearchResultList), { ssr: false });
+// const SearchResultList = dynamic(() => import('./SearchResultList').then(mod => mod.SearchResultList), { ssr: false });
 const SearchResultContent = dynamic(() => import('./SearchResultContent').then(mod => mod.SearchResultContent), {
   ssr: false,
   loading: () => <></>,

--- a/apps/app/src/components/SearchPage/SearchPageBase.tsx
+++ b/apps/app/src/components/SearchPage/SearchPageBase.tsx
@@ -17,7 +17,6 @@ import { mutatePageTree } from '~/stores/page-listing';
 
 import { ForceHideMenuItems } from '../Common/Dropdown/PageItemControl';
 
-// TODO: use dynamic import. refs: https://redmine.weseek.co.jp/issues/127500
 import { SearchResultList } from './SearchResultList';
 
 import styles from './SearchPageBase.module.scss';
@@ -44,8 +43,6 @@ type Props = {
   searchPager: React.ReactNode,
 }
 
-// TODO: use dynamic import. refs: https://redmine.weseek.co.jp/issues/127500
-// const SearchResultList = dynamic(() => import('./SearchResultList').then(mod => mod.SearchResultList), { ssr: false });
 const SearchResultContent = dynamic(() => import('./SearchResultContent').then(mod => mod.SearchResultContent), {
   ssr: false,
   loading: () => <></>,


### PR DESCRIPTION
### task
- https://redmine.weseek.co.jp/issues/127419
- dynamic import と forwardRef, useImperativeHandle は相性が悪いため、ForwardRefRenderFunction を使いながら CSR にするというのは一旦諦める

### 調査結果
- 子コンポーネントで forwardRef を使っていても、該当の子コンポーネントをインポートする側で Next.js の dynamic import を利用していると、ref が参照できないという問題が発生していたことが分かった。
- また、それを回避する方法もあるにはあるが、特殊な方法を用いなければならない。
- 該当の問題と同じ症状を訴える stack overflow の質問: https://stackoverflow.com/questions/63469232/forwardref-error-when-dynamically-importing-a-module-in-next-js
- 当時のより詳しいやり取りはこちらに: https://redmine.weseek.co.jp/issues/127417