### PR TITLE
fix: 135815 fix key prop warning

### DIFF
--- a/apps/app/src/components/Sidebar/PageTreeItem/PageTreeItem.tsx
+++ b/apps/app/src/components/Sidebar/PageTreeItem/PageTreeItem.tsx
@@ -23,7 +23,7 @@ import { Ellipsis } from './Ellipsis';
 const logger = loggerFactory('growi:cli:Item');
 
 type PageTreeItemPropsOptional = 'itemRef' | 'itemClass' | 'mainClassName';
-type PageTreeItemProps = Omit<SimpleItemProps, PageTreeItemPropsOptional> & {key};
+type PageTreeItemProps = Omit<SimpleItemProps, PageTreeItemPropsOptional>;
 
 export const PageTreeItem: FC<PageTreeItemProps> = (props) => {
   const getNewPathAfterMoved = (droppedPagePath: string, newParentPagePath: string): string => {
@@ -158,7 +158,6 @@ export const PageTreeItem: FC<PageTreeItemProps> = (props) => {
 
   return (
     <SimpleItem
-      key={props.key}
       targetPathOrId={props.targetPathOrId}
       itemNode={props.itemNode}
       isOpen

--- a/apps/app/src/components/TreeItem/SimpleItem.tsx
+++ b/apps/app/src/components/TreeItem/SimpleItem.tsx
@@ -252,13 +252,15 @@ export const SimpleItem: FC<SimpleItemProps> = (props) => {
             </button>
           )}
         </div>
-        {SimpleItemContent.map(ItemContent => (
-          <ItemContent key={ItemContent.name} {...SimpleItemContentProps} />
+        {SimpleItemContent.map((ItemContent, index) => (
+          // eslint-disable-next-line react/no-array-index-key
+          <ItemContent key={index} {...SimpleItemContentProps} />
         ))}
       </li>
 
-      {CustomNextComponents?.map(UnderItemContent => (
-        <UnderItemContent key={UnderItemContent.name} {...SimpleItemContentProps} />
+      {CustomNextComponents?.map((UnderItemContent, index) => (
+        // eslint-disable-next-line react/no-array-index-key
+        <UnderItemContent key={index} {...SimpleItemContentProps} />
       ))}
 
       {

--- a/apps/app/src/components/TreeItem/SimpleItem.tsx
+++ b/apps/app/src/components/TreeItem/SimpleItem.tsx
@@ -253,12 +253,12 @@ export const SimpleItem: FC<SimpleItemProps> = (props) => {
           )}
         </div>
         {SimpleItemContent.map(ItemContent => (
-          <ItemContent {...SimpleItemContentProps} />
+          <ItemContent key={ItemContent.name} {...SimpleItemContentProps} />
         ))}
       </li>
 
       {CustomNextComponents?.map(UnderItemContent => (
-        <UnderItemContent {...SimpleItemContentProps} />
+        <UnderItemContent key={UnderItemContent.name} {...SimpleItemContentProps} />
       ))}
 
       {


### PR DESCRIPTION
## タスク
https://redmine.weseek.co.jp/issues/135816

## 概要
![image](https://github.com/weseek/growi/assets/83588003/8cbfe18e-617d-44c5-a16c-bff9787de85e)
上のようなwarningがSimpleItemコンポーネントとPageTreeItemコンポーネントで出てしまう問題を解決しました。