### PR TITLE
fix: Fixing swagger for tag update api

### DIFF
--- a/apps/app/src/server/routes/tag.js
+++ b/apps/app/src/server/routes/tag.js
@@ -107,6 +107,8 @@ module.exports = function(crowi, app) {
    *                properties:
    *                  pageId:
    *                    $ref: '#/components/schemas/Page/properties/_id'
+   *                  revisionId:
+   *                    $ref: '#/components/schemas/Revision/properties/_id'
    *                  tags:
    *                    $ref: '#/components/schemas/Tags'
    *        responses:


### PR DESCRIPTION
## Task
[#128992](https://redmine.weseek.co.jp/issues/128992)  /tags.update の swagger 修正
└ [#128993](https://redmine.weseek.co.jp/issues/128993) 修正