### PR TITLE
feat: Three types of search execution buttons

### DIFF
--- a/apps/app/public/static/locales/en_US/commons.json
+++ b/apps/app/public/static/locales/en_US/commons.json
@@ -42,7 +42,7 @@
     }
   },
 
-  "search_buttons": {
+  "search_method_menu_item": {
     "search_in_all": "Search in all",
     "only_children_of_this_tree": "Only children of this tree",
     "exact_mutch": "Exact match"

--- a/apps/app/public/static/locales/en_US/commons.json
+++ b/apps/app/public/static/locales/en_US/commons.json
@@ -42,6 +42,12 @@
     }
   },
 
+  "search_buttons": {
+    "search_in_all": "Search in all",
+    "only_children_of_this_tree": "Only children of this tree",
+    "exact_mutch": "Exact match"
+  },
+
   "share_links": {
     "Share Link": "Share Link",
     "Page Path": "Page Path",

--- a/apps/app/public/static/locales/ja_JP/commons.json
+++ b/apps/app/public/static/locales/ja_JP/commons.json
@@ -47,7 +47,7 @@
   "search_buttons": {
     "search_in_all": "全てのページ",
     "only_children_of_this_tree": "この階層下の子ページのみ",
-    "exact_mutch": "キーワードに一致したページのみ"
+    "exact_mutch": "キーワードに完全一致した文字を含むページのみ"
   },
 
   "share_links": {

--- a/apps/app/public/static/locales/ja_JP/commons.json
+++ b/apps/app/public/static/locales/ja_JP/commons.json
@@ -44,6 +44,12 @@
     }
   },
 
+  "search_buttons": {
+    "search_in_all": "全てのページ",
+    "only_children_of_this_tree": "この階層下の子ページのみ",
+    "exact_mutch": "キーワードに一致したページのみ"
+  },
+
   "share_links": {
     "Share Link": "共有用リンク",
     "Page Path": "ページパス",

--- a/apps/app/public/static/locales/ja_JP/commons.json
+++ b/apps/app/public/static/locales/ja_JP/commons.json
@@ -44,7 +44,7 @@
     }
   },
 
-  "search_buttons": {
+  "search_method_menu_item": {
     "search_in_all": "全てのページ",
     "only_children_of_this_tree": "この階層下の子ページのみ",
     "exact_mutch": "キーワードに完全一致した文字を含むページのみ"

--- a/apps/app/public/static/locales/zh_CN/commons.json
+++ b/apps/app/public/static/locales/zh_CN/commons.json
@@ -45,6 +45,12 @@
 		}
   },
 
+  "search_buttons": {
+    "search_in_all": "所有页面",
+    "only_children_of_this_tree": "当前分支以下内容",
+    "exact_mutch": "完全匹配"
+  },
+
   "share_links": {
     "Share Link": "Share Link",
     "Page Path": "Page Path",

--- a/apps/app/public/static/locales/zh_CN/commons.json
+++ b/apps/app/public/static/locales/zh_CN/commons.json
@@ -45,7 +45,7 @@
 		}
   },
 
-  "search_buttons": {
+  "search_method_menu_item": {
     "search_in_all": "所有页面",
     "only_children_of_this_tree": "当前分支以下内容",
     "exact_mutch": "完全匹配"

--- a/apps/app/src/features/search/client/components/SearchButtons.tsx
+++ b/apps/app/src/features/search/client/components/SearchButtons.tsx
@@ -39,7 +39,6 @@ export const SearchButtons = (props: SearchButtonsProps): JSX.Element => {
               <span>{t('search_buttons.search_in_all')}</span>
             </div>
           </SearchButton>
-
         )}
 
         <SearchButton>

--- a/apps/app/src/features/search/client/components/SearchButtons.tsx
+++ b/apps/app/src/features/search/client/components/SearchButtons.tsx
@@ -47,7 +47,7 @@ export const SearchButtons = (props: SearchButtonsProps): JSX.Element => {
         )}
 
         <SearchButton onClick={() => {}}>
