### PR TITLE
support: Internationalization USER_REGISTRATION_APPROVAL_REQUEST label for v70x

### DIFF
--- a/apps/app/public/static/locales/en_US/admin.json
+++ b/apps/app/public/static/locales/en_US/admin.json
@@ -912,6 +912,7 @@
     "USER_API_TOKEN_UPDATE": "API Token update",
     "USER_EDITOR_SETTINGS_UPDATE": "Editor settings update",
     "USER_IN_APP_NOTIFICATION_SETTINGS_UPDATE": "In-App Notification settings update",
+    "USER_REGISTRATION_APPROVAL_REQUEST": "User registration request for ID/Password authentication",
     "PAGE_VIEW": "Page view",
     "PAGE_USER_HOME_VIEW": "Page view (User home)",
     "PAGE_FORBIDDEN": "Page view (Fobidden page)",

--- a/apps/app/public/static/locales/ja_JP/admin.json
+++ b/apps/app/public/static/locales/ja_JP/admin.json
@@ -921,6 +921,7 @@
     "USER_API_TOKEN_UPDATE": "API トークンの更新",
     "USER_EDITOR_SETTINGS_UPDATE": "エディター設定の更新",
     "USER_IN_APP_NOTIFICATION_SETTINGS_UPDATE": "アプリ内通知設定の更新",
+    "USER_REGISTRATION_APPROVAL_REQUEST": "ID/Password 認証のユーザー登録リクエスト",
     "PAGE_VIEW": "ページ閲覧",
     "PAGE_USER_HOME_VIEW": "ページ閲覧（ユーザーホーム）",
     "PAGE_FORBIDDEN": "ページ閲覧（fobiddenページ）",

--- a/apps/app/public/static/locales/zh_CN/admin.json
+++ b/apps/app/public/static/locales/zh_CN/admin.json
@@ -920,6 +920,7 @@
     "USER_API_TOKEN_UPDATE": "API 令牌更新",
     "USER_EDITOR_SETTINGS_UPDATE": "编辑器设置更新",
     "USER_IN_APP_NOTIFICATION_SETTINGS_UPDATE": "应用内通知设置更新",
+    "USER_REGISTRATION_APPROVAL_REQUEST": "用户注册 ID/密码验证请求",
     "PAGE_VIEW": "页面浏览量",
     "PAGE_USER_HOME_VIEW": "页面浏览量（用户主页）",
     "PAGE_FORBIDDEN": "页面浏览量（禁止页面）",


### PR DESCRIPTION
## task
https://redmine.weseek.co.jp/issues/131841

## Screenshot
- 手元では dev 環境を立ち上げて i18n されているか確認しました。
- ref: https://github.com/weseek/growi/pull/8129