### PR TITLE
support: Replace ModalHeader custom close icon

### DIFF
--- a/apps/app/_obsolete/src/components/PageEditor/ConflictDiffModal.tsx
+++ b/apps/app/_obsolete/src/components/PageEditor/ConflictDiffModal.tsx
@@ -130,20 +130,16 @@ const ConflictDiffModalCore = (props: ConflictDiffModalCoreProps): JSX.Element =
 
   }, [afterResolvedHandler, close, currentPagePath, currentPathname, optionsToSave, pageId, remoteRevisionId, saveOrUpdate, setRemoteLatestPageData]);
 
-  // TODO: No longer support custom close icon in bootstrap v5
-  // https://redmine.weseek.co.jp/issues/128470
-  // const resizeAndCloseButtons = useMemo(() => (
-  //   <div className="d-flex flex-nowrap">
-  //     <ExpandOrContractButton
-  //       isWindowExpanded={isModalExpanded}
-  //       expandWindow={() => setIsModalExpanded(true)}
-  //       contractWindow={() => setIsModalExpanded(false)}
-  //     />
-  //     <button type="button" className="close text-white" onClick={close} aria-label="Close">
-  //       <span aria-hidden="true">&times;</span>
-  //     </button>
-  //   </div>
-  // ), [isModalExpanded, close]);
+  const resizeAndCloseButtons = useMemo(() => (
+    <div className='me-3 text-right'>
+      <ExpandOrContractButton
+        isWindowExpanded={isModalExpanded}
+        expandWindow={() => setIsModalExpanded(true)}
+        contractWindow={() => setIsModalExpanded(false)}
+      />
+      <button type="button" className="btn btn-close text-white" onClick={close} aria-label="Close"></button>
+    </div>
+  ), [isModalExpanded, close]);
 
   const isOpen = props.isOpen ?? false;
 
@@ -155,8 +151,7 @@ const ConflictDiffModalCore = (props: ConflictDiffModalCoreProps): JSX.Element =
       className={`${isModalExpanded ? ' grw-modal-expanded' : ''}`}
       size="xl"
     >
-      {/* <ModalHeader tag="h4" toggle={onClose} className="bg-primary text-light align-items-center py-3" close={resizeAndCloseButtons}> */}
-      <ModalHeader tag="h4" toggle={onClose} className="bg-primary text-light align-items-center py-3">
+      <ModalHeader tag="h4" toggle={onClose} className="bg-primary text-light align-items-center py-3" close={resizeAndCloseButtons}>
         <i className="icon-fw icon-exclamation" />{t('modal_resolve_conflict.resolve_conflict')}
       </ModalHeader>
       <ModalBody className="mx-4 my-1">

--- a/apps/app/_obsolete/src/components/PageEditor/ConflictDiffModal.tsx
+++ b/apps/app/_obsolete/src/components/PageEditor/ConflictDiffModal.tsx
@@ -130,16 +130,19 @@ const ConflictDiffModalCore = (props: ConflictDiffModalCoreProps): JSX.Element =
 
   }, [afterResolvedHandler, close, currentPagePath, currentPathname, optionsToSave, pageId, remoteRevisionId, saveOrUpdate, setRemoteLatestPageData]);
 
-  const resizeAndCloseButtons = useMemo(() => (
-    <div className='me-3 text-right'>
-      <ExpandOrContractButton
-        isWindowExpanded={isModalExpanded}
-        expandWindow={() => setIsModalExpanded(true)}
-        contractWindow={() => setIsModalExpanded(false)}
-      />
-      <button type="button" className="btn btn-close text-white" onClick={close} aria-label="Close"></button>
-    </div>
-  ), [isModalExpanded, close]);
+  // TODO: No longer support custom close icon in bootstrap v5
+  // const resizeAndCloseButtons = useMemo(() => (
+  //   <div className="d-flex flex-nowrap">
+  //     <ExpandOrContractButton
+  //       isWindowExpanded={isModalExpanded}
+  //       expandWindow={() => setIsModalExpanded(true)}
+  //       contractWindow={() => setIsModalExpanded(false)}
+  //     />
+  //     <button type="button" className="close text-white" onClick={close} aria-label="Close">
+  //       <span aria-hidden="true">&times;</span>
+  //     </button>
+  //   </div>
+  // ), [isModalExpanded, close]);
 
   const isOpen = props.isOpen ?? false;
 
