### PR TITLE
feat: Open drawio modal in editor

### DIFF
--- a/apps/app/src/components/PageEditor/DrawioModal.tsx
+++ b/apps/app/src/components/PageEditor/DrawioModal.tsx
@@ -4,6 +4,7 @@ import React, {
   useMemo,
 } from 'react';
 
+import { useDrawioModalForEditor } from '@growi/editor/src/stores/use-drawio';
 import {
   Modal,
   ModalBody,
@@ -47,7 +48,9 @@ export const DrawioModal = (): JSX.Element => {
   });
 
   const { data: drawioModalData, close: closeDrawioModal } = useDrawioModal();
+  const { data: drawioModalDataInEditor } = useDrawioModalForEditor();
   const isOpened = drawioModalData?.isOpened ?? false;
+  const isOpendInEditor = drawioModalDataInEditor?.isOpened ?? false;
 
   const drawioUriWithParams = useMemo(() => {
     if (rendererConfig == null) {
@@ -109,7 +112,7 @@ export const DrawioModal = (): JSX.Element => {
 
   return (
     <Modal
-      isOpen={isOpened}
+      isOpen={isOpened || isOpendInEditor}
       toggle={() => closeDrawioModal()}
       backdrop="static"
       className="drawio-modal grw-body-only-modal-expanded"

--- a/packages/editor/src/components/CodeMirrorEditor/Toolbar/DiagramButton.tsx
+++ b/packages/editor/src/components/CodeMirrorEditor/Toolbar/DiagramButton.tsx
@@ -4,11 +4,11 @@ import { useDrawioModalForEditor } from '../../../stores/use-drawio';
 
 export const DiagramButton = (): JSX.Element => {
   const { open: openDrawioModal } = useDrawioModalForEditor();
-  const openDrawioModalHandler = useCallback(() => {
+  const onClickOpenDrawioModal = useCallback(() => {
     openDrawioModal();
   }, [openDrawioModal]);
   return (
-    <button type="button" className="btn btn-toolbar-button" onClick={openDrawioModalHandler}>
+    <button type="button" className="btn btn-toolbar-button" onClick={onClickOpenDrawioModal}>
       <span className="material-symbols-outlined fs-5">lan</span>
     </button>
   );

--- a/packages/editor/src/components/CodeMirrorEditor/Toolbar/DiagramButton.tsx
+++ b/packages/editor/src/components/CodeMirrorEditor/Toolbar/DiagramButton.tsx
@@ -6,7 +6,7 @@ export const DiagramButton = (): JSX.Element => {
   const { open: openDrawioModal } = useDrawioModalForEditor();
   const openDrawioModalHandler = useCallback(() => {
     openDrawioModal();
-  }, []);
+  }, [openDrawioModal]);
   return (
     <button type="button" className="btn btn-toolbar-button" onClick={openDrawioModalHandler}>
       <span className="material-symbols-outlined fs-5">lan</span>

--- a/packages/editor/src/components/CodeMirrorEditor/Toolbar/DiagramButton.tsx
+++ b/packages/editor/src/components/CodeMirrorEditor/Toolbar/DiagramButton.tsx
@@ -4,11 +4,11 @@ import { useDrawioModalForEditor } from '../../../stores/use-drawio';
 
 export const DiagramButton = (): JSX.Element => {
   const { open: openDrawioModal } = useDrawioModalForEditor();
-  const onClickOpenDrawioModal = useCallback(() => {
+  const onClickDiagramButton = useCallback(() => {
     openDrawioModal();
   }, [openDrawioModal]);
   return (
-    <button type="button" className="btn btn-toolbar-button" onClick={onClickOpenDrawioModal}>
+    <button type="button" className="btn btn-toolbar-button" onClick={onClickDiagramButton}>
       <span className="material-symbols-outlined fs-5">lan</span>
     </button>
   );

--- a/packages/editor/src/components/CodeMirrorEditor/Toolbar/DiagramButton.tsx
+++ b/packages/editor/src/components/CodeMirrorEditor/Toolbar/DiagramButton.tsx
@@ -1,6 +1,14 @@
+import { useCallback } from 'react';
+
+import { useDrawioModalForEditor } from '../../../stores/use-drawio';
+
 export const DiagramButton = (): JSX.Element => {
+  const { open: openDrawioModal } = useDrawioModalForEditor();
+  const openDrawioModalHandler = useCallback(() => {
+    openDrawioModal();
+  }, []);
   return (
-    <button type="button" className="btn btn-toolbar-button">
+    <button type="button" className="btn btn-toolbar-button" onClick={openDrawioModalHandler}>
       <span className="material-symbols-outlined fs-5">lan</span>
     </button>
   );

--- a/packages/editor/src/stores/use-drawio.ts
+++ b/packages/editor/src/stores/use-drawio.ts
@@ -1,0 +1,41 @@
+import { useCallback } from 'react';
+
+import { useSWRStatic } from '@growi/core/dist/swr';
+import type { SWRResponse } from 'swr';
+
+type DrawioModalSaveHandler = () => void;
+
+type DrawioModalStatus = {
+  isOpened: boolean,
+  onSave?: DrawioModalSaveHandler,
+}
+
+type DrawioModalStatusUtils = {
+  open(
+    onSave?: DrawioModalSaveHandler,
+  ): void,
+  close(): void,
+}
+
+export const useDrawioModalForEditor = (status?: DrawioModalStatus): SWRResponse<DrawioModalStatus, Error> & DrawioModalStatusUtils => {
+  const initialData: DrawioModalStatus = {
+    isOpened: false,
+  };
+  const swrResponse = useSWRStatic<DrawioModalStatus, Error>('drawioModalStatus', status, { fallbackData: initialData });
+
+  const { mutate } = swrResponse;
+
+  const open = useCallback((onSave?: DrawioModalSaveHandler): void => {
+    mutate({ isOpened: true, onSave });
+  }, [mutate]);
+
+  const close = useCallback((): void => {
+    mutate({ isOpened: false, drawioMxFile: '', onSave: undefined });
+  }, [mutate]);
+
+  return {
+    ...swrResponse,
+    open,
+    close,
+  };
+};


### PR DESCRIPTION
# 概要
エディタ画面でDrawioモーダルを開くことができるようにしました。

# やったこと
- useDrawioModalForEditorというフックを作成し、DiagramButtonとDrawioModalから参照できるようにした

# Task
https://redmine.weseek.co.jp/issues/135366

# 後続タスク
(マイグレーション対応)
https://redmine.weseek.co.jp/issues/135426
(TS化)
https://redmine.weseek.co.jp/issues/135842
(図をエディタに入れる)
https://redmine.weseek.co.jp/issues/135845