### PR TITLE
support: Refactor components under components/inappnotification

### DIFF
--- a/apps/app/src/components/InAppNotification/InAppNotificationElm.tsx
+++ b/apps/app/src/components/InAppNotification/InAppNotificationElm.tsx
@@ -8,7 +8,7 @@ import { DropdownItem } from 'reactstrap';
 
 import { IInAppNotificationOpenable } from '~/client/interfaces/in-app-notification-openable';
 import { apiv3Post } from '~/client/util/apiv3-client';
-import { SupportedTargetModel, SupportedAction } from '~/interfaces/activity';
+import { SupportedTargetModel } from '~/interfaces/activity';
 import { IInAppNotification, InAppNotificationStatuses } from '~/interfaces/in-app-notification';
 
 // Change the display for each targetmodel
@@ -86,72 +86,6 @@ const InAppNotificationElm: FC<Props> = (props: Props) => {
 
   const actionUsers = getActionUsers();
 
-  const actionType: string = notification.action;
-  let actionMsg: string;
-  let actionIcon: string;
-
-  switch (actionType) {
-    case SupportedAction.ACTION_PAGE_LIKE:
-      actionMsg = 'liked';
-      actionIcon = 'icon-like';
-      break;
-    case SupportedAction.ACTION_PAGE_BOOKMARK:
-      actionMsg = 'bookmarked on';
-      actionIcon = 'icon-star';
-      break;
-    case SupportedAction.ACTION_PAGE_UPDATE:
-      actionMsg = 'updated on';
-      actionIcon = 'ti ti-agenda';
-      break;
-    case SupportedAction.ACTION_PAGE_RENAME:
-      actionMsg = 'renamed';
-      actionIcon = 'icon-action-redo';
-      break;
-    case SupportedAction.ACTION_PAGE_DUPLICATE:
-      actionMsg = 'duplicated';
-      actionIcon = 'icon-docs';
-      break;
-    case SupportedAction.ACTION_PAGE_DELETE:
-      actionMsg = 'deleted';
-      actionIcon = 'icon-trash';
-      break;
-    case SupportedAction.ACTION_PAGE_DELETE_COMPLETELY:
-      actionMsg = 'completely deleted';
-      actionIcon = 'icon-fire';
-      break;
-    case SupportedAction.ACTION_PAGE_REVERT:
-      actionMsg = 'reverted';
-      actionIcon = 'icon-action-undo';
-      break;
-    case SupportedAction.ACTION_PAGE_RECURSIVELY_RENAME:
-      actionMsg = 'renamed under';
-      actionIcon = 'icon-action-redo';
-      break;
-    case SupportedAction.ACTION_PAGE_RECURSIVELY_DELETE:
-      actionMsg = 'deleted under';
-      actionIcon = 'icon-trash';
-      break;
-    case SupportedAction.ACTION_PAGE_RECURSIVELY_DELETE_COMPLETELY:
-      actionMsg = 'deleted completely under';
-      actionIcon = 'icon-fire';
-      break;
-    case SupportedAction.ACTION_PAGE_RECURSIVELY_REVERT:
-      actionMsg = 'reverted under';
-      actionIcon = 'icon-action-undo';
-      break;
-    case 'COMMENT_CREATE':
-      actionMsg = 'commented on';
-      actionIcon = 'icon-bubble';
-      break;
-    case 'USER_REGISTRATION_APPROVAL_REQUEST':
-      actionMsg = 'requested registration approval';
-      actionIcon = 'icon-bubble';
-      break;
-    default:
-      actionMsg = '';
-      actionIcon = '';
-  }
-
   const isDropdownItem = props.type === 'dropdown-item';
 
   // determine tag
@@ -182,8 +116,6 @@ const InAppNotificationElm: FC<Props> = (props: Props) => {
           <UserModelNotification
             ref={notificationRef}
             notification={notification}
-            actionMsg={actionMsg}
-            actionIcon={actionIcon}
             actionUsers={actionUsers}
           />
         )}

--- a/apps/app/src/components/InAppNotification/InAppNotificationElm.tsx
+++ b/apps/app/src/components/InAppNotification/InAppNotificationElm.tsx
@@ -8,7 +8,7 @@ import { DropdownItem } from 'reactstrap';
 
 import { IInAppNotificationOpenable } from '~/client/interfaces/in-app-notification-openable';
 import { apiv3Post } from '~/client/util/apiv3-client';
