### PR TITLE
feat: Workflow creation page

### DIFF
--- a/apps/app/public/static/locales/en_US/translation.json
+++ b/apps/app/public/static/locales/en_US/translation.json
@@ -828,6 +828,8 @@
   },
   "approval_workflow": {
     "approval_workflow": "Approval Workflow",
+    "name": "Workflow Name",
+    "description": "Description",
     "back": "Back",
     "list": "Workflow List",
     "create": "Create workflow",

--- a/apps/app/public/static/locales/ja_JP/translation.json
+++ b/apps/app/public/static/locales/ja_JP/translation.json
@@ -861,6 +861,8 @@
   },
   "approval_workflow": {
     "approval_workflow": "ワークフロー",
+    "name": "ワークフロー名",
+    "description": "説明",
     "back": "戻る",
     "list": "ワークフロー一覧",
     "create": "ワークフローを作成",

--- a/apps/app/public/static/locales/zh_CN/translation.json
+++ b/apps/app/public/static/locales/zh_CN/translation.json
@@ -831,6 +831,8 @@
   },
   "approval_workflow": {
     "approval_workflow": "工作流程",
+    "name": "工作流程名称",
+    "description": "描述",
     "back": "返回",
     "list": "工作流程列表",
     "create": "创建工作流程",

--- a/apps/app/src/client/services/workflow.ts
+++ b/apps/app/src/client/services/workflow.ts
@@ -1,0 +1,23 @@
+import { useCallback, useState } from 'react';
+
+import { apiv3Post } from '~/client/util/apiv3-client';
+import { IWorkflowHasId, IWorkflowApproverGroupReq } from '~/interfaces/workflow';
+
+
+export const useCreateWorkflow = (
+    pageId?: string, name?: string, comment?: string, approverGroups?: IWorkflowApproverGroupReq[],
+): { createdWorkflow: IWorkflowHasId | undefined, createWorkflow: () => Promise<void> } => {
+  const [createdWorkflow, setCreatedWorkflow] = useState<IWorkflowHasId | undefined>();
+
+  const createWorkflow = useCallback(async() => {
+    if (pageId == null || approverGroups == null) {
+      return;
+    }
+    const response = await apiv3Post('/workflow', {
+      pageId, name, comment, approverGroups,
+    });
+    setCreatedWorkflow(response.data.setCreatedWorkflow as IWorkflowHasId | undefined);
+  }, [approverGroups, comment, name, pageId]);
+
+  return { createdWorkflow, createWorkflow };
+};

--- a/apps/app/src/components/Navbar/GrowiContextualSubNavigation.tsx
+++ b/apps/app/src/components/Navbar/GrowiContextualSubNavigation.tsx
@@ -333,8 +333,8 @@ const GrowiContextualSubNavigation = (props: GrowiContextualSubNavigationProps):
     setIsPageTempleteModalShown(true);
   }, []);
 
