### PR TITLE
support: Bootstrap v5 braking changes Badges

### DIFF
--- a/apps/app/src/components/Admin/AuditLog/AuditLogSettings.tsx
+++ b/apps/app/src/components/Admin/AuditLog/AuditLogSettings.tsx
@@ -37,7 +37,7 @@ export const AuditLogSettings: FC = () => {
 
       <h4 className="mt-4">
         {t('admin:audit_log_management.available_action_list')}
-        <span className="badge rounded-pill badge-secondary ml-2">
+        <span className="badge rounded-pill bg-primary ml-2">
           {`${availableActions.length} / ${AllSupportedActions.length}`}
         </span>
         <a

--- a/apps/app/src/components/Admin/AuditLog/AuditLogSettings.tsx
+++ b/apps/app/src/components/Admin/AuditLog/AuditLogSettings.tsx
@@ -37,7 +37,7 @@ export const AuditLogSettings: FC = () => {
 
       <h4 className="mt-4">
         {t('admin:audit_log_management.available_action_list')}
-        <span className="badge badge-pill badge-secondary ml-2">
+        <span className="badge rounded-pill badge-secondary ml-2">
           {`${availableActions.length} / ${AllSupportedActions.length}`}
         </span>
         <a

--- a/apps/app/src/components/Admin/Customize/ThemeColorBox.tsx
+++ b/apps/app/src/components/Admin/Customize/ThemeColorBox.tsx
@@ -35,7 +35,7 @@ export const ThemeColorBox = (props: Props): JSX.Element => {
         </svg>
       </a>
       <span className="theme-option-name"><b>{ name }</b></span>
-      { !isPresetTheme && <span className="theme-option-badge badge badge-primary mt-1">Plugin</span> }
+      { !isPresetTheme && <span className="theme-option-badge badge bg-primary mt-1">Plugin</span> }
     </div>
   );
 

--- a/apps/app/src/components/Admin/ElasticsearchManagement/StatusTable.jsx
+++ b/apps/app/src/components/Admin/ElasticsearchManagement/StatusTable.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 class StatusTable extends React.PureComponent {
 
   renderPreInitializedLabel() {
-    return <span className="badge rounded-pill badge-default">――</span>;
+    return <span className="badge rounded-pill bg-default">――</span>;
   }
 
   renderConnectionStatusLabels() {
@@ -23,7 +23,7 @@ class StatusTable extends React.PureComponent {
     let connectionStatusLabel = null;
     if (!isConfigured) {
       connectionStatusLabel = (
-        <span className="badge rounded-pill badge-default">
+        <span className="badge rounded-pill bg-default">
           { t('full_text_search_management.connection_status_label_unconfigured') }
         </span>
       );

--- a/apps/app/src/components/Admin/ElasticsearchManagement/StatusTable.jsx
+++ b/apps/app/src/components/Admin/ElasticsearchManagement/StatusTable.jsx
@@ -47,7 +47,7 @@ class StatusTable extends React.PureComponent {
 
     return isNormalized
       ? <span className="badge rounded-pill bg-info">{ t('full_text_search_management.indices_status_label_normalized') }</span>
-      : <span className="badge rounded-pill bg-warning">{ t('full_text_search_management.indices_status_label_unnormalized') }</span>;
+      : <span className="badge rounded-pill bg-warning text-dark">{ t('full_text_search_management.indices_status_label_unnormalized') }</span>;
   }
 
   renderIndexInfoPanel(indexName, body = {}, aliases = []) {

--- a/apps/app/src/components/Admin/ElasticsearchManagement/StatusTable.jsx
+++ b/apps/app/src/components/Admin/ElasticsearchManagement/StatusTable.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 class StatusTable extends React.PureComponent {
 
   renderPreInitializedLabel() {
-    return <span className="badge badge-pill badge-default">――</span>;
+    return <span className="badge rounded-pill badge-default">――</span>;
   }
 
   renderConnectionStatusLabels() {
@@ -17,18 +17,18 @@ class StatusTable extends React.PureComponent {
     } = this.props;
 
     const errorOccuredLabel = isErrorOccuredOnSearchService
-      ? <span className="badge badge-pill badge-danger ml-2">{ t('full_text_search_management.connection_status_label_erroroccured') }</span>
+      ? <span className="badge rounded-pill badge-danger ml-2">{ t('full_text_search_management.connection_status_label_erroroccured') }</span>
       : null;
 
     let connectionStatusLabel = null;
     if (!isConfigured) {
-      connectionStatusLabel = <span className="badge badge-pill badge-default">{ t('full_text_search_management.connection_status_label_unconfigured') }</span>;
+      connectionStatusLabel = <span className="badge rounded-pill badge-default">{ t('full_text_search_management.connection_status_label_unconfigured') }</span>;
     }
     else {
       connectionStatusLabel = isConnected
         // eslint-disable-next-line max-len
-        ? <span data-testid="connection-status-badge-connected" className="badge badge-pill badge-success">{ t('full_text_search_management.connection_status_label_connected') }</span>
-        : <span className="badge badge-pill badge-danger">{ t('full_text_search_management.connection_status_label_disconnected') }</span>;
+        ? <span data-testid="connection-status-badge-connected" className="badge rounded-pill badge-success">{ t('full_text_search_management.connection_status_label_connected') }</span>
+        : <span className="badge rounded-pill badge-danger">{ t('full_text_search_management.connection_status_label_disconnected') }</span>;
     }
 
     return (
@@ -42,8 +42,8 @@ class StatusTable extends React.PureComponent {
     const { t, isNormalized } = this.props;
 
     return isNormalized
-      ? <span className="badge badge-pill badge-info">{ t('full_text_search_management.indices_status_label_normalized') }</span>
-      : <span className="badge badge-pill badge-warning">{ t('full_text_search_management.indices_status_label_unnormalized') }</span>;
+      ? <span className="badge rounded-pill badge-info">{ t('full_text_search_management.indices_status_label_normalized') }</span>
+      : <span className="badge rounded-pill badge-warning">{ t('full_text_search_management.indices_status_label_unnormalized') }</span>;
   }
 
   renderIndexInfoPanel(indexName, body = {}, aliases = []) {
@@ -51,7 +51,7 @@ class StatusTable extends React.PureComponent {
 
     const aliasLabels = aliases.map((aliasName) => {
       return (
-        <span key={`badge-${indexName}-${aliasName}`} className="badge badge-pill badge-primary mr-2">
+        <span key={`badge-${indexName}-${aliasName}`} className="badge rounded-pill badge-primary mr-2">
           <i className="icon-tag"></i> {aliasName}
         </span>
       );

--- a/apps/app/src/components/Admin/ElasticsearchManagement/StatusTable.jsx
+++ b/apps/app/src/components/Admin/ElasticsearchManagement/StatusTable.jsx
@@ -17,7 +17,7 @@ class StatusTable extends React.PureComponent {
     } = this.props;
 
     const errorOccuredLabel = isErrorOccuredOnSearchService
-      ? <span className="badge rounded-pill badge-danger ml-2">{ t('full_text_search_management.connection_status_label_erroroccured') }</span>
+      ? <span className="badge rounded-pill bg-danger ml-2">{ t('full_text_search_management.connection_status_label_erroroccured') }</span>
       : null;
 
     let connectionStatusLabel = null;
@@ -31,8 +31,8 @@ class StatusTable extends React.PureComponent {
     else {
       connectionStatusLabel = isConnected
         // eslint-disable-next-line max-len
-        ? <span data-testid="connection-status-badge-connected" className="badge rounded-pill badge-success">{ t('full_text_search_management.connection_status_label_connected') }</span>
-        : <span className="badge rounded-pill badge-danger">{ t('full_text_search_management.connection_status_label_disconnected') }</span>;
+        ? <span data-testid="connection-status-badge-connected" className="badge rounded-pill bg-success">{ t('full_text_search_management.connection_status_label_connected') }</span>
+        : <span className="badge rounded-pill bg-danger">{ t('full_text_search_management.connection_status_label_disconnected') }</span>;
     }
 
     return (
@@ -46,8 +46,8 @@ class StatusTable extends React.PureComponent {
     const { t, isNormalized } = this.props;
 
     return isNormalized
-      ? <span className="badge rounded-pill badge-info">{ t('full_text_search_management.indices_status_label_normalized') }</span>
-      : <span className="badge rounded-pill badge-warning">{ t('full_text_search_management.indices_status_label_unnormalized') }</span>;
+      ? <span className="badge rounded-pill bg-info">{ t('full_text_search_management.indices_status_label_normalized') }</span>
+      : <span className="badge rounded-pill bg-warning">{ t('full_text_search_management.indices_status_label_unnormalized') }</span>;
   }
 
   renderIndexInfoPanel(indexName, body = {}, aliases = []) {

--- a/apps/app/src/components/Admin/ElasticsearchManagement/StatusTable.jsx
+++ b/apps/app/src/components/Admin/ElasticsearchManagement/StatusTable.jsx
@@ -22,7 +22,11 @@ class StatusTable extends React.PureComponent {
 
     let connectionStatusLabel = null;
     if (!isConfigured) {
-      connectionStatusLabel = <span className="badge rounded-pill badge-default">{ t('full_text_search_management.connection_status_label_unconfigured') }</span>;
+      connectionStatusLabel = (
+        <span className="badge rounded-pill badge-default">
+          { t('full_text_search_management.connection_status_label_unconfigured') }
+        </span>
+      );
     }
     else {
       connectionStatusLabel = isConnected
@@ -51,7 +55,7 @@ class StatusTable extends React.PureComponent {
 
     const aliasLabels = aliases.map((aliasName) => {
       return (
-        <span key={`badge-${indexName}-${aliasName}`} className="badge rounded-pill badge-primary mr-2">
+        <span key={`badge-${indexName}-${aliasName}`} className="badge rounded-pill bg-primary mr-2">
           <i className="icon-tag"></i> {aliasName}
         </span>
       );

--- a/apps/app/src/components/Admin/ImportData/GrowiArchive/ImportCollectionItem.jsx
+++ b/apps/app/src/components/Admin/ImportData/GrowiArchive/ImportCollectionItem.jsx
@@ -200,7 +200,7 @@ export default class ImportCollectionItem extends React.Component {
 
     return (
       <div className="card border-light">
-        <div className="card-header bg-light">
+        <div className="card-header bg-light text-dark">
           <div className="d-flex justify-content-between align-items-center flex-wrap">
             {/* left */}
             {this.renderCheckbox()}

--- a/apps/app/src/components/Admin/Notification/GlobalNotificationList.jsx
+++ b/apps/app/src/components/Admin/Notification/GlobalNotificationList.jsx
@@ -97,12 +97,12 @@ class GlobalNotificationList extends React.Component {
               <td>
                 <ul className="list-inline mb-0">
                   {notification.triggerEvents.includes('pageCreate') && (
-                    <li className="list-inline-item badge rounded-pill badge-success">
+                    <li className="list-inline-item badge rounded-pill bg-success">
                       <i className="icon-doc"></i> CREATE
                     </li>
                   )}
                   {notification.triggerEvents.includes('pageEdit') && (
-                    <li className="list-inline-item badge rounded-pill badge-warning">
+                    <li className="list-inline-item badge rounded-pill bg-warning">
                       <i className="icon-pencil"></i> EDIT
                     </li>
                   )}
@@ -112,12 +112,12 @@ class GlobalNotificationList extends React.Component {
                     </li>
                   )}
                   {notification.triggerEvents.includes('pageDelete') && (
-                    <li className="list-inline-item badge rounded-pill badge-danger">
+                    <li className="list-inline-item badge rounded-pill bg-danger">
                       <i className="icon-fire"></i> DELETE
                     </li>
                   )}
                   {notification.triggerEvents.includes('pageLike') && (
-                    <li className="list-inline-item badge rounded-pill badge-info">
+                    <li className="list-inline-item badge rounded-pill bg-info">
                       <i className="fa fa-heart-o"></i> LIKE
                     </li>
                   )}

--- a/apps/app/src/components/Admin/Notification/GlobalNotificationList.jsx
+++ b/apps/app/src/components/Admin/Notification/GlobalNotificationList.jsx
@@ -107,7 +107,7 @@ class GlobalNotificationList extends React.Component {
                     </li>
                   )}
                   {notification.triggerEvents.includes('pageMove') && (
-                    <li className="list-inline-item badge rounded-pill badge-pink">
+                    <li className="list-inline-item badge rounded-pill bg-pink">
                       <i className="icon-action-redo"></i> MOVE
                     </li>
                   )}

--- a/apps/app/src/components/Admin/Notification/GlobalNotificationList.jsx
+++ b/apps/app/src/components/Admin/Notification/GlobalNotificationList.jsx
@@ -97,32 +97,32 @@ class GlobalNotificationList extends React.Component {
               <td>
                 <ul className="list-inline mb-0">
                   {notification.triggerEvents.includes('pageCreate') && (
-                    <li className="list-inline-item badge badge-pill badge-success">
+                    <li className="list-inline-item badge rounded-pill badge-success">
                       <i className="icon-doc"></i> CREATE
                     </li>
                   )}
                   {notification.triggerEvents.includes('pageEdit') && (
-                    <li className="list-inline-item badge badge-pill badge-warning">
+                    <li className="list-inline-item badge rounded-pill badge-warning">
                       <i className="icon-pencil"></i> EDIT
                     </li>
                   )}
                   {notification.triggerEvents.includes('pageMove') && (
-                    <li className="list-inline-item badge badge-pill badge-pink">
+                    <li className="list-inline-item badge rounded-pill badge-pink">
                       <i className="icon-action-redo"></i> MOVE
                     </li>
                   )}
                   {notification.triggerEvents.includes('pageDelete') && (
-                    <li className="list-inline-item badge badge-pill badge-danger">
+                    <li className="list-inline-item badge rounded-pill badge-danger">
                       <i className="icon-fire"></i> DELETE
                     </li>
                   )}
                   {notification.triggerEvents.includes('pageLike') && (
-                    <li className="list-inline-item badge badge-pill badge-info">
+                    <li className="list-inline-item badge rounded-pill badge-info">
                       <i className="fa fa-heart-o"></i> LIKE
                     </li>
                   )}
                   {notification.triggerEvents.includes('comment') && (
-                    <li className="list-inline-item badge badge-pill badge-secondary">
+                    <li className="list-inline-item badge rounded-pill badge-secondary">
                       <i className="icon-fw icon-bubble"></i> POST
                     </li>
                   )}

--- a/apps/app/src/components/Admin/Notification/GlobalNotificationList.jsx
+++ b/apps/app/src/components/Admin/Notification/GlobalNotificationList.jsx
@@ -122,7 +122,7 @@ class GlobalNotificationList extends React.Component {
                     </li>
                   )}
                   {notification.triggerEvents.includes('comment') && (
-                    <li className="list-inline-item badge rounded-pill badge-secondary">
+                    <li className="list-inline-item badge rounded-pill bg-primary">
                       <i className="icon-fw icon-bubble"></i> POST
                     </li>
                   )}

--- a/apps/app/src/components/Admin/Notification/GlobalNotificationList.jsx
+++ b/apps/app/src/components/Admin/Notification/GlobalNotificationList.jsx
@@ -102,7 +102,7 @@ class GlobalNotificationList extends React.Component {
                     </li>
                   )}
                   {notification.triggerEvents.includes('pageEdit') && (
-                    <li className="list-inline-item badge rounded-pill bg-warning">
+                    <li className="list-inline-item badge rounded-pill bg-warning text-dark">
                       <i className="icon-pencil"></i> EDIT
                     </li>
                   )}

--- a/apps/app/src/components/Admin/Notification/ManageGlobalNotification.tsx
+++ b/apps/app/src/components/Admin/Notification/ManageGlobalNotification.tsx
@@ -237,7 +237,7 @@ const ManageGlobalNotification = (props: Props): JSX.Element => {
                 checked={triggerEvents.has(TriggerEventType.CREATE)}
                 onChange={() => onChangeTriggerEvents(TriggerEventType.CREATE)}
               >
-                <span className="badge rounded-pill badge-success">
+                <span className="badge rounded-pill bg-success">
                   <i className="icon-doc mr-1" /> CREATE
                 </span>
               </TriggerEventCheckBox>
@@ -249,7 +249,7 @@ const ManageGlobalNotification = (props: Props): JSX.Element => {
                 checked={triggerEvents.has(TriggerEventType.EDIT)}
                 onChange={() => onChangeTriggerEvents(TriggerEventType.EDIT)}
               >
-                <span className="badge rounded-pill badge-warning">
+                <span className="badge rounded-pill bg-warning">
                   <i className="icon-pencil mr-1" />EDIT
                 </span>
               </TriggerEventCheckBox>
@@ -273,7 +273,7 @@ const ManageGlobalNotification = (props: Props): JSX.Element => {
                 checked={triggerEvents.has(TriggerEventType.DELETE)}
                 onChange={() => onChangeTriggerEvents(TriggerEventType.DELETE)}
               >
-                <span className="badge rounded-pill badge-danger">
+                <span className="badge rounded-pill bg-danger">
                   <i className="icon-fire mr-1" />DELETE
                 </span>
               </TriggerEventCheckBox>
@@ -285,7 +285,7 @@ const ManageGlobalNotification = (props: Props): JSX.Element => {
                 checked={triggerEvents.has(TriggerEventType.LIKE)}
                 onChange={() => onChangeTriggerEvents(TriggerEventType.LIKE)}
               >
-                <span className="badge rounded-pill badge-info">
+                <span className="badge rounded-pill bg-info">
                   <i className="fa fa-heart-o mr-1" />LIKE
                 </span>
               </TriggerEventCheckBox>

--- a/apps/app/src/components/Admin/Notification/ManageGlobalNotification.tsx
+++ b/apps/app/src/components/Admin/Notification/ManageGlobalNotification.tsx
@@ -261,7 +261,7 @@ const ManageGlobalNotification = (props: Props): JSX.Element => {
                 checked={triggerEvents.has(TriggerEventType.MOVE)}
                 onChange={() => onChangeTriggerEvents(TriggerEventType.MOVE)}
               >
-                <span className="badge rounded-pill badge-pink">
+                <span className="badge rounded-pill bg-pink">
                   <i className="icon-action-redo mr-1" />MOVE
                 </span>
               </TriggerEventCheckBox>

--- a/apps/app/src/components/Admin/Notification/ManageGlobalNotification.tsx
+++ b/apps/app/src/components/Admin/Notification/ManageGlobalNotification.tsx
@@ -249,7 +249,7 @@ const ManageGlobalNotification = (props: Props): JSX.Element => {
                 checked={triggerEvents.has(TriggerEventType.EDIT)}
                 onChange={() => onChangeTriggerEvents(TriggerEventType.EDIT)}
               >
-                <span className="badge rounded-pill bg-warning">
+                <span className="badge rounded-pill bg-warning text-dark">
                   <i className="icon-pencil mr-1" />EDIT
                 </span>
               </TriggerEventCheckBox>

--- a/apps/app/src/components/Admin/Notification/ManageGlobalNotification.tsx
+++ b/apps/app/src/components/Admin/Notification/ManageGlobalNotification.tsx
@@ -237,7 +237,7 @@ const ManageGlobalNotification = (props: Props): JSX.Element => {
                 checked={triggerEvents.has(TriggerEventType.CREATE)}
                 onChange={() => onChangeTriggerEvents(TriggerEventType.CREATE)}
               >
-                <span className="badge badge-pill badge-success">
+                <span className="badge rounded-pill badge-success">
                   <i className="icon-doc mr-1" /> CREATE
                 </span>
               </TriggerEventCheckBox>
@@ -249,7 +249,7 @@ const ManageGlobalNotification = (props: Props): JSX.Element => {
                 checked={triggerEvents.has(TriggerEventType.EDIT)}
                 onChange={() => onChangeTriggerEvents(TriggerEventType.EDIT)}
               >
-                <span className="badge badge-pill badge-warning">
+                <span className="badge rounded-pill badge-warning">
                   <i className="icon-pencil mr-1" />EDIT
                 </span>
               </TriggerEventCheckBox>
@@ -261,7 +261,7 @@ const ManageGlobalNotification = (props: Props): JSX.Element => {
                 checked={triggerEvents.has(TriggerEventType.MOVE)}
                 onChange={() => onChangeTriggerEvents(TriggerEventType.MOVE)}
               >
-                <span className="badge badge-pill badge-pink">
+                <span className="badge rounded-pill badge-pink">
                   <i className="icon-action-redo mr-1" />MOVE
                 </span>
               </TriggerEventCheckBox>
@@ -273,7 +273,7 @@ const ManageGlobalNotification = (props: Props): JSX.Element => {
                 checked={triggerEvents.has(TriggerEventType.DELETE)}
                 onChange={() => onChangeTriggerEvents(TriggerEventType.DELETE)}
               >
-                <span className="badge badge-pill badge-danger">
+                <span className="badge rounded-pill badge-danger">
                   <i className="icon-fire mr-1" />DELETE
                 </span>
               </TriggerEventCheckBox>
@@ -285,7 +285,7 @@ const ManageGlobalNotification = (props: Props): JSX.Element => {
                 checked={triggerEvents.has(TriggerEventType.LIKE)}
                 onChange={() => onChangeTriggerEvents(TriggerEventType.LIKE)}
               >
-                <span className="badge badge-pill badge-info">
+                <span className="badge rounded-pill badge-info">
                   <i className="fa fa-heart-o mr-1" />LIKE
                 </span>
               </TriggerEventCheckBox>
@@ -297,7 +297,7 @@ const ManageGlobalNotification = (props: Props): JSX.Element => {
                 checked={triggerEvents.has(TriggerEventType.POST)}
                 onChange={() => onChangeTriggerEvents(TriggerEventType.POST)}
               >
-                <span className="badge badge-pill badge-secondary">
+                <span className="badge rounded-pill badge-secondary">
                   <i className="icon-bubble mr-1" />POST
                 </span>
               </TriggerEventCheckBox>

--- a/apps/app/src/components/Admin/Notification/ManageGlobalNotification.tsx
+++ b/apps/app/src/components/Admin/Notification/ManageGlobalNotification.tsx
@@ -297,7 +297,7 @@ const ManageGlobalNotification = (props: Props): JSX.Element => {
                 checked={triggerEvents.has(TriggerEventType.POST)}
                 onChange={() => onChangeTriggerEvents(TriggerEventType.POST)}
               >
-                <span className="badge rounded-pill badge-secondary">
+                <span className="badge rounded-pill bg-primary">
                   <i className="icon-bubble mr-1" />POST
                 </span>
               </TriggerEventCheckBox>

--- a/apps/app/src/components/Admin/Notification/NotificationSetting.jsx
+++ b/apps/app/src/components/Admin/Notification/NotificationSetting.jsx
@@ -31,7 +31,7 @@ const Badge = ({ isEnabled }) => {
   const { t } = useTranslation('admin');
 
   return isEnabled
-    ? <span className="badge badge-success">{t('external_notification.enabled')}</span>
+    ? <span className="badge bg-success">{t('external_notification.enabled')}</span>
     : <span className="badge bg-primary">{t('external_notification.disabled')}</span>;
 };
 

--- a/apps/app/src/components/Admin/Notification/NotificationSetting.jsx
+++ b/apps/app/src/components/Admin/Notification/NotificationSetting.jsx
@@ -32,13 +32,13 @@ const Badge = ({ isEnabled }) => {
 
   return isEnabled
     ? <span className="badge badge-success">{t('external_notification.enabled')}</span>
-    : <span className="badge badge-secondary">{t('external_notification.disabled')}</span>;
+    : <span className="badge bg-primary">{t('external_notification.disabled')}</span>;
 };
 
 const SkeletonListItem = () => (
   <li className="list-group-item">
     <h4 className="mb-2">
-      <span className="badge badge-secondary">――</span>
+      <span className="badge bg-primary">――</span>
       <span className="ml-2">...</span>
     </h4>
   </li>

--- a/apps/app/src/components/Admin/Security/GitHubSecuritySettingContents.jsx
+++ b/apps/app/src/components/Admin/Security/GitHubSecuritySettingContents.jsx
@@ -71,7 +71,7 @@ class GitHubSecurityManagementContents extends React.Component {
               </label>
             </div>
             {(!adminGeneralSecurityContainer.state.setupStrategies.includes('github') && isGitHubEnabled)
-              && <div className="badge badge-warning">{t('security_settings.setup_is_not_yet_complete')}</div>}
+              && <div className="badge bg-warning">{t('security_settings.setup_is_not_yet_complete')}</div>}
           </div>
         </div>
 

--- a/apps/app/src/components/Admin/Security/GitHubSecuritySettingContents.jsx
+++ b/apps/app/src/components/Admin/Security/GitHubSecuritySettingContents.jsx
@@ -71,7 +71,7 @@ class GitHubSecurityManagementContents extends React.Component {
               </label>
             </div>
             {(!adminGeneralSecurityContainer.state.setupStrategies.includes('github') && isGitHubEnabled)
-              && <div className="badge bg-warning">{t('security_settings.setup_is_not_yet_complete')}</div>}
+              && <div className="badge bg-warning text-dark">{t('security_settings.setup_is_not_yet_complete')}</div>}
           </div>
         </div>
 

--- a/apps/app/src/components/Admin/Security/GoogleSecuritySettingContents.jsx
+++ b/apps/app/src/components/Admin/Security/GoogleSecuritySettingContents.jsx
@@ -69,7 +69,7 @@ class GoogleSecurityManagementContents extends React.Component {
               </label>
             </div>
             {(!adminGeneralSecurityContainer.state.setupStrategies.includes('google') && isGoogleEnabled)
-              && <div className="badge bg-warning">{t('security_settings.setup_is_not_yet_complete')}</div>}
+              && <div className="badge bg-warning text-dark">{t('security_settings.setup_is_not_yet_complete')}</div>}
           </div>
         </div>
 

--- a/apps/app/src/components/Admin/Security/GoogleSecuritySettingContents.jsx
+++ b/apps/app/src/components/Admin/Security/GoogleSecuritySettingContents.jsx
@@ -69,7 +69,7 @@ class GoogleSecurityManagementContents extends React.Component {
               </label>
             </div>
             {(!adminGeneralSecurityContainer.state.setupStrategies.includes('google') && isGoogleEnabled)
-              && <div className="badge badge-warning">{t('security_settings.setup_is_not_yet_complete')}</div>}
+              && <div className="badge bg-warning">{t('security_settings.setup_is_not_yet_complete')}</div>}
           </div>
         </div>
 

--- a/apps/app/src/components/Admin/Security/LdapSecuritySettingContents.jsx
+++ b/apps/app/src/components/Admin/Security/LdapSecuritySettingContents.jsx
@@ -73,7 +73,7 @@ class LdapSecuritySettingContents extends React.Component {
               </label>
             </div>
             {(!adminGeneralSecurityContainer.state.setupStrategies.includes('ldap') && isLdapEnabled)
-              && <div className="badge bg-warning">{t('security_settings.setup_is_not_yet_complete')}</div>}
+              && <div className="badge bg-warning text-dark">{t('security_settings.setup_is_not_yet_complete')}</div>}
           </div>
         </div>
 

--- a/apps/app/src/components/Admin/Security/LdapSecuritySettingContents.jsx
+++ b/apps/app/src/components/Admin/Security/LdapSecuritySettingContents.jsx
@@ -73,7 +73,7 @@ class LdapSecuritySettingContents extends React.Component {
               </label>
             </div>
             {(!adminGeneralSecurityContainer.state.setupStrategies.includes('ldap') && isLdapEnabled)
-              && <div className="badge badge-warning">{t('security_settings.setup_is_not_yet_complete')}</div>}
+              && <div className="badge bg-warning">{t('security_settings.setup_is_not_yet_complete')}</div>}
           </div>
         </div>
 

--- a/apps/app/src/components/Admin/Security/LocalSecuritySettingContents.jsx
+++ b/apps/app/src/components/Admin/Security/LocalSecuritySettingContents.jsx
@@ -78,7 +78,7 @@ class LocalSecuritySettingContents extends React.Component {
               </label>
             </div>
             {!adminGeneralSecurityContainer.state.setupStrategies.includes('local') && isLocalEnabled && (
-              <div className="badge bg-warning">{t('security_settings.setup_is_not_yet_complete')}</div>
+              <div className="badge bg-warning text-dark">{t('security_settings.setup_is_not_yet_complete')}</div>
             )}
           </div>
         </div>

--- a/apps/app/src/components/Admin/Security/LocalSecuritySettingContents.jsx
+++ b/apps/app/src/components/Admin/Security/LocalSecuritySettingContents.jsx
@@ -78,7 +78,7 @@ class LocalSecuritySettingContents extends React.Component {
               </label>
             </div>
             {!adminGeneralSecurityContainer.state.setupStrategies.includes('local') && isLocalEnabled && (
-              <div className="badge badge-warning">{t('security_settings.setup_is_not_yet_complete')}</div>
+              <div className="badge bg-warning">{t('security_settings.setup_is_not_yet_complete')}</div>
             )}
           </div>
         </div>

--- a/apps/app/src/components/Admin/Security/OidcSecuritySettingContents.jsx
+++ b/apps/app/src/components/Admin/Security/OidcSecuritySettingContents.jsx
@@ -63,7 +63,7 @@ class OidcSecurityManagementContents extends React.Component {
               </label>
             </div>
             {(!adminGeneralSecurityContainer.state.setupStrategies.includes('oidc') && isOidcEnabled)
-              && <div className="badge badge-warning">{t('security_settings.setup_is_not_yet_complete')}</div>}
+              && <div className="badge bg-warning">{t('security_settings.setup_is_not_yet_complete')}</div>}
           </div>
         </div>
 

--- a/apps/app/src/components/Admin/Security/OidcSecuritySettingContents.jsx
+++ b/apps/app/src/components/Admin/Security/OidcSecuritySettingContents.jsx
@@ -63,7 +63,7 @@ class OidcSecurityManagementContents extends React.Component {
               </label>
             </div>
             {(!adminGeneralSecurityContainer.state.setupStrategies.includes('oidc') && isOidcEnabled)
-              && <div className="badge bg-warning">{t('security_settings.setup_is_not_yet_complete')}</div>}
+              && <div className="badge bg-warning text-dark">{t('security_settings.setup_is_not_yet_complete')}</div>}
           </div>
         </div>
 

--- a/apps/app/src/components/Admin/Security/SamlSecuritySettingContents.jsx
+++ b/apps/app/src/components/Admin/Security/SamlSecuritySettingContents.jsx
@@ -80,7 +80,7 @@ class SamlSecurityManagementContents extends React.Component {
               </label>
             </div>
             {(!adminGeneralSecurityContainer.state.setupStrategies.includes('saml') && isSamlEnabled)
-              && <div className="badge bg-warning">{t('security_settings.setup_is_not_yet_complete')}</div>}
+              && <div className="badge bg-warning text-dark">{t('security_settings.setup_is_not_yet_complete')}</div>}
           </div>
         </div>
 

--- a/apps/app/src/components/Admin/Security/SamlSecuritySettingContents.jsx
+++ b/apps/app/src/components/Admin/Security/SamlSecuritySettingContents.jsx
@@ -80,7 +80,7 @@ class SamlSecurityManagementContents extends React.Component {
               </label>
             </div>
             {(!adminGeneralSecurityContainer.state.setupStrategies.includes('saml') && isSamlEnabled)
-              && <div className="badge badge-warning">{t('security_settings.setup_is_not_yet_complete')}</div>}
+              && <div className="badge bg-warning">{t('security_settings.setup_is_not_yet_complete')}</div>}
           </div>
         </div>
 

--- a/apps/app/src/components/Admin/Security/ShareLinkSetting.tsx
+++ b/apps/app/src/components/Admin/Security/ShareLinkSetting.tsx
@@ -129,7 +129,7 @@ const ShareLinkSetting = (props: ShareLinkSettingProps) => {
             </label>
           </div>
           {!setupStrategies.includes('local') && disableLinkSharing && (
-            <div className="badge badge-warning">{t('security_settings.setup_is_not_yet_complete')}</div>
+            <div className="badge bg-warning">{t('security_settings.setup_is_not_yet_complete')}</div>
           )}
         </div>
       </div>

--- a/apps/app/src/components/Admin/Security/ShareLinkSetting.tsx
+++ b/apps/app/src/components/Admin/Security/ShareLinkSetting.tsx
@@ -129,7 +129,7 @@ const ShareLinkSetting = (props: ShareLinkSettingProps) => {
             </label>
           </div>
           {!setupStrategies.includes('local') && disableLinkSharing && (
-            <div className="badge bg-warning">{t('security_settings.setup_is_not_yet_complete')}</div>
+            <div className="badge bg-warning text-dark">{t('security_settings.setup_is_not_yet_complete')}</div>
           )}
         </div>
       </div>

--- a/apps/app/src/components/Admin/SlackIntegration/BotTypeCard.jsx
+++ b/apps/app/src/components/Admin/SlackIntegration/BotTypeCard.jsx
@@ -54,7 +54,7 @@ const BotTypeCard = (props) => {
           {/*  A recommended badge is shown on official bot card, supplementary names are shown on Custom bot cards   */}
           { isBotTypeOfficial
             ? (
-              <span className="badge badge-info mr-2">
+              <span className="badge bg-info mr-2">
                 {t('admin:slack_integration.selecting_bot_types.recommended')}
               </span>
             ) : (

--- a/apps/app/src/components/Admin/UserGroup/UserGroupTable.tsx
+++ b/apps/app/src/components/Admin/UserGroup/UserGroupTable.tsx
@@ -158,7 +158,7 @@ export const UserGroupTable: FC<Props> = (props: Props) => {
                 <td>
                   <ul className="list-inline">
                     {users != null && users.map((user) => {
-                      return <li key={user._id} className="list-inline-item badge rounded-pill bg-warning">{user.username}</li>;
+                      return <li key={user._id} className="list-inline-item badge rounded-pill bg-warning text-dark">{user.username}</li>;
                     })}
                   </ul>
                 </td>

--- a/apps/app/src/components/Admin/UserGroup/UserGroupTable.tsx
+++ b/apps/app/src/components/Admin/UserGroup/UserGroupTable.tsx
@@ -158,7 +158,7 @@ export const UserGroupTable: FC<Props> = (props: Props) => {
                 <td>
                   <ul className="list-inline">
                     {users != null && users.map((user) => {
-                      return <li key={user._id} className="list-inline-item badge rounded-pill badge-warning">{user.username}</li>;
+                      return <li key={user._id} className="list-inline-item badge rounded-pill bg-warning">{user.username}</li>;
                     })}
                   </ul>
                 </td>
@@ -166,7 +166,7 @@ export const UserGroupTable: FC<Props> = (props: Props) => {
                   <ul className="list-inline">
                     {groupIdToChildGroupsMap[group._id] != null && groupIdToChildGroupsMap[group._id].map((group) => {
                       return (
-                        <li key={group._id} className="list-inline-item badge badge-success">
+                        <li key={group._id} className="list-inline-item badge bg-success">
                           {props.isAclEnabled
                             ? (
                               <Link href={`/admin/user-group-detail/${group._id}`}>{group.name}</Link>

--- a/apps/app/src/components/Admin/UserGroup/UserGroupTable.tsx
+++ b/apps/app/src/components/Admin/UserGroup/UserGroupTable.tsx
@@ -158,7 +158,7 @@ export const UserGroupTable: FC<Props> = (props: Props) => {
                 <td>
                   <ul className="list-inline">
                     {users != null && users.map((user) => {
-                      return <li key={user._id} className="list-inline-item badge badge-pill badge-warning">{user.username}</li>;
+                      return <li key={user._id} className="list-inline-item badge rounded-pill badge-warning">{user.username}</li>;
                     })}
                   </ul>
                 </td>

--- a/apps/app/src/components/Admin/UserManagement.tsx
+++ b/apps/app/src/components/Admin/UserManagement.tsx
@@ -169,7 +169,7 @@ const UserManagement = (props: UserManagementProps) => {
               {renderCheckbox('all', 'All', 'secondary')}
               {renderCheckbox('registered', 'Approval Pending', 'info')}
               {renderCheckbox('active', 'Active', 'success')}
-              {renderCheckbox('suspended', 'Suspended', 'warning')}
+              {renderCheckbox('suspended', 'Suspended', 'warning text-dark')}
               {renderCheckbox('invited', 'Invited', 'pink')}
             </div>
             <div>

--- a/apps/app/src/components/Admin/UserManagement.tsx
+++ b/apps/app/src/components/Admin/UserManagement.tsx
@@ -90,7 +90,7 @@ const UserManagement = (props: UserManagementProps) => {
           onChange={() => clickHandler(status)}
         />
         <label className="custom-control-label" htmlFor={`c_${status}`}>
-          <span className={`badge badge-pill badge-${statusColor} d-inline-block vt mt-1`}>
+          <span className={`badge rounded-pill badge-${statusColor} d-inline-block vt mt-1`}>
             {statusLabel}
           </span>
         </label>

--- a/apps/app/src/components/Admin/UserManagement.tsx
+++ b/apps/app/src/components/Admin/UserManagement.tsx
@@ -90,7 +90,7 @@ const UserManagement = (props: UserManagementProps) => {
           onChange={() => clickHandler(status)}
         />
         <label className="custom-control-label" htmlFor={`c_${status}`}>
-          <span className={`badge rounded-pill badge-${statusColor} d-inline-block vt mt-1`}>
+          <span className={`badge rounded-pill bg-${statusColor} d-inline-block vt mt-1`}>
             {statusLabel}
           </span>
         </label>

--- a/apps/app/src/components/Admin/Users/ExternalAccountTable.tsx
+++ b/apps/app/src/components/Admin/Users/ExternalAccountTable.tsx
@@ -84,8 +84,8 @@ const ExternalAccountTable = (props: ExternalAccountTableProps): JSX.Element => 
                 <td><strong>{ea.user.username}</strong></td>
                 <td>
                   {ea.user.password
-                    ? (<span className="badge badge-info">{t('user_management.set')}</span>)
-                    : (<span className="badge badge-warning">{t('user_management.unset')}</span>)
+                    ? (<span className="badge bg-info">{t('user_management.set')}</span>)
+                    : (<span className="badge bg-warning">{t('user_management.unset')}</span>)
                   }
                 </td>
                 <td>{dateFnsFormat(new Date(ea.createdAt), 'yyyy-MM-dd')}</td>

--- a/apps/app/src/components/Admin/Users/ExternalAccountTable.tsx
+++ b/apps/app/src/components/Admin/Users/ExternalAccountTable.tsx
@@ -85,7 +85,7 @@ const ExternalAccountTable = (props: ExternalAccountTableProps): JSX.Element => 
                 <td>
                   {ea.user.password
                     ? (<span className="badge bg-info">{t('user_management.set')}</span>)
-                    : (<span className="badge bg-warning">{t('user_management.unset')}</span>)
+                    : (<span className="badge bg-warning text-dark">{t('user_management.unset')}</span>)
                   }
                 </td>
                 <td>{dateFnsFormat(new Date(ea.createdAt), 'yyyy-MM-dd')}</td>

--- a/apps/app/src/components/Admin/Users/UserTable.tsx
+++ b/apps/app/src/components/Admin/Users/UserTable.tsx
@@ -43,7 +43,7 @@ const UserTable = (props: UserTableProps) => {
         text = 'Deleted';
         break;
       case 5:
-        additionalClassName = 'badge-pink';
+        additionalClassName = 'bg-pink';
         text = 'Invited';
         break;
     }
@@ -153,7 +153,7 @@ const UserTable = (props: UserTableProps) => {
                 <td>
                   {getUserStatusLabel(user.status)}
                   {(user.admin) && (
-                    <span className="badge badge-indigo rounded-pill ml-2">
+                    <span className="badge bg-indigo rounded-pill ml-2">
                       {t('admin:user_management.user_table.administrator')}
                     </span>
                   )}

--- a/apps/app/src/components/Admin/Users/UserTable.tsx
+++ b/apps/app/src/components/Admin/Users/UserTable.tsx
@@ -49,7 +49,7 @@ const UserTable = (props: UserTableProps) => {
     }
 
     return (
-      <span className={`badge badge-pill ${additionalClassName}`}>
+      <span className={`badge rounded-pill ${additionalClassName}`}>
         {text}
       </span>
     );
@@ -153,12 +153,12 @@ const UserTable = (props: UserTableProps) => {
                 <td>
                   {getUserStatusLabel(user.status)}
                   {(user.admin) && (
-                    <span className="badge badge-indigo badge-pill ml-2">
+                    <span className="badge badge-indigo rounded-pill ml-2">
                       {t('admin:user_management.user_table.administrator')}
                     </span>
                   )}
                   {(user.readOnly) && (
-                    <span className="badge badge-light badge-pill ml-2">
+                    <span className="badge badge-light rounded-pill ml-2">
                       {t('admin:user_management.user_table.read_only')}
                     </span>
                   )}

--- a/apps/app/src/components/Admin/Users/UserTable.tsx
+++ b/apps/app/src/components/Admin/Users/UserTable.tsx
@@ -22,24 +22,24 @@ const UserTable = (props: UserTableProps) => {
   const { adminUsersContainer } = props;
 
   const getUserStatusLabel = (userStatus: number) => {
-    let additionalClassName = 'badge-info';
+    let additionalClassName = 'bg-info';
     let text = 'Approval Pending';
 
     switch (userStatus) {
       case 1:
-        additionalClassName = 'badge-info';
+        additionalClassName = 'bg-info';
         text = 'Approval Pending';
         break;
       case 2:
-        additionalClassName = 'badge-success';
+        additionalClassName = 'bg-success';
         text = 'Active';
         break;
       case 3:
-        additionalClassName = 'badge-warning';
+        additionalClassName = 'bg-warning';
         text = 'Suspended';
         break;
       case 4:
-        additionalClassName = 'badge-danger';
+        additionalClassName = 'bg-danger';
         text = 'Deleted';
         break;
       case 5:
@@ -158,7 +158,7 @@ const UserTable = (props: UserTableProps) => {
                     </span>
                   )}
                   {(user.readOnly) && (
-                    <span className="badge badge-light rounded-pill ml-2">
+                    <span className="badge bg-light rounded-pill ml-2">
                       {t('admin:user_management.user_table.read_only')}
                     </span>
                   )}

--- a/apps/app/src/components/Admin/Users/UserTable.tsx
+++ b/apps/app/src/components/Admin/Users/UserTable.tsx
@@ -35,7 +35,7 @@ const UserTable = (props: UserTableProps) => {
         text = 'Active';
         break;
       case 3:
-        additionalClassName = 'bg-warning';
+        additionalClassName = 'bg-warning text-dark';
         text = 'Suspended';
         break;
       case 4:
@@ -158,7 +158,7 @@ const UserTable = (props: UserTableProps) => {
                     </span>
                   )}
                   {(user.readOnly) && (
-                    <span className="badge bg-light rounded-pill ml-2">
+                    <span className="badge bg-light text-dark rounded-pill ml-2">
                       {t('admin:user_management.user_table.read_only')}
                     </span>
                   )}

--- a/apps/app/src/components/Common/CountBadge.tsx
+++ b/apps/app/src/components/Common/CountBadge.tsx
@@ -10,7 +10,7 @@ const CountBadge: FC<CountProps> = (props:CountProps) => {
 
 
   return (
-    <span className="grw-count-badge px-2 badge rounded-pill bg-light">
+    <span className="grw-count-badge px-2 badge rounded-pill bg-light text-dark">
       { count == null && <span className="text-muted">―</span> }
       { count != null && count + offset }
     </span>

--- a/apps/app/src/components/Common/CountBadge.tsx
+++ b/apps/app/src/components/Common/CountBadge.tsx
@@ -10,7 +10,7 @@ const CountBadge: FC<CountProps> = (props:CountProps) => {
 
 
   return (
-    <span className="grw-count-badge px-2 badge rounded-pill badge-light">
+    <span className="grw-count-badge px-2 badge rounded-pill bg-light">
       { count == null && <span className="text-muted">―</span> }
       { count != null && count + offset }
     </span>

--- a/apps/app/src/components/Common/CountBadge.tsx
+++ b/apps/app/src/components/Common/CountBadge.tsx
@@ -10,7 +10,7 @@ const CountBadge: FC<CountProps> = (props:CountProps) => {
 
 
   return (
-    <span className="grw-count-badge px-2 badge badge-pill badge-light">
+    <span className="grw-count-badge px-2 badge rounded-pill badge-light">
       { count == null && <span className="text-muted">―</span> }
       { count != null && count + offset }
     </span>

--- a/apps/app/src/components/InAppNotification/InAppNotificationDropdown.tsx
+++ b/apps/app/src/components/InAppNotification/InAppNotificationDropdown.tsx
@@ -75,7 +75,7 @@ export const InAppNotificationDropdown = (): JSX.Element => {
 
   let badge;
   if (inAppNotificationUnreadStatusCount != null && inAppNotificationUnreadStatusCount > 0) {
-    badge = <span className="badge badge-pill badge-danger grw-notification-badge">{inAppNotificationUnreadStatusCount}</span>;
+    badge = <span className="badge rounded-pill badge-danger grw-notification-badge">{inAppNotificationUnreadStatusCount}</span>;
   }
   else {
     badge = '';

--- a/apps/app/src/components/InAppNotification/InAppNotificationDropdown.tsx
+++ b/apps/app/src/components/InAppNotification/InAppNotificationDropdown.tsx
@@ -75,7 +75,7 @@ export const InAppNotificationDropdown = (): JSX.Element => {
 
   let badge;
   if (inAppNotificationUnreadStatusCount != null && inAppNotificationUnreadStatusCount > 0) {
-    badge = <span className="badge rounded-pill badge-danger grw-notification-badge">{inAppNotificationUnreadStatusCount}</span>;
+    badge = <span className="badge rounded-pill bg-danger grw-notification-badge">{inAppNotificationUnreadStatusCount}</span>;
   }
   else {
     badge = '';

--- a/apps/app/src/components/Layout/Admin.module.scss
+++ b/apps/app/src/components/Layout/Admin.module.scss
@@ -101,7 +101,7 @@ $slack-work-space-name-card-border: #efc1f6;
     .supplementary-bot-name {
       font-size: 1rem;
     }
-    .badge-info {
+    .bg-info {
       font-size: 0.6rem;
     }
     .admin-bot-card {

--- a/apps/app/src/components/Page/RenderTagLabels.tsx
+++ b/apps/app/src/components/Page/RenderTagLabels.tsx
@@ -28,7 +28,7 @@ const RenderTagLabels = React.memo((props: RenderTagLabelsProps) => {
     <>
       {tags.map((tag) => {
         return (
-          <a key={tag} href={`/_search?q=tag:${tag}`} className="grw-tag-label badge badge-secondary mr-2">
+          <a key={tag} href={`/_search?q=tag:${tag}`} className="grw-tag-label badge bg-primary mr-2">
             {tag}
           </a>
         );

--- a/apps/app/src/components/PageEditorByHackmd.tsx
+++ b/apps/app/src/components/PageEditorByHackmd.tsx
@@ -380,7 +380,7 @@ export const PageEditorByHackmd = (): JSX.Element => {
 
           { isHackmdDocumentOutdated && (
             <div className="card border-warning">
-              <div className="card-header bg-warning"><i className="icon-fw icon-info"></i> {t('hackmd.draft_outdated')}</div>
+              <div className="card-header bg-warning text-dark"><i className="icon-fw icon-info"></i> {t('hackmd.draft_outdated')}</div>
               <div className="card-body text-center">
                 {t('hackmd.based_on_revision')}&nbsp;
                 { pageData != null && (

--- a/apps/app/src/components/PageEditorByHackmd.tsx
+++ b/apps/app/src/components/PageEditorByHackmd.tsx
@@ -385,7 +385,7 @@ export const PageEditorByHackmd = (): JSX.Element => {
                 {t('hackmd.based_on_revision')}&nbsp;
                 { pageData != null && (
                   <Link href={urljoin(returnPathForURL(pageData.path, pageData._id), `?revisionId=${revisionIdHackmdSynced}`)} prefetch={false}>
-                    <span className="badge badge-secondary">{revisionIdHackmdSynced?.substr(-8)}</span>
+                    <span className="badge bg-primary">{revisionIdHackmdSynced?.substr(-8)}</span>
                   </Link>
                 )}
                 <div className="text-center mt-3">

--- a/apps/app/src/components/PageHistory/Revision.tsx
+++ b/apps/app/src/components/PageHistory/Revision.tsx
@@ -64,7 +64,7 @@ export const Revision = (props: RevisionProps): JSX.Element => {
         <div className="ml-2">
           <div className="revision-history-author mb-1">
             <strong><Username user={author}></Username></strong>
-            { isLatestRevision && <span className="badge badge-info ml-2">Latest</span> }
+            { isLatestRevision && <span className="badge bg-info ml-2">Latest</span> }
           </div>
           <div className="mb-1">
             <UserDate dateTime={revision.createdAt} />

--- a/apps/app/src/components/PageStatusAlert.tsx
+++ b/apps/app/src/components/PageStatusAlert.tsx
@@ -95,7 +95,7 @@ export const PageStatusAlert = (): JSX.Element => {
       : <span dangerouslySetInnerHTML={{ __html: `${usernameComponentToString} ${t('edited this page')}` }} />;
 
     return {
-      additionalClasses: ['bg-warning'],
+      additionalClasses: ['bg-warning text-dark'],
       label:
   <>
     <i className="icon-fw icon-bulb"></i>

--- a/apps/app/src/components/Sidebar/RecentChanges/RecentChangesSubstance.tsx
+++ b/apps/app/src/components/Sidebar/RecentChanges/RecentChangesSubstance.tsx
@@ -71,7 +71,7 @@ const PageItem = memo(({ page, isSmall }: PageItemProps): JSX.Element => {
       <Link
         key={tag.name}
         href={`/_search?q=tag:${tag.name}`}
-        className="grw-tag-label badge badge-secondary mr-2 small"
+        className="grw-tag-label badge bg-primary mr-2 small"
         prefetch={false}
       >
         {tag.name}

--- a/apps/app/src/components/TagCloudBox.tsx
+++ b/apps/app/src/components/TagCloudBox.tsx
@@ -33,7 +33,7 @@ const TagCloudBox: FC<Props> = memo((props:(Props & typeof defaultProps)) => {
       <Link
         key={tag.name}
         href={`${url.pathname}${url.search}`}
-        className="grw-tag-label badge badge-secondary mr-2"
+        className="grw-tag-label badge bg-primary mr-2"
         prefetch={false}
       >
         {tagNameFormat}

--- a/apps/app/src/components/TagList.tsx
+++ b/apps/app/src/components/TagList.tsx
@@ -44,7 +44,7 @@ const TagList: FC<TagListProps> = (props:(TagListProps & typeof defaultProps)) =
           prefetch={false}
         >
           <div className="text-truncate list-tag-name">{tag.name}</div>
-          <div className="ml-4 my-auto py-1 px-2 list-tag-count badge bg-primary text-white">{tag.count}</div>
+          <div className="ml-4 my-auto py-1 px-2 list-tag-count badge bg-primary">{tag.count}</div>
         </Link>
       );
     });

--- a/apps/app/src/components/TagList.tsx
+++ b/apps/app/src/components/TagList.tsx
@@ -44,7 +44,7 @@ const TagList: FC<TagListProps> = (props:(TagListProps & typeof defaultProps)) =
           prefetch={false}
         >
           <div className="text-truncate list-tag-name">{tag.name}</div>
-          <div className="ml-4 my-auto py-1 px-2 list-tag-count badge badge-secondary text-white">{tag.count}</div>
+          <div className="ml-4 my-auto py-1 px-2 list-tag-count badge bg-primary text-white">{tag.count}</div>
         </Link>
       );
     });

--- a/apps/app/src/features/growi-plugin/client/components/Admin/PluginsExtensionPageContents/PluginCard.tsx
+++ b/apps/app/src/features/growi-plugin/client/components/Admin/PluginsExtensionPageContents/PluginCard.tsx
@@ -119,7 +119,7 @@ export const PluginCard = (props: Props): JSX.Element => {
           </div>
         </div>
       </div>
-      <div className="card-footer px-5 border-top-0 mp-bg-light-blue">
+      <div className="card-footer px-5 border-top-0">
         <p className="d-flex justify-content-between align-self-center mb-0">
         </p>
       </div>

--- a/apps/app/src/features/questionnaire/client/components/ProactiveQuestionnaireModal.tsx
+++ b/apps/app/src/features/questionnaire/client/components/ProactiveQuestionnaireModal.tsx
@@ -93,7 +93,7 @@ const ProactiveQuestionnaireModal = (props: ModalProps): JSX.Element => {
             <form className="px-5" onSubmit={submitHandler}>
               <div className="form-group row mt-5">
                 <label className="col-sm-5 col-form-label" htmlFor="satisfaction">
-                  <span className="badge badge-primary mr-2">{t('questionnaire_modal.required')}</span>{t('questionnaire_modal.satisfaction_with_growi')}
+                  <span className="badge bg-primary mr-2">{t('questionnaire_modal.required')}</span>{t('questionnaire_modal.satisfaction_with_growi')}
                 </label>
                 <select className="col-sm-7 form-control" name="satisfaction" id="satisfaction" required>
                   <option value="">▼ {t('Select')}</option>
@@ -130,7 +130,7 @@ const ProactiveQuestionnaireModal = (props: ModalProps): JSX.Element => {
               </div>
               <div className="form-group row mt-3">
                 <label className="col-sm-5 col-form-label" htmlFor="commentText">
-                  <span className="badge badge-primary mr-2">{t('questionnaire_modal.required')}</span>{t('questionnaire_modal.comment_on_growi')}
+                  <span className="badge bg-primary mr-2">{t('questionnaire_modal.required')}</span>{t('questionnaire_modal.comment_on_growi')}
                 </label>
                 <textarea className="col-sm-7 form-control" name="commentText" id="commentText" rows={5} required />
               </div>

--- a/apps/app/src/features/questionnaire/client/components/QuestionnaireToast.tsx
+++ b/apps/app/src/features/questionnaire/client/components/QuestionnaireToast.tsx
@@ -76,7 +76,7 @@ const QuestionnaireToast = ({ questionnaireOrder }: QuestionnaireToastProps): JS
           <span aria-hidden="true" className="text-light">&times;</span>
         </button>
       </div>
-      <div className="toast-body bg-light d-flex justify-content-end">
+      <div className="toast-body bg-light text-dark d-flex justify-content-end">
         <button type="button" className="btn btn-secondary mr-3" onClick={answerBtnClickHandler}>{t('questionnaire.answer')}</button>
         <button type="button" className="btn btn-secondary" onClick={denyBtnClickHandler}>{t('questionnaire.deny')}</button>
       </div>

--- a/apps/app/src/styles/theme/_hsl-reboot-bootstrap-theme-colors.scss
+++ b/apps/app/src/styles/theme/_hsl-reboot-bootstrap-theme-colors.scss
@@ -96,11 +96,11 @@ $hsl-colors: (
 }
 
 @each $color, $value in $hsl-colors {
-  .badge-#{$color} {
+  .bg-#{$color} {
     @include hsl-badge.badge-variant($value);
   }
 
-  a.badge-#{$color}  {
+  a.bg-#{$color}  {
     @include hsl-badge.badge-variant($value);
   }
 }

--- a/apps/app/src/styles/theme/_reboot-bootstrap-theme-colors.scss
+++ b/apps/app/src/styles/theme/_reboot-bootstrap-theme-colors.scss
@@ -92,10 +92,10 @@
 }
 
 @each $color, $value in $theme-colors {
-  .badge-#{$color} {
+  .bg-#{$color} {
     @include badge-variant($value);
   }
-  a.badge-#{$color} {
+  a.bg-#{$color} {
     @include badge-variant($value);
   }
 }

--- a/packages/editor/src/components/playground/Playground.tsx
+++ b/packages/editor/src/components/playground/Playground.tsx
@@ -22,7 +22,7 @@ export const Playground = (): JSX.Element => {
         <div className="flex-expand-vert">
           <CodeMirrorEditorContainer ref={containerRef} />
         </div>
-        <div className="flex-expand-vert d-none d-lg-flex bg-light border-start border-dark-subtle p-3">
+        <div className="flex-expand-vert d-none d-lg-flex bg-light text-dark border-start border-dark-subtle p-3">
           <PlaygroundController />
         </div>
       </div>

--- a/packages/ui/src/components/Attachment.tsx
+++ b/packages/ui/src/components/Attachment.tsx
@@ -37,7 +37,7 @@ export const Attachment = (props: AttachmentProps): JSX.Element => {
     )
     : '';
   const fileType = <span className="attachment-filetype badge rounded-pill bg-primary">{attachment.fileFormat}</span>;
-  const fileInUse = (inUse) ? <span className="attachment-in-use badge rounded-pill badge-info">In Use</span> : '';
+  const fileInUse = (inUse) ? <span className="attachment-in-use badge rounded-pill bg-info">In Use</span> : '';
 
   return (
     <div className="attachment mb-2">

--- a/packages/ui/src/components/Attachment.tsx
+++ b/packages/ui/src/components/Attachment.tsx
@@ -36,8 +36,8 @@ export const Attachment = (props: AttachmentProps): JSX.Element => {
       </a>
     )
     : '';
-  const fileType = <span className="attachment-filetype badge badge-pill badge-secondary">{attachment.fileFormat}</span>;
-  const fileInUse = (inUse) ? <span className="attachment-in-use badge badge-pill badge-info">In Use</span> : '';
+  const fileType = <span className="attachment-filetype badge rounded-pill badge-secondary">{attachment.fileFormat}</span>;
+  const fileInUse = (inUse) ? <span className="attachment-in-use badge rounded-pill badge-info">In Use</span> : '';
 
   return (
     <div className="attachment mb-2">

--- a/packages/ui/src/components/Attachment.tsx
+++ b/packages/ui/src/components/Attachment.tsx
@@ -36,7 +36,7 @@ export const Attachment = (props: AttachmentProps): JSX.Element => {
       </a>
     )
     : '';
-  const fileType = <span className="attachment-filetype badge rounded-pill badge-secondary">{attachment.fileFormat}</span>;
+  const fileType = <span className="attachment-filetype badge rounded-pill bg-primary">{attachment.fileFormat}</span>;
   const fileInUse = (inUse) ? <span className="attachment-in-use badge rounded-pill badge-info">In Use</span> : '';
 
   return (

--- a/packages/ui/src/components/PagePath/PageListMeta.tsx
+++ b/packages/ui/src/components/PagePath/PageListMeta.tsx
@@ -70,13 +70,13 @@ export const PageListMeta: FC<PageListMetaProps> = (props: PageListMetaProps) =>
   // top check
   let topLabel;
   if (isTopPage(page.path)) {
-    topLabel = <span className={`badge badge-info ${shouldSpaceOutIcon ? 'mr-2' : ''} top-label`}>TOP</span>;
+    topLabel = <span className={`badge bg-info ${shouldSpaceOutIcon ? 'mr-2' : ''} top-label`}>TOP</span>;
   }
 
   // template check
   let templateLabel;
   if (checkTemplatePath(page.path)) {
-    templateLabel = <span className={`badge badge-info ${shouldSpaceOutIcon ? 'mr-2' : ''}`}>TMPL</span>;
+    templateLabel = <span className={`badge bg-info ${shouldSpaceOutIcon ? 'mr-2' : ''}`}>TMPL</span>;
   }
 
   let commentCount;


### PR DESCRIPTION
# task
- https://redmine.weseek.co.jp/issues/128847

# 概要
- https://getbootstrap.com/docs/5.0/migration/#badges の対応

# やったこと
- .badge-pill を .rounded-pill に置換
- .badge-primary 等は .bg-primary に置換
  - デフォルトの文字カラーが `#fff` になっていたので .bg-light, .bg-warning 使用箇所に .text-dark を適用
    - 既存で .text-light が使われていたコード箇所は .text-light を使う
    - 既存で .text-white が使われているコード箇所は .text-white を削除し bg-* に任せる
  - 詳細: https://getbootstrap.com/docs/5.0/components/badge/#background-colors
- .badge-pink, .badge-indigo, badge-default は .bg-* と適用できるように sass と class を置換（今はまだカラー適用されないようなので一応後続タスクを作成しました）
- その他 lint 修正と, 明らかに不要だと判断したクラスを削除

# 後続タスク
- sandbox-bootstrap5.md を作成する https://redmine.weseek.co.jp/issues/128838
- .bg-indigo, .bg-pink, .bg-default が UI に表示されるようにする https://redmine.weseek.co.jp/issues/129069