### PR TITLE
imprv: Do not use loadConfigs in skipSSR

### DIFF
--- a/apps/app/src/pages/[[...path]].page.tsx
+++ b/apps/app/src/pages/[[...path]].page.tsx
@@ -169,6 +169,7 @@ type Props = CommonProps & {
   isIndentSizeForced: boolean,
   disableLinkSharing: boolean,
   skipSSR: boolean,
+  ssrMaxRevisionBodyLength: number,
 
   grantData?: IPageGrantData,
 
@@ -476,7 +477,7 @@ async function injectPageData(context: GetServerSidePropsContext, props: Props):
   if (page != null) {
     page.initLatestRevisionField(revisionId);
     props.isLatestRevision = page.isLatestRevision();
-    props.skipSSR = await skipSSR(page);
+    props.skipSSR = await skipSSR(page, props.ssrMaxRevisionBodyLength);
     await page.populateDataToShowRevision(props.skipSSR); // shouldExcludeBody = skipSSR
   }
 
@@ -602,6 +603,7 @@ function injectServerConfigurations(context: GetServerSidePropsContext, props: P
     highlightJsStyleBorder: crowi.configManager.getConfig('crowi', 'customize:highlightJsStyleBorder'),
   };
 
+  props.ssrMaxRevisionBodyLength = configManager.getConfig('crowi', 'app:ssrMaxRevisionBodyLength');
 }
 
 /**

--- a/apps/app/src/pages/share/[[...path]].page.tsx
+++ b/apps/app/src/pages/share/[[...path]].page.tsx
@@ -44,6 +44,7 @@ type Props = CommonProps & {
   drawioUri: string | null,
   rendererConfig: RendererConfig,
   skipSSR: boolean,
+  ssrMaxRevisionBodyLength: number,
 };
 
 type IShareLinkRelatedPage = IPagePopulatedToShowRevision & PageDocument;
@@ -178,6 +179,8 @@ function injectServerConfigurations(context: GetServerSidePropsContext, props: P
     tagWhitelist: crowi.configManager.getConfig('markdown', 'markdown:rehypeSanitize:tagNames'),
     highlightJsStyleBorder: configManager.getConfig('crowi', 'customize:highlightJsStyleBorder'),
   };
+
+  props.ssrMaxRevisionBodyLength = configManager.getConfig('crowi', 'app:ssrMaxRevisionBodyLength');
 }
 
 async function injectNextI18NextConfigurations(context: GetServerSidePropsContext, props: Props, namespacesRequired?: string[] | undefined): Promise<void> {
@@ -234,7 +237,7 @@ export const getServerSideProps: GetServerSideProps = async(context: GetServerSi
     }
     else {
       props.isNotFound = false;
-      props.skipSSR = await skipSSR(shareLink.relatedPage);
+      props.skipSSR = await skipSSR(shareLink.relatedPage, props.ssrMaxRevisionBodyLength);
       props.shareLinkRelatedPage = await shareLink.relatedPage.populateDataToShowRevision(props.skipSSR); // shouldExcludeBody = skipSSR
       props.isExpired = shareLink.isExpired();
       props.shareLink = shareLink.toObject();

--- a/apps/app/src/pages/utils/commons.ts
+++ b/apps/app/src/pages/utils/commons.ts
@@ -183,8 +183,13 @@ export const skipSSR = async(page: PageDocument): Promise<boolean> => {
     return true;
   }
 
-  const { configManager } = await import('~/server/service/config-manager');
-  await configManager.loadConfigs();
+  const configManager = await import('~/server/service/config-manager')
+    .then(async(mod) => {
+      if (!mod.configManager.isInitialized) {
+        await mod.configManager.loadConfigs();
+      }
+      return mod.configManager;
+    });
   const ssrMaxRevisionBodyLength = configManager.getConfig('crowi', 'app:ssrMaxRevisionBodyLength');
   if (ssrMaxRevisionBodyLength < page.latestRevisionBodyLength) {
     return true;

--- a/apps/app/src/pages/utils/commons.ts
+++ b/apps/app/src/pages/utils/commons.ts
@@ -172,7 +172,7 @@ export const useInitSidebarConfig = (sidebarConfig: ISidebarConfig, userUISettin
   useCurrentProductNavWidth(userUISettings?.currentProductNavWidth);
 };
 
-export const skipSSR = async(page: PageDocument): Promise<boolean> => {
+export const skipSSR = async(page: PageDocument, ssrMaxRevisionBodyLength: number): Promise<boolean> => {
   if (!isServer()) {
     throw new Error('This method is not available on the client-side');
   }
@@ -182,15 +182,6 @@ export const skipSSR = async(page: PageDocument): Promise<boolean> => {
   if (latestRevisionBodyLength == null) {
     return true;
   }
-
-  const configManager = await import('~/server/service/config-manager')
-    .then(async(mod) => {
-      if (!mod.configManager.isInitialized) {
-        await mod.configManager.loadConfigs();
-      }
-      return mod.configManager;
-    });
-  const ssrMaxRevisionBodyLength = configManager.getConfig('crowi', 'app:ssrMaxRevisionBodyLength');
 
   return ssrMaxRevisionBodyLength < latestRevisionBodyLength;
 };

--- a/apps/app/src/server/service/config-manager.ts
+++ b/apps/app/src/server/service/config-manager.ts
@@ -58,7 +58,7 @@ class ConfigManagerImpl implements ConfigManager, S2sMessageHandlable {
 
   private lastLoadedAt?: Date;
 
-  get isInitialized() {
+  private get isInitialized() {
     return this.lastLoadedAt != null;
   }
 

--- a/apps/app/src/server/service/config-manager.ts
+++ b/apps/app/src/server/service/config-manager.ts
@@ -58,7 +58,7 @@ class ConfigManagerImpl implements ConfigManager, S2sMessageHandlable {
 
   private lastLoadedAt?: Date;
 
-  private get isInitialized() {
+  get isInitialized() {
     return this.lastLoadedAt != null;
   }
 


### PR DESCRIPTION
## task
- https://redmine.weseek.co.jp/issues/127797

## 概要
- ~~`configManager.isInitialized` を class 外でも実行できるようにする~~
- ~~load されていない場合だけ `configManager.loadConfigs()` されるようにする~~
- crowi から config を取得するように変更しました

## メモ
- Node.js のcacheがなくなってシングルトンが再生成されてしまう
  - https://github.com/vercel/next.js/issues/10933
  - https://stackoverflow.com/questions/75272877/how-to-prevent-next-js-from-instantiating-a-singleton-class-object-multiple-time
- skipSSR 内で import したインスタンスに対して一度 loadConfigs すればそれは次回の skipSSR 時には引き継がれはする

## 関連PR
- https://github.com/weseek/growi/pull/7927