-  const workflowItemClickedHandler = useCallback(() => {
-    openWorkflowModal();
+  const workflowItemClickedHandler = useCallback((pageId: string) => {
+    openWorkflowModal(pageId);
   }, [openWorkflowModal]);
 
   const RightComponent = () => {

--- a/apps/app/src/components/Navbar/SubNavButtons.tsx
+++ b/apps/app/src/components/Navbar/SubNavButtons.tsx
@@ -41,7 +41,7 @@ type CommonProps = {
   onClickRenameMenuItem?: (pageToRename: IPageToRenameWithMeta) => void,
   onClickDeleteMenuItem?: (pageToDelete: IPageToDeleteWithMeta) => void,
   onClickSwitchContentWidth?: (pageId: string, value: boolean) => void,
-  onClickWorkflowMenuItem?: () => void,
+  onClickWorkflowMenuItem?: (pageId: string) => void,
 }
 
 type SubNavButtonsSubstanceProps = CommonProps & {
@@ -156,12 +156,12 @@ const SubNavButtonsSubstance = (props: SubNavButtonsSubstanceProps): JSX.Element
     }
   }, [isGuestUser, isReadOnlyUser, onClickSwitchContentWidth, pageId, pageInfo]);
 
-  const workflowMenuItemClickHandler = useCallback(async() => {
+  const workflowMenuItemClickHandler = useCallback(async(pageId: string) => {
     if (onClickWorkflowMenuItem == null) {
       return;
     }
 
-    onClickWorkflowMenuItem();
+    onClickWorkflowMenuItem(pageId);
   }, [onClickWorkflowMenuItem]);
 
   const additionalMenuItemOnTopRenderer = useMemo(() => {
@@ -173,7 +173,7 @@ const SubNavButtonsSubstance = (props: SubNavButtonsSubstanceProps): JSX.Element
         <>
           <WideViewMenuItem onClickMenuItem={switchContentWidthClickHandler} expandContentWidth={expandContentWidth} />
           <DropdownItem divider />
-          <CommunicationMenuItems onClickWokflowMenuItem={workflowMenuItemClickHandler} />
+          <CommunicationMenuItems pageId={pageId} onClickWokflowMenuItem={workflowMenuItemClickHandler} />
         </>
       );
     };

--- a/apps/app/src/components/SubNavButtons/CommunicationMenuItems.tsx
+++ b/apps/app/src/components/SubNavButtons/CommunicationMenuItems.tsx
@@ -5,17 +5,18 @@ import { DropdownItem } from 'reactstrap';
 
 
 type CommunicationMenuItemsProps = {
-  onClickWokflowMenuItem: () => void,
+  pageId: string,
+  onClickWokflowMenuItem: (pageId: string) => void,
 }
 
 export const CommunicationMenuItems = (props: CommunicationMenuItemsProps): JSX.Element => {
   const { t } = useTranslation();
 
-  const { onClickWokflowMenuItem } = props;
+  const { pageId, onClickWokflowMenuItem } = props;
 
   return (
     // TODO: Add dropdown items for announcements and in-app notifications
-    <DropdownItem onClick={() => onClickWokflowMenuItem()}>
+    <DropdownItem onClick={() => onClickWokflowMenuItem(pageId)}>
       <i className="fa fa-fw icon-organization grw-page-control-dropdown-icon"></i>
       { t('approval_workflow.approval_workflow') }
     </DropdownItem>

--- a/apps/app/src/components/Workflow/CreateWorkflowPage.tsx
+++ b/apps/app/src/components/Workflow/CreateWorkflowPage.tsx
@@ -4,10 +4,10 @@ import { useTranslation } from 'next-i18next';
 import { ModalHeader, ModalBody, ModalFooter } from 'reactstrap';
 
 import { apiv3Post } from '~/client/util/apiv3-client';
-import { IWorkflowApproverGroup } from '~/interfaces/workflow';
+import { IWorkflowApproverGroup, WorkflowApprovalType, WorkflowApproverStatus } from '~/interfaces/workflow';
 
 type Props = {
-  pageId?: string,
+  pageId: string,
   onClickWorkflowListPageBackButton: () => void;
 }
 
@@ -16,9 +16,23 @@ export const CreateWorkflowPage = (props: Props): JSX.Element => {
 
   const { onClickWorkflowListPageBackButton, pageId } = props;
 
+  const approverGroupsDummyData = [{
+    approvalType: WorkflowApprovalType.AND,
+    approvers: [
+      {
+        user: '64e4072930f26dcc81590064',
+        status: WorkflowApproverStatus.NONE,
+      },
+      {
+        user: '64e4072930f86dcc81590068',
+        status: WorkflowApproverStatus.NONE,
+      },
+    ],
+  }] as unknown as IWorkflowApproverGroup[];
+
   const [workflowName, setWorkflowName] = useState<string>('');
   const [workflowDescription, setWorkflowDescription] = useState<string>('');
-  const [approverGroup, setApproverGroup] = useState<IWorkflowApproverGroup | undefined>();
+  const [approverGroups, setApproverGroups] = useState<IWorkflowApproverGroup[] | undefined>(approverGroupsDummyData);
 
   const workflowNameChangeHandler = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
     setWorkflowName(event.target.value);
@@ -39,15 +53,14 @@ export const CreateWorkflowPage = (props: Props): JSX.Element => {
   const createWorkflowButtonClickHandler = useCallback(async() => {
     try {
       await apiv3Post('/workflow', {
-        pageId, name: workflowName, comment: workflowDescription, approverGroup,
+        pageId, name: workflowName, comment: workflowDescription, approverGroups,
       });
-
       // TODO: Move to the detail screen
     }
     catch (err) {
       // TODO: Consider how to display errors
     }
-  }, [pageId, approverGroup, workflowDescription, workflowName]);
+  }, [pageId, approverGroups, workflowDescription, workflowName]);
 
   return (
     <>

--- a/apps/app/src/components/Workflow/CreateWorkflowPage.tsx
+++ b/apps/app/src/components/Workflow/CreateWorkflowPage.tsx
@@ -38,14 +38,16 @@ export const CreateWorkflowPage = (props: Props): JSX.Element => {
 
   const createWorkflowButtonClickHandler = useCallback(async() => {
     try {
-      await apiv3Post('_api/v3/workflow', {
+      await apiv3Post('/workflow', {
         pageId, name: workflowName, comment: workflowDescription, approverGroup,
       });
+
+      // TODO: Move to the detail screen
     }
     catch (err) {
-      //
+      // TODO: Consider how to display errors
     }
-  }, []);
+  }, [pageId, approverGroup, workflowDescription, workflowName]);
 
   return (
     <>

--- a/apps/app/src/components/Workflow/CreateWorkflowPage.tsx
+++ b/apps/app/src/components/Workflow/CreateWorkflowPage.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useState } from 'react';
 import { useTranslation } from 'next-i18next';
 import { ModalHeader, ModalBody, ModalFooter } from 'reactstrap';
 
-import { apiv3Post } from '~/client/util/apiv3-client';
+import { useCreateWorkflow } from '~/client/services/workflow';
 import { IWorkflowApproverGroupReq, WorkflowApprovalType, WorkflowApproverStatus } from '~/interfaces/workflow';
 
 type Props = {
@@ -14,7 +14,7 @@ type Props = {
 export const CreateWorkflowPage = (props: Props): JSX.Element => {
   const { t } = useTranslation();
 
-  const { onClickWorkflowListPageBackButton, pageId } = props;
+  const { pageId, onClickWorkflowListPageBackButton } = props;
 
   const approverGroupsDummyData = [{
     approvalType: WorkflowApprovalType.AND,
@@ -24,7 +24,7 @@ export const CreateWorkflowPage = (props: Props): JSX.Element => {
         status: WorkflowApproverStatus.NONE,
       },
       {
-        user: '64e4116aaa753ef87fk73777',
+        user: '64ec3bcd763893423f32b9dd',
         status: WorkflowApproverStatus.NONE,
       },
     ],
@@ -33,6 +33,8 @@ export const CreateWorkflowPage = (props: Props): JSX.Element => {
   const [workflowName, setWorkflowName] = useState<string>('');
   const [workflowDescription, setWorkflowDescription] = useState<string>('');
   const [approverGroups, setApproverGroups] = useState<IWorkflowApproverGroupReq[] | undefined>(approverGroupsDummyData);
+
+  const { createWorkflow } = useCreateWorkflow(pageId, workflowName, workflowDescription, approverGroups);
 
   const workflowNameChangeHandler = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
     setWorkflowName(event.target.value);
@@ -51,16 +53,18 @@ export const CreateWorkflowPage = (props: Props): JSX.Element => {
   }, [onClickWorkflowListPageBackButton]);
 
   const createWorkflowButtonClickHandler = useCallback(async() => {
+    if (approverGroups == null) {
+      return;
+    }
+
     try {
-      await apiv3Post('/workflow', {
-        pageId, name: workflowName, comment: workflowDescription, approverGroups,
-      });
+      await createWorkflow();
       // TODO: Move to the detail screen
     }
     catch (err) {
       // TODO: Consider how to display errors
     }
-  }, [pageId, approverGroups, workflowDescription, workflowName]);
+  }, [approverGroups, createWorkflow]);
 
   return (
     <>

--- a/apps/app/src/components/Workflow/CreateWorkflowPage.tsx
+++ b/apps/app/src/components/Workflow/CreateWorkflowPage.tsx
@@ -3,8 +3,8 @@ import React, { useCallback, useState } from 'react';
 import { useTranslation } from 'next-i18next';
 import { ModalHeader, ModalBody, ModalFooter } from 'reactstrap';
 
-
 type Props = {
+  pageId?: string,
   onClickWorkflowListPageBackButton: () => void;
 }
 
@@ -12,7 +12,7 @@ type Props = {
 export const CreateWorkflowPage = (props: Props): JSX.Element => {
   const { t } = useTranslation();
 
-  const { onClickWorkflowListPageBackButton } = props;
+  const { onClickWorkflowListPageBackButton, pageId } = props;
 
   const [workflowName, setWorkflowName] = useState<string>('');
   const [workflowDescription, setWorkflowDescription] = useState<string>('');
@@ -32,6 +32,10 @@ export const CreateWorkflowPage = (props: Props): JSX.Element => {
 
     onClickWorkflowListPageBackButton();
   }, [onClickWorkflowListPageBackButton]);
+
+  const createWorkflowButtonClickHandler = useCallback(() => {
+    //
+  }, []);
 
   return (
     <>
@@ -82,7 +86,7 @@ export const CreateWorkflowPage = (props: Props): JSX.Element => {
       </ModalBody>
 
       <ModalFooter>
-        <button type="button">
+        <button type="button" onClick={createWorkflowButtonClickHandler}>
           {t('approval_workflow.create')}
         </button>
 

--- a/apps/app/src/components/Workflow/CreateWorkflowPage.tsx
+++ b/apps/app/src/components/Workflow/CreateWorkflowPage.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'next-i18next';
 import { ModalHeader, ModalBody, ModalFooter } from 'reactstrap';
 
 import { apiv3Post } from '~/client/util/apiv3-client';
-import { IWorkflowApproverGroup, WorkflowApprovalType, WorkflowApproverStatus } from '~/interfaces/workflow';
+import { IWorkflowApproverGroupReq, WorkflowApprovalType, WorkflowApproverStatus } from '~/interfaces/workflow';
 
 type Props = {
   pageId: string,
@@ -20,19 +20,19 @@ export const CreateWorkflowPage = (props: Props): JSX.Element => {
     approvalType: WorkflowApprovalType.AND,
     approvers: [
       {
-        user: '64e4072930f26dcc81590064',
+        user: '64e41166aa753ef87f073770',
         status: WorkflowApproverStatus.NONE,
       },
       {
-        user: '64e4072930f86dcc81590068',
+        user: '64e4116aaa753ef87fk73777',
         status: WorkflowApproverStatus.NONE,
       },
     ],
-  }] as unknown as IWorkflowApproverGroup[];
+  }] as IWorkflowApproverGroupReq[];
 
   const [workflowName, setWorkflowName] = useState<string>('');
   const [workflowDescription, setWorkflowDescription] = useState<string>('');
-  const [approverGroups, setApproverGroups] = useState<IWorkflowApproverGroup[] | undefined>(approverGroupsDummyData);
+  const [approverGroups, setApproverGroups] = useState<IWorkflowApproverGroupReq[] | undefined>(approverGroupsDummyData);
 
   const workflowNameChangeHandler = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
     setWorkflowName(event.target.value);

--- a/apps/app/src/components/Workflow/CreateWorkflowPage.tsx
+++ b/apps/app/src/components/Workflow/CreateWorkflowPage.tsx
@@ -3,11 +3,13 @@ import React, { useCallback, useState } from 'react';
 import { useTranslation } from 'next-i18next';
 import { ModalHeader, ModalBody, ModalFooter } from 'reactstrap';
 
+import { apiv3Post } from '~/client/util/apiv3-client';
+import { IWorkflowApproverGroup } from '~/interfaces/workflow';
+
 type Props = {
   pageId?: string,
   onClickWorkflowListPageBackButton: () => void;
 }
-
 
 export const CreateWorkflowPage = (props: Props): JSX.Element => {
   const { t } = useTranslation();
@@ -16,6 +18,7 @@ export const CreateWorkflowPage = (props: Props): JSX.Element => {
 
   const [workflowName, setWorkflowName] = useState<string>('');
   const [workflowDescription, setWorkflowDescription] = useState<string>('');
+  const [approverGroup, setApproverGroup] = useState<IWorkflowApproverGroup | undefined>();
 
   const workflowNameChangeHandler = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
     setWorkflowName(event.target.value);
@@ -33,8 +36,15 @@ export const CreateWorkflowPage = (props: Props): JSX.Element => {
     onClickWorkflowListPageBackButton();
   }, [onClickWorkflowListPageBackButton]);
 
-  const createWorkflowButtonClickHandler = useCallback(() => {
-    //
+  const createWorkflowButtonClickHandler = useCallback(async() => {
+    try {
+      await apiv3Post('_api/v3/workflow', {
+        pageId, name: workflowName, comment: workflowDescription, approverGroup,
+      });
+    }
+    catch (err) {
+      //
+    }
   }, []);
 
   return (

--- a/apps/app/src/components/Workflow/CreateWorkflowPage.tsx
+++ b/apps/app/src/components/Workflow/CreateWorkflowPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 
 import { useTranslation } from 'next-i18next';
 import { ModalHeader, ModalBody, ModalFooter } from 'reactstrap';
@@ -13,6 +13,17 @@ export const CreateWorkflowPage = (props: Props): JSX.Element => {
   const { t } = useTranslation();
 
   const { onClickWorkflowListPageBackButton } = props;
+
+  const [workflowName, setWorkflowName] = useState<string>('');
+  const [workflowDescription, setWorkflowDescription] = useState<string>('');
+
+  const workflowNameChangeHandler = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    setWorkflowName(event.target.value);
+  }, []);
+
+  const workflowDescriptionChangeHandler = useCallback((event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setWorkflowDescription(event.target.value);
+  }, []);
 
   const workflowListPageBackButtonClickHandler = useCallback(() => {
     if (onClickWorkflowListPageBackButton == null) {
@@ -29,7 +40,45 @@ export const CreateWorkflowPage = (props: Props): JSX.Element => {
       </ModalHeader>
 
       <ModalBody>
-        Body
+
+        <div className="row align-items-center">
+          <label htmlFor="name" className="col-md-4 col-form-label">
+            {t('approval_workflow.name')}
+          </label>
+          <div className="col-md-8 mb-3">
+            <div className="row">
+              <div className="col">
+                <input
+                  className="form-control"
+                  type="text"
+                  name="name"
+                  value={workflowName}
+                  onChange={workflowNameChangeHandler}
+                  required
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="row">
+          <label htmlFor="description" className="col-md-4 col-form-label">
+            {t('approval_workflow.description')}
+          </label>
+          <div className="col-md-8">
+            <div className="row">
+              <div className="col">
+                <textarea
+                  className="form-control"
+                  name="description"
+                  value={workflowDescription}
+                  onChange={workflowDescriptionChangeHandler}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+
       </ModalBody>
 
       <ModalFooter>

--- a/apps/app/src/components/Workflow/WorkflowModal.tsx
+++ b/apps/app/src/components/Workflow/WorkflowModal.tsx
@@ -35,6 +35,10 @@ const WorkflowModal = (): JSX.Element => {
     setPageType(PageType.list);
   }, []);
 
+  if (workflowModalData?.pageId == null) {
+    return <></>;
+  }
+
   return (
     <Modal isOpen={workflowModalData?.isOpened ?? false} toggle={() => closeWorkflowModal()}>
       { pageType === PageType.list && (
@@ -45,7 +49,7 @@ const WorkflowModal = (): JSX.Element => {
 
       { pageType === PageType.create && (
         <CreateWorkflowPage
-          pageId={workflowModalData?.pageId}
+          pageId={workflowModalData.pageId}
           onClickWorkflowListPageBackButton={workflowListPageBackButtonClickHandler}
         />
       )}

--- a/apps/app/src/components/Workflow/WorkflowModal.tsx
+++ b/apps/app/src/components/Workflow/WorkflowModal.tsx
@@ -45,6 +45,7 @@ const WorkflowModal = (): JSX.Element => {
 
       { pageType === PageType.create && (
         <CreateWorkflowPage
+          pageId={workflowModalData?.pageId}
           onClickWorkflowListPageBackButton={workflowListPageBackButtonClickHandler}
         />
       )}

--- a/apps/app/src/stores/modal.tsx
+++ b/apps/app/src/stores/modal.tsx
@@ -744,11 +744,12 @@ export const useLinkEditModal = (): SWRResponse<LinkEditModalStatus, Error> & Li
 * workflowModal
 */
 export type WorkflowModalStatus = {
+  pageId?: string,
   isOpened: boolean,
 }
 
 type WorkflowModalUtils = {
-  open(): void,
+  open(pageId: string): void,
   close(): void,
 }
 
@@ -758,8 +759,8 @@ export const useWorkflowModal = (): SWRResponse<WorkflowModalStatus, Error> & Wo
   const swrResponse = useStaticSWR<WorkflowModalStatus, Error>('workflowModal', undefined, { fallbackData: initialStatus });
 
   return Object.assign(swrResponse, {
-    open: () => {
-      swrResponse.mutate({ isOpened: true });
+    open: (pageId: string) => {
+      swrResponse.mutate({ isOpened: true, pageId });
     },
     close: () => {
       swrResponse.mutate({ isOpened: false });


### PR DESCRIPTION
## Task
[#129420](https://redmine.weseek.co.jp/issues/129420) [approval-workflow] ワークフロー作成画面を実装しワークフローデータを作成できる
└  [#130125](https://redmine.weseek.co.jp/issues/130125) [client] ワークフロー作成画面の実装
└ [#130001](https://redmine.weseek.co.jp/issues/130001) [client] POST: /workflow へリクエストするための fetcher を実装し、ワークフロー作成ボタンを押した時に DB にデータを保存することができる