### PR TITLE
support: Enable build preset-themes blackboard.scss

### DIFF
--- a/packages/preset-themes/src/styles/blackboard.scss
+++ b/packages/preset-themes/src/styles/blackboard.scss
@@ -1,4 +1,4 @@
-@use '@growi/core/scss/bootstrap/init' as *;
+@use '@growi/core/scss/bootstrap/init' as bs;
 
 @use './variables' as var;
 @use './theme/mixins/page-editor-mode-manager';
@@ -20,7 +20,7 @@
   --bgcolor-global: hsl(var(--bgcolor-global-hs),var(--bgcolor-global-l));
   --bgcolor-global-hs: 140,24%;
   --bgcolor-global-l: 17%;
-  --bgcolor-inline-code: #{$gray-100}; //optional
+  --bgcolor-inline-code: #{bs.$gray-100}; //optional
   --bgcolor-card: #{hsl.darken(var(--bgcolor-global), 5%)};
   --bgcolor-blinked-section: #{hsl.alpha(var(--primary), 50%)};
   --bgcolor-keyword-highlighted: #{darken(var.$grw-marker-red, 30%)};

--- a/packages/preset-themes/src/styles/blackboard.scss
+++ b/packages/preset-themes/src/styles/blackboard.scss
@@ -1,6 +1,6 @@
 @use '@growi/core/scss/bootstrap/init' as bs;
 
-@use './variables' as *;
+@use './variables' as var;
 @use './theme/mixins/page-editor-mode-manager';
 @use './theme/hsl-functions' as hsl;
 
@@ -20,10 +20,10 @@
   --bgcolor-global: hsl(var(--bgcolor-global-hs),var(--bgcolor-global-l));
   --bgcolor-global-hs: 140,24%;
   --bgcolor-global-l: 17%;
-  --bgcolor-inline-code: #{$gray-100}; //optional
+  --bgcolor-inline-code: #{bs.$gray-100}; //optional
   --bgcolor-card: #{hsl.darken(var(--bgcolor-global), 5%)};
   --bgcolor-blinked-section: #{hsl.alpha(var(--primary), 50%)};
-  --bgcolor-keyword-highlighted: #{darken($grw-marker-red, 30%)};
+  --bgcolor-keyword-highlighted: #{darken(var.$grw-marker-red, 30%)};
 
   // Font colors
   --color-global: hsl(var(--color-global-hs),var(--color-global-l));

--- a/packages/preset-themes/src/styles/blackboard.scss
+++ b/packages/preset-themes/src/styles/blackboard.scss
@@ -1,4 +1,4 @@
-@use '@growi/core/scss/bootstrap/init' as bs;
+@use '@growi/core/scss/bootstrap/init' as *;
 
 @use './variables' as var;
 @use './theme/mixins/page-editor-mode-manager';
@@ -20,7 +20,7 @@
   --bgcolor-global: hsl(var(--bgcolor-global-hs),var(--bgcolor-global-l));
   --bgcolor-global-hs: 140,24%;
   --bgcolor-global-l: 17%;
-  --bgcolor-inline-code: #{bs.$gray-100}; //optional
+  --bgcolor-inline-code: #{$gray-100}; //optional
   --bgcolor-card: #{hsl.darken(var(--bgcolor-global), 5%)};
   --bgcolor-blinked-section: #{hsl.alpha(var(--primary), 50%)};
   --bgcolor-keyword-highlighted: #{darken(var.$grw-marker-red, 30%)};

--- a/packages/preset-themes/vite.themes.config.ts
+++ b/packages/preset-themes/vite.themes.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
     rollupOptions: {
       input: [
         // '/src/styles/antarctic.scss',
-        // '/src/styles/blackboard.scss',
+        '/src/styles/blackboard.scss',
         // '/src/styles/christmas.scss',
         '/src/styles/default.scss',
         // '/src/styles/fire-red.scss',


### PR DESCRIPTION
task: https://redmine.weseek.co.jp/issues/128305

## 概要
- turbo run watch で失敗箇所を修正
- bootstrap/init をアスタリスクで呼び出す
- build してテーマ変更してみました

## Screenshot
![localhost_3000_](https://github.com/weseek/growi/assets/68407388/3a0a48ba-f295-4b76-a238-a1a515218e2d)