### PR TITLE
feat: Uneditable approver group card

### DIFF
--- a/apps/app/public/static/locales/en_US/translation.json
+++ b/apps/app/public/static/locales/en_US/translation.json
@@ -837,6 +837,7 @@
       "CANCEL": "CANCEL"
     },
     "approver_status": {
+      "NONE": "Unapproved",
       "APPROVE": "Approve",
       "REMAND": "Remand",
       "DELEGATE": "Delegate"

--- a/apps/app/public/static/locales/ja_JP/translation.json
+++ b/apps/app/public/static/locales/ja_JP/translation.json
@@ -870,6 +870,7 @@
       "CANCEL": "キャンセル"
     },
     "approver_status": {
+      "NONE": "未承認",
       "APPROVE": "承認",
       "REMAND": "差し戻し",
       "DELEGATE": "委譲"

--- a/apps/app/public/static/locales/zh_CN/translation.json
+++ b/apps/app/public/static/locales/zh_CN/translation.json
@@ -840,6 +840,7 @@
       "CANCEL": "取消"
     },
     "approver_status": {
+      "NONE": "未经批准",
       "APPROVE": "批准",
       "REMAND": "还押",
       "DELEGATE": "代表们"

--- a/apps/app/src/features/approval-workflow/client/components/ModalComponents/ApproverGroupCards.tsx
+++ b/apps/app/src/features/approval-workflow/client/components/ModalComponents/ApproverGroupCards.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+
+import { UserPicture } from '@growi/ui/dist/components';
+import { useTranslation } from 'next-i18next';
+
+
+import {
+  IWorkflowHasId,
+  IWorkflowApproverGroupHasId,
+  IWorkflowApproverHasId,
+} from '../../../interfaces/workflow';
+
+
+type ApproverItemProps = {
+  approver: IWorkflowApproverHasId
+}
+
+const ApproverItem = (props: ApproverItemProps): JSX.Element => {
+  const { approver } = props;
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <div className="container my-2">
+        <div className="row">
+          <div className="col-4">
+            <UserPicture user={approver.user} />
+          </div>
+          <div className="col-4">
+            { approver.user.username }
+          </div>
+          <div className="col-4">
+            { t(`approval_workflow.approver_status.${approver.status}`)}
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+
+type ApproverGroupCardProps = {
+  approverGroup: IWorkflowApproverGroupHasId
+}
+
+const ApproverGroupCard = (props: ApproverGroupCardProps): JSX.Element => {
+  const { approverGroup } = props;
+
+  const approvers = approverGroup.approvers;
+
+  return (
+    <div className="card rounded  my-2">
+      <div className="card-body">
+        { approvers.map(approver => (
+          <ApproverItem
+            key={approver._id}
+            approver={approver}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+
+type ApproverGroupCardsProps = {
+  workflow: IWorkflowHasId;
+};
+
+export const ApproverGroupCards = (props: ApproverGroupCardsProps): JSX.Element => {
+  const { workflow } = props;
+
+  const approverGroups = workflow.approverGroups;
+
+
+  return (
+    <>
+      {approverGroups.map(approverGroup => (
+        <ApproverGroupCard
+          key={approverGroup._id}
+          approverGroup={approverGroup}
+        />
+      ))}
+    </>
+  );
+};

--- a/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowDetailModalContent.tsx
+++ b/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowDetailModalContent.tsx
@@ -7,6 +7,7 @@ import { ModalBody, ModalFooter } from 'reactstrap';
 import { type IWorkflowHasId, WorkflowApproverStatus } from '../../../interfaces/workflow';
 import { useSWRxWorkflow } from '../../stores/workflow';
 
+import { ApproverGroupCards } from './ApproverGroupCards';
 import { WorkflowModalHeader } from './WorkflowModalHeader';
 
 
@@ -31,6 +32,10 @@ export const WorkflowDetailModalContent = (props: Props): JSX.Element => {
     }
   }, [updateApproverStatus]);
 
+  if (workflow == null) {
+    return <></>;
+  }
+
   return (
     <>
       <WorkflowModalHeader
@@ -40,7 +45,8 @@ export const WorkflowDetailModalContent = (props: Props): JSX.Element => {
 
       <ModalBody>
         <button type="button" onClick={() => { onClickWorkflowEditButton() }}>{t('approval_workflow.edit')}</button>
-        詳細ページ
+        <ApproverGroupCards workflow={workflow} />
+
       </ModalBody>
 
       <ModalFooter>

--- a/apps/app/src/features/approval-workflow/interfaces/workflow.ts
+++ b/apps/app/src/features/approval-workflow/interfaces/workflow.ts
@@ -33,7 +33,7 @@ export type WorkflowApproverStatus = typeof WorkflowApproverStatus[keyof typeof 
 export type WorkflowApprovalType = typeof WorkflowApprovalType [keyof typeof WorkflowApprovalType];
 
 
-type IWorkflowApproverHasId = {
+export type IWorkflowApproverHasId = {
   _id: string,
   user: IUserHasId,
   status: WorkflowApproverStatus,


### PR DESCRIPTION
## Task
[#130337](https://redmine.weseek.co.jp/issues/130337) [approval-workflow] XD 通りにワークフロー詳細画面を実装しワークフローのステータスを更新することができる
┗ [#135169](https://redmine.weseek.co.jp/issues/135169) uneditable な ApproverGroupCard の実装