### PR TITLE
fix: User homepage deletion server login error on search

### DIFF
--- a/apps/app/src/server/service/page.ts
+++ b/apps/app/src/server/service/page.ts
@@ -153,6 +153,8 @@ class PageService {
 
     // init
     this.initPageEvent();
+    this.canDeleteCompletely = this.canDeleteCompletely.bind(this);
+    this.canDelete = this.canDelete.bind(this);
   }
 
   private initPageEvent() {
@@ -260,7 +262,7 @@ class PageService {
     const filteredPages = pages.filter(p => p.isEmpty || canDeleteFunction(p.path, p.creator, user, isRecursively));
 
     if (!this.canDeleteUserHomepageByConfig()) {
-      return filteredPages;
+      return filteredPages.filter(p => !isUsersHomepage(p.path));
     }
 
     // Confirmation of deletion of user homepages is an asynchronous process,


### PR DESCRIPTION
task: https://redmine.weseek.co.jp/issues/135857

動作確認後の修正です。
- `/_search` での一括削除時に server 側でエラー
原因: this.canDelete および this.canDeleteCompletely メソッド内で呼び出している this.crowi or this.canDeleteLogic が undefined になる
修正: constractor で bind した

- canDeleteUserHomepageByConfig false の時に server 側でエラー
原因: return する pages から user homepage を除かないといけなかったがその処理が抜けていた。
修正: filter した。

修正後、一通り依存している config を変更し動作確認し、期待通りでした。
- security:user-homepage-deletion:isEnabled
- security:pageDeletionAuthority
- security:pageRecursiveDeletionAuthority