### PR TITLE
feat: Add search button to suvnavigation

### DIFF
--- a/apps/app/src/components/PageControls/PageControls.tsx
+++ b/apps/app/src/components/PageControls/PageControls.tsx
@@ -26,6 +26,7 @@ import {
 
 import { BookmarkButtons } from './BookmarkButtons';
 import LikeButtons from './LikeButtons';
+import SearchButton from './SearchButton';
 import SeenUserInfo from './SeenUserInfo';
 import SubscribeButton from './SubscribeButton';
 
@@ -241,6 +242,7 @@ const PageControlsSubstance = (props: PageControlsSubstanceProps): JSX.Element =
 
   return (
     <div className={`grw-page-controls ${styles['grw-page-controls']} d-flex`} style={{ gap: '2px' }}>
+      <SearchButton />
       {revisionId != null && !isViewMode && (
         <Tags
           onClickEditTagsButton={onClickEditTagsButton}

--- a/apps/app/src/components/PageControls/SearchButton.tsx
+++ b/apps/app/src/components/PageControls/SearchButton.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 
 const SearchButton = (): JSX.Element => {
   return (
-    <button type="button" className="btn">
-      <span className="material-symbols-outlined me-1">search</span>
+    <button type="button" className="btn border-0 d-flex align-items-center">
+      <span className="material-symbols-outlined">search</span>
     </button>
   );
 };

--- a/apps/app/src/components/PageControls/SearchButton.tsx
+++ b/apps/app/src/components/PageControls/SearchButton.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const SearchButton = (): JSX.Element => {
+  return (
+    <button type="button" className="btn">
+      <span className="material-symbols-outlined me-1">search</span>
+    </button>
+  );
+};
+
+export default SearchButton;


### PR DESCRIPTION
## Task
[#134381](https://redmine.weseek.co.jp/issues/134381) [v7][search] subnavigation の search アイコンクリックで全文検索用モーダルを表示できる
┗ [#134539](https://redmine.weseek.co.jp/issues/134539) suvnavigation に search アイコンを設置する

## Screenshot
<img width="338" alt="スクリーンショット 2023-11-13 14 17 18" src="https://github.com/weseek/growi/assets/34241526/883c3c56-5f76-4071-b977-7914a9f6852b">
