### PR TITLE
imprv: i18n resetting password mail body

### DIFF
--- a/apps/app/src/server/routes/apiv3/users.js
+++ b/apps/app/src/server/routes/apiv3/users.js
@@ -187,11 +187,12 @@ module.exports = (crowi) => {
   const sendEmailByUser = async(user) => {
     const { appService, mailService } = crowi;
     const appTitle = appService.getAppTitle();
+    const locale = configManager.getConfig('crowi', 'app:globalLang');
 
     await mailService.send({
       to: user.email,
       subject: `New password for ${appTitle}`,
-      template: path.join(crowi.localeDir, `${locale}/admin/userResetPassword.ejs'),
+      template: path.join(crowi.localeDir, `${locale}/admin/userResetPassword.ejs`),
       vars: {
         email: user.email,
         password: user.password,

--- a/apps/app/src/server/routes/apiv3/users.js
+++ b/apps/app/src/server/routes/apiv3/users.js
@@ -191,7 +191,7 @@ module.exports = (crowi) => {
     await mailService.send({
       to: user.email,
       subject: `New password for ${appTitle}`,
-      template: path.join(crowi.localeDir, 'en_US/admin/userResetPassword.ejs'),
+      template: path.join(crowi.localeDir, `${locale}/admin/userResetPassword.ejs'),
       vars: {
         email: user.email,
         password: user.password,


### PR DESCRIPTION
### 概要
ユーザー管理のパスワードリセットメールをi18n化

### Task

- https://redmine.weseek.co.jp/issues/128471
　　　- https://redmine.weseek.co.jp/issues/129936

補足
zh_CNに関してはテンプレートの中国語がなかったので、中国語に言語設定をしてもパスワードリセットメールが中国語で送信されない