### PR TITLE
feat: EditableApproverGroupCard

### DIFF
--- a/apps/app/src/features/approval-workflow/client/components/ModalComponents/ApproverGroupCards.tsx
+++ b/apps/app/src/features/approval-workflow/client/components/ModalComponents/ApproverGroupCards.tsx
@@ -5,15 +5,15 @@ import {
   Dropdown, DropdownMenu, DropdownToggle, DropdownItem, UncontrolledTooltip,
 } from 'reactstrap';
 
-import { WorkflowApprovalType, IWorkflowApproverGroupReqForRenderList } from '../../../interfaces/workflow';
+import { WorkflowApprovalType, type EditingApproverGroup } from '../../../interfaces/workflow';
 
 import { SearchUserTypeahead } from './SearchUserTypeahead';
 
 
 type Props = {
   excludedSearchUserIds: string[]
-  editingApproverGroups: IWorkflowApproverGroupReqForRenderList[]
-  onUpdateApproverGroups?: (groupIndex: number, updateApproverGroupData: IWorkflowApproverGroupReqForRenderList) => void
+  editingApproverGroups: EditingApproverGroup[]
+  onUpdateApproverGroups?: (groupIndex: number, updateApproverGroupData: EditingApproverGroup) => void
   onClickAddApproverGroupCard?: (groupIndex: number) => void
   onClickRemoveApproverGroupCard?: (groupIndex: number) => void
 }
@@ -31,12 +31,12 @@ const ApproverGroupCard = (props: Props & { groupIndex: number }): JSX.Element =
   const editingApprovalType = editingApproverGroup.approvalType ?? WorkflowApprovalType.AND;
 
   const isDeletebleEditingApproverGroup = editingApproverGroups.length > 1;
-
   const isCreatableEditingApproverGroup = editingApproverGroup.approvers.length > 0;
-
   const isChangeableApprovealType = editingApproverGroup.approvers.length > 1;
-
   const isApprovalTypeAnd = editingApprovalType === WorkflowApprovalType.AND;
