### PR TITLE
imprv: Add CSP style-src for Safari and Content-Disposition of attachment (for v6.1.x)

### DIFF
--- a/apps/app/src/server/routes/attachment.js
+++ b/apps/app/src/server/routes/attachment.js
@@ -261,7 +261,8 @@ module.exports = function(crowi, app) {
     else {
       res.set({
         'Content-Type': attachment.fileFormat,
-        'Content-Security-Policy': "script-src 'unsafe-hashes'; object-src 'none'; require-trusted-types-for 'script'; media-src 'self'; default-src 'none';",
+        'Content-Security-Policy': "script-src 'unsafe-hashes'; style-src 'self' 'unsafe-inline'; object-src 'none'; require-trusted-types-for 'script'; media-src 'self'; default-src 'none';",
+        'Content-Disposition': `inline;filename*=UTF-8''${encodeURIComponent(attachment.originalName)}`,
       });
     }
   }

--- a/apps/app/src/server/routes/attachment.js
+++ b/apps/app/src/server/routes/attachment.js
@@ -261,6 +261,7 @@ module.exports = function(crowi, app) {
     else {
       res.set({
         'Content-Type': attachment.fileFormat,
+        // eslint-disable-next-line max-len
         'Content-Security-Policy': "script-src 'unsafe-hashes'; style-src 'self' 'unsafe-inline'; object-src 'none'; require-trusted-types-for 'script'; media-src 'self'; default-src 'none';",
         'Content-Disposition': `inline;filename*=UTF-8''${encodeURIComponent(attachment.originalName)}`,
       });


### PR DESCRIPTION
- Fix https://github.com/weseek/growi/issues/2529
- Backport from https://github.com/weseek/growi/pull/8049