### PR TITLE
feat: Create ApproverGroupCard

### DIFF
--- a/apps/app/public/static/locales/en_US/translation.json
+++ b/apps/app/public/static/locales/en_US/translation.json
@@ -824,6 +824,9 @@
     "edit_workflow": "Edit workflow",
     "cancel": "Cancel",
     "completion": "completion",
+    "add_flow": "フローの追加",
+    "completion_conditions": "Completion conditions",
+    "description_for_new_creation": "When the final flow is completed, the workflow is marked as finished",
     "approval_type": {
       "and": "Everyone's approval",
       "or": "One person's approval"

--- a/apps/app/public/static/locales/en_US/translation.json
+++ b/apps/app/public/static/locales/en_US/translation.json
@@ -828,8 +828,8 @@
     "completion_conditions": "Completion conditions",
     "description_for_new_creation": "When the final flow is completed, the workflow is marked as finished",
     "approval_type": {
-      "and": "Everyone's approval",
-      "or": "One person's approval"
+      "AND": "Everyone's approval",
+      "OR": "One person's approval"
     },
     "statuses": {
       "INPROGRESS": "IN-PROGRESS",

--- a/apps/app/public/static/locales/en_US/translation.json
+++ b/apps/app/public/static/locales/en_US/translation.json
@@ -824,6 +824,10 @@
     "edit_workflow": "Edit workflow",
     "cancel": "Cancel",
     "completion": "completion",
+    "approval_type": {
+      "and": "Everyone's approval",
+      "or": "One person's approval"
+    },
     "statuses": {
       "INPROGRESS": "IN-PROGRESS",
       "APPROVE": "APPROVE",

--- a/apps/app/public/static/locales/ja_JP/translation.json
+++ b/apps/app/public/static/locales/ja_JP/translation.json
@@ -857,6 +857,9 @@
     "show_detail": "詳細を見る",
     "cancel": "キャンセル",
     "completion": "完了",
+    "add_flow": "フローの追加",
+    "completion_conditions": "完了条件",
+    "description_for_new_creation": "最後のフローが完了するとワークフローは完了になります",
     "approval_type": {
       "AND": "全員が承認",
       "OR": "1人が承認"

--- a/apps/app/public/static/locales/ja_JP/translation.json
+++ b/apps/app/public/static/locales/ja_JP/translation.json
@@ -857,6 +857,10 @@
     "show_detail": "詳細を見る",
     "cancel": "キャンセル",
     "completion": "完了",
+    "approval_type": {
+      "AND": "全員が承認",
+      "OR": "1人が承認"
+    },
     "statuses": {
       "INPROGRESS": "進行中",
       "APPROVE": "承認",

--- a/apps/app/public/static/locales/zh_CN/translation.json
+++ b/apps/app/public/static/locales/zh_CN/translation.json
@@ -827,6 +827,10 @@
     "edit_workflow": "编辑工作流程",
     "cancel": "取消",
     "completion": "完成",
+    "approval_type": {
+      "and": "大家的认可",
+      "or": "一个人的认可"
+    },
     "statuses": {
       "INPROGRESS": "进行中",
       "APPROVE": "批准",

--- a/apps/app/public/static/locales/zh_CN/translation.json
+++ b/apps/app/public/static/locales/zh_CN/translation.json
@@ -831,8 +831,8 @@
     "completion_conditions": "完工条件",
     "description_for_new_creation": "当最终流程完成时，工作流程被标记为已完成",
     "approval_type": {
-      "and": "大家的认可",
-      "or": "一个人的认可"
+      "AND": "大家的认可",
+      "OR": "一个人的认可"
     },
     "statuses": {
       "INPROGRESS": "进行中",

--- a/apps/app/public/static/locales/zh_CN/translation.json
+++ b/apps/app/public/static/locales/zh_CN/translation.json
@@ -827,6 +827,9 @@
     "edit_workflow": "编辑工作流程",
     "cancel": "取消",
     "completion": "完成",
+    "add_flow": "额外流量",
+    "completion_conditions": "完工条件",
+    "description_for_new_creation": "当最终流程完成时，工作流程被标记为已完成",
     "approval_type": {
       "and": "大家的认可",
       "or": "一个人的认可"

--- a/apps/app/src/features/approval-workflow/client/components/ModalComponents/ApproverGroupCard.tsx
+++ b/apps/app/src/features/approval-workflow/client/components/ModalComponents/ApproverGroupCard.tsx
@@ -1,0 +1,40 @@
+import React, { useState, useCallback } from 'react';
+
+
+import { useTranslation } from 'next-i18next';
+
+import { WorkflowApprovalType, IWorkflowApproverGroupReq } from '../../../interfaces/workflow';
+
+export const ApproverGroupCard = (): JSX.Element => {
+  const { t } = useTranslation();
+
+  const [approvalType, setApprovalType] = useState<WorkflowApprovalType>(WorkflowApprovalType.AND);
+
+  const changeApprovalTypeButtonClickHandler = useCallback(() => {
+    setApprovalType(approvalType === WorkflowApprovalType.AND ? WorkflowApprovalType.OR : WorkflowApprovalType.AND);
+  }, [approvalType]);
+
+  return (
+    <div className="card rounded">
+      <div className="card-body">
+        <div className="text-muted">
+          <i className="fa fa-user" />
+        </div>
+
+        <div className="dropdown">
+          <a className="btn btn-light btn-sm rounded-pill dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+            {t(`approval_workflow.approval_type.${approvalType}`)}
+          </a>
+          <ul className="dropdown-menu" onClick={() => changeApprovalTypeButtonClickHandler()}>
+            { approvalType === WorkflowApprovalType.AND
+              ? <>{t('approval_workflow.approval_type.OR')}</>
+              : <>{t('approval_workflow.approval_type.AND')}</>
+            }
+          </ul>
+        </div>
+
+        完了条件
+      </div>
+    </div>
+  );
+};

--- a/apps/app/src/features/approval-workflow/client/components/ModalComponents/ApproverGroupCard.tsx
+++ b/apps/app/src/features/approval-workflow/client/components/ModalComponents/ApproverGroupCard.tsx
@@ -9,11 +9,12 @@ type Props = {
   groupIndex: number
   editingApproverGroups: IWorkflowApproverGroupReq[]
   onUpdateApproverGroups?: (groupIndex: number, updateApproverGroupData: IWorkflowApproverGroupReq) => void
+  onClickAddApproverGroupCard?: (groupIndex: number) => void
 }
 
 export const ApproverGroupCard = (props: Props): JSX.Element => {
   const {
-    creatorId, groupIndex, editingApproverGroups, onUpdateApproverGroups,
+    creatorId, groupIndex, editingApproverGroups, onUpdateApproverGroups, onClickAddApproverGroupCard,
   } = props;
 
   const { t } = useTranslation();
@@ -44,30 +45,45 @@ export const ApproverGroupCard = (props: Props): JSX.Element => {
 
   const isApprovalTypeAnd = editingApprovalType === WorkflowApprovalType.AND;
 
+
   return (
-    <div className="card rounded">
-      <div className="card-body">
-        <div className="text-muted">
-          <i className="fa fa-user" />
+    <div className="mt-4">
+      {onClickAddApproverGroupCard != null && (
+        <div className="text-center mt-2">
+          <button type="button" onClick={() => onClickAddApproverGroupCard(Math.max(0, groupIndex - 1))}>フローを追加</button>
         </div>
+      )}
 
-        <div className="dropdown">
-          <a className="btn btn-light btn-sm rounded-pill dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-            {t(`approval_workflow.approval_type.${editingApprovalType}`)}
-          </a>
-          <ul
-            className="dropdown-menu"
-            onClick={() => changeApprovalTypeButtonClickHandler(isApprovalTypeAnd ? WorkflowApprovalType.OR : WorkflowApprovalType.AND)}
-          >
-            { isApprovalTypeAnd
-              ? <>{t('approval_workflow.approval_type.OR')}</>
-              : <>{t('approval_workflow.approval_type.AND')}</>
-            }
-          </ul>
+      <div className="card rounded">
+        <div className="card-body">
+          <div className="text-muted">
+            <i className="fa fa-user" />
+          </div>
+
+          <div className="dropdown">
+            <a className="btn btn-light btn-sm rounded-pill dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+              {t(`approval_workflow.approval_type.${editingApprovalType}`)}
+            </a>
+            <ul
+              className="dropdown-menu"
+              onClick={() => changeApprovalTypeButtonClickHandler(isApprovalTypeAnd ? WorkflowApprovalType.OR : WorkflowApprovalType.AND)}
+            >
+              { isApprovalTypeAnd
+                ? <>{t('approval_workflow.approval_type.OR')}</>
+                : <>{t('approval_workflow.approval_type.AND')}</>
+              }
+            </ul>
+          </div>
+
+          完了条件
         </div>
-
-        完了条件
       </div>
+
+      {onClickAddApproverGroupCard != null && (
+        <div className="text-center mt-2">
+          <button type="button" onClick={() => onClickAddApproverGroupCard(Math.max(0, groupIndex + 1))}>フローを追加</button>
+        </div>
+      )}
     </div>
   );
 };

--- a/apps/app/src/features/approval-workflow/client/components/ModalComponents/ApproverGroupCard.tsx
+++ b/apps/app/src/features/approval-workflow/client/components/ModalComponents/ApproverGroupCard.tsx
@@ -50,7 +50,7 @@ export const ApproverGroupCard = (props: Props): JSX.Element => {
     <div className="mt-4">
       {onClickAddApproverGroupCard != null && (
         <div className="text-center mt-2">
-          <button type="button" onClick={() => onClickAddApproverGroupCard(Math.max(0, groupIndex - 1))}>フローを追加</button>
+          <button type="button" onClick={() => onClickAddApproverGroupCard(Math.max(0, groupIndex - 1))}>{t('approval_workflow.add_flow')}</button>
         </div>
       )}
 
@@ -75,13 +75,13 @@ export const ApproverGroupCard = (props: Props): JSX.Element => {
             </ul>
           </div>
 
-          完了条件
+          {t('approval_workflow.completion_conditions')}
         </div>
       </div>
 
       {onClickAddApproverGroupCard != null && (
         <div className="text-center mt-2">
-          <button type="button" onClick={() => onClickAddApproverGroupCard(Math.max(0, groupIndex + 1))}>フローを追加</button>
+          <button type="button" onClick={() => onClickAddApproverGroupCard(Math.max(0, groupIndex + 1))}>{t('approval_workflow.add_flow')}</button>
         </div>
       )}
     </div>

--- a/apps/app/src/features/approval-workflow/client/components/ModalComponents/ApproverGroupCards.tsx
+++ b/apps/app/src/features/approval-workflow/client/components/ModalComponents/ApproverGroupCards.tsx
@@ -4,6 +4,8 @@ import { useTranslation } from 'next-i18next';
 
 import { WorkflowApprovalType, IWorkflowApproverGroupReq } from '../../../interfaces/workflow';
 
+import { SearchUserTypeahead } from './SearchUserTypeahead';
+
 type Props = {
   creatorId?: string
   editingApproverGroups: IWorkflowApproverGroupReq[]
@@ -32,9 +34,9 @@ const ApproverGroupCard = (props: Props & { groupIndex: number }): JSX.Element =
     }
   }, [editingApproverGroup, groupIndex, onUpdateApproverGroups]);
 
-  const updateApproversHandler = useCallback((userIds: string[]) => {
+  const updateApproversHandler = useCallback((userIds?: string[]) => {
     const clonedApproverGroup = { ...editingApproverGroup };
-    const approvers = userIds.map(userId => ({ user: userId }));
+    const approvers = userIds != null ? userIds.map(userId => ({ user: userId })) : [];
     clonedApproverGroup.approvers = approvers;
 
     if (onUpdateApproverGroups != null) {
@@ -56,6 +58,8 @@ const ApproverGroupCard = (props: Props & { groupIndex: number }): JSX.Element =
 
       <div className="card rounded">
         <div className="card-body">
+
+          <SearchUserTypeahead onChange={updateApproversHandler} />
 
           <div className="d-flex justify-content-center align-items-center mt-3">
 

--- a/apps/app/src/features/approval-workflow/client/components/ModalComponents/ApproverGroupCards.tsx
+++ b/apps/app/src/features/approval-workflow/client/components/ModalComponents/ApproverGroupCards.tsx
@@ -6,13 +6,12 @@ import { WorkflowApprovalType, IWorkflowApproverGroupReq } from '../../../interf
 
 type Props = {
   creatorId?: string
-  groupIndex: number
   editingApproverGroups: IWorkflowApproverGroupReq[]
   onUpdateApproverGroups?: (groupIndex: number, updateApproverGroupData: IWorkflowApproverGroupReq) => void
   onClickAddApproverGroupCard?: (groupIndex: number) => void
 }
 
-export const ApproverGroupCard = (props: Props): JSX.Element => {
+const ApproverGroupCard = (props: Props & { groupIndex: number }): JSX.Element => {
   const {
     creatorId, groupIndex, editingApproverGroups, onUpdateApproverGroups, onClickAddApproverGroupCard,
   } = props;
@@ -45,7 +44,6 @@ export const ApproverGroupCard = (props: Props): JSX.Element => {
 
   const isApprovalTypeAnd = editingApprovalType === WorkflowApprovalType.AND;
 
-
   return (
     <div className="mt-4">
       {onClickAddApproverGroupCard != null && (
@@ -75,7 +73,7 @@ export const ApproverGroupCard = (props: Props): JSX.Element => {
             </ul>
           </div>
 
-          {t('approval_workflow.completion_conditions')}
+          {t('approval_workflow.')}
         </div>
       </div>
 
@@ -85,5 +83,27 @@ export const ApproverGroupCard = (props: Props): JSX.Element => {
         </div>
       )}
     </div>
+  );
+};
+
+export const ApproverGroupCards = (props: Props): JSX.Element => {
+  const {
+    creatorId, editingApproverGroups, onUpdateApproverGroups, onClickAddApproverGroupCard,
+  } = props;
+
+  return (
+    <>
+      {editingApproverGroups?.map((_, index) => (
+        <ApproverGroupCard
+          // eslint-disable-next-line react/no-array-index-key
+          key={index}
+          creatorId={creatorId}
+          groupIndex={index}
+          editingApproverGroups={editingApproverGroups}
+          onUpdateApproverGroups={onUpdateApproverGroups}
+          onClickAddApproverGroupCard={onClickAddApproverGroupCard}
+        />
+      ))}
+    </>
   );
 };

--- a/apps/app/src/features/approval-workflow/client/components/ModalComponents/ApproverGroupCards.tsx
+++ b/apps/app/src/features/approval-workflow/client/components/ModalComponents/ApproverGroupCards.tsx
@@ -56,26 +56,29 @@ const ApproverGroupCard = (props: Props & { groupIndex: number }): JSX.Element =
 
       <div className="card rounded">
         <div className="card-body">
-          <div className="text-muted">
-            <i className="fa fa-user" />
-          </div>
 
-          <div className="dropdown">
-            <a className="btn btn-light btn-sm rounded-pill dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-              {t(`approval_workflow.approval_type.${editingApprovalType}`)}
-            </a>
-            <ul
-              className="dropdown-menu"
-              onClick={() => changeApprovalTypeButtonClickHandler(isApprovalTypeAnd ? WorkflowApprovalType.OR : WorkflowApprovalType.AND)}
-            >
-              { isApprovalTypeAnd
-                ? <>{t('approval_workflow.approval_type.OR')}</>
-                : <>{t('approval_workflow.approval_type.AND')}</>
-              }
-            </ul>
-          </div>
+          <div className="d-flex justify-content-center align-items-center mt-3">
 
-          {t('approval_workflow.completion_conditions')}
+            <span className="text-muted">
+              {t('approval_workflow.completion_conditions')}
+            </span>
+
+            <div className="dropdown">
+              <a className="btn btn-light btn-sm rounded-pill dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                {t(`approval_workflow.approval_type.${editingApprovalType}`)}
+              </a>
+              <ul
+                className="dropdown-menu"
+                onClick={() => changeApprovalTypeButtonClickHandler(isApprovalTypeAnd ? WorkflowApprovalType.OR : WorkflowApprovalType.AND)}
+              >
+                { isApprovalTypeAnd
+                  ? <>{t('approval_workflow.approval_type.OR')}</>
+                  : <>{t('approval_workflow.approval_type.AND')}</>
+                }
+              </ul>
+            </div>
+
+          </div>
         </div>
       </div>
 

--- a/apps/app/src/features/approval-workflow/client/components/ModalComponents/ApproverGroupCards.tsx
+++ b/apps/app/src/features/approval-workflow/client/components/ModalComponents/ApproverGroupCards.tsx
@@ -42,12 +42,14 @@ const ApproverGroupCard = (props: Props & { groupIndex: number }): JSX.Element =
     }
   }, [editingApproverGroup, groupIndex, onUpdateApproverGroups]);
 
+  const isCreatableEditingApproverGroup = editingApproverGroup.approvers.length > 0;
+
   const isApprovalTypeAnd = editingApprovalType === WorkflowApprovalType.AND;
 
   return (
-    <div className="mt-4">
-      {onClickAddApproverGroupCard != null && (
-        <div className="text-center mt-2">
+    <>
+      {onClickAddApproverGroupCard != null && groupIndex === 0 && isCreatableEditingApproverGroup && (
+        <div className="text-center my-2">
           <button type="button" onClick={() => onClickAddApproverGroupCard(Math.max(0, groupIndex - 1))}>{t('approval_workflow.add_flow')}</button>
         </div>
       )}
@@ -73,35 +75,28 @@ const ApproverGroupCard = (props: Props & { groupIndex: number }): JSX.Element =
             </ul>
           </div>
 
-          {t('approval_workflow.')}
+          {t('approval_workflow.completion_conditions')}
         </div>
       </div>
 
-      {onClickAddApproverGroupCard != null && (
-        <div className="text-center mt-2">
+      {onClickAddApproverGroupCard != null && isCreatableEditingApproverGroup && (
+        <div className="text-center my-2">
           <button type="button" onClick={() => onClickAddApproverGroupCard(Math.max(0, groupIndex + 1))}>{t('approval_workflow.add_flow')}</button>
         </div>
       )}
-    </div>
+    </>
   );
 };
 
 export const ApproverGroupCards = (props: Props): JSX.Element => {
-  const {
-    creatorId, editingApproverGroups, onUpdateApproverGroups, onClickAddApproverGroupCard,
-  } = props;
-
   return (
     <>
-      {editingApproverGroups?.map((_, index) => (
+      {props.editingApproverGroups?.map((_, index) => (
         <ApproverGroupCard
           // eslint-disable-next-line react/no-array-index-key
           key={index}
-          creatorId={creatorId}
           groupIndex={index}
-          editingApproverGroups={editingApproverGroups}
-          onUpdateApproverGroups={onUpdateApproverGroups}
-          onClickAddApproverGroupCard={onClickAddApproverGroupCard}
+          {...props}
         />
       ))}
     </>

--- a/apps/app/src/features/approval-workflow/client/components/ModalComponents/ApproverGroupCards.tsx
+++ b/apps/app/src/features/approval-workflow/client/components/ModalComponents/ApproverGroupCards.tsx
@@ -2,20 +2,21 @@ import React, { useCallback } from 'react';
 
 import { useTranslation } from 'next-i18next';
 
-import { WorkflowApprovalType, IWorkflowApproverGroupReq } from '../../../interfaces/workflow';
+import { WorkflowApprovalType, IWorkflowApproverGroupReqForRenderList } from '../../../interfaces/workflow';
 
 import { SearchUserTypeahead } from './SearchUserTypeahead';
 
 type Props = {
   creatorId?: string
-  editingApproverGroups: IWorkflowApproverGroupReq[]
-  onUpdateApproverGroups?: (groupIndex: number, updateApproverGroupData: IWorkflowApproverGroupReq) => void
+  editingApproverGroups: IWorkflowApproverGroupReqForRenderList[]
+  onUpdateApproverGroups?: (groupIndex: number, updateApproverGroupData: IWorkflowApproverGroupReqForRenderList) => void
   onClickAddApproverGroupCard?: (groupIndex: number) => void
+  onClickRemoveApproverGroupCard?: (groupIndex: number) => void
 }
 
 const ApproverGroupCard = (props: Props & { groupIndex: number }): JSX.Element => {
   const {
-    creatorId, groupIndex, editingApproverGroups, onUpdateApproverGroups, onClickAddApproverGroupCard,
+    creatorId, groupIndex, editingApproverGroups, onUpdateApproverGroups, onClickAddApproverGroupCard, onClickRemoveApproverGroupCard,
   } = props;
 
   const { t } = useTranslation();
@@ -44,6 +45,8 @@ const ApproverGroupCard = (props: Props & { groupIndex: number }): JSX.Element =
     }
   }, [editingApproverGroup, groupIndex, onUpdateApproverGroups]);
 
+  const isDeletebleEditingApproverGroup = editingApproverGroups.length > 1;
+
   const isCreatableEditingApproverGroup = editingApproverGroup.approvers.length > 0;
 
   const isApprovalTypeAnd = editingApprovalType === WorkflowApprovalType.AND;
@@ -59,7 +62,13 @@ const ApproverGroupCard = (props: Props & { groupIndex: number }): JSX.Element =
       <div className="card rounded">
         <div className="card-body">
 
-          <SearchUserTypeahead onChange={updateApproversHandler} />
+          <div className="d-flex justify-content-center align-items-center">
+            <SearchUserTypeahead onChange={updateApproversHandler} />
+
+            { isDeletebleEditingApproverGroup && onClickRemoveApproverGroupCard != null && (
+              <button type="button" className="btn-close" aria-label="Close" onClick={() => { onClickRemoveApproverGroupCard(groupIndex) }}></button>
+            )}
+          </div>
 
           <div className="d-flex justify-content-center align-items-center mt-3">
 
@@ -98,10 +107,9 @@ const ApproverGroupCard = (props: Props & { groupIndex: number }): JSX.Element =
 export const ApproverGroupCards = (props: Props): JSX.Element => {
   return (
     <>
-      {props.editingApproverGroups?.map((_, index) => (
+      {props.editingApproverGroups?.map((data, index) => (
         <ApproverGroupCard
-          // eslint-disable-next-line react/no-array-index-key
-          key={index}
+          key={data.uuidForRenderList}
           groupIndex={index}
           {...props}
         />

--- a/apps/app/src/features/approval-workflow/client/components/ModalComponents/SearchUserTypeahead.tsx
+++ b/apps/app/src/features/approval-workflow/client/components/ModalComponents/SearchUserTypeahead.tsx
@@ -51,9 +51,8 @@ export const SearchUserTypeahead = (props: Props): JSX.Element => {
   const onChangeHandler = useCallback((usernames: string[]) => {
     setSelectedUsernames(usernames);
 
-    const userIds = getUserIdsByUsernames(dumyUserData, usernames);
-
     if (onChange != null) {
+      const userIds = getUserIdsByUsernames(dumyUserData, usernames);
       onChange(userIds);
     }
   }, [onChange]);

--- a/apps/app/src/features/approval-workflow/client/components/ModalComponents/SearchUserTypeahead.tsx
+++ b/apps/app/src/features/approval-workflow/client/components/ModalComponents/SearchUserTypeahead.tsx
@@ -1,0 +1,82 @@
+import React, { useState, useCallback, useRef } from 'react';
+
+import type { IUserHasId } from '@growi/core';
+import { AsyncTypeahead } from 'react-bootstrap-typeahead';
+import { useTranslation } from 'react-i18next';
+
+import { IClearable } from '~/client/interfaces/clearable';
+
+const dumyUserData = [
+  {
+    _id: '653140203f643f1ba8496867',
+    username: 'test-user1',
+  },
+  {
+    _id: '65314045a45f085023861c7a',
+    username: 'test-user2',
+  },
+  {
+    _id: '65314dfff63cae573793c2b8',
+    username: 'test-user3',
+  },
+] as unknown as IUserHasId[];
+
+const getUserIdsByUsernames = (data, usernames: string[] | undefined): string[] | undefined => {
+  if (usernames == null || usernames.length === 0) {
+    return;
+  }
+
+  return data
+    .filter(item => usernames.includes(item.username))
+    .map(item => item._id);
+};
+
+type Props = {
+  onChange?: (userIds?: string[]) => void
+};
+
+export const SearchUserTypeahead = (props: Props): JSX.Element => {
+  const { t } = useTranslation();
+
+  const [selectedUsernames, setSelectedUsernames] = useState<string[]>();
+
+  const { onChange } = props;
+
+  const typeaheadRef = useRef<IClearable>(null);
+
+  const onSearchHandler = useCallback((
+      //
+  ) => {}, []);
+
+  const onChangeHandler = useCallback((usernames: string[]) => {
+    setSelectedUsernames(usernames);
+
+    const userIds = getUserIdsByUsernames(dumyUserData, usernames);
+
+    if (onChange != null) {
+      onChange(userIds);
+    }
+  }, [onChange]);
+
+  return (
+    <div className="input-group me-2">
+      <span className="input-group-text">
+        <i className="icon-people" />
+      </span>
+      <AsyncTypeahead
+        id="user-typeahead-asynctypeahea"
+        ref={typeaheadRef}
+        multiple
+        delay={400}
+        minLength={0}
+        caseSensitive={false}
+        // isLoading={isLoading}
+        // options={allUser}
+        onSearch={onSearchHandler}
+        onChange={onChangeHandler}
+        selected={selectedUsernames}
+        options={dumyUserData.map(v => v.username)}
+      />
+    </div>
+  );
+};

--- a/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowCreationModalContent.tsx
+++ b/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowCreationModalContent.tsx
@@ -124,7 +124,6 @@ export const WorkflowCreationModalContent = (props: Props): JSX.Element => {
           onUpdateApproverGroups={approverGroupsChangeHandler}
           onClickAddApproverGroupCard={addApproverGroupCardButtonClickHandler}
         />
-
       </ModalBody>
 
       <ModalFooter>

--- a/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowCreationModalContent.tsx
+++ b/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowCreationModalContent.tsx
@@ -30,13 +30,13 @@ const EditableApproverGroupCard = (props: EditableApproverGroupCardProps): JSX.E
 };
 
 
-type Props = {
+type WorkflowCreationModalContentProps = {
   pageId: string,
   onCreated?: () => void
   onClickWorkflowListPageBackButton: () => void;
 }
 
-export const WorkflowCreationModalContent = (props: Props): JSX.Element => {
+export const WorkflowCreationModalContent = (props: WorkflowCreationModalContentProps): JSX.Element => {
   const { t } = useTranslation();
 
   const { pageId, onCreated, onClickWorkflowListPageBackButton } = props;
@@ -55,30 +55,26 @@ export const WorkflowCreationModalContent = (props: Props): JSX.Element => {
     ],
   }] as IWorkflowApproverGroupReq[];
 
-  const [workflowName, setWorkflowName] = useState<string | undefined>();
-  const [workflowDescription, setWorkflowDescription] = useState<string | undefined>();
-  const [approverGroups, setApproverGroups] = useState<IWorkflowApproverGroupReq[]>(approverGroupsDummyData);
+  const [editingWorkflowName, setEditingWorkflowName] = useState<string | undefined>();
+  const [editingWorkflowDescription, setEditingWorkflowDescription] = useState<string | undefined>();
+  const [editingApproverGroups, setEditingApproverGroups] = useState<IWorkflowApproverGroupReq[]>(approverGroupsDummyData);
 
-  const { trigger: createWorkflow } = useSWRMUTxCreateWorkflow(pageId, approverGroups, workflowName, workflowDescription);
+  const { trigger: createWorkflow } = useSWRMUTxCreateWorkflow(pageId, editingApproverGroups, editingWorkflowName, editingWorkflowDescription);
 
   const workflowNameChangeHandler = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
-    setWorkflowName(event.target.value);
+    setEditingWorkflowName(event.target.value);
   }, []);
 
   const workflowDescriptionChangeHandler = useCallback((event: React.ChangeEvent<HTMLTextAreaElement>) => {
-    setWorkflowDescription(event.target.value);
+    setEditingWorkflowDescription(event.target.value);
   }, []);
 
-  // const approverGroupChangeHandler = useCallback(() => {
-
-  // }, []);
-
   const addApproverGroupCardButtonClickHandler = () => {
-    setApproverGroups([...approverGroups, [] as any]);
+    setEditingApproverGroups([...editingApproverGroups, [] as any]);
   };
 
   const createWorkflowButtonClickHandler = useCallback(async() => {
-    if (approverGroups == null) {
+    if (editingApproverGroups == null) {
       return;
     }
 
@@ -92,7 +88,7 @@ export const WorkflowCreationModalContent = (props: Props): JSX.Element => {
     catch (err) {
       // TODO: Consider how to display errors
     }
-  }, [approverGroups, createWorkflow, onCreated]);
+  }, [createWorkflow, editingApproverGroups, onCreated]);
 
   return (
     <>
@@ -114,7 +110,7 @@ export const WorkflowCreationModalContent = (props: Props): JSX.Element => {
                   className="form-control"
                   type="text"
                   name="name"
-                  value={workflowName}
+                  value={editingWorkflowName}
                   onChange={workflowNameChangeHandler}
                   required
                 />
@@ -133,7 +129,7 @@ export const WorkflowCreationModalContent = (props: Props): JSX.Element => {
                 <textarea
                   className="form-control"
                   name="description"
-                  value={workflowDescription}
+                  value={editingWorkflowDescription}
                   onChange={workflowDescriptionChangeHandler}
                 />
               </div>
@@ -144,10 +140,9 @@ export const WorkflowCreationModalContent = (props: Props): JSX.Element => {
         {/* <ApproverGroupCard /> */}
 
 
-        {approverGroups?.map((data, index) => (
+        {editingApproverGroups?.map((data, index) => (
           <EditableApproverGroupCard onClickAddApproverGroupCard={addApproverGroupCardButtonClickHandler} />
         ))}
-
 
       </ModalBody>
 

--- a/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowCreationModalContent.tsx
+++ b/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowCreationModalContent.tsx
@@ -18,7 +18,7 @@ const createInitialApproverGroup = (): IWorkflowApproverGroupReqForRenderList =>
   return {
     approvalType: 'AND',
     approvers: [],
-    uuidForRenderList: crypto.randomUUID(), // When rendering with a map, if you don't have a unique key, it will cause problems
+    uuidForRenderList: crypto.randomUUID(),
   };
 };
 

--- a/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowCreationModalContent.tsx
+++ b/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowCreationModalContent.tsx
@@ -1,5 +1,5 @@
 // TODO: https://redmine.weseek.co.jp/issues/130338
-import React, { useCallback, useState } from 'react';
+import React, { FC, useCallback, useState } from 'react';
 
 import { useTranslation } from 'next-i18next';
 import { ModalBody, ModalFooter } from 'reactstrap';
@@ -9,6 +9,26 @@ import { useSWRMUTxCreateWorkflow } from '../../stores/workflow';
 
 import { ApproverGroupCard } from './ApproverGroupCard';
 import { WorkflowModalHeader } from './WorkflowModalHeader';
+
+
+type EditableApproverGroupCardProps = {
+  onClickAddApproverGroupCard: () => void
+}
+
+const EditableApproverGroupCard = (props: EditableApproverGroupCardProps): JSX.Element => {
+  const { onClickAddApproverGroupCard } = props;
+
+  return (
+    <div className="mt-4">
+      <ApproverGroupCard />
+
+      <div className="text-center mt-2">
+        <button type="button" onClick={() => onClickAddApproverGroupCard()}>フローを追加</button>
+      </div>
+    </div>
+  );
+};
+
 
 type Props = {
   pageId: string,
@@ -37,7 +57,7 @@ export const WorkflowCreationModalContent = (props: Props): JSX.Element => {
 
   const [workflowName, setWorkflowName] = useState<string | undefined>();
   const [workflowDescription, setWorkflowDescription] = useState<string | undefined>();
-  const [approverGroups, setApproverGroups] = useState<IWorkflowApproverGroupReq[] | undefined>(approverGroupsDummyData);
+  const [approverGroups, setApproverGroups] = useState<IWorkflowApproverGroupReq[]>(approverGroupsDummyData);
 
   const { trigger: createWorkflow } = useSWRMUTxCreateWorkflow(pageId, approverGroups, workflowName, workflowDescription);
 
@@ -48,6 +68,14 @@ export const WorkflowCreationModalContent = (props: Props): JSX.Element => {
   const workflowDescriptionChangeHandler = useCallback((event: React.ChangeEvent<HTMLTextAreaElement>) => {
     setWorkflowDescription(event.target.value);
   }, []);
+
+  // const approverGroupChangeHandler = useCallback(() => {
+
+  // }, []);
+
+  const addApproverGroupCardButtonClickHandler = () => {
+    setApproverGroups([...approverGroups, [] as any]);
+  };
 
   const createWorkflowButtonClickHandler = useCallback(async() => {
     if (approverGroups == null) {
@@ -113,7 +141,13 @@ export const WorkflowCreationModalContent = (props: Props): JSX.Element => {
           </div>
         </div>
 
-        <ApproverGroupCard />
+        {/* <ApproverGroupCard /> */}
+
+
+        {approverGroups?.map((data, index) => (
+          <EditableApproverGroupCard onClickAddApproverGroupCard={addApproverGroupCardButtonClickHandler} />
+        ))}
+
 
       </ModalBody>
 

--- a/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowCreationModalContent.tsx
+++ b/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowCreationModalContent.tsx
@@ -6,21 +6,11 @@ import { ModalBody, ModalFooter } from 'reactstrap';
 
 import { useCurrentUser } from '~/stores/context';
 
-import { IWorkflowApproverGroupReqForRenderList } from '../../../interfaces/workflow';
+import { useEditingApproverGroups } from '../../services/workflow';
 import { useSWRMUTxCreateWorkflow } from '../../stores/workflow';
 
 import { ApproverGroupCards } from './ApproverGroupCards';
 import { WorkflowModalHeader } from './WorkflowModalHeader';
-
-// see: https://robinpokorny.medium.com/index-as-a-key-is-an-anti-pattern-e0349aece318
-// When rendering with maps, without a unique key, unintended behavior can occur.
-const createInitialApproverGroup = (): IWorkflowApproverGroupReqForRenderList => {
-  return {
-    approvalType: 'AND',
-    approvers: [],
-    uuidForRenderList: crypto.randomUUID(),
-  };
-};
 
 type Props = {
   pageId: string,
@@ -31,12 +21,14 @@ type Props = {
 export const WorkflowCreationModalContent = (props: Props): JSX.Element => {
   const { t } = useTranslation();
   const { data: currentUser } = useCurrentUser();
+  const {
+    editingApproverGroups, updateApproverGroupHandler, addApproverGroupHandler, removeApproverGroupHandler,
+  } = useEditingApproverGroups();
 
   const { pageId, onCreated, onClickWorkflowListPageBackButton } = props;
 
   const [editingWorkflowName, setEditingWorkflowName] = useState<string | undefined>();
   const [editingWorkflowDescription, setEditingWorkflowDescription] = useState<string | undefined>();
-  const [editingApproverGroups, setEditingApproverGroups] = useState<IWorkflowApproverGroupReqForRenderList[]>([createInitialApproverGroup()]);
 
   const { trigger: createWorkflow } = useSWRMUTxCreateWorkflow(pageId, editingApproverGroups, editingWorkflowName, editingWorkflowDescription);
 
@@ -47,25 +39,6 @@ export const WorkflowCreationModalContent = (props: Props): JSX.Element => {
   const workflowDescriptionChangeHandler = useCallback((event: React.ChangeEvent<HTMLTextAreaElement>) => {
     setEditingWorkflowDescription(event.target.value);
   }, []);
-
-  const approverGroupsChangeHandler = useCallback((groupIndex: number, updateApproverGroupData: IWorkflowApproverGroupReqForRenderList) => {
-    const clonedApproverGroups = [...editingApproverGroups];
-    clonedApproverGroups[groupIndex] = updateApproverGroupData;
-    setEditingApproverGroups(clonedApproverGroups);
-  }, [editingApproverGroups]);
-
-  const addApproverGroupCardButtonClickHandler = useCallback((groupIndex: number) => {
-    const clonedApproverGroups = [...editingApproverGroups];
-    clonedApproverGroups.splice(groupIndex, 0, createInitialApproverGroup());
-    setEditingApproverGroups(clonedApproverGroups);
-  }, [editingApproverGroups]);
-
-  const deleteApproverGroupHandler = useCallback((groupIndex: number) => {
-    const clonedApproverGroups = [...editingApproverGroups];
-    clonedApproverGroups.splice(groupIndex, 1);
-    setEditingApproverGroups(clonedApproverGroups);
-  }, [editingApproverGroups]);
-
 
   const createWorkflowButtonClickHandler = useCallback(async() => {
     if (editingApproverGroups == null) {
@@ -135,9 +108,9 @@ export const WorkflowCreationModalContent = (props: Props): JSX.Element => {
         <ApproverGroupCards
           creatorId={currentUser?._id}
           editingApproverGroups={editingApproverGroups}
-          onUpdateApproverGroups={approverGroupsChangeHandler}
-          onClickAddApproverGroupCard={addApproverGroupCardButtonClickHandler}
-          onClickRemoveApproverGroupCard={deleteApproverGroupHandler}
+          onUpdateApproverGroups={updateApproverGroupHandler}
+          onClickAddApproverGroupCard={addApproverGroupHandler}
+          onClickRemoveApproverGroupCard={removeApproverGroupHandler}
         />
       </ModalBody>
 

--- a/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowCreationModalContent.tsx
+++ b/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowCreationModalContent.tsx
@@ -9,7 +9,7 @@ import { useCurrentUser } from '~/stores/context';
 import { IWorkflowApproverGroupReq, WorkflowApprovalType } from '../../../interfaces/workflow';
 import { useSWRMUTxCreateWorkflow } from '../../stores/workflow';
 
-import { ApproverGroupCard } from './ApproverGroupCard';
+import { ApproverGroupCards } from './ApproverGroupCards';
 import { WorkflowModalHeader } from './WorkflowModalHeader';
 
 type WorkflowCreationModalContentProps = {
@@ -118,15 +118,12 @@ export const WorkflowCreationModalContent = (props: WorkflowCreationModalContent
           </div>
         </div>
 
-        {editingApproverGroups?.map((_, index) => (
-          <ApproverGroupCard
-            creatorId={currentUser?._id}
-            groupIndex={index}
-            editingApproverGroups={editingApproverGroups}
-            onUpdateApproverGroups={approverGroupsChangeHandler}
-            onClickAddApproverGroupCard={addApproverGroupCardButtonClickHandler}
-          />
-        ))}
+        <ApproverGroupCards
+          creatorId={currentUser?._id}
+          editingApproverGroups={editingApproverGroups}
+          onUpdateApproverGroups={approverGroupsChangeHandler}
+          onClickAddApproverGroupCard={addApproverGroupCardButtonClickHandler}
+        />
 
       </ModalBody>
 

--- a/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowCreationModalContent.tsx
+++ b/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowCreationModalContent.tsx
@@ -80,39 +80,41 @@ export const WorkflowCreationModalContent = (props: Props): JSX.Element => {
       />
 
       <ModalBody>
-        <div className="row align-items-center">
-          <label htmlFor="name" className="col-md-4 col-form-label">
-            {t('approval_workflow.name')}
-          </label>
-          <div className="col-md-8 mb-3">
-            <div className="row">
-              <div className="col">
-                <input
-                  className="form-control"
-                  type="text"
-                  name="name"
-                  value={editingWorkflowName}
-                  onChange={workflowNameChangeHandler}
-                  required
-                />
+        <div className="mb-3">
+          <div className="row align-items-center">
+            <label htmlFor="name" className="col-md-4 col-form-label">
+              {t('approval_workflow.name')}
+            </label>
+            <div className="col-md-8 mb-3">
+              <div className="row">
+                <div className="col">
+                  <input
+                    className="form-control"
+                    type="text"
+                    name="name"
+                    value={editingWorkflowName}
+                    onChange={workflowNameChangeHandler}
+                    required
+                  />
+                </div>
               </div>
             </div>
           </div>
-        </div>
 
-        <div className="row">
-          <label htmlFor="description" className="col-md-4 col-form-label">
-            {t('approval_workflow.description')}
-          </label>
-          <div className="col-md-8">
-            <div className="row">
-              <div className="col">
-                <textarea
-                  className="form-control"
-                  name="description"
-                  value={editingWorkflowDescription}
-                  onChange={workflowDescriptionChangeHandler}
-                />
+          <div className="row">
+            <label htmlFor="description" className="col-md-4 col-form-label">
+              {t('approval_workflow.description')}
+            </label>
+            <div className="col-md-8">
+              <div className="row">
+                <div className="col">
+                  <textarea
+                    className="form-control"
+                    name="description"
+                    value={editingWorkflowDescription}
+                    onChange={workflowDescriptionChangeHandler}
+                  />
+                </div>
               </div>
             </div>
           </div>

--- a/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowCreationModalContent.tsx
+++ b/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowCreationModalContent.tsx
@@ -12,36 +12,6 @@ import { useSWRMUTxCreateWorkflow } from '../../stores/workflow';
 import { ApproverGroupCard } from './ApproverGroupCard';
 import { WorkflowModalHeader } from './WorkflowModalHeader';
 
-type EditableApproverGroupCardProps = {
-  creatorId?: string
-  groupIndex: number
-  editingApproverGroups: IWorkflowApproverGroupReq[]
-  onUpdateApproverGroups: (groupIndex: number, updateApproverGroupData: IWorkflowApproverGroupReq) => void
-  onClickAddApproverGroupCard: () => void
-}
-
-const EditableApproverGroupCard = (props: EditableApproverGroupCardProps): JSX.Element => {
-  const {
-    creatorId, groupIndex, editingApproverGroups, onClickAddApproverGroupCard, onUpdateApproverGroups,
-  } = props;
-
-  return (
-    <div className="mt-4">
-      <ApproverGroupCard
-        creatorId={creatorId}
-        groupIndex={groupIndex}
-        editingApproverGroups={editingApproverGroups}
-        onUpdateApproverGroups={onUpdateApproverGroups}
-      />
-
-      <div className="text-center mt-2">
-        <button type="button" onClick={() => onClickAddApproverGroupCard()}>フローを追加</button>
-      </div>
-    </div>
-  );
-};
-
-
 type WorkflowCreationModalContentProps = {
   pageId: string,
   onCreated?: () => void
@@ -79,8 +49,10 @@ export const WorkflowCreationModalContent = (props: WorkflowCreationModalContent
     setEditingApproverGroups(clonedApproverGroups);
   }, [editingApproverGroups]);
 
-  const addApproverGroupCardButtonClickHandler = () => {
-    setEditingApproverGroups([...editingApproverGroups, [] as any]);
+  const addApproverGroupCardButtonClickHandler = (groupIndex: number) => {
+    const clonedApproverGroups = [...editingApproverGroups];
+    clonedApproverGroups.splice(groupIndex, 0, initialApproverGroup);
+    setEditingApproverGroups(clonedApproverGroups);
   };
 
   const createWorkflowButtonClickHandler = useCallback(async() => {
@@ -108,7 +80,6 @@ export const WorkflowCreationModalContent = (props: WorkflowCreationModalContent
       />
 
       <ModalBody>
-
         <div className="row align-items-center">
           <label htmlFor="name" className="col-md-4 col-form-label">
             {t('approval_workflow.name')}
@@ -148,7 +119,7 @@ export const WorkflowCreationModalContent = (props: WorkflowCreationModalContent
         </div>
 
         {editingApproverGroups?.map((_, index) => (
-          <EditableApproverGroupCard
+          <ApproverGroupCard
             creatorId={currentUser?._id}
             groupIndex={index}
             editingApproverGroups={editingApproverGroups}

--- a/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowCreationModalContent.tsx
+++ b/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowCreationModalContent.tsx
@@ -7,6 +7,7 @@ import { ModalBody, ModalFooter } from 'reactstrap';
 import { IWorkflowApproverGroupReq, WorkflowApprovalType, WorkflowApproverStatus } from '../../../interfaces/workflow';
 import { useSWRMUTxCreateWorkflow } from '../../stores/workflow';
 
+import { ApproverGroupCard } from './ApproverGroupCard';
 import { WorkflowModalHeader } from './WorkflowModalHeader';
 
 type Props = {
@@ -111,6 +112,8 @@ export const WorkflowCreationModalContent = (props: Props): JSX.Element => {
             </div>
           </div>
         </div>
+
+        <ApproverGroupCard />
 
       </ModalBody>
 

--- a/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowCreationModalContent.tsx
+++ b/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowCreationModalContent.tsx
@@ -12,22 +12,22 @@ import { useSWRMUTxCreateWorkflow } from '../../stores/workflow';
 import { ApproverGroupCards } from './ApproverGroupCards';
 import { WorkflowModalHeader } from './WorkflowModalHeader';
 
-type WorkflowCreationModalContentProps = {
+const initialApproverGroup = {
+  approvalType: WorkflowApprovalType.AND,
+  approvers: [],
+};
+
+type Props = {
   pageId: string,
   onCreated?: () => void
   onClickWorkflowListPageBackButton: () => void;
 }
 
-export const WorkflowCreationModalContent = (props: WorkflowCreationModalContentProps): JSX.Element => {
+export const WorkflowCreationModalContent = (props: Props): JSX.Element => {
   const { t } = useTranslation();
   const { data: currentUser } = useCurrentUser();
 
   const { pageId, onCreated, onClickWorkflowListPageBackButton } = props;
-
-  const initialApproverGroup = {
-    approvalType: WorkflowApprovalType.AND,
-    approvers: [],
-  };
 
   const [editingWorkflowName, setEditingWorkflowName] = useState<string | undefined>();
   const [editingWorkflowDescription, setEditingWorkflowDescription] = useState<string | undefined>();
@@ -49,11 +49,11 @@ export const WorkflowCreationModalContent = (props: WorkflowCreationModalContent
     setEditingApproverGroups(clonedApproverGroups);
   }, [editingApproverGroups]);
 
-  const addApproverGroupCardButtonClickHandler = (groupIndex: number) => {
+  const addApproverGroupCardButtonClickHandler = useCallback((groupIndex: number) => {
     const clonedApproverGroups = [...editingApproverGroups];
     clonedApproverGroups.splice(groupIndex, 0, initialApproverGroup);
     setEditingApproverGroups(clonedApproverGroups);
-  };
+  }, [editingApproverGroups]);
 
   const createWorkflowButtonClickHandler = useCallback(async() => {
     if (editingApproverGroups == null) {

--- a/apps/app/src/features/approval-workflow/client/components/ModalComponents/index.ts
+++ b/apps/app/src/features/approval-workflow/client/components/ModalComponents/index.ts
@@ -2,6 +2,3 @@ export { WorkflowListModalContent } from './WorkflowListModalContent';
 export { WorkflowDetailModalContent } from './WorkflowDetailModalContent';
 export { WorkflowCreationModalContent } from './WorkflowCreationModalContent';
 export { WorkflowEditModalContent } from './WorkflowEditModalContent';
-
-export { WorkflowModalHeader } from './WorkflowModalHeader';
-export { ApproverGroupCard } from './ApproverGroupCard';

--- a/apps/app/src/features/approval-workflow/client/components/ModalComponents/index.ts
+++ b/apps/app/src/features/approval-workflow/client/components/ModalComponents/index.ts
@@ -2,4 +2,6 @@ export { WorkflowListModalContent } from './WorkflowListModalContent';
 export { WorkflowDetailModalContent } from './WorkflowDetailModalContent';
 export { WorkflowCreationModalContent } from './WorkflowCreationModalContent';
 export { WorkflowEditModalContent } from './WorkflowEditModalContent';
+
 export { WorkflowModalHeader } from './WorkflowModalHeader';
+export { ApproverGroupCard } from './ApproverGroupCard';

--- a/apps/app/src/features/approval-workflow/client/services/workflow.ts
+++ b/apps/app/src/features/approval-workflow/client/services/workflow.ts
@@ -1,5 +1,53 @@
+import { useState, useCallback } from 'react';
+
 import { apiv3Delete } from '~/client/util/apiv3-client';
+
+import { IWorkflowApproverGroupReqForRenderList } from '../../interfaces/workflow';
 
 export const deleteWorkflow = async(workflowId: string): Promise<void> => {
   await apiv3Delete(`/workflow/${workflowId}`);
+};
+
+
+// see: https://robinpokorny.medium.com/index-as-a-key-is-an-anti-pattern-e0349aece318
+// When rendering with maps, without a unique key, unintended behavior can occur.
+const createInitialApproverGroup = (): IWorkflowApproverGroupReqForRenderList => {
+  return {
+    approvalType: 'AND',
+    approvers: [],
+    uuidForRenderList: crypto.randomUUID(),
+  };
+};
+
+type UseEditingApproverGroups = {
+  editingApproverGroups: IWorkflowApproverGroupReqForRenderList[],
+  updateApproverGroupHandler: (groupIndex: number, updateApproverGroupData: IWorkflowApproverGroupReqForRenderList) => void
+  addApproverGroupHandler: (groupIndex: number) => void
+  removeApproverGroupHandler: (groupIndex: number) => void
+}
+
+export const useEditingApproverGroups = (): UseEditingApproverGroups => {
+  const [editingApproverGroups, setEditingApproverGroups] = useState<IWorkflowApproverGroupReqForRenderList[]>([createInitialApproverGroup()]);
+
+  const updateApproverGroupHandler = useCallback((groupIndex: number, updateApproverGroupData: IWorkflowApproverGroupReqForRenderList) => {
+    const clonedApproverGroups = [...editingApproverGroups];
+    clonedApproverGroups[groupIndex] = updateApproverGroupData;
+    setEditingApproverGroups(clonedApproverGroups);
+  }, [editingApproverGroups]);
+
+  const addApproverGroupHandler = useCallback((groupIndex: number) => {
+    const clonedApproverGroups = [...editingApproverGroups];
+    clonedApproverGroups.splice(groupIndex, 0, createInitialApproverGroup());
+    setEditingApproverGroups(clonedApproverGroups);
+  }, [editingApproverGroups]);
+
+  const removeApproverGroupHandler = useCallback((groupIndex: number) => {
+    const clonedApproverGroups = [...editingApproverGroups];
+    clonedApproverGroups.splice(groupIndex, 1);
+    setEditingApproverGroups(clonedApproverGroups);
+  }, [editingApproverGroups]);
+
+  return {
+    editingApproverGroups, updateApproverGroupHandler, addApproverGroupHandler, removeApproverGroupHandler,
+  };
 };

--- a/apps/app/src/features/approval-workflow/interfaces/workflow.ts
+++ b/apps/app/src/features/approval-workflow/interfaces/workflow.ts
@@ -60,6 +60,8 @@ export type IWorkflowApproverGroupReq = Omit<IWorkflowApproverGroup, 'isApproved
 export type IWorkflowReq = Omit<IWorkflow, '_id' | 'creator' | 'approverGroups' | 'createdAt'>
   & { creator: ObjectIdLike, approverGroups: IWorkflowApproverGroupReq[] }
 
+export type IWorkflowApproverGroupReqForRenderList = IWorkflowApproverGroupReq & { uuidForRenderList: string };
+
 // TODO: If you don't need it, delete it
 export type IWorkflowApproverHasId = IWorkflowApprover & HasObjectId;
 export type IWorkflowApproverGroupHasId = Omit<IWorkflowApproverGroup, 'approvers'> & { approvers: IWorkflowApproverHasId[] } & HasObjectId;

--- a/apps/app/src/features/approval-workflow/interfaces/workflow.ts
+++ b/apps/app/src/features/approval-workflow/interfaces/workflow.ts
@@ -31,7 +31,7 @@ export const WorkflowApprovalTypes = Object.values(WorkflowApprovalType);
 
 type WorkflowStatus = typeof WorkflowStatus[keyof typeof WorkflowStatus];
 type WorkflowApproverStatus = typeof WorkflowApproverStatus[keyof typeof WorkflowApproverStatus];
-type WorkflowApprovalType = typeof WorkflowApprovalType [keyof typeof WorkflowApprovalType];
+export type WorkflowApprovalType = typeof WorkflowApprovalType [keyof typeof WorkflowApprovalType];
 
 
 export type IWorkflowApprover = {


### PR DESCRIPTION
## Task
[#130338](https://redmine.weseek.co.jp/issues/130338) [approval-workflow] XD 通りにワークフロー作成画面を実装しワークフローの作成ができる
└ [#132629](https://redmine.weseek.co.jp/issues/132629) [front] 承認者を選択するためのフォームを持つカードの実装
└ [#132630](https://redmine.weseek.co.jp/issues/132630) [front] 承認者 (user) を選択するための form の実装

## ScreenRecord
https://github.com/weseek/growi/assets/34241526/c1fd2484-2b5a-42ae-ae50-2282c10de726


 