### PR TITLE
support: Update user homepage deletion description

### DIFF
--- a/apps/app/public/static/locales/en_US/admin.json
+++ b/apps/app/public/static/locales/en_US/admin.json
@@ -47,8 +47,8 @@
     "anyone": "Anyone",
     "user_homepage_deletion": {
       "user_homepage_deletion": "User homepage deletion",
-      "enable_user_homepage_deletion": "Enable user homepage deletion when deleting a user",
-      "desc": "When a user is deleted, the user homepage and its sub pages are completely deleted."
+      "enable_user_homepage_deletion": "Complete deletion of user home page at the time of user deletion",
+      "desc": "When deleting a user, the user homepage and its sub pages are also completely deleted."
     },
     "session": "Session",
     "max_age": "Max age (msec)",

--- a/apps/app/public/static/locales/en_US/admin.json
+++ b/apps/app/public/static/locales/en_US/admin.json
@@ -47,8 +47,8 @@
     "anyone": "Anyone",
     "user_homepage_deletion": {
       "user_homepage_deletion": "User homepage deletion",
-      "enable_user_homepage_deletion": "Enable user homepage deletion",
-      "when_deleting_a_user_the_user_homepage_is_also_deleted": "When deleting a user, the user homepage is also deleted."
+      "enable_user_homepage_deletion": "Enable user homepage deletion when deleting a user",
+      "desc": "When a user is deleted, the user homepage and its sub pages are completely deleted."
     },
     "session": "Session",
     "max_age": "Max age (msec)",

--- a/apps/app/public/static/locales/en_US/admin.json
+++ b/apps/app/public/static/locales/en_US/admin.json
@@ -47,7 +47,7 @@
     "anyone": "Anyone",
     "user_homepage_deletion": {
       "user_homepage_deletion": "User homepage deletion",
-      "enable_user_homepage_deletion": "Complete deletion of user home page at the time of user deletion",
+      "enable_user_homepage_deletion": "Complete deletion of user homepage, when user deletion",
       "desc": "When deleting a user, the user homepage and its sub pages are also completely deleted."
     },
     "session": "Session",

--- a/apps/app/public/static/locales/ja_JP/admin.json
+++ b/apps/app/public/static/locales/ja_JP/admin.json
@@ -55,8 +55,8 @@
     "anyone": "誰でも可能",
     "user_homepage_deletion": {
       "user_homepage_deletion": "ユーザーホームページの削除",
-      "enable_user_homepage_deletion": "ユーザー削除時のユーザーホームページ削除を有効化",
-      "desc": "ユーザー削除時にユーザーホームページとその配下のページを完全削除します。"
+      "enable_user_homepage_deletion": "ユーザー削除時にユーザーホームページを完全削除する",
+      "desc": "ユーザーを削除する際に、ユーザーホームページとその配下のページも完全削除されます。"
     },
     "session": "セッション",
     "max_age": "有効期間 (ミリ秒)",

--- a/apps/app/public/static/locales/ja_JP/admin.json
+++ b/apps/app/public/static/locales/ja_JP/admin.json
@@ -54,9 +54,9 @@
     "admin_and_author": "管理者とページ作者が可能",
     "anyone": "誰でも可能",
     "user_homepage_deletion": {
-      "user_homepage_deletion": "ユーザーページの削除",
-      "enable_user_homepage_deletion": "ユーザーページの削除を有効化",
-      "when_deleting_a_user_the_user_homepage_is_also_deleted": "ユーザー削除時にユーザーページも削除します。"
+      "user_homepage_deletion": "ユーザーホームページの削除",
+      "enable_user_homepage_deletion": "ユーザー削除時のユーザーホームページ削除を有効化",
+      "desc": "ユーザー削除時にユーザーホームページとその配下のページを完全削除します。"
     },
     "session": "セッション",
     "max_age": "有効期間 (ミリ秒)",

--- a/apps/app/public/static/locales/zh_CN/admin.json
+++ b/apps/app/public/static/locales/zh_CN/admin.json
@@ -55,8 +55,8 @@
 		"anyone": "任何人",
     "user_homepage_deletion": {
       "user_homepage_deletion": "删除用户页面",
-      "enable_user_homepage_deletion": "启用删除用户页面",
-      "when_deleting_a_user_the_user_homepage_is_also_deleted": "当一个用户被删除时，用户页面也会被删除。"
+      "enable_user_homepage_deletion": "删除用户时启用用户主页删除功能",
+      "desc": "删除用户时，用户主页及其子页面将被完全删除。"
     },
     "session": "会议",
     "max_age": "有效期间  (msec)",

--- a/apps/app/public/static/locales/zh_CN/admin.json
+++ b/apps/app/public/static/locales/zh_CN/admin.json
@@ -55,7 +55,7 @@
 		"anyone": "任何人",
     "user_homepage_deletion": {
       "user_homepage_deletion": "删除用户页面",
-      "enable_user_homepage_deletion": "在删除用户时完全删除用户主页",
+      "enable_user_homepage_deletion": "用户删除时，完全删除用户主页",
       "desc": "删除用户时，用户主页及其下属页面也会被完全删除。"
     },
     "session": "会议",

--- a/apps/app/public/static/locales/zh_CN/admin.json
+++ b/apps/app/public/static/locales/zh_CN/admin.json
@@ -55,8 +55,8 @@
 		"anyone": "任何人",
     "user_homepage_deletion": {
       "user_homepage_deletion": "删除用户页面",
-      "enable_user_homepage_deletion": "删除用户时启用用户主页删除功能",
-      "desc": "删除用户时，用户主页及其子页面将被完全删除。"
+      "enable_user_homepage_deletion": "在删除用户时完全删除用户主页",
+      "desc": "删除用户时，用户主页及其下属页面也会被完全删除。"
     },
     "session": "会议",
     "max_age": "有效期间  (msec)",

--- a/apps/app/src/components/Admin/Security/SecuritySetting.jsx
+++ b/apps/app/src/components/Admin/Security/SecuritySetting.jsx
@@ -470,7 +470,7 @@ class SecuritySetting extends React.Component {
             </div>
             <p
               className="form-text text-muted small"
-              dangerouslySetInnerHTML={{ __html: t('security_settings.user_homepage_deletion.when_deleting_a_user_the_user_homepage_is_also_deleted') }}
+              dangerouslySetInnerHTML={{ __html: t('security_settings.user_homepage_deletion.desc') }}
             />
           </div>
         </div>


### PR DESCRIPTION
### task
https://redmine.weseek.co.jp/issues/129488

### 概要
現状だと仕様であるユーザー新規登録時のユーザーホームページ削除も有効化/無効化設定できそうな文言だったので、
ユーザーホームページ削除に関して管理画面で設定できるのはあくまでもユーザー削除時にユーザーホームページを削除する設定だけであることを明記するよう修正しました。

### Screenshot
![image](https://github.com/weseek/growi/assets/68407388/3261460f-88a9-4b0b-88b2-04e81bb596cc)