@@ -151,7 +154,8 @@ const ConflictDiffModalCore = (props: ConflictDiffModalCoreProps): JSX.Element =
       className={`${isModalExpanded ? ' grw-modal-expanded' : ''}`}
       size="xl"
     >
-      <ModalHeader tag="h4" toggle={onClose} className="bg-primary text-light align-items-center py-3" close={resizeAndCloseButtons}>
+      {/* <ModalHeader tag="h4" toggle={onClose} className="bg-primary text-light align-items-center py-3" close={resizeAndCloseButtons}> */}
+      <ModalHeader tag="h4" toggle={onClose} className="bg-primary text-light align-items-center py-3">
         <i className="icon-fw icon-exclamation" />{t('modal_resolve_conflict.resolve_conflict')}
       </ModalHeader>
       <ModalBody className="mx-4 my-1">

--- a/apps/app/src/components/DescendantsPageListModal.tsx
+++ b/apps/app/src/components/DescendantsPageListModal.tsx
@@ -71,14 +71,14 @@ export const DescendantsPageListModal = (): JSX.Element => {
   }, [isSharedUser, status, t]);
 
   const buttons = useMemo(() => (
-    <div className='me-3 text-right'>
+    <span className='me-3'>
       <ExpandOrContractButton
         isWindowExpanded={isWindowExpanded}
         expandWindow={() => setIsWindowExpanded(true)}
         contractWindow={() => setIsWindowExpanded(false)}
       />
       <button type="button" className="btn btn-close" onClick={close} aria-label="Close"></button>
-    </div>
+    </span>
   ), [close, isWindowExpanded]);
 
   if (status == null) {

--- a/apps/app/src/components/DescendantsPageListModal.tsx
+++ b/apps/app/src/components/DescendantsPageListModal.tsx
@@ -70,21 +70,16 @@ export const DescendantsPageListModal = (): JSX.Element => {
     };
   }, [isSharedUser, status, t]);
 
