### PR TITLE
fix: Pages can be created under a non-existent user page (During attachment upload)

### DIFF
--- a/apps/app/src/server/routes/apiv3/pages.js
+++ b/apps/app/src/server/routes/apiv3/pages.js
@@ -303,6 +303,10 @@ module.exports = (crowi) => {
     // check whether path starts slash
     path = addHeadingSlash(path);
 
+    if (!isCreatablePage(path)) {
+      return res.apiv3Err(`Could not use the path '${path}'`);
+    }
+
     if (isUserPage(path)) {
       const isExistUser = await User.isExistUserByUserPagePath(path);
       if (!isExistUser) {

--- a/apps/app/src/server/routes/attachment.js
+++ b/apps/app/src/server/routes/attachment.js
@@ -1,4 +1,4 @@
-import { isUserPage } from '@growi/core/dist/utils/page-path-utils';
+import { isCreatablePage, isUserPage } from '@growi/core/dist/utils/page-path-utils';
 
 import { SupportedAction } from '~/interfaces/activity';
 import { AttachmentType } from '~/server/interfaces/attachment';
@@ -470,6 +470,10 @@ module.exports = function(crowi, app) {
     let page;
     if (pageId == null) {
       logger.debug('Create page before file upload');
+
+      if (!isCreatablePage(pagePath)) {
+        return res.json(ApiResponse.error(`Could not use the path '${pagePath}'`));
+      }
 
       if (isUserPage(pagePath)) {
         const isExistUser = await User.isExistUserByUserPagePath(pagePath);

--- a/apps/app/src/server/routes/attachment.js
+++ b/apps/app/src/server/routes/attachment.js
@@ -478,7 +478,6 @@ module.exports = function(crowi, app) {
         }
       }
 
-
       const isAclEnabled = crowi.aclService.isAclEnabled();
       const grant = isAclEnabled ? Page.GRANT_OWNER : Page.GRANT_PUBLIC;
 

--- a/apps/app/src/server/routes/attachment.js
+++ b/apps/app/src/server/routes/attachment.js
@@ -1,3 +1,5 @@
+import { isUserPage } from '@growi/core/dist/utils/page-path-utils';
+
 import { SupportedAction } from '~/interfaces/activity';
 import { AttachmentType } from '~/server/interfaces/attachment';
 import loggerFactory from '~/utils/logger';
@@ -134,6 +136,7 @@ const ApiResponse = require('../util/apiResponse');
 module.exports = function(crowi, app) {
   const Attachment = crowi.model('Attachment');
   const Page = crowi.model('Page');
+  const User = crowi.model('User');
   const GlobalNotificationSetting = crowi.model('GlobalNotificationSetting');
   const { attachmentService, globalNotificationService } = crowi;
 
@@ -467,6 +470,14 @@ module.exports = function(crowi, app) {
     let page;
     if (pageId == null) {
       logger.debug('Create page before file upload');
+
+      if (isUserPage(pagePath)) {
+        const isExistUser = await User.isExistUserByUserPagePath(pagePath);
+        if (!isExistUser) {
+          return res.json(ApiResponse.error("Unable to create a page under a non-existent user's user page"));
+        }
+      }
+
 
       const isAclEnabled = crowi.aclService.isAclEnabled();
       const grant = isAclEnabled ? Page.GRANT_OWNER : Page.GRANT_PUBLIC;


### PR DESCRIPTION
## Task
[#125056](https://redmine.weseek.co.jp/issues/125056) [User homapage] `/user/{存在しないusername}/{任意のページ}` でページが作成できてしまう
└ [#128784](https://redmine.weseek.co.jp/issues/128784) attachment をアップロードしてページを作成する時の対応