### PR TITLE
fix: Do not work img tag if use style property

### DIFF
--- a/apps/app/src/components/ReactMarkdownComponents/LightBox.tsx
+++ b/apps/app/src/components/ReactMarkdownComponents/LightBox.tsx
@@ -4,9 +4,11 @@ import FsLightbox from 'fslightbox-react';
 
 export const LightBox = (props) => {
   const [toggler, setToggler] = useState(false);
+  const { node, ...rest } = props;
+
   return (
     <>
-      <img {...props.node.properties} onClick={() => setToggler(!toggler)}/>
+      <img {...rest} onClick={() => setToggler(!toggler)} />
       <FsLightbox
         toggler={toggler}
         sources={[props.src]}


### PR DESCRIPTION
## task
https://redmine.weseek.co.jp/issues/128719

## 概要
- v6.1.12 で img タグに style を渡すと error boundary に引っ掛かるようになっていた
- その他 class が `class='mt-3, has-data-line'` のようになって正しく渡せていなかった

## 原因
- `...props.node.properties` を JSX の img タグに渡すようにしていたため, style='width:50%' のように渡ってしまっていた。

## 修正方針
- LightBox 導入前の v6.1.8 で, img タグに [このサイト](https://html-coding.co.jp/annex/dictionary/html/img/) にある属性と適当に作ったダミー属性を入れてみて、生成される DOM を開発者ツールから確認する
- dev/6.1.x からブランチを切り img タグと属性を書いてみて、View に同じ DOM が生成されるようにするような方向で修正する

## 修正案
- JSX の img へ {...props} のように渡すとよさそうだったので、node プロパティだけ除いたうえで props をJSX の img へ渡すように修正しました。

## 確認 Screenshot
### v6.1.8 の input した img タグと生成される DOM
![image (3)](https://github.com/weseek/growi/assets/68407388/cda47a48-8875-4f4f-aa4e-74b948042630)

### この PR の修正で同じ img タグの入力に対し v6.1.8 と同じ DOM が生成されている
![image (5)](https://github.com/weseek/growi/assets/68407388/7ea0a828-eb6b-4bd2-8499-335fce238b09)
