### PR TITLE
imprv: Improve default behavior of skipSSR

### DIFF
--- a/apps/app/src/pages/utils/commons.ts
+++ b/apps/app/src/pages/utils/commons.ts
@@ -177,7 +177,7 @@ export const skipSSR = async(page: PageDocument): Promise<boolean> => {
     throw new Error('This method is not available on the client-side');
   }
 
-  const latestRevisionBodyLength = await page.ensureLatestRevisionBodyLength();
+  const latestRevisionBodyLength = await page.getLatestRevisionBodyLength();
 
   if (latestRevisionBodyLength == null) {
     return false;

--- a/apps/app/src/pages/utils/commons.ts
+++ b/apps/app/src/pages/utils/commons.ts
@@ -2,7 +2,6 @@ import type { ColorScheme, IUserHasId } from '@growi/core';
 import {
   DevidedPagePath, Lang, AllLang, isServer,
 } from '@growi/core';
-import mongoose from 'mongoose';
 import type { GetServerSideProps, GetServerSidePropsContext } from 'next';
 import type { SSRConfig, UserConfig } from 'next-i18next';
 
@@ -12,7 +11,7 @@ import { detectLocaleFromBrowserAcceptLanguage } from '~/client/util/locale-util
 import type { CrowiRequest } from '~/interfaces/crowi-request';
 import type { ISidebarConfig } from '~/interfaces/sidebar-config';
 import type { IUserUISettings } from '~/interfaces/user-ui-settings';
-import type { PageModel, PageDocument } from '~/server/models/page';
+import type { PageDocument } from '~/server/models/page';
 import type { UserUISettingsDocument } from '~/server/models/user-ui-settings';
 import {
   useCurrentProductNavWidth, useCurrentSidebarContents, usePreferDrawerModeByUser, usePreferDrawerModeOnEditByUser, useSidebarCollapsed,
@@ -173,21 +172,16 @@ export const useInitSidebarConfig = (sidebarConfig: ISidebarConfig, userUISettin
   useCurrentProductNavWidth(userUISettings?.currentProductNavWidth);
 };
 
-async function ensureLatestRevisionBodyLength(page: PageDocument): Promise<number> {
-  if (!page.isLatestRevision() || page.latestRevisionBodyLength == null) {
-    const Page = mongoose.model('Page') as unknown as PageModel;
-    return Page.updateLatestRevisionBodyLength(page._id);
-  }
-
-  return page.latestRevisionBodyLength;
-}
-
 export const skipSSR = async(page: PageDocument): Promise<boolean> => {
   if (!isServer()) {
     throw new Error('This method is not available on the client-side');
   }
 
-  const latestRevisionBodyLength = await ensureLatestRevisionBodyLength(page);
+  const latestRevisionBodyLength = await page.ensureLatestRevisionBodyLength();
+
+  if (latestRevisionBodyLength == null) {
+    return false;
+  }
 
   const { configManager } = await import('~/server/service/config-manager');
   await configManager.loadConfigs();

--- a/apps/app/src/pages/utils/commons.ts
+++ b/apps/app/src/pages/utils/commons.ts
@@ -180,7 +180,7 @@ export const skipSSR = async(page: PageDocument): Promise<boolean> => {
   const latestRevisionBodyLength = await page.getLatestRevisionBodyLength();
 
   if (latestRevisionBodyLength == null) {
-    return false;
+    return true;
   }
 
   const { configManager } = await import('~/server/service/config-manager');

--- a/apps/app/src/server/models/page.ts
+++ b/apps/app/src/server/models/page.ts
@@ -2,7 +2,9 @@
 
 import nodePath from 'path';
 
-import { HasObjectId, pagePathUtils, pathUtils } from '@growi/core';
+import {
+  HasObjectId, isPopulated, pagePathUtils, pathUtils,
+} from '@growi/core';
 import { collectAncestorPaths } from '@growi/core/dist/utils/page-path-utils/collect-ancestor-paths';
 import escapeStringRegexp from 'escape-string-regexp';
 import mongoose, {
@@ -985,14 +987,10 @@ schema.methods.calculateAndUpdateLatestRevisionBodyLength = async function(this:
     return;
   }
 
-  // Infer the type as Omit<PageDocument, never> due to the population
-  // Cast the type back to PageDocument to restore the original type
   // eslint-disable-next-line rulesdir/no-populate
-  const populatedPageDocument = await this.populate('revision', 'body') as PageDocument;
+  const populatedPageDocument = await this.populate<PageDocument>('revision', 'body');
 
-  if (typeof populatedPageDocument.revision === 'string') {
-    throw new Error('Failed to populate revision field in the page document.');
-  }
+  assert(isPopulated(populatedPageDocument.revision));
 
   this.latestRevisionBodyLength = populatedPageDocument.revision.body.length;
   await this.save();

--- a/apps/app/src/server/models/page.ts
+++ b/apps/app/src/server/models/page.ts
@@ -960,11 +960,12 @@ schema.statics.findNonEmptyClosestAncestor = async function(path: string): Promi
   return ancestors[0];
 };
 
-export async function calculateAndUpdateLatestRevisionBodyLength(page: PageDocument): Promise<number> {
+export async function calculateAndUpdateLatestRevisionBodyLength(page: PageDocument): Promise<number | null> {
   const latestRevisionData = await mongoose.model('Revision').findById(page.revision, { body: 1 });
 
   if (latestRevisionData == null || typeof latestRevisionData.body !== 'string') {
-    throw new Error('The latest revision body could not be found or is not a string.');
+    logger.error('The latest revision body could not be found or is not a string.');
+    return null;
   }
 
   const latestRevisionBodyLength = latestRevisionData.body.length;


### PR DESCRIPTION
- task: https://redmine.weseek.co.jp/issues/126576

## 実装方針
1. 先に page に latestRevisionBodyLength フィールドがあるかないかを確認する
2. なければそのページに対して model 層のメソッドで revision から latestRevisioinBodyLength を取得 + Page モデルのフィールドに追加
3. この後に skip ssr するかの閾値判断