### PR TITLE
fix: Do not work image tag properties

### DIFF
--- a/apps/app/src/components/ReactMarkdownComponents/LightBox.tsx
+++ b/apps/app/src/components/ReactMarkdownComponents/LightBox.tsx
@@ -6,7 +6,7 @@ export const LightBox = (props) => {
   const [toggler, setToggler] = useState(false);
   return (
     <>
-      <img src={props.src} alt={props.alt} onClick={() => setToggler(!toggler)}/>
+      <img {...props.node.properties} onClick={() => setToggler(!toggler)}/>
       <FsLightbox
         toggler={toggler}
         sources={[props.src]}


### PR DESCRIPTION
# task
- https://redmine.weseek.co.jp/issues/128483

# 概要
- properties をそのまま渡すようにしました。
- カスタムホワイトリストが有効なことを確認しました。