### PR TITLE
fix: Pages can be created under a non-existent user page

### DIFF
--- a/apps/app/src/server/models/user.js
+++ b/apps/app/src/server/models/user.js
@@ -712,9 +712,13 @@ module.exports = function(crowi) {
 
   userSchema.statics.isExistUserByUserPagePath = async function(path) {
     const username = this.getUsernameByPath(path);
-    const user = await this.findOne({ username });
 
-    return user != null;
+    if (username == null) {
+      return false;
+    }
+
+    const isExist = (await this.count({ username })) > 0;
+    return isExist;
   };
 
   userSchema.statics.updateIsInvitationEmailSended = async function(id) {

--- a/apps/app/src/server/models/user.js
+++ b/apps/app/src/server/models/user.js
@@ -717,8 +717,8 @@ module.exports = function(crowi) {
       return false;
     }
 
-    const isExist = (await this.count({ username })) > 0;
-    return isExist;
+    const user = await this.exists({ username });
+    return user != null;
   };
 
   userSchema.statics.updateIsInvitationEmailSended = async function(id) {

--- a/apps/app/src/server/models/user.js
+++ b/apps/app/src/server/models/user.js
@@ -702,16 +702,6 @@ module.exports = function(crowi) {
     });
   };
 
-  userSchema.statics.getUsernameByPath = function(path) {
-    let username = null;
-    const match = path.match(/^\/user\/([^/]+)\/?/);
-    if (match) {
-      username = match[1];
-    }
-
-    return username;
-  };
-
   userSchema.statics.isExistUserByUserPagePath = async function(path) {
     const username = pagePathUtils.getUsernameByPath(path);
 

--- a/apps/app/src/server/models/user.js
+++ b/apps/app/src/server/models/user.js
@@ -710,6 +710,13 @@ module.exports = function(crowi) {
     return username;
   };
 
+  userSchema.statics.isExistUserByUserPagePath = async function(path) {
+    const username = this.getUsernameByPath(path);
+    const user = await this.findOne({ username });
+
+    return user != null;
+  };
+
   userSchema.statics.updateIsInvitationEmailSended = async function(id) {
     const user = await this.findById(id);
 

--- a/apps/app/src/server/models/user.js
+++ b/apps/app/src/server/models/user.js
@@ -1,4 +1,6 @@
 /* eslint-disable no-use-before-define */
+import { pagePathUtils } from '@growi/core/dist/utils';
+
 import { i18n } from '^/config/next-i18next.config';
 
 import { generateGravatarSrc } from '~/utils/gravatar';
@@ -711,7 +713,7 @@ module.exports = function(crowi) {
   };
 
   userSchema.statics.isExistUserByUserPagePath = async function(path) {
-    const username = this.getUsernameByPath(path);
+    const username = pagePathUtils.getUsernameByPath(path);
 
     if (username == null) {
       return false;

--- a/apps/app/src/server/routes/apiv3/pages.js
+++ b/apps/app/src/server/routes/apiv3/pages.js
@@ -773,7 +773,7 @@ module.exports = (crowi) => {
       if (isUserPage(newPagePath)) {
         const isExistUser = await User.isExistUserByUserPagePath(newPagePath);
         if (!isExistUser) {
-          return res.apiv3Err("Unable to rename a page under a non-existent user's user page");
+          return res.apiv3Err("Unable to duplicate a page under a non-existent user's user page");
         }
       }
 

--- a/apps/app/src/server/routes/apiv3/pages.js
+++ b/apps/app/src/server/routes/apiv3/pages.js
@@ -1,7 +1,7 @@
 
 import { PageGrant } from '@growi/core';
 import { ErrorV3 } from '@growi/core/dist/models';
-import { isCreatablePage, isTrashPage } from '@growi/core/dist/utils/page-path-utils';
+import { isCreatablePage, isTrashPage, isUserPage } from '@growi/core/dist/utils/page-path-utils';
 import { normalizePath, addHeadingSlash, attachTitleHeader } from '@growi/core/dist/utils/path-utils';
 
 import { SupportedTargetModel, SupportedAction } from '~/interfaces/activity';
@@ -303,6 +303,13 @@ module.exports = (crowi) => {
     // check whether path starts slash
     path = addHeadingSlash(path);
 
+    if (isUserPage(path)) {
+      const isExistUser = await User.isExistUserByUserPagePath(path);
+      if (!isExistUser) {
+        return res.apiv3Err("Unable to create a page under a non-existent user's user page");
+      }
+    }
+
     const options = { overwriteScopesOfDescendants };
     if (grant != null) {
       options.grant = grant;
@@ -524,6 +531,13 @@ module.exports = (crowi) => {
 
     if (!isCreatablePage(newPagePath)) {
       return res.apiv3Err(new ErrorV3(`Could not use the path '${newPagePath}'`, 'invalid_path'), 409);
+    }
+
+    if (isUserPage(newPagePath)) {
+      const isExistUser = await User.isExistUserByUserPagePath(newPagePath);
+      if (!isExistUser) {
+        return res.apiv3Err("Unable to rename a page under a non-existent user's user page");
+      }
     }
 
     // check whether path starts slash
@@ -754,6 +768,13 @@ module.exports = (crowi) => {
       const isCreatable = isCreatablePage(newPagePath);
       if (!isCreatable) {
         return res.apiv3Err(new ErrorV3('This page path is invalid', 'invalid_path'), 400);
+      }
+
+      if (isUserPage(newPagePath)) {
+        const isExistUser = await User.isExistUserByUserPagePath(newPagePath);
+        if (!isExistUser) {
+          return res.apiv3Err("Unable to rename a page under a non-existent user's user page");
+        }
       }
 
       // check page existence

--- a/apps/app/test/integration/models/user.test.js
+++ b/apps/app/test/integration/models/user.test.js
@@ -144,7 +144,7 @@ describe('User', () => {
       });
 
       test('not found', async() => {
-        const userPagePath = '/user/usertest2';
+        const userPagePath = '/user/usertest-hoge';
         const isExist = await User.isExistUserByUserPagePath(userPagePath);
 
         expect(isExist).toBe(false);

--- a/apps/app/test/integration/models/user.test.js
+++ b/apps/app/test/integration/models/user.test.js
@@ -73,7 +73,6 @@ describe('User', () => {
         expect(user).toBeInstanceOf(User);
         expect(user.name).toBe('Example for User Test');
       });
-
     });
 
   });
@@ -133,6 +132,22 @@ describe('User', () => {
         let username = null;
         username = User.getUsernameByPath('/the/page/is/not/related/to/user/page');
         expect(username).toBeNull();
+      });
+    });
+
+    describe('Get user exists from user page path', () => {
+      test('found', async() => {
+        const userPagePath = '/user/usertest';
+        const isExist = await User.isExistUserByUserPagePath(userPagePath);
+
+        expect(isExist).toBe(true);
+      });
+
+      test('not found', async() => {
+        const userPagePath = '/user/usertest2';
+        const isExist = await User.isExistUserByUserPagePath(userPagePath);
+
+        expect(isExist).toBe(false);
       });
     });
   });

--- a/apps/app/test/integration/models/user.test.js
+++ b/apps/app/test/integration/models/user.test.js
@@ -118,23 +118,6 @@ describe('User', () => {
   });
 
   describe('User Utilities', () => {
-    describe('Get username from path', () => {
-      test('found', () => {
-        let username = null;
-        username = User.getUsernameByPath('/user/sotarok');
-        expect(username).toEqual('sotarok');
-
-        username = User.getUsernameByPath('/user/some.user.name12/'); // with slash
-        expect(username).toEqual('some.user.name12');
-      });
-
-      test('not found', () => {
-        let username = null;
-        username = User.getUsernameByPath('/the/page/is/not/related/to/user/page');
-        expect(username).toBeNull();
-      });
-    });
-
     describe('Get user exists from user page path', () => {
       test('found', async() => {
         const userPagePath = '/user/usertest';

--- a/packages/core/src/utils/page-path-utils/index.spec.ts
+++ b/packages/core/src/utils/page-path-utils/index.spec.ts
@@ -1,5 +1,5 @@
 import {
-  isMovablePage, convertToNewAffiliationPath, isCreatablePage, omitDuplicateAreaPathFromPaths,
+  isMovablePage, convertToNewAffiliationPath, isCreatablePage, omitDuplicateAreaPathFromPaths, getUsernameByPath,
 } from './index';
 
 describe.concurrent('isMovablePage test', () => {
@@ -117,4 +117,23 @@ describe.concurrent('isCreatablePage test', () => {
       expect(omitDuplicateAreaPathFromPaths(paths)).toStrictEqual(expectedPaths);
     });
   });
+
+
+  describe.concurrent('Test getUsernameByPath', () => {
+    test.concurrent('found', () => {
+      const username = getUsernameByPath('/user/sotarok');
+      expect(username).toBe('sotarok');
+    });
+
+    test.concurrent('found with slash', () => {
+      const username = getUsernameByPath('/user/some.user.name12/');
+      expect(username).toBe('some.user.name12');
+    });
+
+    test.concurrent('not found', () => {
+      const username = getUsernameByPath('/the/page/is/not/related/to/user/page');
+      expect(username).toBeNull();
+    });
+  });
+
 });

--- a/packages/core/src/utils/page-path-utils/index.ts
+++ b/packages/core/src/utils/page-path-utils/index.ts
@@ -287,5 +287,21 @@ export const generateChildrenRegExp = (path: string): RegExp => {
   return new RegExp(`^${path}(\\/[^/]+)\\/?$`);
 };
 
+/**
+ * Get username from user page path
+ * @param path string
+ * @returns string | null
+ */
+export const getUsernameByPath = (path: string): string | null => {
+  let username: string | null = null;
+  const match = path.match(/^\/user\/([^/]+)\/?/);
+  if (match) {
+    username = match[1];
+  }
+
+  return username;
+};
+
+
 export * from './is-top-page';
 export * from './collect-ancestor-paths';

--- a/packages/core/src/utils/page-path-utils/index.ts
+++ b/packages/core/src/utils/page-path-utils/index.ts
@@ -294,6 +294,7 @@ export const generateChildrenRegExp = (path: string): RegExp => {
  */
 export const getUsernameByPath = (path: string): string | null => {
   let username: string | null = null;
+  // https://regex101.com/r/qj4SfD/1
   const match = path.match(/^\/user\/([^/]+)\/?/);
   if (match) {
     username = match[1];


### PR DESCRIPTION
## Task
[#125056](https://redmine.weseek.co.jp/issues/125056) [User homapage] `/user/{存在しないusername}/{任意のページ}` でページが作成できてしまう
└ 128138 存在しない user page 配下にページを 作成/移動/複製 できないようにする