### PR TITLE
feat: Delete workflows associated with the target page when the page is deleted

### DIFF
--- a/apps/app/src/server/service/page.ts
+++ b/apps/app/src/server/service/page.ts
@@ -32,6 +32,7 @@ import { createBatchStream } from '~/server/util/batch-stream';
 import loggerFactory from '~/utils/logger';
 import { prepareDeleteConfigValuesForCalc } from '~/utils/page-delete-config';
 
+import Workflow from '../../features/approval-workflow/server/models/workflow';
 import { ObjectIdLike } from '../interfaces/mongoose-utils';
 import { Attachment } from '../models';
 import { PathAlreadyExistsError } from '../models/errors';
@@ -1710,6 +1711,7 @@ class PageService {
       Page.deleteMany({ _id: { $in: pageIds } }),
       PageRedirect.deleteMany({ $or: [{ fromPath: { $in: pagePaths } }, { toPath: { $in: pagePaths } }] }),
       attachmentService.removeAllAttachments(attachments),
+      Workflow.deleteMany({ pageId: { $in: pageIds } }),
     ]);
   }
 


### PR DESCRIPTION
## Task
[#130369](https://redmine.weseek.co.jp/issues/130369) [approval-workflow] ページが完全削除された時にそれに対応するワークフローを全て削除できる
┗ [#135475](https://redmine.weseek.co.jp/issues/135475) 実装