### PR TITLE
fix: Remove redundant toastSuccess for pasted attachments

### DIFF
--- a/apps/app/public/static/locales/en_US/translation.json
+++ b/apps/app/public/static/locales/en_US/translation.json
@@ -442,7 +442,6 @@
     "page_not_found_in_preview": "\"{{path}}\" is not a GROWI page."
   },
   "toaster": {
-    "file_upload_succeeded": "File upload succeeded.",
     "file_upload_failed": "File upload failed.",
     "initialize_successed": "Succeeded to initialize {{target}}",
     "remove_share_link_success": "Succeeded to remove {{shareLinkId}}",

--- a/apps/app/public/static/locales/ja_JP/translation.json
+++ b/apps/app/public/static/locales/ja_JP/translation.json
@@ -475,7 +475,6 @@
     "page_not_found_in_preview": "\"{{path}}\" というページはありません。"
   },
   "toaster": {
-    "file_upload_succeeded": "ファイルをアップロードしました",
     "file_upload_failed": "ファイルのアップロードに失敗しました",
     "initialize_successed": "{{target}}を初期化しました",
     "remove_share_link_success": "{{shareLinkId}}を削除しました",

--- a/apps/app/public/static/locales/zh_CN/translation.json
+++ b/apps/app/public/static/locales/zh_CN/translation.json
@@ -431,7 +431,6 @@
     "page_not_found_in_preview": "\"{{path}}\" is not a GROWI page."
   },
 	"toaster": {
-    "file_upload_succeeded": "文件上传成功",
     "file_upload_failed": "文件上传失败",
     "initialize_successed": "Succeeded to initialize {{target}}",
     "switch_disable_link_sharing_success": "成功更新分享链接设置",

--- a/apps/app/src/components/PageEditor/Editor.tsx
+++ b/apps/app/src/components/PageEditor/Editor.tsx
@@ -134,8 +134,6 @@ const Editor: ForwardRefRenderFunction<IEditorMethods, EditorPropsType> = (props
   const pasteFilesHandler = useCallback((event) => {
     const items = event.clipboardData.items || event.clipboardData.files || [];
 
-    toastSuccess(t('toaster.file_upload_succeeded'));
-
     // abort if length is not 1
     if (items.length < 1) {
       return;


### PR DESCRIPTION
## task
- https://redmine.weseek.co.jp/issues/129107

## 概要
- GROWI に画像などのアタッチメントを添付するとき以下の 3 種類方法のうちペーストだけ atttachment の添付が成功したときにトースターが表示されていた
  1. スタイルバー(navbar) からボタンを押してファイルから選択する
  2. ドラッグアンドドロップ
  3. ペースト
- 成功表示されるのは文字列のペースト等と区別するためかと思われる
- 失敗すべき場所で成功トースターが表示されるという表示上の不具合があった
![image (7)](https://github.com/weseek/growi/assets/68407388/637b6b66-616a-459c-9207-e05d917c2cb0)
- 貼り付け成功したことはエディタとプレビューに表示されてわかると思うので toastSuccess を削除 or 呼び出す場所を工夫するか

## UX 相談
https://wsgrowi.slack.com/archives/C0111HG81GB/p1693456983062959