### PR TITLE
feat: Approver status can be changed from the UI

### DIFF
--- a/apps/app/public/static/locales/en_US/translation.json
+++ b/apps/app/public/static/locales/en_US/translation.json
@@ -830,11 +830,16 @@
       "AND": "Everyone's approval",
       "OR": "One person's approval"
     },
-    "statuses": {
+    "workflow_status": {
       "INPROGRESS": "IN-PROGRESS",
       "APPROVE": "APPROVE",
       "REJECT": "REJECT",
       "CANCEL": "CANCEL"
+    },
+    "approver_status": {
+      "APPROVE": "Approve",
+      "REMAND": "Remand",
+      "DELEGATE": "Delegate"
     }
   }
 }

--- a/apps/app/public/static/locales/ja_JP/translation.json
+++ b/apps/app/public/static/locales/ja_JP/translation.json
@@ -863,11 +863,16 @@
       "AND": "全員が承認",
       "OR": "1人が承認"
     },
-    "statuses": {
+    "workflow_status": {
       "INPROGRESS": "進行中",
       "APPROVE": "承認",
       "REJECT": "却下",
       "CANCEL": "キャンセル"
+    },
+    "approver_status": {
+      "APPROVE": "承認",
+      "REMAND": "差し戻し",
+      "DELEGATE": "委譲"
     }
   }
 }

--- a/apps/app/public/static/locales/zh_CN/translation.json
+++ b/apps/app/public/static/locales/zh_CN/translation.json
@@ -833,7 +833,7 @@
       "AND": "大家的认可",
       "OR": "一个人的认可"
     },
-    "workflow-statuses": {
+    "workflow_status": {
       "INPROGRESS": "进行中",
       "APPROVE": "批准",
       "REJECT": "拒绝",

--- a/apps/app/public/static/locales/zh_CN/translation.json
+++ b/apps/app/public/static/locales/zh_CN/translation.json
@@ -833,11 +833,16 @@
       "AND": "大家的认可",
       "OR": "一个人的认可"
     },
-    "statuses": {
+    "workflow-statuses": {
       "INPROGRESS": "进行中",
       "APPROVE": "批准",
       "REJECT": "拒绝",
       "CANCEL": "取消"
+    },
+    "approver_status": {
+      "APPROVE": "批准",
+      "REMAND": "还押",
+      "DELEGATE": "代表们"
     }
   }
 }

--- a/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowDetailModalContent.tsx
+++ b/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowDetailModalContent.tsx
@@ -1,10 +1,11 @@
 // TODO: https://redmine.weseek.co.jp/issues/130337
-import React from 'react';
+import React, { useCallback } from 'react';
 
 import { useTranslation } from 'next-i18next';
 import { ModalBody, ModalFooter } from 'reactstrap';
 
-import { IWorkflowHasId } from '../../../interfaces/workflow';
+import { type IWorkflowHasId, WorkflowApproverStatus } from '../../../interfaces/workflow';
+import { useSWRxWorkflow } from '../../stores/workflow';
 
 import { WorkflowModalHeader } from './WorkflowModalHeader';
 
