### PR TITLE
Enable negative margin

### DIFF
--- a/apps/app/src/styles/_variables.scss
+++ b/apps/app/src/styles/_variables.scss
@@ -26,3 +26,5 @@ $grw-logo-width: $grw-sidebar-nav-width;
 $grw-logomark-width: 36px;
 
 $grw-scroll-margin-top-in-view: 130px;
+
+$enable-negative-margins: true;


### PR DESCRIPTION
## やったこと
bootstrap5 では、negative margin がデフォルトで無効になっている。
→ sass に $enable-negative-margins: true を追加することで、negative margin を有効にした。

## タスク
https://redmine.weseek.co.jp/issues/129248

## 参考
https://getbootstrap.com/docs/5.2/utilities/spacing/#negative-margin