### PR TITLE
Fix/128041 129379 large ldap group tree sync error

### DIFF
--- a/apps/app/src/features/external-user-group/server/service/external-user-group-sync.ts
+++ b/apps/app/src/features/external-user-group/server/service/external-user-group-sync.ts
@@ -65,7 +65,7 @@ abstract class ExternalUserGroupSyncService {
    * 2. For every element in node.userInfos, call getMemberUser and create an ExternalUserGroupRelation with ExternalUserGroup if it does not have one
    * 3. Retrun ExternalUserGroup
    * @param {string} node Node of external group tree
-   * @param {string} parentId Parent group id (id in GROWI) of the group we wan't to create/update
+   * @param {string} parentId Parent group id (id in GROWI) of the group we want to create/update
    * @returns {Promise<IExternalUserGroupHasId>} ExternalUserGroup that was created/updated
   */
   async createUpdateExternalUserGroup(node: ExternalUserGroupTreeNode, parentId?: string): Promise<IExternalUserGroupHasId> {

--- a/apps/app/src/features/external-user-group/server/service/ldap-user-group-sync.ts
+++ b/apps/app/src/features/external-user-group/server/service/ldap-user-group-sync.ts
@@ -15,7 +15,7 @@ const logger = loggerFactory('growi:service:ldap-user-sync-service');
 // When d = max depth of group trees
 // Max space complexity of generateExternalUserGroupTrees will be:
 // O(TREES_BATCH_SIZE * d * USERS_BATCH_SIZE)
-const TREES_BATCH_SIZE = 30;
+const TREES_BATCH_SIZE = 10;
 const USERS_BATCH_SIZE = 30;
 
 class LdapUserGroupSyncService extends ExternalUserGroupSyncService {

--- a/apps/app/src/server/service/ldap.ts
+++ b/apps/app/src/server/service/ldap.ts
@@ -97,6 +97,11 @@ class LdapService {
     const searchResults: SearchResultEntry[] = [];
 
     return new Promise((resolve, reject) => {
+      // reject on client connection error (occures when not binded or host is not found)
+      this.client.on('error', (err) => {
+        reject(err);
+      });
+
       this.client.search(base || this.searchBase, {
         scope, filter, paged: true, sizeLimit: 200,
       }, (err, res) => {

--- a/apps/app/src/server/service/ldap.ts
+++ b/apps/app/src/server/service/ldap.ts
@@ -53,6 +53,10 @@ class LdapService {
     });
   }
 
+  /**
+   * Bind to LDAP server.
+   * This method is declared independently, so multiple operations can be requested to the LDAP server with a single bind.
+   */
   bind(): Promise<void> {
     const isLdapEnabled = configManager?.getConfig('crowi', 'security:passport-ldap:isEnabled');
     if (!isLdapEnabled) {
@@ -84,6 +88,7 @@ class LdapService {
 
   /**
    * Execute search on LDAP server and return result
+   * Execution of bind() is necessary before search
    * @param {string} filter Search filter
    * @param {string} base Base DN to execute search on
    * @returns {SearchEntry[]} Search result. Default scope is set to 'sub'.

--- a/apps/app/test/integration/service/ldap-user-group-sync.test.ts
+++ b/apps/app/test/integration/service/ldap-user-group-sync.test.ts
@@ -16,17 +16,23 @@ describe('LdapUserGroupSyncService.generateExternalUserGroupTrees', () => {
     'external-user-group:ldap:groupDescriptionAttribute': 'description',
     'external-user-group:ldap:groupMembershipAttributeType': 'DN',
     'external-user-group:ldap:groupSearchBase': 'ou=groups,dc=example,dc=org',
+    'security:passport-ldap:serverUrl': 'ldap://openldap:1389/dc=example,dc=org',
   };
 
   jest.mock('../../../src/server/service/ldap');
+  const mockBind = jest.spyOn(LdapService.prototype, 'bind');
   const mockLdapSearch = jest.spyOn(LdapService.prototype, 'search');
 
   beforeAll(async() => {
     crowi = await getInstance();
+    await configManager.updateConfigsInTheSameNamespace('crowi', configParams, true);
+
     const passportService = new PassportService(crowi);
     ldapGroupSyncService = new LdapUserGroupSyncService(passportService);
 
-    await configManager.updateConfigsInTheSameNamespace('crowi', configParams, true);
+    mockBind.mockImplementation(() => {
+      return Promise.resolve();
+    });
   });
 
   describe('When there is no circular reference in group tree', () => {

--- a/apps/app/test/integration/service/ldap-user-group-sync.test.ts
+++ b/apps/app/test/integration/service/ldap-user-group-sync.test.ts
@@ -35,6 +35,10 @@ describe('LdapUserGroupSyncService.generateExternalUserGroupTrees', () => {
     });
   });
 
+  afterAll(async() => {
+    await configManager.updateConfigsInTheSameNamespace('crowi', { 'security:passport-ldap:serverUrl': undefined }, true);
+  });
+
   describe('When there is no circular reference in group tree', () => {
     it('creates ExternalUserGroupTrees', async() => {
       // mock search on LDAP server

--- a/apps/app/test/integration/service/ldap-user-group-sync.test.ts
+++ b/apps/app/test/integration/service/ldap-user-group-sync.test.ts
@@ -23,6 +23,13 @@ describe('LdapUserGroupSyncService.generateExternalUserGroupTrees', () => {
   const mockBind = jest.spyOn(LdapService.prototype, 'bind');
   const mockLdapSearch = jest.spyOn(LdapService.prototype, 'search');
 
+  // mock LdapService constructor
+  const OriginalLdapService = { ...LdapService };
+  const mockConstructor = jest.fn(function(username, password) {
+    OriginalLdapService.constructor.call(this, 'Mocked LdapServer');
+  });
+  LdapService.prototype.constructor = mockConstructor;
+
   beforeAll(async() => {
     crowi = await getInstance();
     await configManager.updateConfigsInTheSameNamespace('crowi', configParams, true);
@@ -33,10 +40,6 @@ describe('LdapUserGroupSyncService.generateExternalUserGroupTrees', () => {
     mockBind.mockImplementation(() => {
       return Promise.resolve();
     });
-  });
-
-  afterAll(async() => {
-    await configManager.updateConfigsInTheSameNamespace('crowi', { 'security:passport-ldap:serverUrl': undefined }, true);
   });
 
   describe('When there is no circular reference in group tree', () => {

--- a/apps/app/test/integration/service/ldap-user-group-sync.test.ts
+++ b/apps/app/test/integration/service/ldap-user-group-sync.test.ts
@@ -31,13 +31,13 @@ describe('LdapUserGroupSyncService.generateExternalUserGroupTrees', () => {
     crowi = await getInstance();
     await configManager.updateConfigsInTheSameNamespace('crowi', configParams, true);
 
-    const passportService = new PassportService(crowi);
-    ldapGroupSyncService = new LdapUserGroupSyncService(passportService);
-
     mockBind.mockImplementation(() => {
       return Promise.resolve();
     });
     mockLdapCreateClient.mockImplementation(() => { return {} as Client });
+
+    const passportService = new PassportService(crowi);
+    ldapGroupSyncService = new LdapUserGroupSyncService(passportService);
   });
 
   describe('When there is no circular reference in group tree', () => {

--- a/apps/app/test/integration/service/ldap-user-group-sync.test.ts
+++ b/apps/app/test/integration/service/ldap-user-group-sync.test.ts
@@ -1,8 +1,11 @@
+import ldap, { Client } from 'ldapjs';
+
 import LdapUserGroupSyncService from '../../../src/features/external-user-group/server/service/ldap-user-group-sync';
 import { configManager } from '../../../src/server/service/config-manager';
 import LdapService from '../../../src/server/service/ldap';
 import PassportService from '../../../src/server/service/passport';
 import { getInstance } from '../setup-crowi';
+
 
 describe('LdapUserGroupSyncService.generateExternalUserGroupTrees', () => {
   let crowi;
@@ -22,13 +25,7 @@ describe('LdapUserGroupSyncService.generateExternalUserGroupTrees', () => {
   jest.mock('../../../src/server/service/ldap');
   const mockBind = jest.spyOn(LdapService.prototype, 'bind');
   const mockLdapSearch = jest.spyOn(LdapService.prototype, 'search');
-
-  // mock LdapService constructor
-  const OriginalLdapService = { ...LdapService };
-  const mockConstructor = jest.fn(function(username, password) {
-    OriginalLdapService.constructor.call(this, 'Mocked LdapServer');
-  });
-  LdapService.prototype.constructor = mockConstructor;
+  const mockLdapCreateClient = jest.spyOn(ldap, 'createClient');
 
   beforeAll(async() => {
     crowi = await getInstance();
@@ -40,6 +37,7 @@ describe('LdapUserGroupSyncService.generateExternalUserGroupTrees', () => {
     mockBind.mockImplementation(() => {
       return Promise.resolve();
     });
+    mockLdapCreateClient.mockImplementation(() => { return {} as Client });
   });
 
   describe('When there is no circular reference in group tree', () => {


### PR DESCRIPTION
## やったこと
100 ユーザが所属するグループを 100 個 ldap サーバ上に用意し、同期できるかどうか確認したところ、失敗したので修正しました。
原因は、ldapsearch リクエストの度に bind を行っていたため、ldap サーバ側でコネクションの上限数を超えていたことでした。
bind を独立して実行できるように変更しました。

## 修正後同期実行結果
- 実行環境
    - M1 macbook air
    - docker に割り当てているリソース
        - CPUs: 6
        - Memory: 10GB

### 100 グループツリーのケース (1group/tree)
- 実行時間: 4:02.583 (m:ss.mmm)
    - ユーザごとにページを作成したり ES の index を更新したりで、そこそこ時間がかかるようです。後続タスクで「同期実行中」ステータスを示す UI を表示しようかと思っています（ES の index 更新ページが参考になりそうです）。
- 同期実行直前/実行中/実行直後のメモリ使用（docker の .MemUsage を10秒ごとに出力、参考程度）
```
2.666GiB / 9.718GiB
2.758GiB / 9.718GiB
3.415GiB / 9.718GiB
3.193GiB / 9.718GiB
3.286GiB / 9.718GiB
3.184GiB / 9.718GiB
3.61GiB / 9.718GiB
3.421GiB / 9.718GiB
3.329GiB / 9.718GiB
3.198GiB / 9.718GiB
3.375GiB / 9.718GiB
3.602GiB / 9.718GiB
3.458GiB / 9.718GiB
3.306GiB / 9.718GiB
3.334GiB / 9.718GiB
3.278GiB / 9.718GiB
3.375GiB / 9.718GiB
3.611GiB / 9.718GiB
3.44GiB / 9.718GiB
3.344GiB / 9.718GiB
3.367GiB / 9.718GiB
3.46GiB / 9.718GiB
3.315GiB / 9.718GiB
2.689GiB / 9.718GiB
2.68GiB / 9.718GiB
```
### 10 グループツリーのケース (10 groups/tree, 深さ 10)
- 実行時間: 4:49.302 (m:ss.mmm)
- 同期実行直前/実行中/実行直後のメモリ使用
```
2.795GiB / 9.718GiB
2.992GiB / 9.718GiB
3.375GiB / 9.718GiB
3.329GiB / 9.718GiB
3.681GiB / 9.718GiB
3.529GiB / 9.718GiB
3.337GiB / 9.718GiB
3.474GiB / 9.718GiB
3.478GiB / 9.718GiB
3.383GiB / 9.718GiB
3.699GiB / 9.718GiB
3.513GiB / 9.718GiB
3.403GiB / 9.718GiB
3.371GiB / 9.718GiB
3.421GiB / 9.718GiB
3.446GiB / 9.718GiB
3.616GiB / 9.718GiB
3.431GiB / 9.718GiB
3.431GiB / 9.718GiB
3.394GiB / 9.718GiB
3.418GiB / 9.718GiB
3.427GiB / 9.718GiB
3.374GiB / 9.718GiB
3.463GiB / 9.718GiB
3.453GiB / 9.718GiB
3.459GiB / 9.718GiB
3.508GiB / 9.718GiB
3.508GiB / 9.718GiB
2.738GiB / 9.718GiB
2.732GiB / 9.718GiB
```

## task
https://redmine.weseek.co.jp/issues/129379