### PR TITLE
feat: Incremental search results

### DIFF
--- a/apps/app/src/features/search/client/components/SearchModal.tsx
+++ b/apps/app/src/features/search/client/components/SearchModal.tsx
@@ -10,7 +10,7 @@ import { useSearchModal } from '../stores/search';
 
 import { SearchForm } from './SearchForm';
 import { SearchHelp } from './SearchHelp';
-import { SearchResults } from './SearchResults';
+import { SearchResultMenuItem } from './SearchResultMenuItem';
 
 const SearchModal = (): JSX.Element => {
   const [searchKeyword, setSearchKeyword] = useState('');
@@ -41,7 +41,7 @@ const SearchModal = (): JSX.Element => {
           onClickClearButton={clickClearButtonHandler}
         />
         <div className="border-top mt-4 mb-3" />
-        <SearchResults searchResult={searchResult} />
+        <SearchResultMenuItem searchResult={searchResult} />
         <SearchHelp />
       </ModalBody>
     </Modal>

--- a/apps/app/src/features/search/client/components/SearchModal.tsx
+++ b/apps/app/src/features/search/client/components/SearchModal.tsx
@@ -4,8 +4,6 @@ import React, {
 
 import { Modal, ModalBody } from 'reactstrap';
 
-import { useSWRxSearch } from '~/stores/search';
-
 import { useSearchModal } from '../stores/search';
 
 import { SearchForm } from './SearchForm';
@@ -16,7 +14,6 @@ const SearchModal = (): JSX.Element => {
   const [searchKeyword, setSearchKeyword] = useState('');
 
   const { data: searchModalData, close: closeSearchModal } = useSearchModal();
-  const { data: searchResult } = useSWRxSearch(searchKeyword, null, { limit: 10 });
 
   const changeSearchTextHandler = useCallback((searchText: string) => {
     setSearchKeyword(searchText);
@@ -41,7 +38,7 @@ const SearchModal = (): JSX.Element => {
           onClickClearButton={clickClearButtonHandler}
         />
         <div className="border-top mt-4 mb-3" />
-        <SearchResultMenuItem searchResult={searchResult} />
+        <SearchResultMenuItem searchKeyword={searchKeyword} />
         <SearchHelp />
       </ModalBody>
     </Modal>

--- a/apps/app/src/features/search/client/components/SearchModal.tsx
+++ b/apps/app/src/features/search/client/components/SearchModal.tsx
@@ -4,15 +4,19 @@ import React, {
 
 import { Modal, ModalBody } from 'reactstrap';
 
+import { useSWRxSearch } from '~/stores/search';
+
 import { useSearchModal } from '../stores/search';
 
 import { SearchForm } from './SearchForm';
 import { SearchHelp } from './SearchHelp';
+import { SearchResults } from './SearchResults';
 
 const SearchModal = (): JSX.Element => {
-  const { data: searchModalData, close: closeSearchModal } = useSearchModal();
-
   const [searchKeyword, setSearchKeyword] = useState('');
+
+  const { data: searchModalData, close: closeSearchModal } = useSearchModal();
+  const { data: searchResult } = useSWRxSearch(searchKeyword, null, { limit: 10 });
 
   const changeSearchTextHandler = useCallback((searchText: string) => {
     setSearchKeyword(searchText);
@@ -37,6 +41,7 @@ const SearchModal = (): JSX.Element => {
           onClickClearButton={clickClearButtonHandler}
         />
         <div className="border-top mt-4 mb-3" />
+        <SearchResults searchResult={searchResult} />
         <SearchHelp />
       </ModalBody>
     </Modal>

--- a/apps/app/src/features/search/client/components/SearchResultMenuItem.tsx
+++ b/apps/app/src/features/search/client/components/SearchResultMenuItem.tsx
@@ -8,7 +8,7 @@ import type { IFormattedSearchResult } from '~/interfaces/search';
 type Props = {
   searchResult?: IFormattedSearchResult
 }
-export const SearchResults = (props: Props): JSX.Element => {
+export const SearchResultMenuItem = (props: Props): JSX.Element => {
   const { searchResult } = props;
 
   if (searchResult == null || searchResult.data.length === 0) {

--- a/apps/app/src/features/search/client/components/SearchResultMenuItem.tsx
+++ b/apps/app/src/features/search/client/components/SearchResultMenuItem.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { PagePathLabel, UserPicture } from '@growi/ui/dist/components';
+import { useDebounce } from 'usehooks-ts';
 
 import { useSWRxSearch } from '~/stores/search';
 
@@ -11,7 +12,8 @@ type Props = {
 export const SearchResultMenuItem = (props: Props): JSX.Element => {
   const { searchKeyword } = props;
 
-  const { data: searchResult } = useSWRxSearch(searchKeyword, null, { limit: 10 });
+  const debouncedKeyword = useDebounce(searchKeyword, 500);
+  const { data: searchResult } = useSWRxSearch(debouncedKeyword, null, { limit: 10 });
 
   if (searchResult == null || searchResult.data.length === 0) {
     return <></>;

--- a/apps/app/src/features/search/client/components/SearchResultMenuItem.tsx
+++ b/apps/app/src/features/search/client/components/SearchResultMenuItem.tsx
@@ -12,11 +12,11 @@ type Props = {
 export const SearchResultMenuItem = (props: Props): JSX.Element => {
   const { searchKeyword } = props;
 
-  const isEmptyKeyword = searchKeyword.trim() === '';
-
   const debouncedKeyword = useDebounce(searchKeyword, 500);
 
-  const { data: searchResult } = useSWRxSearch(isEmptyKeyword ? null : debouncedKeyword, null, { limit: 10 });
+  const isEmptyKeyword = debouncedKeyword.trim() === '';
+
+  const { data: searchResult } = useSWRxSearch(isEmptyKeyword ? null : searchKeyword, null, { limit: 10 });
 
   if (isEmptyKeyword || searchResult == null || searchResult.data.length === 0) {
     return <></>;

--- a/apps/app/src/features/search/client/components/SearchResultMenuItem.tsx
+++ b/apps/app/src/features/search/client/components/SearchResultMenuItem.tsx
@@ -28,10 +28,17 @@ export const SearchResultMenuItem = (props: Props): JSX.Element => {
         <tbody>
           {searchResult.data?.map(pageWithMeta => (
             <tr key={pageWithMeta.data._id}>
-              <div className="ps-1 mb-2">
-                <UserPicture />
-                <span className="ms-3 text-break text-wrap"><PagePathLabel path={pageWithMeta.data.path} /></span>
-                <span className="ms-3">{pageWithMeta.data.seenUsers.length}</span>
+              <div className="ps-1 mb-2 d-flex">
+                <UserPicture user={pageWithMeta.data.creator} />
+
+                <span className="ms-3 text-break text-wrap">
+                  <PagePathLabel path={pageWithMeta.data.path} />
+                </span>
+
+                <span className="ms-2 text-muted d-flex justify-content-center align-items-center">
+                  <span className="material-symbols-outlined fs-5">footprint</span>
+                  <span>{pageWithMeta.data.seenUsers.length}</span>
+                </span>
               </div>
             </tr>
           ))}

--- a/apps/app/src/features/search/client/components/SearchResultMenuItem.tsx
+++ b/apps/app/src/features/search/client/components/SearchResultMenuItem.tsx
@@ -2,14 +2,16 @@ import React from 'react';
 
 import { PagePathLabel, UserPicture } from '@growi/ui/dist/components';
 
-import type { IFormattedSearchResult } from '~/interfaces/search';
+import { useSWRxSearch } from '~/stores/search';
 
 
 type Props = {
-  searchResult?: IFormattedSearchResult
+  searchKeyword: string,
 }
 export const SearchResultMenuItem = (props: Props): JSX.Element => {
-  const { searchResult } = props;
+  const { searchKeyword } = props;
+
+  const { data: searchResult } = useSWRxSearch(searchKeyword, null, { limit: 10 });
 
   if (searchResult == null || searchResult.data.length === 0) {
     return <></>;

--- a/apps/app/src/features/search/client/components/SearchResultMenuItem.tsx
+++ b/apps/app/src/features/search/client/components/SearchResultMenuItem.tsx
@@ -12,10 +12,13 @@ type Props = {
 export const SearchResultMenuItem = (props: Props): JSX.Element => {
   const { searchKeyword } = props;
 
-  const debouncedKeyword = useDebounce(searchKeyword, 500);
-  const { data: searchResult } = useSWRxSearch(debouncedKeyword, null, { limit: 10 });
+  const isEmptyKeyword = searchKeyword.trim() === '';
 
-  if (searchResult == null || searchResult.data.length === 0) {
+  const debouncedKeyword = useDebounce(searchKeyword, 500);
+
+  const { data: searchResult } = useSWRxSearch(isEmptyKeyword ? null : debouncedKeyword, null, { limit: 10 });
+
+  if (isEmptyKeyword || searchResult == null || searchResult.data.length === 0) {
     return <></>;
   }
 
@@ -34,7 +37,7 @@ export const SearchResultMenuItem = (props: Props): JSX.Element => {
           ))}
         </tbody>
       </table>
-      <div className="border-top mt-2 mb-2" />
+      <div className="border-top mb-2" />
     </>
   );
 };

--- a/apps/app/src/features/search/client/components/SearchResults.tsx
+++ b/apps/app/src/features/search/client/components/SearchResults.tsx
@@ -19,8 +19,8 @@ export const SearchResults = (props: Props): JSX.Element => {
     <>
       <table>
         <tbody>
-          {searchResult.data?.map((pageWithMeta, index) => (
-            <tr>
+          {searchResult.data?.map(pageWithMeta => (
+            <tr key={pageWithMeta.data._id}>
               <div className="ps-1 mb-2">
                 <UserPicture />
                 <span className="ms-3 text-break text-wrap"><PagePathLabel path={pageWithMeta.data.path} /></span>

--- a/apps/app/src/features/search/client/components/SearchResults.tsx
+++ b/apps/app/src/features/search/client/components/SearchResults.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+import { PagePathLabel, UserPicture } from '@growi/ui/dist/components';
+
+import type { IFormattedSearchResult } from '~/interfaces/search';
+
+
+type Props = {
+  searchResult?: IFormattedSearchResult
+}
+export const SearchResults = (props: Props): JSX.Element => {
+  const { searchResult } = props;
+
+  if (searchResult == null || searchResult.data.length === 0) {
+    return <></>;
+  }
+
+  return (
+    <>
+      <table>
+        <tbody>
+          {searchResult.data?.map((pageWithMeta, index) => (
+            <tr>
+              <div className="ps-1 mb-2">
+                <UserPicture />
+                <span className="ms-3 text-break text-wrap"><PagePathLabel path={pageWithMeta.data.path} /></span>
+                <span className="ms-3">{pageWithMeta.data.seenUsers.length}</span>
+              </div>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div className="border-top mt-2 mb-2" />
+    </>
+  );
+};


### PR DESCRIPTION
## Task
[#134384](https://redmine.weseek.co.jp/issues/134384) [v7][search] 全文検索用モーダルでインクリメンタルサーチ結果を表示し、それを選択することで検索結果画面へ遷移できる
┗ [#135930](https://redmine.weseek.co.jp/issues/135930) インクリメンタルサーチ結果を表示する見た目の実装
┗ [#135931](https://redmine.weseek.co.jp/issues/135931) SearchForm にテキストが入力された時に _api/search へ GET リクエストする
┗ [#136094](https://redmine.weseek.co.jp/issues/136094) SearchForm に入力中のキーワードに debounce 処理を追加する
┗ [#136023](https://redmine.weseek.co.jp/issues/136023) seen users count を表示する

## XD
<img width="579" alt="スクリーンショット 2023-11-30 20 17 37" src="https://github.com/weseek/growi/assets/34241526/2c69462a-e4d4-43f4-89ea-28b41d715f3e">

## ScreenRecord (debounce 処理追加後)
https://github.com/weseek/growi/assets/34241526/755dc764-e08e-45ae-82ae-5d2a1b908be7



