### PR TITLE
support: Remove questionnaire logger

### DIFF
--- a/apps/app/public/static/locales/en_US/admin.json
+++ b/apps/app/public/static/locales/en_US/admin.json
@@ -1068,6 +1068,6 @@
     "remove_plugin_success": "Succeeded to removing {{pluginName}}"
   },
   "forbidden_page": {
-    "do_not_have_admin_permission": "Users without administrative rights cannot access the administration screen."
+    "do_not_have_admin_permission": "Users without administrative rights cannot access the administration screen"
   }
 }

--- a/apps/app/public/static/locales/ja_JP/admin.json
+++ b/apps/app/public/static/locales/ja_JP/admin.json
@@ -1076,6 +1076,6 @@
     "remove_plugin_success": "{{pluginName}}を削除しました"
   },
   "forbidden_page": {
-    "do_not_have_admin_permission": "管理者権限のないユーザーでは管理画面にはアクセスできません。"
+    "do_not_have_admin_permission": "管理者権限のないユーザーでは管理画面にはアクセスできません"
   }
 }

--- a/apps/app/public/static/locales/zh_CN/admin.json
+++ b/apps/app/public/static/locales/zh_CN/admin.json
@@ -1076,6 +1076,6 @@
     "remove_plugin_success": "Succeeded to removing {{pluginName}}"
   },
   "forbidden_page": {
-    "do_not_have_admin_permission": "没有管理权限的用户无法访问管理屏幕。"
+    "do_not_have_admin_permission": "没有管理权限的用户无法访问管理屏幕"
   }
 }

--- a/apps/app/src/features/questionnaire/server/service/questionnaire.ts
+++ b/apps/app/src/features/questionnaire/server/service/questionnaire.ts
@@ -42,7 +42,7 @@ class QuestionnaireService {
     // https://mongoosejs.com/docs/6.x/docs/api.html#model_Model-findOne
     // https://stackoverflow.com/questions/13443069/mongoose-findone-with-sorting
     const user = await User.findOne({ createdAt: { $ne: null } }).sort({ createdAt: 1 });
-    logger.debug(user);
+
     const installedAtByOldestUser = user ? user.createdAt : null;
 
     const appInstalledConfig = await Config.findOne({ key: 'app:installed' });


### PR DESCRIPTION
# やったこと
- logger.debug の削除
- 句点の削除
  - `import DefaultErrorPage from 'next/error';` が句点が付く仕様だった

## before
<img src="https://github.com/weseek/growi/assets/68407388/d5a75b57-65bb-4d8e-ab5c-5ab72f643b44" width="50%" />

## after
<img src="https://github.com/weseek/growi/assets/68407388/958fed76-bc45-4cb3-b9ca-483ab425483b" width="50%" />