-          <code>{currentPagePath}</code>
+          <code>prefix: {currentPagePath}</code>
           <span className="ms-2">{searchKeyword}</span>
           <div className="ms-auto">
             <span>{t('search_buttons.only_children_of_this_tree')}</span>

--- a/apps/app/src/features/search/client/components/SearchButtons.tsx
+++ b/apps/app/src/features/search/client/components/SearchButtons.tsx
@@ -6,9 +6,10 @@ import { useCurrentPagePath } from '~/stores/page';
 
 type SearchButtonProps = {
   children: React.ReactNode
+  onClick: () => void
 }
 const SearchButton = (props: SearchButtonProps): JSX.Element => {
-  const { children } = props;
+  const { children, onClick } = props;
 
   return (
     <tr>
@@ -27,9 +28,9 @@ type SearchButtonsProps = {
 export const SearchButtons = (props: SearchButtonsProps): JSX.Element => {
   const { t } = useTranslation('commons');
 
-  const { searchKeyword } = props;
-
   const { data: currentPagePath } = useCurrentPagePath();
+
+  const { searchKeyword } = props;
 
   const shouldShowButton = searchKeyword.length > 0;
 
@@ -37,7 +38,7 @@ export const SearchButtons = (props: SearchButtonsProps): JSX.Element => {
     <table className="table">
       <tbody>
         { shouldShowButton && (
-          <SearchButton>
+          <SearchButton onClick={() => {}}>
             <span>{searchKeyword}</span>
             <div className="ms-auto">
               <span>{t('search_buttons.search_in_all')}</span>
@@ -45,7 +46,7 @@ export const SearchButtons = (props: SearchButtonsProps): JSX.Element => {
           </SearchButton>
         )}
 
-        <SearchButton>
+        <SearchButton onClick={() => {}}>
           <code>{currentPagePath}</code>
           <span className="ms-2">{searchKeyword}</span>
           <div className="ms-auto">
@@ -53,9 +54,8 @@ export const SearchButtons = (props: SearchButtonsProps): JSX.Element => {
           </div>
         </SearchButton>
 
-
         { shouldShowButton && (
-          <SearchButton>
+          <SearchButton onClick={() => {}}>
             <span>{`"${searchKeyword}"`}</span>
             <div className="ms-auto">
               <span>{t('search_buttons.exact_mutch')}</span>

--- a/apps/app/src/features/search/client/components/SearchButtons.tsx
+++ b/apps/app/src/features/search/client/components/SearchButtons.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { useTranslation } from 'next-i18next';
 
+import { useCurrentPagePath } from '~/stores/page';
 
 type SearchButtonProps = {
   children: React.ReactNode
@@ -21,20 +22,23 @@ const SearchButton = (props: SearchButtonProps): JSX.Element => {
 
 
 type SearchButtonsProps = {
-  searchText: string
+  searchKeyword: string
 }
 export const SearchButtons = (props: SearchButtonsProps): JSX.Element => {
   const { t } = useTranslation('commons');
-  const { searchText } = props;
 
-  const shouldShowButton = searchText.length > 0;
+  const { searchKeyword } = props;
+
+  const { data: currentPagePath } = useCurrentPagePath();
+
+  const shouldShowButton = searchKeyword.length > 0;
 
   return (
     <table className="table">
       <tbody>
         { shouldShowButton && (
           <SearchButton>
-            <span>{searchText}</span>
+            <span>{searchKeyword}</span>
             <div className="ms-auto">
               <span>{t('search_buttons.search_in_all')}</span>
             </div>
@@ -42,8 +46,8 @@ export const SearchButtons = (props: SearchButtonsProps): JSX.Element => {
         )}
 
         <SearchButton>
-          <code>~pagehoge/</code>
-          <span className="ms-2">{searchText}</span>
+          <code>{currentPagePath}</code>
+          <span className="ms-2">{searchKeyword}</span>
           <div className="ms-auto">
             <span>{t('search_buttons.only_children_of_this_tree')}</span>
           </div>
@@ -52,7 +56,7 @@ export const SearchButtons = (props: SearchButtonsProps): JSX.Element => {
 
         { shouldShowButton && (
           <SearchButton>
-            <span>{`"${searchText}"`}</span>
+            <span>{`"${searchKeyword}"`}</span>
             <div className="ms-auto">
               <span>{t('search_buttons.exact_mutch')}</span>
             </div>

--- a/apps/app/src/features/search/client/components/SearchButtons.tsx
+++ b/apps/app/src/features/search/client/components/SearchButtons.tsx
@@ -2,39 +2,55 @@ import React from 'react';
 
 import { useTranslation } from 'next-i18next';
 
-export const SearchButtons = (): JSX.Element => {
+type Props = {
+  searchText: string
+}
+
+export const SearchButtons = (props: Props): JSX.Element => {
   const { t } = useTranslation('commons');
+  const { searchText } = props;
+
+  const shouldShowButton = searchText.length > 0;
 
   return (
     <table className="table">
       <tbody>
-        <tr>
-          <div className="text-muted ps-1 d-flex">
-            <span className="material-symbols-outlined fs-4 me-3">search</span>
-            <div className="ms-auto">
-              <span>Search in all</span>
+
+        { shouldShowButton && (
+          <tr>
+            <div className="text-muted ps-1 d-flex">
+              <span className="material-symbols-outlined fs-4 me-3">search</span>
+              <span>{searchText}</span>
+              <div className="ms-auto">
+                <span>Search in all</span>
+              </div>
             </div>
-          </div>
-        </tr>
+          </tr>
+        )}
 
         <tr>
           <div className="text-muted ps-1 d-flex">
             <span className="material-symbols-outlined fs-4 me-3">search</span>
             <code>~pagehoge/</code>
+            <span className="ms-2">{searchText}</span>
             <div className="ms-auto">
               <span>{t('header_search_box.item_label.This tree')}</span>
             </div>
           </div>
         </tr>
 
-        <tr>
-          <div className="text-muted ps-1 d-flex">
-            <span className="material-symbols-outlined fs-4 me-3">search</span>
-            <div className="ms-auto">
-              <span>Exact match</span>
+        { shouldShowButton && (
+          <tr>
+            <div className="text-muted ps-1 d-flex">
+              <span className="material-symbols-outlined fs-4 me-3">search</span>
+              <span>{`"${searchText}"`}</span>
+              <div className="ms-auto">
+                <span>Exact match</span>
+              </div>
             </div>
-          </div>
-        </tr>
+          </tr>
+        ) }
+
       </tbody>
     </table>
   );

--- a/apps/app/src/features/search/client/components/SearchButtons.tsx
+++ b/apps/app/src/features/search/client/components/SearchButtons.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+
+import { useTranslation } from 'next-i18next';
+
+export const SearchButtons = (): JSX.Element => {
+  const { t } = useTranslation('commons');
+
+  return (
+    <table className="table">
+      <tbody>
+        <tr>
+          <div className="text-muted ps-1 d-flex">
+            <span className="material-symbols-outlined fs-4 me-3">search</span>
+            <div className="ms-auto">
+              <span>Search in all</span>
+            </div>
+          </div>
+        </tr>
+
+        <tr>
+          <div className="text-muted ps-1 d-flex">
+            <span className="material-symbols-outlined fs-4 me-3">search</span>
+            <code>~pagehoge/</code>
+            <div className="ms-auto">
+              <span>{t('header_search_box.item_label.This tree')}</span>
+            </div>
+          </div>
+        </tr>
+
+        <tr>
+          <div className="text-muted ps-1 d-flex">
+            <span className="material-symbols-outlined fs-4 me-3">search</span>
+            <div className="ms-auto">
+              <span>Exact match</span>
+            </div>
+          </div>
+        </tr>
+      </tbody>
+    </table>
+  );
+};

--- a/apps/app/src/features/search/client/components/SearchButtons.tsx
+++ b/apps/app/src/features/search/client/components/SearchButtons.tsx
@@ -22,7 +22,7 @@ export const SearchButtons = (props: Props): JSX.Element => {
               <span className="material-symbols-outlined fs-4 me-3">search</span>
               <span>{searchText}</span>
               <div className="ms-auto">
-                <span>Search in all</span>
+                <span>{t('search_buttons.search_in_all')}</span>
               </div>
             </div>
           </tr>
@@ -34,7 +34,7 @@ export const SearchButtons = (props: Props): JSX.Element => {
             <code>~pagehoge/</code>
             <span className="ms-2">{searchText}</span>
             <div className="ms-auto">
-              <span>{t('header_search_box.item_label.This tree')}</span>
+              <span>{t('search_buttons.only_children_of_this_tree')}</span>
             </div>
           </div>
         </tr>
@@ -45,7 +45,7 @@ export const SearchButtons = (props: Props): JSX.Element => {
               <span className="material-symbols-outlined fs-4 me-3">search</span>
               <span>{`"${searchText}"`}</span>
               <div className="ms-auto">
-                <span>Exact match</span>
+                <span>{t('search_buttons.exact_mutch')}</span>
               </div>
             </div>
           </tr>

--- a/apps/app/src/features/search/client/components/SearchButtons.tsx
+++ b/apps/app/src/features/search/client/components/SearchButtons.tsx
@@ -2,11 +2,28 @@ import React from 'react';
 
 import { useTranslation } from 'next-i18next';
 
-type Props = {
+
+type SearchButtonProps = {
+  children: React.ReactNode
+}
+const SearchButton = (props: SearchButtonProps): JSX.Element => {
+  const { children } = props;
+
+  return (
+    <tr>
+      <div className="text-muted ps-1 d-flex">
+        <span className="material-symbols-outlined fs-4 me-3">search</span>
+        { children }
+      </div>
+    </tr>
+  );
+};
+
+
+type SearchButtonsProps = {
   searchText: string
 }
-
-export const SearchButtons = (props: Props): JSX.Element => {
+export const SearchButtons = (props: SearchButtonsProps): JSX.Element => {
   const { t } = useTranslation('commons');
   const { searchText } = props;
 
@@ -15,42 +32,33 @@ export const SearchButtons = (props: Props): JSX.Element => {
   return (
     <table className="table">
       <tbody>
-
         { shouldShowButton && (
-          <tr>
-            <div className="text-muted ps-1 d-flex">
-              <span className="material-symbols-outlined fs-4 me-3">search</span>
-              <span>{searchText}</span>
-              <div className="ms-auto">
-                <span>{t('search_buttons.search_in_all')}</span>
-              </div>
+          <SearchButton>
+            <span>{searchText}</span>
+            <div className="ms-auto">
+              <span>{t('search_buttons.search_in_all')}</span>
             </div>
-          </tr>
+          </SearchButton>
+
         )}
 
-        <tr>
-          <div className="text-muted ps-1 d-flex">
-            <span className="material-symbols-outlined fs-4 me-3">search</span>
-            <code>~pagehoge/</code>
-            <span className="ms-2">{searchText}</span>
-            <div className="ms-auto">
-              <span>{t('search_buttons.only_children_of_this_tree')}</span>
-            </div>
+        <SearchButton>
+          <code>~pagehoge/</code>
+          <span className="ms-2">{searchText}</span>
+          <div className="ms-auto">
+            <span>{t('search_buttons.only_children_of_this_tree')}</span>
           </div>
-        </tr>
+        </SearchButton>
+
 
         { shouldShowButton && (
-          <tr>
-            <div className="text-muted ps-1 d-flex">
-              <span className="material-symbols-outlined fs-4 me-3">search</span>
-              <span>{`"${searchText}"`}</span>
-              <div className="ms-auto">
-                <span>{t('search_buttons.exact_mutch')}</span>
-              </div>
+          <SearchButton>
+            <span>{`"${searchText}"`}</span>
+            <div className="ms-auto">
+              <span>{t('search_buttons.exact_mutch')}</span>
             </div>
-          </tr>
+          </SearchButton>
         ) }
-
       </tbody>
     </table>
   );

--- a/apps/app/src/features/search/client/components/SearchHelp.tsx
+++ b/apps/app/src/features/search/client/components/SearchHelp.tsx
@@ -10,7 +10,7 @@ export const SearchHelp = (): JSX.Element => {
 
   return (
     <>
-      <button type="button" className="btn border-0 text-muted d-flex justify-content-center align-items-center mb-2 ps-1" onClick={() => setIsOpen(!isOpen)}>
+      <button type="button" className="btn border-0 text-muted d-flex justify-content-center align-items-center  ps-1" onClick={() => setIsOpen(!isOpen)}>
         <span className="material-symbols-outlined me-2">help</span>
         { t('search_help.title') }
         <span className="material-symbols-outlined ms-2">{isOpen ? 'expand_less' : 'expand_more'}</span>

--- a/apps/app/src/features/search/client/components/SearchMethodMenuItem.tsx
+++ b/apps/app/src/features/search/client/components/SearchMethodMenuItem.tsx
@@ -41,7 +41,7 @@ export const SearchMethodMenuItem = (props: SearchMethodMenuItemProps): JSX.Elem
           <MenuItem onClick={() => {}}>
             <span>{searchKeyword}</span>
             <div className="ms-auto">
-              <span>{t('search_buttons.search_in_all')}</span>
+              <span>{t('search_method_menu_item.search_in_all')}</span>
             </div>
           </MenuItem>
         )}
@@ -50,7 +50,7 @@ export const SearchMethodMenuItem = (props: SearchMethodMenuItemProps): JSX.Elem
           <code>prefix: {currentPagePath}</code>
           <span className="ms-2">{searchKeyword}</span>
           <div className="ms-auto">
-            <span>{t('search_buttons.only_children_of_this_tree')}</span>
+            <span>{t('search_method_menu_item.only_children_of_this_tree')}</span>
           </div>
         </MenuItem>
 
@@ -58,7 +58,7 @@ export const SearchMethodMenuItem = (props: SearchMethodMenuItemProps): JSX.Elem
           <MenuItem onClick={() => {}}>
             <span>{`"${searchKeyword}"`}</span>
             <div className="ms-auto">
-              <span>{t('search_buttons.exact_mutch')}</span>
+              <span>{t('search_method_menu_item.exact_mutch')}</span>
             </div>
           </MenuItem>
         ) }

--- a/apps/app/src/features/search/client/components/SearchMethodMenuItem.tsx
+++ b/apps/app/src/features/search/client/components/SearchMethodMenuItem.tsx
@@ -4,11 +4,11 @@ import { useTranslation } from 'next-i18next';
 
 import { useCurrentPagePath } from '~/stores/page';
 
-type SearchButtonProps = {
+type MenuItemProps = {
   children: React.ReactNode
   onClick: () => void
 }
-const SearchButton = (props: SearchButtonProps): JSX.Element => {
+const MenuItem = (props: MenuItemProps): JSX.Element => {
   const { children, onClick } = props;
 
   return (
@@ -22,10 +22,10 @@ const SearchButton = (props: SearchButtonProps): JSX.Element => {
 };
 
 
-type SearchButtonsProps = {
+type SearchMethodMenuItemProps = {
   searchKeyword: string
 }
-export const SearchButtons = (props: SearchButtonsProps): JSX.Element => {
+export const SearchMethodMenuItem = (props: SearchMethodMenuItemProps): JSX.Element => {
   const { t } = useTranslation('commons');
 
   const { data: currentPagePath } = useCurrentPagePath();
@@ -38,29 +38,29 @@ export const SearchButtons = (props: SearchButtonsProps): JSX.Element => {
     <table className="table">
       <tbody>
         { shouldShowButton && (
-          <SearchButton onClick={() => {}}>
+          <MenuItem onClick={() => {}}>
             <span>{searchKeyword}</span>
             <div className="ms-auto">
               <span>{t('search_buttons.search_in_all')}</span>
             </div>
-          </SearchButton>
+          </MenuItem>
         )}
 
-        <SearchButton onClick={() => {}}>
+        <MenuItem onClick={() => {}}>
           <code>prefix: {currentPagePath}</code>
           <span className="ms-2">{searchKeyword}</span>
           <div className="ms-auto">
             <span>{t('search_buttons.only_children_of_this_tree')}</span>
           </div>
-        </SearchButton>
+        </MenuItem>
 
         { shouldShowButton && (
-          <SearchButton onClick={() => {}}>
+          <MenuItem onClick={() => {}}>
             <span>{`"${searchKeyword}"`}</span>
             <div className="ms-auto">
               <span>{t('search_buttons.exact_mutch')}</span>
             </div>
-          </SearchButton>
+          </MenuItem>
         ) }
       </tbody>
     </table>

--- a/apps/app/src/features/search/client/components/SearchModal.tsx
+++ b/apps/app/src/features/search/client/components/SearchModal.tsx
@@ -38,7 +38,7 @@ const SearchModal = (): JSX.Element => {
           onClickClearButton={clickClearButtonHandler}
         />
         <div className="border-top mt-3 mb-3" />
-        <SearchButtons searchText={searchText} />
+        <SearchButtons searchKeyword={searchKeyword} />
         <div className="border-top mt-2 mb-2" />
         <SearchHelp />
       </ModalBody>

--- a/apps/app/src/features/search/client/components/SearchModal.tsx
+++ b/apps/app/src/features/search/client/components/SearchModal.tsx
@@ -38,7 +38,7 @@ const SearchModal = (): JSX.Element => {
           onClickClearButton={clickClearButtonHandler}
         />
         <div className="border-top mt-3 mb-3" />
-        <SearchButtons />
+        <SearchButtons searchText={searchText} />
         <div className="border-top mt-2 mb-2" />
         <SearchHelp />
       </ModalBody>

--- a/apps/app/src/features/search/client/components/SearchModal.tsx
+++ b/apps/app/src/features/search/client/components/SearchModal.tsx
@@ -6,9 +6,9 @@ import { Modal, ModalBody } from 'reactstrap';
 
 import { useSearchModal } from '../stores/search';
 
-import { SearchButtons } from './SearchButtons';
 import { SearchForm } from './SearchForm';
 import { SearchHelp } from './SearchHelp';
+import { SearchMethodMenuItem } from './SearchMethodMenuItem';
 
 const SearchModal = (): JSX.Element => {
   const { data: searchModalData, close: closeSearchModal } = useSearchModal();
@@ -38,7 +38,7 @@ const SearchModal = (): JSX.Element => {
           onClickClearButton={clickClearButtonHandler}
         />
         <div className="border-top mt-3 mb-3" />
-        <SearchButtons searchKeyword={searchKeyword} />
+        <SearchMethodMenuItem searchKeyword={searchKeyword} />
         <div className="border-top mt-2 mb-2" />
         <SearchHelp />
       </ModalBody>

--- a/apps/app/src/features/search/client/components/SearchModal.tsx
+++ b/apps/app/src/features/search/client/components/SearchModal.tsx
@@ -6,6 +6,7 @@ import { Modal, ModalBody } from 'reactstrap';
 
 import { useSearchModal } from '../stores/search';
 
+import { SearchButtons } from './SearchButtons';
 import { SearchForm } from './SearchForm';
 import { SearchHelp } from './SearchHelp';
 
@@ -36,7 +37,9 @@ const SearchModal = (): JSX.Element => {
           onChangeSearchText={changeSearchTextHandler}
           onClickClearButton={clickClearButtonHandler}
         />
-        <div className="border-top mt-4 mb-3" />
+        <div className="border-top mt-3 mb-3" />
+        <SearchButtons />
+        <div className="border-top mt-2 mb-2" />
         <SearchHelp />
       </ModalBody>
     </Modal>


### PR DESCRIPTION
## Task
[#134383](https://redmine.weseek.co.jp/issues/134383) [v7][search] 全文検索用モーダルで入力中のキーワードに対して3種の検索実行(検索結果画面へ遷移)ができる
┗ [#134549](https://redmine.weseek.co.jp/issues/134549) 三種の検索実行ボタンの見た目の実装

## XD 
<img width="461" alt="スクリーンショット 2023-11-30 18 48 49" src="https://github.com/weseek/growi/assets/34241526/b3a3efc6-4da2-4f9c-a88e-b09099227ba6">

## ScreenRecord
https://github.com/weseek/growi/assets/34241526/befa1080-df4d-471f-967b-a14aeb78af7f