+
+  // for updated
+  const selectedUsers = editingApproverGroup.approvers.map(approver => approver.user);
 
   const changeApprovalTypeButtonClickHandler = useCallback((approvalType: WorkflowApprovalType) => {
     const clonedApproverGroup = { ...editingApproverGroup };
@@ -80,6 +80,7 @@ const ApproverGroupCard = (props: Props & { groupIndex: number }): JSX.Element =
 
           <div className="d-flex justify-content-center align-items-center">
             <SearchUserTypeahead
+              selectedUsers={selectedUsers}
               excludedSearchUserIds={excludedSearchUserIds}
               onChange={updateApproversHandler}
               onRemoveLastEddtingApprover={removeApproverGroupCardHandler}

--- a/apps/app/src/features/approval-workflow/client/components/ModalComponents/ApproverGroupCards.tsx
+++ b/apps/app/src/features/approval-workflow/client/components/ModalComponents/ApproverGroupCards.tsx
@@ -13,6 +13,7 @@ import { SearchUserTypeahead } from './SearchUserTypeahead';
 type Props = {
   excludedSearchUserIds: string[]
   editingApproverGroups: EditingApproverGroup[]
+  latestApprovedApproverGroupIndex?: number
   onUpdateApproverGroups?: (groupIndex: number, updateApproverGroupData: EditingApproverGroup) => void
   onClickAddApproverGroupCard?: (groupIndex: number) => void
   onClickRemoveApproverGroupCard?: (groupIndex: number) => void
@@ -20,7 +21,13 @@ type Props = {
 
 const ApproverGroupCard = (props: Props & { groupIndex: number }): JSX.Element => {
   const {
-    groupIndex, editingApproverGroups, excludedSearchUserIds, onUpdateApproverGroups, onClickAddApproverGroupCard, onClickRemoveApproverGroupCard,
+    groupIndex,
+    editingApproverGroups,
+    excludedSearchUserIds,
+    latestApprovedApproverGroupIndex,
+    onUpdateApproverGroups,
+    onClickAddApproverGroupCard,
+    onClickRemoveApproverGroupCard,
   } = props;
 
   const { t } = useTranslation();
@@ -30,9 +37,11 @@ const ApproverGroupCard = (props: Props & { groupIndex: number }): JSX.Element =
   const editingApproverGroup = editingApproverGroups?.[groupIndex];
   const editingApprovalType = editingApproverGroup.approvalType ?? WorkflowApprovalType.AND;
 
-  const isDeletebleEditingApproverGroup = editingApproverGroups.length > 1;
-  const isCreatableEditingApproverGroup = editingApproverGroup.approvers.length > 0;
-  const isChangeableApprovealType = editingApproverGroup.approvers.length > 1;
+  const isEditable = latestApprovedApproverGroupIndex == null ? true : groupIndex > latestApprovedApproverGroupIndex;
+  const isCreatableButtomApproverGroup = (isEditable && editingApproverGroup.approvers.length > 0) || (groupIndex === latestApprovedApproverGroupIndex);
+  const isCreatableTopApporverGroup = isCreatableButtomApproverGroup && groupIndex === 0;
+  const isDeletebleEditingApproverGroup = isEditable && editingApproverGroups.length > 1;
+  const isChangeableApprovealType = isEditable && editingApproverGroup.approvers.length > 1;
   const isApprovalTypeAnd = editingApprovalType === WorkflowApprovalType.AND;
 
   // for updated
@@ -69,9 +78,14 @@ const ApproverGroupCard = (props: Props & { groupIndex: number }): JSX.Element =
 
   return (
     <>
-      {onClickAddApproverGroupCard != null && groupIndex === 0 && isCreatableEditingApproverGroup && (
+      {onClickAddApproverGroupCard != null && groupIndex === 0 && (
         <div className="text-center my-2">
-          <button type="button" onClick={() => onClickAddApproverGroupCard(Math.max(0, groupIndex - 1))}>{t('approval_workflow.add_flow')}</button>
+          <button
+            type="button"
+            disabled={!isCreatableTopApporverGroup}
+            onClick={() => onClickAddApproverGroupCard(Math.max(0, groupIndex - 1))}
+          >{t('approval_workflow.add_flow')}
+          </button>
         </div>
       )}
 
@@ -80,6 +94,7 @@ const ApproverGroupCard = (props: Props & { groupIndex: number }): JSX.Element =
 
           <div className="d-flex justify-content-center align-items-center">
             <SearchUserTypeahead
+              isEditable={isEditable}
               selectedUsers={selectedUsers}
               excludedSearchUserIds={excludedSearchUserIds}
               onChange={updateApproversHandler}
@@ -131,9 +146,14 @@ const ApproverGroupCard = (props: Props & { groupIndex: number }): JSX.Element =
         </div>
       </div>
 
-      {onClickAddApproverGroupCard != null && isCreatableEditingApproverGroup && (
+      {onClickAddApproverGroupCard != null && (
         <div className="text-center my-2">
-          <button type="button" onClick={() => onClickAddApproverGroupCard(Math.max(0, groupIndex + 1))}>{t('approval_workflow.add_flow')}</button>
+          <button
+            type="button"
+            disabled={!isCreatableButtomApproverGroup}
+            onClick={() => onClickAddApproverGroupCard(Math.max(0, groupIndex + 1))}
+          >{t('approval_workflow.add_flow')}
+          </button>
         </div>
       )}
     </>

--- a/apps/app/src/features/approval-workflow/client/components/ModalComponents/EditableApproverGroupCards.tsx
+++ b/apps/app/src/features/approval-workflow/client/components/ModalComponents/EditableApproverGroupCards.tsx
@@ -19,7 +19,7 @@ type Props = {
   onClickRemoveApproverGroupCard?: (groupIndex: number) => void
 }
 
-const ApproverGroupCard = (props: Props & { groupIndex: number }): JSX.Element => {
+const EditableApproverGroupCard = (props: Props & { groupIndex: number }): JSX.Element => {
   const {
     groupIndex,
     editingApproverGroups,
@@ -160,11 +160,11 @@ const ApproverGroupCard = (props: Props & { groupIndex: number }): JSX.Element =
   );
 };
 
-export const ApproverGroupCards = (props: Props): JSX.Element => {
+export const EditableApproverGroupCards = (props: Props): JSX.Element => {
   return (
     <>
       {props.editingApproverGroups?.map((data, index) => (
-        <ApproverGroupCard
+        <EditableApproverGroupCard
           key={data.uuidForRenderList}
           groupIndex={index}
           {...props}

--- a/apps/app/src/features/approval-workflow/client/components/ModalComponents/SearchUserTypeahead.tsx
+++ b/apps/app/src/features/approval-workflow/client/components/ModalComponents/SearchUserTypeahead.tsx
@@ -10,6 +10,7 @@ import { IClearable } from '~/client/interfaces/clearable';
 import { useSWRMUTxSearchUser } from '~/stores/user';
 
 type Props = {
+  selectedUsers?: IUserHasId[] // for updated
   excludedSearchUserIds?: string[]
   onChange?: (userIds: string[]) => void
   onRemoveLastEddtingApprover?: () => void
@@ -19,7 +20,7 @@ export const SearchUserTypeahead = (props: Props): JSX.Element => {
   const { t } = useTranslation();
 
   const {
-    excludedSearchUserIds, onChange, onRemoveLastEddtingApprover,
+    selectedUsers, excludedSearchUserIds, onChange, onRemoveLastEddtingApprover,
   } = props;
 
   const typeaheadRef = useRef<IClearable>(null);
@@ -67,6 +68,7 @@ export const SearchUserTypeahead = (props: Props): JSX.Element => {
         onChange={onChangeHandler}
         options={userData?.docs ?? []}
         labelKey={(doc: IUserHasId) => doc.username}
+        defaultSelected={selectedUsers ?? undefined}
       />
     </div>
   );

--- a/apps/app/src/features/approval-workflow/client/components/ModalComponents/SearchUserTypeahead.tsx
+++ b/apps/app/src/features/approval-workflow/client/components/ModalComponents/SearchUserTypeahead.tsx
@@ -10,6 +10,7 @@ import { IClearable } from '~/client/interfaces/clearable';
 import { useSWRMUTxSearchUser } from '~/stores/user';
 
 type Props = {
+  isEditable: boolean
   selectedUsers?: IUserHasId[] // for updated
   excludedSearchUserIds?: string[]
   onChange?: (userIds: string[]) => void
@@ -20,7 +21,7 @@ export const SearchUserTypeahead = (props: Props): JSX.Element => {
   const { t } = useTranslation();
 
   const {
-    selectedUsers, excludedSearchUserIds, onChange, onRemoveLastEddtingApprover,
+    isEditable, selectedUsers, excludedSearchUserIds, onChange, onRemoveLastEddtingApprover,
   } = props;
 
   const typeaheadRef = useRef<IClearable>(null);
@@ -59,6 +60,7 @@ export const SearchUserTypeahead = (props: Props): JSX.Element => {
         id="user-typeahead-asynctypeahead"
         ref={typeaheadRef}
         multiple
+        disabled={!isEditable}
         delay={200}
         minLength={1}
         useCache={false}
@@ -66,9 +68,9 @@ export const SearchUserTypeahead = (props: Props): JSX.Element => {
         isLoading={isMutating}
         onSearch={onSearchHandler}
         onChange={onChangeHandler}
+        defaultSelected={selectedUsers}
         options={userData?.docs ?? []}
         labelKey={(doc: IUserHasId) => doc.username}
-        defaultSelected={selectedUsers ?? undefined}
       />
     </div>
   );

--- a/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowCreationModalContent.tsx
+++ b/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowCreationModalContent.tsx
@@ -9,7 +9,7 @@ import { useCurrentUser } from '~/stores/context';
 import { useEditingApproverGroups } from '../../services/workflow';
 import { useSWRMUTxCreateWorkflow } from '../../stores/workflow';
 
-import { ApproverGroupCards } from './ApproverGroupCards';
+import { EditableApproverGroupCards } from './EditableApproverGroupCards';
 import { WorkflowModalHeader } from './WorkflowModalHeader';
 
 type Props = {
@@ -113,7 +113,7 @@ export const WorkflowCreationModalContent = (props: Props): JSX.Element => {
           </div>
         </div>
 
-        <ApproverGroupCards
+        <EditableApproverGroupCards
           editingApproverGroups={editingApproverGroups}
           excludedSearchUserIds={excludedSearchUserIds}
           onUpdateApproverGroups={updateApproverGroupHandler}

--- a/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowEditModalContent.tsx
+++ b/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowEditModalContent.tsx
@@ -5,6 +5,7 @@ import { ModalBody, ModalFooter } from 'reactstrap';
 
 import { IWorkflowHasId } from '~/features/approval-workflow/interfaces/workflow';
 
+import { getLatestApprovedApproverGroupIndex } from '../../../utils/workflow';
 import { useEditingApproverGroups } from '../../services/workflow';
 import { useSWRxWorkflow } from '../../stores/workflow';
 
@@ -31,6 +32,7 @@ export const WorkflowEditModalContent = (props: Props): JSX.Element => {
 
   const { update: updateWorkflow } = useSWRxWorkflow(workflow?._id);
 
+  const latestApprovedApproverGroupIndex = getLatestApprovedApproverGroupIndex(workflow);
   const excludedSearchUserIds = [workflow.creator._id, ...allEditingApproverIds];
 
   const clickSaveWorkflowButtonClickHandler = useCallback(async() => {
@@ -64,6 +66,7 @@ export const WorkflowEditModalContent = (props: Props): JSX.Element => {
         <ApproverGroupCards
           editingApproverGroups={editingApproverGroups}
           excludedSearchUserIds={excludedSearchUserIds}
+          latestApprovedApproverGroupIndex={latestApprovedApproverGroupIndex ?? undefined}
           onUpdateApproverGroups={updateApproverGroupHandler}
           onClickAddApproverGroupCard={addApproverGroupHandler}
           onClickRemoveApproverGroupCard={removeApproverGroupHandler}

--- a/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowEditModalContent.tsx
+++ b/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowEditModalContent.tsx
@@ -9,7 +9,7 @@ import { getLatestApprovedApproverGroupIndex } from '../../../utils/workflow';
 import { useEditingApproverGroups } from '../../services/workflow';
 import { useSWRxWorkflow } from '../../stores/workflow';
 
-import { ApproverGroupCards } from './ApproverGroupCards';
+import { EditableApproverGroupCards } from './EditableApproverGroupCards';
 import { WorkflowModalHeader } from './WorkflowModalHeader';
 
 type Props = {
@@ -63,7 +63,7 @@ export const WorkflowEditModalContent = (props: Props): JSX.Element => {
       />
 
       <ModalBody>
-        <ApproverGroupCards
+        <EditableApproverGroupCards
           editingApproverGroups={editingApproverGroups}
           excludedSearchUserIds={excludedSearchUserIds}
           latestApprovedApproverGroupIndex={latestApprovedApproverGroupIndex ?? undefined}

--- a/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowEditModalContent.tsx
+++ b/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowEditModalContent.tsx
@@ -8,6 +8,7 @@ import { IWorkflowHasId } from '~/features/approval-workflow/interfaces/workflow
 import { useEditingApproverGroups } from '../../services/workflow';
 import { useSWRxWorkflow } from '../../stores/workflow';
 
+import { ApproverGroupCards } from './ApproverGroupCards';
 import { WorkflowModalHeader } from './WorkflowModalHeader';
 
 type Props = {
@@ -21,12 +22,16 @@ export const WorkflowEditModalContent = (props: Props): JSX.Element => {
 
   const { workflow, onUpdated, onClickWorkflowDetailPageBackButton } = props;
 
-  const { editingApproverGroups } = useEditingApproverGroups(workflow.approverGroups);
+  const {
+    editingApproverGroups, allEditingApproverIds, updateApproverGroupHandler, addApproverGroupHandler, removeApproverGroupHandler,
+  } = useEditingApproverGroups(workflow.approverGroups);
 
   const [editingWorkflowName, setEditingWorkflowName] = useState<string | undefined>(workflow.name);
   const [editingWorkflowDescription, setEditingWorkflowDescription] = useState<string | undefined>(workflow.comment);
 
   const { update: updateWorkflow } = useSWRxWorkflow(workflow?._id);
+
+  const excludedSearchUserIds = [workflow.creator._id, ...allEditingApproverIds];
 
   const clickSaveWorkflowButtonClickHandler = useCallback(async() => {
     try {
@@ -56,7 +61,13 @@ export const WorkflowEditModalContent = (props: Props): JSX.Element => {
       />
 
       <ModalBody>
-        Edit Page
+        <ApproverGroupCards
+          editingApproverGroups={editingApproverGroups}
+          excludedSearchUserIds={excludedSearchUserIds}
+          onUpdateApproverGroups={updateApproverGroupHandler}
+          onClickAddApproverGroupCard={addApproverGroupHandler}
+          onClickRemoveApproverGroupCard={removeApproverGroupHandler}
+        />
       </ModalBody>
 
       <ModalFooter>

--- a/apps/app/src/features/approval-workflow/client/services/workflow.ts
+++ b/apps/app/src/features/approval-workflow/client/services/workflow.ts
@@ -53,11 +53,6 @@ type UseEditingApproverGroupsForUpdate = {
   removeApproverGroupHandler: (groupIndex: number) => void
 }
 
-// type UseEditingApproverGroups = {
-//   (): UseEditingApproverGroupsForCreate
-//   (initialData: IWorkflowApproverGroupHasId[]): UseEditingApproverGroupsForUpdate
-// };
-
 export function useEditingApproverGroups(): UseEditingApproverGroupsForCreate
 export function useEditingApproverGroups(initialData: IWorkflowApproverGroupHasId[]): UseEditingApproverGroupsForUpdate
 
@@ -68,7 +63,6 @@ export function useEditingApproverGroups(initialData?: IWorkflowApproverGroupHas
 
   const allEditingApproverIds = useMemo(() => getAllApproverIds(editingApproverGroups), [editingApproverGroups]);
 
-  // eslint-disable-next-line max-len
   const updateApproverGroupHandler = useCallback((groupIndex: number, updateApproverGroupData: EditingApproverGroup) => {
     const clonedApproverGroups = [...editingApproverGroups];
     clonedApproverGroups[groupIndex] = updateApproverGroupData;

--- a/apps/app/src/features/approval-workflow/interfaces/workflow.ts
+++ b/apps/app/src/features/approval-workflow/interfaces/workflow.ts
@@ -61,6 +61,8 @@ export type IWorkflowReq = Omit<IWorkflow, '_id' | 'creator' | 'approverGroups' 
   & { creator: ObjectIdLike, approverGroups: IWorkflowApproverGroupReq[] }
 
 export type IWorkflowApproverGroupReqForRenderList = IWorkflowApproverGroupReq & { uuidForRenderList: string };
+export type IWorkflowApproverGroupForRenderList = IWorkflowApproverGroupHasId & { uuidForRenderList: string };
+export type EditingApproverGroup = IWorkflowApproverGroupReqForRenderList | IWorkflowApproverGroupForRenderList
 
 // TODO: If you don't need it, delete it
 export type IWorkflowApproverHasId = IWorkflowApprover & HasObjectId;

--- a/apps/app/src/features/approval-workflow/utils/workflow.ts
+++ b/apps/app/src/features/approval-workflow/utils/workflow.ts
@@ -1,0 +1,14 @@
+import { IWorkflowHasId } from '../interfaces/workflow';
+
+export const getLatestApprovedApproverGroupIndex = (workflow: IWorkflowHasId): number | null => {
+  const apprverGroupsLength = workflow.approverGroups.length;
+
+  for (let i = apprverGroupsLength; i > 0; i--) {
+    const groupIndex = i - 1;
+    if (workflow.approverGroups[groupIndex].isApproved) {
+      return groupIndex;
+    }
+  }
+
+  return null;
+};


### PR DESCRIPTION
## Task
[#132622](https://redmine.weseek.co.jp/issues/132622) [approval-workflow] XD 通りにワークフロー編集画面を実装しワークフローを編集できる
┗ [#133880](https://redmine.weseek.co.jp/issues/133880) [client] ApproverGroupCard.tsx を新規作成画面と編集画面で使いまわせるように改修

## ScreenRecord
https://github.com/weseek/growi/assets/34241526/8b9d620f-b946-4811-9ba5-2c0fbe786df5