-import { SupportedTargetModel } from '~/interfaces/activity';
+import { SupportedTargetModel, SupportedAction } from '~/interfaces/activity';
 import { IInAppNotification, InAppNotificationStatuses } from '~/interfaces/in-app-notification';
 
 // Change the display for each targetmodel
@@ -91,51 +91,51 @@ const InAppNotificationElm: FC<Props> = (props: Props) => {
   let actionIcon: string;
 
   switch (actionType) {
-    case 'PAGE_LIKE':
+    case SupportedAction.ACTION_PAGE_LIKE:
       actionMsg = 'liked';
       actionIcon = 'icon-like';
       break;
-    case 'PAGE_BOOKMARK':
+    case SupportedAction.ACTION_PAGE_BOOKMARK:
       actionMsg = 'bookmarked on';
       actionIcon = 'icon-star';
       break;
-    case 'PAGE_UPDATE':
+    case SupportedAction.ACTION_PAGE_UPDATE:
       actionMsg = 'updated on';
       actionIcon = 'ti ti-agenda';
       break;
-    case 'PAGE_RENAME':
+    case SupportedAction.ACTION_PAGE_RENAME:
       actionMsg = 'renamed';
       actionIcon = 'icon-action-redo';
       break;
-    case 'PAGE_DUPLICATE':
+    case SupportedAction.ACTION_PAGE_DUPLICATE:
       actionMsg = 'duplicated';
       actionIcon = 'icon-docs';
       break;
-    case 'PAGE_DELETE':
+    case SupportedAction.ACTION_PAGE_DELETE:
       actionMsg = 'deleted';
       actionIcon = 'icon-trash';
       break;
-    case 'PAGE_DELETE_COMPLETELY':
+    case SupportedAction.ACTION_PAGE_DELETE_COMPLETELY:
       actionMsg = 'completely deleted';
       actionIcon = 'icon-fire';
       break;
-    case 'PAGE_REVERT':
+    case SupportedAction.ACTION_PAGE_REVERT:
       actionMsg = 'reverted';
       actionIcon = 'icon-action-undo';
       break;
-    case 'PAGE_RECURSIVELY_RENAME':
+    case SupportedAction.ACTION_PAGE_RECURSIVELY_RENAME:
       actionMsg = 'renamed under';
       actionIcon = 'icon-action-redo';
       break;
-    case 'PAGE_RECURSIVELY_DELETE':
+    case SupportedAction.ACTION_PAGE_RECURSIVELY_DELETE:
       actionMsg = 'deleted under';
       actionIcon = 'icon-trash';
       break;
-    case 'PAGE_RECURSIVELY_DELETE_COMPLETELY':
+    case SupportedAction.ACTION_PAGE_RECURSIVELY_DELETE_COMPLETELY:
       actionMsg = 'deleted completely under';
       actionIcon = 'icon-fire';
       break;
-    case 'PAGE_RECURSIVELY_REVERT':
+    case SupportedAction.ACTION_PAGE_RECURSIVELY_REVERT:
       actionMsg = 'reverted under';
       actionIcon = 'icon-action-undo';
       break;
@@ -175,8 +175,6 @@ const InAppNotificationElm: FC<Props> = (props: Props) => {
           <PageModelNotification
             ref={notificationRef}
             notification={notification}
-            actionMsg={actionMsg}
-            actionIcon={actionIcon}
             actionUsers={actionUsers}
           />
         )}

--- a/apps/app/src/components/InAppNotification/PageNotification/ModelNotification.tsx
+++ b/apps/app/src/components/InAppNotification/PageNotification/ModelNotification.tsx
@@ -1,0 +1,45 @@
+import React, { FC, useImperativeHandle } from 'react';
+
+import type { HasObjectId } from '@growi/core';
+import { PagePathLabel } from '@growi/ui/dist/components/PagePath';
+
+import type { IInAppNotificationOpenable } from '~/client/interfaces/in-app-notification-openable';
+import type { IInAppNotification } from '~/interfaces/in-app-notification';
+
+import FormattedDistanceDate from '../../FormattedDistanceDate';
+
+type Props = {
+  notification: IInAppNotification & HasObjectId
+  actionMsg: string
+  actionIcon: string
+  actionUsers: string
+  publishOpen:() => void
+  ref: React.ForwardedRef<IInAppNotificationOpenable>
+};
+
+export const ModelNotification: FC<Props> = (props) => {
+  const {
+    notification, actionMsg, actionIcon, actionUsers, publishOpen, ref,
+  } = props;
+
+  useImperativeHandle(ref, () => ({
+    open() {
+      publishOpen();
+    },
+  }));
+
+  return (
+    <div className="p-2 overflow-hidden">
+      <div className="text-truncate">
+        <b>{actionUsers}</b> {actionMsg} <PagePathLabel path={notification.parsedSnapshot?.path ?? ''} />
+      </div>
+      <i className={`${actionIcon} me-2`} />
+      <FormattedDistanceDate
+        id={notification._id}
+        date={notification.createdAt}
+        isShowTooltip={false}
+        differenceForAvoidingFormat={Number.POSITIVE_INFINITY}
+      />
+    </div>
+  );
+};

--- a/apps/app/src/components/InAppNotification/PageNotification/PageModelNotification.tsx
+++ b/apps/app/src/components/InAppNotification/PageNotification/PageModelNotification.tsx
@@ -75,7 +75,7 @@ const useActionMsgAndIcon = (notification: IInAppNotification & HasObjectId): Ac
       actionMsg = 'reverted under';
       actionIcon = 'icon-action-undo';
       break;
-    case 'COMMENT_CREATE':
+    case SupportedAction.ACTION_COMMENT_CREATE:
       actionMsg = 'commented on';
       actionIcon = 'icon-bubble';
       break;

--- a/apps/app/src/components/InAppNotification/PageNotification/PageModelNotification.tsx
+++ b/apps/app/src/components/InAppNotification/PageNotification/PageModelNotification.tsx
@@ -5,8 +5,8 @@ import React, {
 import type { HasObjectId } from '@growi/core';
 import { useRouter } from 'next/router';
 
-import { SupportedAction } from '~/interfaces/activity';
 import type { IInAppNotificationOpenable } from '~/client/interfaces/in-app-notification-openable';
+import { SupportedAction } from '~/interfaces/activity';
 import type { IInAppNotification } from '~/interfaces/in-app-notification';
 
 import { ModelNotification } from './ModelNotification';
@@ -16,12 +16,12 @@ interface Props {
   actionUsers: string
 }
 
-type useActionMsgAndIconType = {
+export type ActionMsgAndIconType = {
   actionMsg: string
   actionIcon: string
 }
 
-const useActionMsgAndIcon = (notification: IInAppNotification & HasObjectId): useActionMsgAndIconType => {
+const useActionMsgAndIcon = (notification: IInAppNotification & HasObjectId): ActionMsgAndIconType => {
   const actionType: string = notification.action;
   let actionMsg: string;
   let actionIcon: string;
@@ -75,13 +75,18 @@ const useActionMsgAndIcon = (notification: IInAppNotification & HasObjectId): us
       actionMsg = 'reverted under';
       actionIcon = 'icon-action-undo';
       break;
+    case 'COMMENT_CREATE':
+      actionMsg = 'commented on';
+      actionIcon = 'icon-bubble';
+      break;
     default:
       actionMsg = '';
       actionIcon = '';
+  }
 
   return {
     actionMsg,
-    actionIcon
+    actionIcon,
   };
 };
 
@@ -91,9 +96,7 @@ const PageModelNotification: ForwardRefRenderFunction<IInAppNotificationOpenable
     notification, actionUsers,
   } = props;
 
-  const actionData = useActionMsgAndIcon(notification);
-  const actionMsg = actionData.actionMsg;
-  const actionIcon = actionData.actionIcon;
+  const { actionMsg, actionIcon } = useActionMsgAndIcon(notification);
 
   const router = useRouter();
 

--- a/apps/app/src/components/InAppNotification/PageNotification/PageModelNotification.tsx
+++ b/apps/app/src/components/InAppNotification/PageNotification/PageModelNotification.tsx
@@ -6,89 +6,16 @@ import type { HasObjectId } from '@growi/core';
 import { useRouter } from 'next/router';
 
 import type { IInAppNotificationOpenable } from '~/client/interfaces/in-app-notification-openable';
-import { SupportedAction } from '~/interfaces/activity';
 import type { IInAppNotification } from '~/interfaces/in-app-notification';
 
 import { ModelNotification } from './ModelNotification';
+import { useActionMsgAndIconForPageModelNotification } from './useActionAndMsg';
+
 
 interface Props {
   notification: IInAppNotification & HasObjectId
   actionUsers: string
 }
-
-export type ActionMsgAndIconType = {
-  actionMsg: string
-  actionIcon: string
-}
-
-const useActionMsgAndIcon = (notification: IInAppNotification & HasObjectId): ActionMsgAndIconType => {
-  const actionType: string = notification.action;
-  let actionMsg: string;
-  let actionIcon: string;
-
-  switch (actionType) {
-    case SupportedAction.ACTION_PAGE_LIKE:
-      actionMsg = 'liked';
-      actionIcon = 'icon-like';
-      break;
-    case SupportedAction.ACTION_PAGE_BOOKMARK:
-      actionMsg = 'bookmarked on';
-      actionIcon = 'icon-star';
-      break;
-    case SupportedAction.ACTION_PAGE_UPDATE:
-      actionMsg = 'updated on';
-      actionIcon = 'ti ti-agenda';
-      break;
-    case SupportedAction.ACTION_PAGE_RENAME:
-      actionMsg = 'renamed';
-      actionIcon = 'icon-action-redo';
-      break;
-    case SupportedAction.ACTION_PAGE_DUPLICATE:
-      actionMsg = 'duplicated';
-      actionIcon = 'icon-docs';
-      break;
-    case SupportedAction.ACTION_PAGE_DELETE:
-      actionMsg = 'deleted';
-      actionIcon = 'icon-trash';
-      break;
-    case SupportedAction.ACTION_PAGE_DELETE_COMPLETELY:
-      actionMsg = 'completely deleted';
-      actionIcon = 'icon-fire';
-      break;
-    case SupportedAction.ACTION_PAGE_REVERT:
-      actionMsg = 'reverted';
-      actionIcon = 'icon-action-undo';
-      break;
-    case SupportedAction.ACTION_PAGE_RECURSIVELY_RENAME:
-      actionMsg = 'renamed under';
-      actionIcon = 'icon-action-redo';
-      break;
-    case SupportedAction.ACTION_PAGE_RECURSIVELY_DELETE:
-      actionMsg = 'deleted under';
-      actionIcon = 'icon-trash';
-      break;
-    case SupportedAction.ACTION_PAGE_RECURSIVELY_DELETE_COMPLETELY:
-      actionMsg = 'deleted completely under';
-      actionIcon = 'icon-fire';
-      break;
-    case SupportedAction.ACTION_PAGE_RECURSIVELY_REVERT:
-      actionMsg = 'reverted under';
-      actionIcon = 'icon-action-undo';
-      break;
-    case SupportedAction.ACTION_COMMENT_CREATE:
-      actionMsg = 'commented on';
-      actionIcon = 'icon-bubble';
-      break;
-    default:
-      actionMsg = '';
-      actionIcon = '';
-  }
-
-  return {
-    actionMsg,
-    actionIcon,
-  };
-};
 
 const PageModelNotification: ForwardRefRenderFunction<IInAppNotificationOpenable, Props> = (props: Props, ref) => {
 
@@ -96,7 +23,7 @@ const PageModelNotification: ForwardRefRenderFunction<IInAppNotificationOpenable
     notification, actionUsers,
   } = props;
 
-  const { actionMsg, actionIcon } = useActionMsgAndIcon(notification);
+  const { actionMsg, actionIcon } = useActionMsgAndIconForPageModelNotification(notification);
 
   const router = useRouter();
 

--- a/apps/app/src/components/InAppNotification/PageNotification/PageModelNotification.tsx
+++ b/apps/app/src/components/InAppNotification/PageNotification/PageModelNotification.tsx
@@ -1,15 +1,14 @@
 import React, {
-  forwardRef, ForwardRefRenderFunction, useImperativeHandle,
+  forwardRef, ForwardRefRenderFunction,
 } from 'react';
 
 import type { HasObjectId } from '@growi/core';
-import { PagePathLabel } from '@growi/ui/dist/components/PagePath';
 import { useRouter } from 'next/router';
 
 import type { IInAppNotificationOpenable } from '~/client/interfaces/in-app-notification-openable';
 import type { IInAppNotification } from '~/interfaces/in-app-notification';
 
-import FormattedDistanceDate from '../../FormattedDistanceDate';
+import { ModelNotification } from './ModelNotification';
 
 interface Props {
   notification: IInAppNotification & HasObjectId
@@ -27,31 +26,25 @@ const PageModelNotification: ForwardRefRenderFunction<IInAppNotificationOpenable
   const router = useRouter();
 
   // publish open()
-  useImperativeHandle(ref, () => ({
-    open() {
-      if (notification.target != null) {
-        // jump to target page
-        const targetPagePath = notification.target.path;
-        if (targetPagePath != null) {
-          router.push(targetPagePath);
-        }
+  const publishOpen = () => {
+    if (notification.target != null) {
+      // jump to target page
+      const targetPagePath = notification.target.path;
+      if (targetPagePath != null) {
+        router.push(targetPagePath);
       }
-    },
-  }));
+    }
+  };
 
   return (
-    <div className="p-2 overflow-hidden">
-      <div className="text-truncate">
-        <b>{actionUsers}</b> {actionMsg} <PagePathLabel path={notification.parsedSnapshot?.path ?? ''} />
-      </div>
-      <i className={`${actionIcon} me-2`} />
-      <FormattedDistanceDate
-        id={notification._id}
-        date={notification.createdAt}
-        isShowTooltip={false}
-        differenceForAvoidingFormat={Number.POSITIVE_INFINITY}
-      />
-    </div>
+    <ModelNotification
+      notification={notification}
+      actionMsg={actionMsg}
+      actionIcon={actionIcon}
+      actionUsers={actionUsers}
+      publishOpen={publishOpen}
+      ref={ref}
+    />
   );
 };
 

--- a/apps/app/src/components/InAppNotification/PageNotification/PageModelNotification.tsx
+++ b/apps/app/src/components/InAppNotification/PageNotification/PageModelNotification.tsx
@@ -5,6 +5,7 @@ import React, {
 import type { HasObjectId } from '@growi/core';
 import { useRouter } from 'next/router';
 
+import { SupportedAction } from '~/interfaces/activity';
 import type { IInAppNotificationOpenable } from '~/client/interfaces/in-app-notification-openable';
 import type { IInAppNotification } from '~/interfaces/in-app-notification';
 
@@ -12,16 +13,87 @@ import { ModelNotification } from './ModelNotification';
 
 interface Props {
   notification: IInAppNotification & HasObjectId
-  actionMsg: string
-  actionIcon: string
   actionUsers: string
 }
+
+type useActionMsgAndIconType = {
+  actionMsg: string
+  actionIcon: string
+}
+
+const useActionMsgAndIcon = (notification: IInAppNotification & HasObjectId): useActionMsgAndIconType => {
+  const actionType: string = notification.action;
+  let actionMsg: string;
+  let actionIcon: string;
+
+  switch (actionType) {
+    case SupportedAction.ACTION_PAGE_LIKE:
+      actionMsg = 'liked';
+      actionIcon = 'icon-like';
+      break;
+    case SupportedAction.ACTION_PAGE_BOOKMARK:
+      actionMsg = 'bookmarked on';
+      actionIcon = 'icon-star';
+      break;
+    case SupportedAction.ACTION_PAGE_UPDATE:
+      actionMsg = 'updated on';
+      actionIcon = 'ti ti-agenda';
+      break;
+    case SupportedAction.ACTION_PAGE_RENAME:
+      actionMsg = 'renamed';
+      actionIcon = 'icon-action-redo';
+      break;
+    case SupportedAction.ACTION_PAGE_DUPLICATE:
+      actionMsg = 'duplicated';
+      actionIcon = 'icon-docs';
+      break;
+    case SupportedAction.ACTION_PAGE_DELETE:
+      actionMsg = 'deleted';
+      actionIcon = 'icon-trash';
+      break;
+    case SupportedAction.ACTION_PAGE_DELETE_COMPLETELY:
+      actionMsg = 'completely deleted';
+      actionIcon = 'icon-fire';
+      break;
+    case SupportedAction.ACTION_PAGE_REVERT:
+      actionMsg = 'reverted';
+      actionIcon = 'icon-action-undo';
+      break;
+    case SupportedAction.ACTION_PAGE_RECURSIVELY_RENAME:
+      actionMsg = 'renamed under';
+      actionIcon = 'icon-action-redo';
+      break;
+    case SupportedAction.ACTION_PAGE_RECURSIVELY_DELETE:
+      actionMsg = 'deleted under';
+      actionIcon = 'icon-trash';
+      break;
+    case SupportedAction.ACTION_PAGE_RECURSIVELY_DELETE_COMPLETELY:
+      actionMsg = 'deleted completely under';
+      actionIcon = 'icon-fire';
+      break;
+    case SupportedAction.ACTION_PAGE_RECURSIVELY_REVERT:
+      actionMsg = 'reverted under';
+      actionIcon = 'icon-action-undo';
+      break;
+    default:
+      actionMsg = '';
+      actionIcon = '';
+
+  return {
+    actionMsg,
+    actionIcon
+  };
+};
 
 const PageModelNotification: ForwardRefRenderFunction<IInAppNotificationOpenable, Props> = (props: Props, ref) => {
 
   const {
-    notification, actionMsg, actionIcon, actionUsers,
+    notification, actionUsers,
   } = props;
+
+  const actionData = useActionMsgAndIcon(notification);
+  const actionMsg = actionData.actionMsg;
+  const actionIcon = actionData.actionIcon;
 
   const router = useRouter();
 

--- a/apps/app/src/components/InAppNotification/PageNotification/UserModelNotification.tsx
+++ b/apps/app/src/components/InAppNotification/PageNotification/UserModelNotification.tsx
@@ -1,5 +1,5 @@
 import React, {
-  forwardRef, ForwardRefRenderFunction, useImperativeHandle,
+  forwardRef, ForwardRefRenderFunction,
 } from 'react';
 
 import type { HasObjectId } from '@growi/core';
@@ -8,7 +8,7 @@ import { useRouter } from 'next/router';
 import type { IInAppNotificationOpenable } from '~/client/interfaces/in-app-notification-openable';
 import type { IInAppNotification } from '~/interfaces/in-app-notification';
 
-import FormattedDistanceDate from '../../FormattedDistanceDate';
+import { ModelNotification } from './ModelNotification';
 
 const UserModelNotification: ForwardRefRenderFunction<IInAppNotificationOpenable, {
   notification: IInAppNotification & HasObjectId
@@ -21,25 +21,19 @@ const UserModelNotification: ForwardRefRenderFunction<IInAppNotificationOpenable
   const router = useRouter();
 
   // publish open()
-  useImperativeHandle(ref, () => ({
-    open() {
-      router.push('/admin/users');
-    },
-  }));
+  const publishOpen = () => {
+    router.push('/admin/users');
+  };
 
   return (
-    <div className="p-2 overflow-hidden">
-      <div className="text-truncate">
-        <b>{actionUsers}</b> {actionMsg}
-      </div>
-      <i className={`${actionIcon} me-2`} />
-      <FormattedDistanceDate
-        id={notification._id}
-        date={notification.createdAt}
-        isShowTooltip={false}
-        differenceForAvoidingFormat={Number.POSITIVE_INFINITY}
-      />
-    </div>
+    <ModelNotification
+      notification={notification}
+      actionMsg={actionMsg}
+      actionIcon={actionIcon}
+      actionUsers={actionUsers}
+      publishOpen={publishOpen}
+      ref={ref}
+    />
   );
 };
 

--- a/apps/app/src/components/InAppNotification/PageNotification/UserModelNotification.tsx
+++ b/apps/app/src/components/InAppNotification/PageNotification/UserModelNotification.tsx
@@ -6,32 +6,11 @@ import type { HasObjectId } from '@growi/core';
 import { useRouter } from 'next/router';
 
 import type { IInAppNotificationOpenable } from '~/client/interfaces/in-app-notification-openable';
-import { SupportedAction } from '~/interfaces/activity';
 import type { IInAppNotification } from '~/interfaces/in-app-notification';
 
 import { ModelNotification } from './ModelNotification';
-import type { ActionMsgAndIconType } from './PageModelNotification';
+import { useActionMsgAndIconForUserModelNotification } from './useActionAndMsg';
 
-const useActionMsgAndIcon = (notification: IInAppNotification & HasObjectId): ActionMsgAndIconType => {
-  const actionType: string = notification.action;
-  let actionMsg: string;
-  let actionIcon: string;
-
-  switch (actionType) {
-    case SupportedAction.ACTION_USER_REGISTRATION_APPROVAL_REQUEST:
-      actionMsg = 'requested registration approval';
-      actionIcon = 'icon-bubble';
-      break;
-    default:
-      actionMsg = '';
-      actionIcon = '';
-  }
-
-  return {
-    actionMsg,
-    actionIcon,
-  };
-};
 
 const UserModelNotification: ForwardRefRenderFunction<IInAppNotificationOpenable, {
   notification: IInAppNotification & HasObjectId
@@ -41,7 +20,7 @@ const UserModelNotification: ForwardRefRenderFunction<IInAppNotificationOpenable
 }, ref) => {
   const router = useRouter();
 
-  const { actionMsg, actionIcon } = useActionMsgAndIcon(notification);
+  const { actionMsg, actionIcon } = useActionMsgAndIconForUserModelNotification(notification);
 
   // publish open()
   const publishOpen = () => {

--- a/apps/app/src/components/InAppNotification/PageNotification/UserModelNotification.tsx
+++ b/apps/app/src/components/InAppNotification/PageNotification/UserModelNotification.tsx
@@ -6,6 +6,7 @@ import type { HasObjectId } from '@growi/core';
 import { useRouter } from 'next/router';
 
 import type { IInAppNotificationOpenable } from '~/client/interfaces/in-app-notification-openable';
+import { SupportedAction } from '~/interfaces/activity';
 import type { IInAppNotification } from '~/interfaces/in-app-notification';
 
 import { ModelNotification } from './ModelNotification';
@@ -17,7 +18,7 @@ const useActionMsgAndIcon = (notification: IInAppNotification & HasObjectId): Ac
   let actionIcon: string;
 
   switch (actionType) {
-    case 'USER_REGISTRATION_APPROVAL_REQUEST':
+    case SupportedAction.ACTION_USER_REGISTRATION_APPROVAL_REQUEST:
       actionMsg = 'requested registration approval';
       actionIcon = 'icon-bubble';
       break;

--- a/apps/app/src/components/InAppNotification/PageNotification/UserModelNotification.tsx
+++ b/apps/app/src/components/InAppNotification/PageNotification/UserModelNotification.tsx
@@ -9,16 +9,38 @@ import type { IInAppNotificationOpenable } from '~/client/interfaces/in-app-noti
 import type { IInAppNotification } from '~/interfaces/in-app-notification';
 
 import { ModelNotification } from './ModelNotification';
+import type { ActionMsgAndIconType } from './PageModelNotification';
+
+const useActionMsgAndIcon = (notification: IInAppNotification & HasObjectId): ActionMsgAndIconType => {
+  const actionType: string = notification.action;
+  let actionMsg: string;
+  let actionIcon: string;
+
+  switch (actionType) {
+    case 'USER_REGISTRATION_APPROVAL_REQUEST':
+      actionMsg = 'requested registration approval';
+      actionIcon = 'icon-bubble';
+      break;
+    default:
+      actionMsg = '';
+      actionIcon = '';
+  }
+
+  return {
+    actionMsg,
+    actionIcon,
+  };
+};
 
 const UserModelNotification: ForwardRefRenderFunction<IInAppNotificationOpenable, {
   notification: IInAppNotification & HasObjectId
-  actionMsg: string
-  actionIcon: string
   actionUsers: string
 }> = ({
-  notification, actionMsg, actionIcon, actionUsers,
+  notification, actionUsers,
 }, ref) => {
   const router = useRouter();
+
+  const { actionMsg, actionIcon } = useActionMsgAndIcon(notification);
 
   // publish open()
   const publishOpen = () => {

--- a/apps/app/src/components/InAppNotification/PageNotification/useActionAndMsg.ts
+++ b/apps/app/src/components/InAppNotification/PageNotification/useActionAndMsg.ts
@@ -1,0 +1,99 @@
+import type { HasObjectId } from '@growi/core';
+
+import { SupportedAction } from '~/interfaces/activity';
+import type { IInAppNotification } from '~/interfaces/in-app-notification';
+
+export type ActionMsgAndIconType = {
+  actionMsg: string
+  actionIcon: string
+}
+
+export const useActionMsgAndIconForPageModelNotification = (notification: IInAppNotification & HasObjectId): ActionMsgAndIconType => {
+  const actionType: string = notification.action;
+  let actionMsg: string;
+  let actionIcon: string;
+
+  switch (actionType) {
+    case SupportedAction.ACTION_PAGE_LIKE:
+      actionMsg = 'liked';
+      actionIcon = 'icon-like';
+      break;
+    case SupportedAction.ACTION_PAGE_BOOKMARK:
+      actionMsg = 'bookmarked on';
+      actionIcon = 'icon-star';
+      break;
+    case SupportedAction.ACTION_PAGE_UPDATE:
+      actionMsg = 'updated on';
+      actionIcon = 'ti ti-agenda';
+      break;
+    case SupportedAction.ACTION_PAGE_RENAME:
+      actionMsg = 'renamed';
+      actionIcon = 'icon-action-redo';
+      break;
+    case SupportedAction.ACTION_PAGE_DUPLICATE:
+      actionMsg = 'duplicated';
+      actionIcon = 'icon-docs';
+      break;
+    case SupportedAction.ACTION_PAGE_DELETE:
+      actionMsg = 'deleted';
+      actionIcon = 'icon-trash';
+      break;
+    case SupportedAction.ACTION_PAGE_DELETE_COMPLETELY:
+      actionMsg = 'completely deleted';
+      actionIcon = 'icon-fire';
+      break;
+    case SupportedAction.ACTION_PAGE_REVERT:
+      actionMsg = 'reverted';
+      actionIcon = 'icon-action-undo';
+      break;
+    case SupportedAction.ACTION_PAGE_RECURSIVELY_RENAME:
+      actionMsg = 'renamed under';
+      actionIcon = 'icon-action-redo';
+      break;
+    case SupportedAction.ACTION_PAGE_RECURSIVELY_DELETE:
+      actionMsg = 'deleted under';
+      actionIcon = 'icon-trash';
+      break;
+    case SupportedAction.ACTION_PAGE_RECURSIVELY_DELETE_COMPLETELY:
+      actionMsg = 'deleted completely under';
+      actionIcon = 'icon-fire';
+      break;
+    case SupportedAction.ACTION_PAGE_RECURSIVELY_REVERT:
+      actionMsg = 'reverted under';
+      actionIcon = 'icon-action-undo';
+      break;
+    case SupportedAction.ACTION_COMMENT_CREATE:
+      actionMsg = 'commented on';
+      actionIcon = 'icon-bubble';
+      break;
+    default:
+      actionMsg = '';
+      actionIcon = '';
+  }
+
+  return {
+    actionMsg,
+    actionIcon,
+  };
+};
+
+export const useActionMsgAndIconForUserModelNotification = (notification: IInAppNotification & HasObjectId): ActionMsgAndIconType => {
+  const actionType: string = notification.action;
+  let actionMsg: string;
+  let actionIcon: string;
+
+  switch (actionType) {
+    case SupportedAction.ACTION_USER_REGISTRATION_APPROVAL_REQUEST:
+      actionMsg = 'requested registration approval';
+      actionIcon = 'icon-bubble';
+      break;
+    default:
+      actionMsg = '';
+      actionIcon = '';
+  }
+
+  return {
+    actionMsg,
+    actionIcon,
+  };
+};


### PR DESCRIPTION
## タスク
https://redmine.weseek.co.jp/issues/133697
## 概要
PageModelNotification、UserModelNotificationの共通部分をModelNotificationコンポーネントとし、HOC化しました。
また、InAppNotificationElm内のswitch文での条件分岐を、PageModelNotificationとUserModelNotificationに移し、各条件分岐を文字列ではなくSupportedActionを用いることでバグが発生しにくくなるようにしました。