-  // TODO: No longer support custom close icon in bootstrap v5
-  // https://redmine.weseek.co.jp/issues/128470
-  // const buttons = useMemo(() => (
-  //   <div className="d-flex flex-nowrap">
-  //     <ExpandOrContractButton
-  //       isWindowExpanded={isWindowExpanded}
-  //       expandWindow={() => setIsWindowExpanded(true)}
-  //       contractWindow={() => setIsWindowExpanded(false)}
-  //     />
-  //     <button type="button" className="close" onClick={close} aria-label="Close">
-  //       <span aria-hidden="true">&times;</span>
-  //     </button>
-  //   </div>
-  // ), [close, isWindowExpanded]);
-
+  const buttons = useMemo(() => (
+    <div className='me-3 text-right'>
+      <ExpandOrContractButton
+        isWindowExpanded={isWindowExpanded}
+        expandWindow={() => setIsWindowExpanded(true)}
+        contractWindow={() => setIsWindowExpanded(false)}
+      />
+      <button type="button" className="btn btn-close" onClick={close} aria-label="Close"></button>
+    </div>
+  ), [close, isWindowExpanded]);
 
   if (status == null) {
     return <></>;
@@ -100,8 +95,7 @@ export const DescendantsPageListModal = (): JSX.Element => {
       data-testid="descendants-page-list-modal"
       className={`grw-descendants-page-list-modal ${styles['grw-descendants-page-list-modal']} ${isWindowExpanded ? 'grw-modal-expanded' : ''} `}
     >
-      {/* <ModalHeader className="p-0" toggle={close} close={buttons}> */}
-      <ModalHeader className="p-0" toggle={close}>
+      <ModalHeader className="p-0" toggle={close} close={buttons}>
         <CustomNavTab
           activeTab={activeTab}
           navTabMapping={navTabMapping}

--- a/apps/app/src/components/ExpandOrContractButton.tsx
+++ b/apps/app/src/components/ExpandOrContractButton.tsx
@@ -1,6 +1,5 @@
 import React, { FC } from 'react';
 
-
 type Props = {
   isWindowExpanded: boolean,
   contractWindow?: () => void,
@@ -25,10 +24,9 @@ const ExpandOrContractButton: FC<Props> = (props: Props) => {
   return (
     <button
       type="button"
-      className="close"
+      className={`btn ${isWindowExpanded ? 'icon-size-actual' : 'icon-size-fullscreen'}`}
       onClick={isWindowExpanded ? clickContractButtonHandler : clickExpandButtonHandler}
     >
-      <i className={`${isWindowExpanded ? 'icon-size-actual' : 'icon-size-fullscreen'}`} style={{ fontSize: '0.8em' }} aria-hidden="true"></i>
     </button>
   );
 };

--- a/apps/app/src/components/PageAccessoriesModal/PageAccessoriesModal.tsx
+++ b/apps/app/src/components/PageAccessoriesModal/PageAccessoriesModal.tsx
@@ -71,20 +71,16 @@ export const PageAccessoriesModal = (): JSX.Element => {
     };
   }, [t, close, isGuestUser, isReadOnlyUser, isSharedUser, isLinkSharingDisabled]);
 
-  // TODO: No longer support custom close icon in bootstrap v5
-  // https://redmine.weseek.co.jp/issues/128470
-  // const buttons = useMemo(() => (
-  //   <div className="d-flex flex-nowrap">
-  //     <ExpandOrContractButton
-  //       isWindowExpanded={isWindowExpanded}
-  //       expandWindow={() => setIsWindowExpanded(true)}
-  //       contractWindow={() => setIsWindowExpanded(false)}
-  //     />
-  //     <button type="button" className="close" onClick={close} aria-label="Close">
-  //       <span aria-hidden="true">&times;</span>
-  //     </button>
-  //   </div>
-  // ), [close, isWindowExpanded]);
+  const buttons = useMemo(() => (
+    <div className='me-3 text-right'>
+      <ExpandOrContractButton
+        isWindowExpanded={isWindowExpanded}
+        expandWindow={() => setIsWindowExpanded(true)}
+        contractWindow={() => setIsWindowExpanded(false)}
+      />
+      <button type="button" className="btn btn-close" onClick={close} aria-label="Close"></button>
+    </div>
+  ), [close, isWindowExpanded]);
 
   if (status == null || status.activatedContents == null) {
     return <></>;
@@ -100,8 +96,7 @@ export const PageAccessoriesModal = (): JSX.Element => {
       data-testid="page-accessories-modal"
       className={`grw-page-accessories-modal ${styles['grw-page-accessories-modal']} ${isWindowExpanded ? 'grw-modal-expanded' : ''} `}
     >
-      {/* <ModalHeader className="p-0" toggle={close} close={buttons}> */}
-      <ModalHeader className="p-0" toggle={close}>
+      <ModalHeader className="p-0" toggle={close} close={buttons}>
         <CustomNavTab
           activeTab={status.activatedContents}
           navTabMapping={navTabMapping}

--- a/apps/app/src/components/PageAccessoriesModal/PageAccessoriesModal.tsx
+++ b/apps/app/src/components/PageAccessoriesModal/PageAccessoriesModal.tsx
@@ -72,14 +72,14 @@ export const PageAccessoriesModal = (): JSX.Element => {
   }, [t, close, isGuestUser, isReadOnlyUser, isSharedUser, isLinkSharingDisabled]);
 
   const buttons = useMemo(() => (
-    <div className='me-3 text-right'>
+    <span className='me-3'>
       <ExpandOrContractButton
         isWindowExpanded={isWindowExpanded}
         expandWindow={() => setIsWindowExpanded(true)}
         contractWindow={() => setIsWindowExpanded(false)}
       />
       <button type="button" className="btn btn-close" onClick={close} aria-label="Close"></button>
-    </div>
+    </span>
   ), [close, isWindowExpanded]);
 
   if (status == null || status.activatedContents == null) {

--- a/apps/app/src/components/PageEditor/HandsontableModal.tsx
+++ b/apps/app/src/components/PageEditor/HandsontableModal.tsx
@@ -430,13 +430,12 @@ export const HandsontableModal = (): JSX.Element => {
 
   const closeButton = (
     <span>
-      {/* change order because of `float: right` by '.close' class */}
-      <button type="button" className="btn btn-close" onClick={cancel} aria-label="Close"></button>
       <ExpandOrContractButton
         isWindowExpanded={isWindowExpanded}
         contractWindow={contractWindow}
         expandWindow={expandWindow}
       />
+      <button type="button" className="btn btn-close" onClick={cancel} aria-label="Close"></button>
     </span>
   );
 

--- a/apps/app/src/components/PageEditor/HandsontableModal.tsx
+++ b/apps/app/src/components/PageEditor/HandsontableModal.tsx
@@ -428,21 +428,17 @@ export const HandsontableModal = (): JSX.Element => {
     contextMenu: createCustomizedContextMenu(),
   });
 
-  // TODO: No longer support custom close icon in bootstrap v5
-  // https://redmine.weseek.co.jp/issues/128470
-  // const closeButton = (
-  //   <span>
-  //     {/* change order because of `float: right` by '.close' class */}
-  //     <button type="button" className="close" onClick={cancel} aria-label="Close">
-  //       <span aria-hidden="true">&times;</span>
-  //     </button>
-  //     <ExpandOrContractButton
-  //       isWindowExpanded={isWindowExpanded}
-  //       contractWindow={contractWindow}
-  //       expandWindow={expandWindow}
-  //     />
-  //   </span>
-  // );
+  const closeButton = (
+    <span>
+      {/* change order because of `float: right` by '.close' class */}
+      <button type="button" className="btn btn-close" onClick={cancel} aria-label="Close"></button>
+      <ExpandOrContractButton
+        isWindowExpanded={isWindowExpanded}
+        contractWindow={contractWindow}
+        expandWindow={expandWindow}
+      />
+    </span>
+  );
 
   return (
     <Modal
@@ -455,8 +451,7 @@ export const HandsontableModal = (): JSX.Element => {
       className={`handsontable-modal ${isWindowExpanded && 'grw-modal-expanded'}`}
       onOpened={handleModalOpen}
     >
-      {/* <ModalHeader tag="h4" toggle={cancel} close={closeButton} className="bg-primary text-light"> */}
-      <ModalHeader tag="h4" toggle={cancel} className="bg-primary text-light">
+      <ModalHeader tag="h4" toggle={cancel} close={closeButton} className="bg-primary text-light">
         {t('handsontable_modal.title')}
       </ModalHeader>
       <ModalBody className="p-0 d-flex flex-column">


### PR DESCRIPTION
## task
- https://redmine.weseek.co.jp/issues/128470

## 概要
- モーダル右上の expand icon と close icon の部分の修正

## Screenshot
### Before v6
### PageAccessoriesModal, DescendantsPageListModal
![image](https://github.com/weseek/growi/assets/68407388/a99de87d-b81b-40bf-bda9-e49b985f8a00)
![image](https://github.com/weseek/growi/assets/68407388/0d3117f9-bd19-4f57-802a-bab7b2089b51)
### HandsontableModal
![image](https://github.com/weseek/growi/assets/68407388/777d266a-15c7-4797-b196-70385631b2af)

### Before dev/7.0.x
### PageAccessoriesModal, DescendantsPageListModal
![image](https://github.com/weseek/growi/assets/68407388/f9f31a23-ede1-4306-be32-f56dfe1b7f6b)

### HandsontableModal
![image](https://github.com/weseek/growi/assets/68407388/62c9fdaf-c711-4176-8166-0a75513bbba9)

### After
### PageAccessoriesModal
![image](https://github.com/weseek/growi/assets/68407388/1ef441d3-b5c7-4ea8-976e-594f4e4ca60c)

### DescendantsPageListModal
![image](https://github.com/weseek/growi/assets/68407388/b26ddb94-c908-4e4c-a276-223f1180e02f)

### HandsontableModal
![image](https://github.com/weseek/growi/assets/68407388/800bfda6-e108-442d-b71f-60c9bfc6e2d2)


