### PR TITLE
imprv: WorkflowDetailModalContent

### DIFF
--- a/apps/app/public/static/locales/en_US/translation.json
+++ b/apps/app/public/static/locales/en_US/translation.json
@@ -827,6 +827,10 @@
     "completion_conditions": "Completion conditions",
     "cannot_change_approval_type": "Cannot be changed when there is only one approver",
     "description_for_new_creation": "When the final flow is completed, the workflow is marked as finished",
+    "detail_modal_content_message": {
+      "INPROGRESS": "The workflow is complete when the last flow is completed",
+      "APPROVE": "Workflow has been completed"
+    },
     "approval_type": {
       "AND": "Everyone's approval",
       "OR": "One person's approval"

--- a/apps/app/public/static/locales/ja_JP/translation.json
+++ b/apps/app/public/static/locales/ja_JP/translation.json
@@ -860,6 +860,10 @@
     "completion_conditions": "完了条件",
     "cannot_change_approval_type": "承認者が1人の時は変更できません",
     "description_for_new_creation": "最後のフローが完了するとワークフローは完了になります",
+    "detail_modal_content_message": {
+      "INPROGRESS": "最後のフローが完了するとワークフローは完了になります",
+      "APPROVE": "ワークフローが完了しました"
+    },
     "approval_type": {
       "AND": "全員が承認",
       "OR": "1人が承認"

--- a/apps/app/public/static/locales/zh_CN/translation.json
+++ b/apps/app/public/static/locales/zh_CN/translation.json
@@ -830,6 +830,10 @@
     "completion_conditions": "完工条件",
     "cannot_change_approval_type": "如果只有一个审批人，则无法更改",
     "description_for_new_creation": "当最终流程完成时，工作流程被标记为已完成",
+    "detail_modal_content_message": {
+      "INPROGRESS": "当最后一个流程完成时，工作流程完成",
+      "APPROVE": "工作流程已完成"
+    },
     "approval_type": {
       "AND": "大家的认可",
       "OR": "一个人的认可"

--- a/apps/app/src/features/approval-workflow/client/components/ModalComponents/ApproverGroupCards.tsx
+++ b/apps/app/src/features/approval-workflow/client/components/ModalComponents/ApproverGroupCards.tsx
@@ -82,10 +82,14 @@ const ApproverGroupCard = (props: ApproverGroupCardProps): JSX.Element => {
   const { approverGroup } = props;
 
   const approvers = approverGroup.approvers;
+  const isApproved = approverGroup.isApproved;
 
   return (
-    <div className="card rounded my-3">
+    <div className="card rounded my-4">
       <div className="card-body">
+        { isApproved && (
+          <span className="material-symbols-outlined fs-2 position-absolute top-0 start-0 translate-middle text-success">check_circle</span>
+        )}
         { approvers.map(approver => (
           <>
             <CreatorOrApproverItem

--- a/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowCreationModalContent.tsx
+++ b/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowCreationModalContent.tsx
@@ -67,10 +67,9 @@ export const WorkflowCreationModalContent = (props: Props): JSX.Element => {
 
   return (
     <>
-      <WorkflowModalHeader
-        title={t('approval_workflow.create_new')}
-        onClickPageBackButton={() => onClickWorkflowListPageBackButton()}
-      />
+      <WorkflowModalHeader onClickPageBackButton={() => onClickWorkflowListPageBackButton()}>
+        <span className="fw-bold">{t('approval_workflow.create_new')}</span>
+      </WorkflowModalHeader>
 
       <ModalBody>
         <div className="mb-3">

--- a/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowDetailModalContent.tsx
+++ b/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowDetailModalContent.tsx
@@ -57,16 +57,27 @@ export const WorkflowDetailModalContent = (props: Props): JSX.Element => {
     }
   }, [updateApproverStatus]);
 
+  const getBadgeColor = useCallback(() => {
+    switch (workflow?.status) {
+      case WorkflowStatus.INPROGRESS:
+        return 'text-bg-primary';
+      case WorkflowStatus.APPROVE:
+        return 'text-bg-success';
+      default:
+        return '';
+    }
+  }, [workflow?.status]);
+
   if (workflow == null) {
     return <></>;
   }
 
   return (
     <>
-      <WorkflowModalHeader
-        title={workflow?.name ?? ''}
-        onClickPageBackButton={onClickWorkflowListPageBackButton}
-      />
+      <WorkflowModalHeader onClickPageBackButton={onClickWorkflowListPageBackButton}>
+        <span className={`badge rounded-pill ${getBadgeColor()}`}>{t(`approval_workflow.workflow_status.${workflow.status}`)}</span>
+        <span className="fw-bold">{workflow.name}</span>
+      </WorkflowModalHeader>
 
       <ModalBody>
         <button type="button" disabled={!isAbleEditButton} onClick={onClickWorkflowEditButton}>{t('approval_workflow.edit')}</button>

--- a/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowDetailModalContent.tsx
+++ b/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowDetailModalContent.tsx
@@ -30,24 +30,23 @@ export const WorkflowDetailModalContent = (props: Props): JSX.Element => {
   const { data: currentUser } = useCurrentUser();
   const { updateApproverStatus } = useSWRxWorkflow(workflow?._id);
 
-  const isExistApprover = useCallback(() => {
+  const findApprover = useCallback(() => {
     if (workflow == null || currentUser == null) {
-      return false;
+      return;
     }
 
     for (const approverGroup of workflow.approverGroups) {
       for (const approver of approverGroup.approvers) {
         if (approver.user._id === currentUser._id) {
-          return true;
+          return approver;
         }
       }
     }
-
-    return false;
   }, [currentUser, workflow]);
 
-  const isAbleEditButton = workflow?.status === WorkflowStatus.INPROGRESS && (currentUser?.admin || isExistApprover());
-  const isAbleApproveButton = workflow?.status === WorkflowStatus.INPROGRESS && isExistApprover();
+  const approver = findApprover();
+  const isAbleEditButton = workflow?.status === WorkflowStatus.INPROGRESS && (currentUser?.admin || approver != null);
+  const isAbleApproveButton = workflow?.status === WorkflowStatus.INPROGRESS && approver != null && approver.status === WorkflowApproverStatus.NONE;
 
   const approveButtonClickHandler = useCallback(async() => {
     try {

--- a/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowDetailModalContent.tsx
+++ b/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowDetailModalContent.tsx
@@ -18,12 +18,15 @@ import { WorkflowModalHeader } from './WorkflowModalHeader';
 
 type Props = {
   workflow?: IWorkflowHasId,
+  onUpdate?: () => void,
   onClickWorkflowEditButton: () => void,
   onClickWorkflowListPageBackButton: () => void,
 }
 
 export const WorkflowDetailModalContent = (props: Props): JSX.Element => {
-  const { workflow, onClickWorkflowEditButton, onClickWorkflowListPageBackButton } = props;
+  const {
+    workflow, onUpdate, onClickWorkflowEditButton, onClickWorkflowListPageBackButton,
+  } = props;
 
   const { t } = useTranslation();
 
@@ -51,11 +54,14 @@ export const WorkflowDetailModalContent = (props: Props): JSX.Element => {
   const approveButtonClickHandler = useCallback(async() => {
     try {
       await updateApproverStatus(WorkflowApproverStatus.APPROVE);
+      if (onUpdate != null) {
+        return onUpdate();
+      }
     }
     catch (err) {
       // TODO: Consider how to display errors
     }
-  }, [updateApproverStatus]);
+  }, [onUpdate, updateApproverStatus]);
 
   const getBadgeColor = useCallback(() => {
     switch (workflow?.status) {

--- a/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowDetailModalContent.tsx
+++ b/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowDetailModalContent.tsx
@@ -75,14 +75,14 @@ export const WorkflowDetailModalContent = (props: Props): JSX.Element => {
   return (
     <>
       <WorkflowModalHeader onClickPageBackButton={onClickWorkflowListPageBackButton}>
-        <span className={`badge rounded-pill ${getBadgeColor()}`}>{t(`approval_workflow.workflow_status.${workflow.status}`)}</span>
-        <span className="fw-bold">{workflow.name}</span>
+        <div className={`me-2 badge rounded-pill ${getBadgeColor()}`}>{t(`approval_workflow.workflow_status.${workflow.status}`)}</div>
+        <div className="fw-bold">{workflow.name}</div>
       </WorkflowModalHeader>
 
       <ModalBody>
         <button type="button" disabled={!isAbleEditButton} onClick={onClickWorkflowEditButton}>{t('approval_workflow.edit')}</button>
         <ApproverGroupCards workflow={workflow} />
-        <div className="mt-4 text-center">{t(`approval_workflow.detail_modal_content_message.${workflow.status}`)}</div>
+        <div className="text-center">{t(`approval_workflow.detail_modal_content_message.${workflow.status}`)}</div>
       </ModalBody>
 
       <ModalFooter>

--- a/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowDetailModalContent.tsx
+++ b/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowDetailModalContent.tsx
@@ -33,7 +33,7 @@ export const WorkflowDetailModalContent = (props: Props): JSX.Element => {
   const { data: currentUser } = useCurrentUser();
   const { updateApproverStatus } = useSWRxWorkflow(workflow?._id);
 
-  const findApprover = useCallback(() => {
+  const findApprover = () => {
     if (workflow == null || currentUser == null) {
       return;
     }
@@ -45,7 +45,7 @@ export const WorkflowDetailModalContent = (props: Props): JSX.Element => {
         }
       }
     }
-  }, [currentUser, workflow]);
+  };
 
   const approver = findApprover();
   const isAbleEditButton = workflow?.status === WorkflowStatus.INPROGRESS && (currentUser?.admin || approver != null);
@@ -54,9 +54,7 @@ export const WorkflowDetailModalContent = (props: Props): JSX.Element => {
   const approveButtonClickHandler = useCallback(async() => {
     try {
       await updateApproverStatus(WorkflowApproverStatus.APPROVE);
-      if (onUpdate != null) {
-        return onUpdate();
-      }
+      onUpdate?.();
     }
     catch (err) {
       // TODO: Consider how to display errors

--- a/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowDetailModalContent.tsx
+++ b/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowDetailModalContent.tsx
@@ -72,6 +72,7 @@ export const WorkflowDetailModalContent = (props: Props): JSX.Element => {
       <ModalBody>
         <button type="button" disabled={!isAbleEditButton} onClick={onClickWorkflowEditButton}>{t('approval_workflow.edit')}</button>
         <ApproverGroupCards workflow={workflow} />
+        <div className="mt-4 text-center">{t(`approval_workflow.detail_modal_content_message.${workflow.status}`)}</div>
       </ModalBody>
 
       <ModalFooter>

--- a/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowDetailModalContent.tsx
+++ b/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowDetailModalContent.tsx
@@ -5,7 +5,11 @@ import { ModalBody, ModalFooter } from 'reactstrap';
 
 import { useCurrentUser } from '~/stores/context';
 
-import { type IWorkflowHasId, WorkflowApproverStatus } from '../../../interfaces/workflow';
+import {
+  type IWorkflowHasId,
+  WorkflowStatus,
+  WorkflowApproverStatus,
+} from '../../../interfaces/workflow';
 import { useSWRxWorkflow } from '../../stores/workflow';
 
 import { ApproverGroupCards } from './ApproverGroupCards';
@@ -42,6 +46,9 @@ export const WorkflowDetailModalContent = (props: Props): JSX.Element => {
     return false;
   }, [currentUser, workflow]);
 
+  const isAbleEditButton = workflow?.status === WorkflowStatus.INPROGRESS && (currentUser?.admin || isExistApprover());
+  const isAbleApproveButton = workflow?.status === WorkflowStatus.INPROGRESS && isExistApprover();
+
   const approveButtonClickHandler = useCallback(async() => {
     try {
       await updateApproverStatus(WorkflowApproverStatus.APPROVE);
@@ -63,12 +70,12 @@ export const WorkflowDetailModalContent = (props: Props): JSX.Element => {
       />
 
       <ModalBody>
-        <button type="button" disabled={!isExistApprover() && !currentUser?.admin} onClick={onClickWorkflowEditButton}>{t('approval_workflow.edit')}</button>
+        <button type="button" disabled={!isAbleEditButton} onClick={onClickWorkflowEditButton}>{t('approval_workflow.edit')}</button>
         <ApproverGroupCards workflow={workflow} />
       </ModalBody>
 
       <ModalFooter>
-        <button type="button" disabled={!isExistApprover()} onClick={approveButtonClickHandler}>{t('approval_workflow.approver_status.APPROVE')}</button>
+        <button type="button" disabled={!isAbleApproveButton} onClick={approveButtonClickHandler}>{t('approval_workflow.approver_status.APPROVE')}</button>
       </ModalFooter>
     </>
   );

--- a/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowEditModalContent.tsx
+++ b/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowEditModalContent.tsx
@@ -172,10 +172,9 @@ export const WorkflowEditModalContent = (props: Props): JSX.Element => {
 
   return (
     <>
-      <WorkflowModalHeader
-        title={t('approval_workflow.edit_workflow')}
-        onClickPageBackButton={onClickWorkflowDetailPageBackButton}
-      />
+      <WorkflowModalHeader onClickPageBackButton={onClickWorkflowDetailPageBackButton}>
+        <span className="fw-bold">{t('approval_workflow.edit_workflow')} </span>
+      </WorkflowModalHeader>
 
       <ModalBody>
         <div className="mb-3">

--- a/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowEditModalContent.tsx
+++ b/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowEditModalContent.tsx
@@ -160,9 +160,7 @@ export const WorkflowEditModalContent = (props: Props): JSX.Element => {
       };
       await updateWorkflow(updateData);
 
-      if (onUpdated != null) {
-        onUpdated();
-      }
+      onUpdated?.();
     }
     catch (err) {
       // TODO: Consider how to display errors

--- a/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowListModalContent.tsx
+++ b/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowListModalContent.tsx
@@ -92,9 +92,9 @@ export const WorkflowListModalContent = (props: Props): JSX.Element => {
 
   return (
     <>
-      <WorkflowModalHeader
-        title={t('approval_workflow.list')}
-      />
+      <WorkflowModalHeader>
+        <span className="fw-bold">{t('approval_workflow.list')}</span>
+      </WorkflowModalHeader>
 
       <ModalBody>
         {(workflows.length === 0) && (

--- a/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowListModalContent.tsx
+++ b/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowListModalContent.tsx
@@ -4,13 +4,15 @@ import React, { useState, useCallback } from 'react';
 import { format } from 'date-fns';
 import { useTranslation } from 'next-i18next';
 import {
-  ModalHeader, ModalBody, ModalFooter, Dropdown, DropdownMenu, DropdownToggle, DropdownItem, UncontrolledTooltip,
+  ModalBody, ModalFooter, Dropdown, DropdownMenu, DropdownToggle, DropdownItem, UncontrolledTooltip,
 } from 'reactstrap';
 
 import { useCurrentUser } from '~/stores/context';
 
 import { type IWorkflowHasId } from '../../../interfaces/workflow';
 import { deleteWorkflow } from '../../services/workflow';
+
+import { WorkflowModalHeader } from './WorkflowModalHeader';
 
 
 type Props = {
@@ -90,9 +92,9 @@ export const WorkflowListModalContent = (props: Props): JSX.Element => {
 
   return (
     <>
-      <ModalHeader className="bg-primary">
-        {t('approval_workflow.list')}
-      </ModalHeader>
+      <WorkflowModalHeader
+        title={t('approval_workflow.list')}
+      />
 
       <ModalBody>
         {(workflows.length === 0) && (

--- a/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowModalHeader.tsx
+++ b/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowModalHeader.tsx
@@ -4,22 +4,22 @@ import { ModalHeader } from 'reactstrap';
 
 
 type Props = {
-  title?: string
+  children: React.ReactNode,
   onClickPageBackButton?: () => void,
 }
 
 export const WorkflowModalHeader = (props: Props): JSX.Element => {
-  const { title, onClickPageBackButton } = props;
+  const { children, onClickPageBackButton } = props;
 
   return (
-    <ModalHeader className="bg-primary">
+    <ModalHeader>
       { onClickPageBackButton != null && (
         <button type="button" className="btn" onClick={onClickPageBackButton}>
           <i className="fa fa-fw fa-chevron-left" aria-hidden="true" />
         </button>
       ) }
 
-      { title }
+      {children}
     </ModalHeader>
   );
 };

--- a/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowModalHeader.tsx
+++ b/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowModalHeader.tsx
@@ -1,29 +1,24 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 
 import { ModalHeader } from 'reactstrap';
 
 
 type Props = {
-  title: string
-  onClickPageBackButton: () => void,
+  title?: string
+  onClickPageBackButton?: () => void,
 }
 
 export const WorkflowModalHeader = (props: Props): JSX.Element => {
   const { title, onClickPageBackButton } = props;
 
-  const pageBackbuttonClickHandler = useCallback(() => {
-    if (onClickPageBackButton == null) {
-      return;
-    }
-
-    onClickPageBackButton();
-  }, [onClickPageBackButton]);
-
   return (
     <ModalHeader className="bg-primary">
-      <button type="button" className="btn" onClick={() => pageBackbuttonClickHandler()}>
-        <i className="fa fa-fw fa-chevron-left" aria-hidden="true"></i>
-      </button>
+      { onClickPageBackButton != null && (
+        <button type="button" className="btn" onClick={onClickPageBackButton}>
+          <i className="fa fa-fw fa-chevron-left" aria-hidden="true" />
+        </button>
+      ) }
+
       { title }
     </ModalHeader>
   );

--- a/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowModalHeader.tsx
+++ b/apps/app/src/features/approval-workflow/client/components/ModalComponents/WorkflowModalHeader.tsx
@@ -13,13 +13,15 @@ export const WorkflowModalHeader = (props: Props): JSX.Element => {
 
   return (
     <ModalHeader>
-      { onClickPageBackButton != null && (
-        <button type="button" className="btn" onClick={onClickPageBackButton}>
-          <i className="fa fa-fw fa-chevron-left" aria-hidden="true" />
-        </button>
-      ) }
+      <div className="d-flex align-items-center">
+        { onClickPageBackButton != null && (
+          <button type="button" className="btn" onClick={onClickPageBackButton}>
+            <i className="fa fa-fw fa-chevron-left" aria-hidden="true" />
+          </button>
+        ) }
 
-      {children}
+        {children}
+      </div>
     </ModalHeader>
   );
 };

--- a/apps/app/src/features/approval-workflow/client/components/WorkflowModal.tsx
+++ b/apps/app/src/features/approval-workflow/client/components/WorkflowModal.tsx
@@ -94,6 +94,7 @@ const WorkflowModal = (): JSX.Element => {
       { pageType === PageType.detail && (
         <WorkflowDetailModalContent
           workflow={selectedWorkflow}
+          onUpdate={mutateWorkflows}
           onClickWorkflowEditButton={workflowEditButtonClickHandler}
           onClickWorkflowListPageBackButton={workflowListPageBackButtonClickHandler}
         />


### PR DESCRIPTION
## Task
[#130337](https://redmine.weseek.co.jp/issues/130337) [approval-workflow] XD 通りにワークフロー詳細画面を実装しワークフローのステータスを更新することができる
┗ [#135363](https://redmine.weseek.co.jp/issues/135363) 詳細画面のフッターに表示させるメッセージ実装 (workflow.status によって変化する)
┗ [#135361](https://redmine.weseek.co.jp/issues/135361) 承認済みのフローにバッジを表示させる
┗ [#135189](https://redmine.weseek.co.jp/issues/135189) 詳細画面のヘッダーに workflow.status を表示させる

## Screenrecord
https://github.com/weseek/growi/assets/34241526/e6a78f17-d286-46ae-b44b-def6dad152a2


