### PR TITLE
fix: Transitioning to a non-existent page under "/me" results in a 500 error

### DIFF
--- a/apps/app/src/pages/me/[[...path]].page.tsx
+++ b/apps/app/src/pages/me/[[...path]].page.tsx
@@ -72,6 +72,13 @@ const MePage: NextPageWithLayout<Props> = (props: Props) => {
 
   const getTargetPageToRender = (pagesMap, keys): {title: string, component: JSX.Element} => {
     return keys.reduce((pagesMap, key) => {
+      const page = pagesMap[key];
+      if (page == null) {
+        return {
+          title: 'NotFoundPage',
+          component: <h1 className="title">{t('commons:not_found_page.page_not_exist')}</h1>,
+        };
+      }
       return pagesMap[key];
     }, pagesMap);
   };

--- a/apps/app/src/pages/me/[[...path]].page.tsx
+++ b/apps/app/src/pages/me/[[...path]].page.tsx
@@ -76,7 +76,7 @@ const MePage: NextPageWithLayout<Props> = (props: Props) => {
       if (page == null) {
         return {
           title: 'NotFoundPage',
-          component: <h1 className="title">{t('commons:not_found_page.page_not_exist')}</h1>,
+          component: <h2>{t('commons:not_found_page.page_not_exist')}</h2>,
         };
       }
       return pagesMap[key];


### PR DESCRIPTION
## Task
[#128014](https://redmine.weseek.co.jp/issues/128014) `/me/hoge` とすると 500 internal server error になる
└ [#127972](https://redmine.weseek.co.jp/issues/127972) 修正