@@ -19,6 +20,16 @@ export const WorkflowDetailModalContent = (props: Props): JSX.Element => {
   const { t } = useTranslation();
 
   const { workflow, onClickWorkflowEditButton, onClickWorkflowListPageBackButton } = props;
+  const { updateApproverStatus } = useSWRxWorkflow(workflow?._id);
+
+  const approveButtonClickHandler = useCallback(async() => {
+    try {
+      updateApproverStatus(WorkflowApproverStatus.APPROVE);
+    }
+    catch (err) {
+      // TODO: Consider how to display errors
+    }
+  }, [updateApproverStatus]);
 
   return (
     <>
@@ -33,6 +44,7 @@ export const WorkflowDetailModalContent = (props: Props): JSX.Element => {
       </ModalBody>
 
       <ModalFooter>
+        <button type="button" onClick={approveButtonClickHandler}>{t('approval_workflow.approver_status.APPROVE')}</button>
       </ModalFooter>
     </>
   );

--- a/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowDetailModalContent.tsx
+++ b/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowDetailModalContent.tsx
@@ -24,7 +24,7 @@ export const WorkflowDetailModalContent = (props: Props): JSX.Element => {
 
   const approveButtonClickHandler = useCallback(async() => {
     try {
-      updateApproverStatus(WorkflowApproverStatus.APPROVE);
+      await updateApproverStatus(WorkflowApproverStatus.APPROVE);
     }
     catch (err) {
       // TODO: Consider how to display errors

--- a/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowListModalContent.tsx
+++ b/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowListModalContent.tsx
@@ -9,7 +9,7 @@ import {
 
 import { useCurrentUser } from '~/stores/context';
 
-import { IWorkflowHasId } from '../../../interfaces/workflow';
+import { type IWorkflowHasId } from '../../../interfaces/workflow';
 import { deleteWorkflow } from '../../services/workflow';
 
 

--- a/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowListModalContent.tsx
+++ b/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowListModalContent.tsx
@@ -127,7 +127,7 @@ export const WorkflowListModalContent = (props: Props): JSX.Element => {
                       </div>
                     </td>
                     <td>
-                      {t(`approval_workflow.statuses.${workflow.status}`)}
+                      {t(`approval_workflow.workflow_status.${workflow.status}`)}
                     </td>
                     <td>
                       {workflow.creator.username}

--- a/apps/app/src/features/approval-workflow/client/stores/workflow.ts
+++ b/apps/app/src/features/approval-workflow/client/stores/workflow.ts
@@ -9,13 +9,14 @@ import useSWRMutation, { type SWRMutationResponse } from 'swr/mutation';
 import { apiv3Get, apiv3Post, apiv3Put } from '~/client/util/apiv3-client';
 import { useStaticSWR } from '~/stores/use-static-swr';
 
-import type {
-  IWorkflowHasId,
-  IWorkflowPaginateResult,
-  EditingApproverGroup,
-  CreateWorkflowApproverGroupData,
-  CreateApproverGroupData,
-  UpdateApproverGroupData,
+import {
+  WorkflowApproverStatus,
+  type IWorkflowHasId,
+  type IWorkflowPaginateResult,
+  type EditingApproverGroup,
+  type CreateWorkflowApproverGroupData,
+  type CreateApproverGroupData,
+  type UpdateApproverGroupData,
 } from '../../interfaces/workflow';
 
 
@@ -54,6 +55,7 @@ type UpdateWorkflowData = {
 
 type UseSWRxWorkflowUtils = {
   update(updateData: UpdateWorkflowData): Promise<void>
+  updateApproverStatus(approverStatus: WorkflowApproverStatus): Promise<void>
 };
 
 export const useSWRxWorkflow = (workflowId?: string): SWRResponseWithUtils<UseSWRxWorkflowUtils, IWorkflowHasId, Error> => {
@@ -75,7 +77,12 @@ export const useSWRxWorkflow = (workflowId?: string): SWRResponseWithUtils<UseSW
     swrResponse.mutate(response.data.updatedWorkflow);
   }, [swrResponse, workflowId]);
 
-  return withUtils<UseSWRxWorkflowUtils, IWorkflowHasId, Error>(swrResponse, { update });
+  const updateApproverStatus = useCallback(async(approverStatus: WorkflowApproverStatus) => {
+    const response = await apiv3Put(`/workflow/${workflowId}/status`, { approverStatus });
+    swrResponse.mutate(response.data.updatedWorkflow);
+  }, [swrResponse, workflowId]);
+
+  return withUtils<UseSWRxWorkflowUtils, IWorkflowHasId, Error>(swrResponse, { update, updateApproverStatus });
 };
 
 

--- a/apps/app/src/features/approval-workflow/client/stores/workflow.ts
+++ b/apps/app/src/features/approval-workflow/client/stores/workflow.ts
@@ -68,6 +68,10 @@ export const useSWRxWorkflow = (workflowId?: string): SWRResponseWithUtils<UseSW
 
   // utils
   const update = useCallback(async(updateData: UpdateWorkflowData) => {
+    if (workflowId == null) {
+      throw Error('workflowId is null');
+    }
+
     const response = await apiv3Put(`/workflow/${workflowId}`, {
       name: updateData.name,
       comment: updateData.comment,
@@ -78,6 +82,10 @@ export const useSWRxWorkflow = (workflowId?: string): SWRResponseWithUtils<UseSW
   }, [swrResponse, workflowId]);
 
   const updateApproverStatus = useCallback(async(approverStatus: WorkflowApproverStatus) => {
+    if (workflowId == null) {
+      throw Error('workflowId is null');
+    }
+
     const response = await apiv3Put(`/workflow/${workflowId}/status`, { approverStatus });
     swrResponse.mutate(response.data.updatedWorkflow);
   }, [swrResponse, workflowId]);


### PR DESCRIPTION
## Task
[#130337](https://redmine.weseek.co.jp/issues/130337) [approval-workflow] XD 通りにワークフロー詳細画面を実装しワークフローのステータスを更新することができる
┗ [#135171](https://redmine.weseek.co.jp/issues/135171) PUT: /:workflowId/status (承認時) を叩く fetcher の実装
┗ [#135173](https://redmine.weseek.co.jp/issues/135173) 「承認」ボタンを設置し、ボタンを押下した時に approver.status を "APPROVE" にできる