### PR TITLE
fix: Do not work register button

### DIFF
--- a/apps/app/src/components/LoginForm.tsx
+++ b/apps/app/src/components/LoginForm.tsx
@@ -518,7 +518,7 @@ export const LoginForm = (props: LoginFormProps): JSX.Element => {
           {/* Sign up button (submit) */}
           <div className="input-group justify-content-center my-4">
             <button
-              type="button"
+              type="submit"
               className="btn btn-fill rounded-0"
               id="register"
               disabled={(!isMailerSetup && isEmailAuthenticationEnabled) || isLoading}


### PR DESCRIPTION
## task
- https://redmine.weseek.co.jp/issues/129387

## 概要
- master ブランチで `/login#register` でのユーザー新規登録ができなくなっていた.
- submit ボタンをつかさどっていた button タグにこれまで type 属性が明示されていなかったためデフォルトの type="submit" が適用されて動いていた. master ブランチでは該当の button タグに type="button" と属性が明示されていたため form タグの submit ができていなかった.
- リリース前なので PR の Labels に `flag/exclude-from-changelog` を付与.