### PR TITLE
imprv: Enable Marp in presentation mode

### DIFF
--- a/apps/app/src/components/PagePresentationModal.tsx
+++ b/apps/app/src/components/PagePresentationModal.tsx
@@ -8,6 +8,7 @@ import {
   Modal, ModalBody,
 } from 'reactstrap';
 
+import { useIsEnabledMarp } from '~/stores/context';
 import { usePagePresentationModal } from '~/stores/modal';
 import { useSWRxCurrentPage } from '~/stores/page';
 import { usePresentationViewOptions } from '~/stores/renderer';
@@ -34,6 +35,8 @@ const PagePresentationModal = (): JSX.Element => {
 
   const { data: currentPage } = useSWRxCurrentPage();
   const { data: rendererOptions } = usePresentationViewOptions();
+
+  const { data: isEnabledMarp } = useIsEnabledMarp();
 
   const toggleFullscreenHandler = useCallback(() => {
     if (fullscreen.active) {
@@ -85,6 +88,7 @@ const PagePresentationModal = (): JSX.Element => {
               },
               isDarkMode,
             }}
+            isEnabledMarp = {isEnabledMarp}
           >
             {markdown}
           </Presentation>

--- a/packages/presentation/src/components/Presentation.tsx
+++ b/packages/presentation/src/components/Presentation.tsx
@@ -1,6 +1,11 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 
+
+import remarkFrontmatter from 'remark-frontmatter';
+import remarkParse from 'remark-parse';
+import remarkStringify from 'remark-stringify';
 import Reveal from 'reveal.js';
+import { unified } from 'unified';
 
 import type { PresentationOptions } from '../consts';
 
@@ -39,6 +44,8 @@ export const Presentation = (props: PresentationProps): JSX.Element => {
   const { options, children } = props;
   const { revealOptions } = options;
 
+  const [marp, setMarp] = useState<boolean>(false);
+
   useEffect(() => {
     let deck: Reveal.Api;
     if (children != null) {
@@ -50,16 +57,34 @@ export const Presentation = (props: PresentationProps): JSX.Element => {
       deck.on('slidechanged', removeAllHiddenElements);
     }
 
+    unified()
+      .use(remarkParse)
+      .use(remarkStringify)
+      .use(remarkFrontmatter, ['yaml'])
+      .use(() => (obj) => {
+        setMarp(false);
+        if (obj.children[0]?.type === 'yaml') {
+          const lines = (obj.children[0]?.value as string).split('\n');
+          lines.forEach((line) => {
+            const [key, value] = line.split(':').map(part => part.trim());
+            if (key === 'marp' && value === 'true') {
+              setMarp(true);
+            }
+          });
+        }
+      })
+      .process(children as string);
+
     return function cleanup() {
       deck?.off('ready', removeAllHiddenElements);
       deck?.off('slidechanged', removeAllHiddenElements);
     };
-  }, [children, revealOptions]);
+  }, [children, revealOptions, setMarp]);
 
   return (
     <div className={`grw-presentation ${styles['grw-presentation']} reveal ${MARP_CONTAINER_CLASS_NAME}`}>
       <div className="slides">
-        <Slides options={options}>{children}</Slides>
+        <Slides options={options} hasMarpFlag={marp}>{children}</Slides>
       </div>
     </div>
   );

--- a/packages/presentation/src/components/Presentation.tsx
+++ b/packages/presentation/src/components/Presentation.tsx
@@ -37,11 +37,12 @@ const removeAllHiddenElements = () => {
 
 export type PresentationProps = {
   options: PresentationOptions,
+  isEnabledMarp: boolean,
   children?: string,
 }
 
 export const Presentation = (props: PresentationProps): JSX.Element => {
-  const { options, children } = props;
+  const { options, isEnabledMarp, children } = props;
   const { revealOptions } = options;
 
   const [marp, setMarp] = useState<boolean>(false);
@@ -84,7 +85,7 @@ export const Presentation = (props: PresentationProps): JSX.Element => {
   return (
     <div className={`grw-presentation ${styles['grw-presentation']} reveal ${MARP_CONTAINER_CLASS_NAME}`}>
       <div className="slides">
-        <Slides options={options} hasMarpFlag={marp}>{children}</Slides>
+        <Slides options={options} hasMarpFlag={marp && isEnabledMarp}>{children}</Slides>
       </div>
     </div>
   );


### PR DESCRIPTION
# 概要
- プレゼンテーションモードで Marp を使用可能にする。
- 管理者設定で Marp が使用可能になっており、かつプレゼンテーションモードを使用する文書の frontmatter に marp: true が指定されている場合のみ、Marp によるプレゼンテーションモードを可能にする。

# Task
- https://redmine.weseek.co.jp/issues/115673
   - https://redmine.weseek.co.jp/issues/126792

# 備考
- このタスクはプレゼンテーションモード時に Marp を呼び出せるようにしかしていない。
- 実際に Marp のスライドを遷移させられるようになるためには、Marp とGROWI スライドの要素を揃える次のタスクが必要。
  - https://redmine.weseek.co.jp/issues/125680