### PR TITLE
fix: Url to join to the slack team

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,5 +4,5 @@ contact_links:
     url: https://github.com/weseek/growi/discussions
     about: If you have feature requests or suggestions, you can create a new discussion and consider it with the community.
   - name: Questions
-    url: https://growi-slackin.weseek.co.jp/
+    url: https://communityinviter.com/apps/wsgrowi/invite/
     about: If you have questions, you can join our Slack team and talk about anything, anytime.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 </p>
 <p align="center">
   <a href="https://github.com/weseek/growi/releases/latest"><img src="https://img.shields.io/github/release/weseek/growi.svg"></a>
-  <a href="https://growi-slackin.weseek.co.jp/"><img src="https://growi-slackin.weseek.co.jp/badge.svg"></a>
+  <a href="https://communityinviter.com/apps/wsgrowi/invite/">join our Slack team</a>
 </p>
 
 <p align="center">
@@ -132,7 +132,7 @@ You can write issues and PRs in English or Japanese.
 
 ## Discussion
 
-If you have questions or suggestions, you can [join our Slack team](https://growi-slackin.weseek.co.jp/) and talk about anything, anytime.
+If you have questions or suggestions, you can [join our Slack team](https://communityinviter.com/apps/wsgrowi/invite/) and talk about anything, anytime.
 
 # License
 

--- a/README_JP.md
+++ b/README_JP.md
@@ -6,7 +6,7 @@
   </p>
   <p align="center">
     <a href="https://github.com/weseek/growi/releases/latest"><img src="https://img.shields.io/github/release/weseek/growi.svg"></a>
-    <a href="https://growi-slackin.weseek.co.jp/"><img src="https://growi-slackin.weseek.co.jp/badge.svg"></a>
+    <a href="https://communityinviter.com/apps/wsgrowi/invite/">join our Slack team</a>
   </p>
 
 <p align="center">
@@ -129,7 +129,7 @@ Issue と Pull requests の作成は英語・日本語どちらでも受け付�
 
 ## GROWI について話し合いましょう！
 
-質問や提案があれば、私たちの [Slack team](https://growi-slackin.weseek.co.jp/) にぜひご参加ください。
+質問や提案があれば、私たちの [Slack team](https://communityinviter.com/apps/wsgrowi/invite/) にぜひご参加ください。
 いつでも、どこでも GROWI について議論しましょう！
 
 # ライセンス

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,7 +13,7 @@
 
 If you believe you have found a security vulnerability in any GROWI related repository, please report it to us using one of the methods described below.
 
-  * [Join our Slack team](https://growi-slackin.weseek.co.jp/) and send DM to `@yuki` who is the lead developer
+  * [Join our Slack team](https://communityinviter.com/apps/wsgrowi/invite/) and send DM to `@yuki` who is the lead developer
   * Report to JPCERT/CC[^jpcertcc]
     * [[PDF] JPCERT/CC Vulnerability Coordination and Disclosure Policy](https://www.jpcert.or.jp/english/vh/vul-coordination-disclosure-policy_2019.pdf)
 

--- a/apps/app/resource/locales/en_US/welcome.md
+++ b/apps/app/resource/locales/en_US/welcome.md
@@ -58,7 +58,7 @@ We can display the content list using a table and `$lsx`.
 
 # Slack
 
-<a href="https://growi-slackin.weseek.co.jp/"><img src="https://growi-slackin.weseek.co.jp/badge.svg"></a>
+<a href="https://communityinviter.com/apps/wsgrowi/invite/">join our Slack team</a>
 
 We welcome newcomers joining our slack channel to help improve GROWI.
 In addition to discussing development, we are also happy to answer your questions when you join.

--- a/apps/app/resource/locales/ja_JP/welcome.md
+++ b/apps/app/resource/locales/ja_JP/welcome.md
@@ -54,7 +54,7 @@ GROWI は個人・法人向けの Wiki | ナレッジベースツールです。
 
 # Slack
 
-<a href="https://growi-slackin.weseek.co.jp/"><img src="https://growi-slackin.weseek.co.jp/badge.svg"></a>
+<a href="https://communityinviter.com/apps/wsgrowi/invite/">join our Slack team</a>
 
 GROWI をより良いものにするために、是非 Slack に参加してください。  
 開発に関する議論を行っている他、導入時の質問等も受け付けています。

--- a/apps/app/resource/locales/zh_CN/welcome.md
+++ b/apps/app/resource/locales/zh_CN/welcome.md
@@ -58,7 +58,7 @@ GROWI是一个针对个人和公司的Wiki - 一个知识库工具。
 
 # Slack
 
-<a href="https://growi-slackin.weseek.co.jp/"><img src="https://growi-slackin.weseek.co.jp/badge.svg"></a>
+<a href="https://communityinviter.com/apps/wsgrowi/invite/">join our Slack team</a>
 
 我们欢迎新人加入我们的slack频道，帮助改善Growi。
 除了讨论发展问题，我们也很乐意在你加入时回答你的问题。

--- a/apps/app/test/cypress/e2e/20-basic-features/20-basic-features--sticky-features.cy.ts
+++ b/apps/app/test/cypress/e2e/20-basic-features/20-basic-features--sticky-features.cy.ts
@@ -111,7 +111,6 @@ context('Access to any page', () => {
     });
     cy.waitUntil(() => {
       cy.getByTestid('grw-subnav-switcher').within(() => {
-        // cy.getByTestid('editor-button').should('be.visible').click();
         cy.getByTestid('editor-button').as('editorButton').should('be.visible');
         cy.get('@editorButton').click();
       });

--- a/apps/app/test/cypress/e2e/20-basic-features/20-basic-features--sticky-features.cy.ts
+++ b/apps/app/test/cypress/e2e/20-basic-features/20-basic-features--sticky-features.cy.ts
@@ -112,8 +112,8 @@ context('Access to any page', () => {
     cy.waitUntil(() => {
       cy.getByTestid('grw-subnav-switcher').within(() => {
         // cy.getByTestid('editor-button').should('be.visible').click();
-        cy.getByTestid('editor-button').as('editorButton').click()
-        cy.get('@editorButton').should('be.visible')
+        cy.getByTestid('editor-button').as('editorButton').should('be.visible');
+        cy.get('@editorButton').click();
       });
       return cy.get('.layout-root').then($elem => $elem.hasClass('editing'));
     });

--- a/apps/app/test/cypress/e2e/20-basic-features/20-basic-features--sticky-features.cy.ts
+++ b/apps/app/test/cypress/e2e/20-basic-features/20-basic-features--sticky-features.cy.ts
@@ -111,7 +111,9 @@ context('Access to any page', () => {
     });
     cy.waitUntil(() => {
       cy.getByTestid('grw-subnav-switcher').within(() => {
-        cy.getByTestid('editor-button').should('be.visible').click();
+        // cy.getByTestid('editor-button').should('be.visible').click();
+        cy.getByTestid('editor-button').as('editorButton').click()
+        cy.get('@editorButton').should('be.visible')
       });
       return cy.get('.layout-root').then($elem => $elem.hasClass('editing'));
     });

--- a/apps/slackbot-proxy/src/views/top.ejs
+++ b/apps/slackbot-proxy/src/views/top.ejs
@@ -38,7 +38,7 @@
           </ul>
         <div class="mt-3">
           GROWI is open-source software developed by WESEEK, Inc and we are looking for contributors who can work with us.<br>
-          Please <a href="https://growi-slackin.weseek.co.jp/">join</a> Slack and feel free to talk to WESEEK members!
+          Please <a href="https://communityinviter.com/apps/wsgrowi/invite/">join</a> Slack and feel free to talk to WESEEK members!
         </div>
       </div>
     </div>


### PR DESCRIPTION
### タスク
https://redmine.weseek.co.jp/issues/130077

### 概要
slackin （GROWI の Slack のワークスペースに簡単に招待できるサービス） が使えなくなったため、代替手段として communityinviter を使うことになった。GROWI リポジトリ内に存在する slackin の URL を communityinviter の URL に置き換える必要がある。