### PR TITLE
show error message when ldap auth is not enabled and group sync is ex…

### DIFF
--- a/apps/app/public/static/locales/en_US/admin.json
+++ b/apps/app/public/static/locales/en_US/admin.json
@@ -1082,7 +1082,8 @@
       "name_mapper_detail": "Attribute to map as group name",
       "updated_group_sync_settings": "Updated LDAP group sync settings",
       "password": "Password",
-      "password_detail": "Login password is necessary because Bind type is set to User Bind"
+      "password_detail": "Login password is necessary because Bind type is set to User Bind",
+      "auth_not_set": "Enable and configure LDAP auth in security settings before sync"
     },
     "keycloak": {
       "group_sync_settings": "Keycloak Group Sync Settings",
@@ -1098,7 +1099,7 @@
       "group_sync_client_secret_detail": "Id of the secret used to authenticate to request to Keycloak admin API",
       "updated_group_sync_settings": "Updated Keycloak group sync settings",
       "preserve_deleted_keycloak_groups": "Preserve Deleted Keycloak Groups",
-      "auth_not_set": "Please set up and enable OIDC or SAML with Keycloak in security settings before sync"
+      "auth_not_set": "Enable and configure OIDC or SAML with Keycloak in security settings before sync"
     },
     "auto_generate_user_on_sync": "Auto Generate User on Sync",
     "description_mapper_detail": "Attribute to map as group description. Description can be edited after sync. However, when a mapper is set, the edited value can possibly be overwritten by the next sync."

--- a/apps/app/public/static/locales/ja_JP/admin.json
+++ b/apps/app/public/static/locales/ja_JP/admin.json
@@ -1091,7 +1091,8 @@
       "name_mapper_detail": "グループの「名前」として読み込む属性",
       "updated_group_sync_settings": "LDAP グループ同期設定を更新しました",
       "password": "パスワード",
-      "password_detail": "認証設定がユーザ Bind のため、ログイン時のパスワードの入力が必要となります"
+      "password_detail": "認証設定がユーザ Bind のため、ログイン時のパスワードの入力が必要となります",
+      "auth_not_set": "同期実行前にセキュリティ設定で LDAP 認証を有効にし、設定してください"
     },
     "keycloak": {
       "group_sync_settings": "Keycloak グループ同期設定",
@@ -1107,7 +1108,7 @@
       "group_sync_client_secret_detail": "Keycloak admin API にリクエストするための認証に使う client の secret",
       "updated_group_sync_settings": "Keycloak グループ同期設定を更新しました",
       "preserve_deleted_keycloak_groups": "Keycloak から削除されたグループを GROWI に残す",
-      "auth_not_set": "同期実行前に、セキュリティ設定で Keycloak を使った OIDC または SAML 認証を設定し、有効にしてください"
+      "auth_not_set": "同期実行前にセキュリティ設定で Keycloak を使った OIDC または SAML 認証を有効にし、設定してください"
     },
     "auto_generate_user_on_sync": "作成されていない GROWI アカウントを自動生成する",
     "description_mapper_detail": "グループの「説明」として読み込む属性。「説明」は同期後に編集可能です。ただし、mapper が設定されている場合、編集内容は再同期によって上書きされます。"

--- a/apps/app/public/static/locales/zh_CN/admin.json
+++ b/apps/app/public/static/locales/zh_CN/admin.json
@@ -1090,7 +1090,8 @@
       "name_mapper_detail": "Attribute to map as group name",
       "updated_group_sync_settings": "Updated LDAP group sync settings",
       "password": "Password",
-      "password_detail": "Login password is necessary because Bind type is set to User Bind"
+      "password_detail": "Login password is necessary because Bind type is set to User Bind",
+      "auth_not_set": "Enable and configure LDAP auth in security settings before sync"
     },
     "keycloak": {
       "group_sync_settings": "Keycloak Group Sync Settings",
@@ -1106,7 +1107,7 @@
       "group_sync_client_secret_detail": "Id of the secret used to authenticate to request to Keycloak admin API",
       "updated_group_sync_settings": "Updated Keycloak group sync settings",
       "preserve_deleted_keycloak_groups": "Preserve Deleted Keycloak Groups",
-      "auth_not_set": "Please set up and enable OIDC or SAML with Keycloak in security settings before sync"
+      "auth_not_set": "Enable and configure OIDC or SAML with Keycloak in security settings before sync"
     },
     "auto_generate_user_on_sync": "Auto Generate User on Sync",
     "description_mapper_detail": "Attribute to map as group description. Description can be edited after sync. However, when a mapper is set, the edited value can possibly be overwritten by the next sync."

--- a/apps/app/src/features/external-user-group/server/routes/apiv3/external-user-group.ts
+++ b/apps/app/src/features/external-user-group/server/routes/apiv3/external-user-group.ts
@@ -323,16 +323,17 @@ module.exports = (crowi: Crowi): Router => {
 
     try {
       await crowi.ldapUserGroupSyncService?.init(req.user.name, req.body.password);
-      // Do not await for sync to finish. Result (completed, failed) will be notified to the client by socket-io.
-      crowi.ldapUserGroupSyncService?.syncExternalUserGroups();
-
-      return res.apiv3({}, 202);
     }
     catch (e) {
       return res.apiv3Err(
         new ErrorV3('LDAP group sync failed', 'external_user_group.sync_failed'), 500,
       );
     }
+
+    // Do not await for sync to finish. Result (completed, failed) will be notified to the client by socket-io.
+    crowi.ldapUserGroupSyncService?.syncExternalUserGroups();
+
+    return res.apiv3({}, 202);
   });
 
   router.put('/keycloak/sync', loginRequiredStrictly, adminRequired, async(req: AuthorizedRequest, res: ApiV3Response) => {


### PR DESCRIPTION
## task
https://redmine.weseek.co.jp/issues/133126

## 備考
エラーがサービス層で生じているのですが、こちらは詳細な内容をクライアントに伝搬する仕組みが整備されておりません。
参考) https://wsgrowi.slack.com/archives/C053LBNH9T3/p1691672516017849
https://wsgrowi.slack.com/archives/C053LBNH9T3/p1691690498263069

とりあえず ldap の同期も、keycloak 同期と同様、実行前に enabled になっているかを確認するようにしました。