### PR TITLE
imprv: Add CSP style-src  for Safari and Content-Disposition of attachment

### DIFF
--- a/apps/app/src/server/routes/attachment.js
+++ b/apps/app/src/server/routes/attachment.js
@@ -264,7 +264,8 @@ module.exports = function(crowi, app) {
     else {
       res.set({
         'Content-Type': attachment.fileFormat,
-        'Content-Security-Policy': "script-src 'unsafe-hashes'; object-src 'none'; require-trusted-types-for 'script'; media-src 'self'; default-src 'none';",
+        'Content-Security-Policy': "script-src 'unsafe-hashes'; style-src 'self' 'unsafe-inline'; object-src 'none'; require-trusted-types-for 'script'; media-src 'self'; default-src 'none';",
+        'Content-Disposition': `inline;filename*=UTF-8''${encodeURIComponent(attachment.originalName)}`,
       });
     }
   }


### PR DESCRIPTION
## 要点
1. /attachmentから開いた添付ファイルを本来のファイル名で保存できるよう、Content-Dispositionを修正しました。
2. デスクトップ版のSafari 16.4-6上でpdfが正しく表示されない問題を解消しました。
## 解消したい問題点の説明
1. 添付ファイル名横のクラウドアイコンをクリックすれば/downloadから本来のファイル名でダウンロードできる一方で、ファイル名をクリックして/attachmentから開いたpdf等をダウンロードするとファイル名がid（数字列）になってしまいます。これを"Content-Dispsition: inline;filename*=..." を追加することで解消しました。
   - [#2529のコメント](https://github.com/weseek/growi/issues/2529#issuecomment-658513465)にあった対応策がそのまま有効でした。
2. [こちらのstackoverflow](https://stackoverflow.com/questions/76077768/webkit-pdf-display-seems-to-require-csp-with-unsafe-inline-style-src)などで報告されていますが、default-src 'none'などの制限のある場合に、style-src 'unsafe-inline'を付与しないとpdfのheightが150pxで打ち切られてしまう問題がSafari 16.4から発生し、現在最新版の16.6でも未解消のため、style-srcを追加しました。
   - この問題はデスクトップ版のみで発生し、iOSでは正常に閲覧できるようです。
   - growi v5でも150pxになっていたはずです。
## 環境
- サーバはUbuntu20.04に立てて、Mac (Vertuna) のSafari、およびWindows10のEdge, Chromeで正常動作を確認しました。
- 残念ながらMacのChromeでは依然/attachmentからは元のファイル名でダウンロードできません。