### PR TITLE
imprv: Correspond with codemirror migration 

### DIFF
--- a/apps/app/src/components/PageEditor/MarkdownDrawioUtil.js
+++ b/apps/app/src/components/PageEditor/MarkdownDrawioUtil.js
@@ -20,7 +20,7 @@ class MarkdownDrawioUtil {
     return editor.state.doc;
   }
 
-  // get first line numbet
+  // get first line number
   firstLine() {
     return 1;
   }
@@ -30,6 +30,7 @@ class MarkdownDrawioUtil {
     return this.doc(editor).lines;
   }
 
+  // get line information
   getLine(editor, lineNum) {
     return this.doc(editor).line(lineNum);
   }

--- a/apps/app/src/components/PageEditor/MarkdownDrawioUtil.js
+++ b/apps/app/src/components/PageEditor/MarkdownDrawioUtil.js
@@ -114,7 +114,7 @@ class MarkdownDrawioUtil {
       // skip block begin sesion("``` drawio")
       this.doc(editor).lineAt(bod).number++;
       // skip block end sesion("```")
-      this.doc.lineAt(eod).number--;
+      this.doc(editor).lineAt(eod).number--;
 
       return editor.state.sliceDoc(bod, eod);
     }
@@ -131,8 +131,8 @@ class MarkdownDrawioUtil {
       endPos = this.getEod(editor);
     }
     else {
-      beginPos = this.doc(editor).lineAt(this.curPos(editor));
-      endPos = this.doc(editor).lineAt(this.curPos(editor));
+      beginPos = this.doc(editor).lineAt(this.curPos(editor)).from;
+      endPos = this.doc(editor).lineAt(this.curPos(editor)).to;
     }
 
     editor.dispatch({

--- a/apps/app/src/components/PageEditor/MarkdownDrawioUtil.js
+++ b/apps/app/src/components/PageEditor/MarkdownDrawioUtil.js
@@ -10,32 +10,32 @@ class MarkdownDrawioUtil {
     this.doc = this.doc.bind(this);
   }
 
-  // get cursor position from editor
+  // get cursor position(number)
   curPos(editor) {
     return editor.state.selection.main.head;
   }
 
-  // get doc from editor
+  // get doc(Text)
   doc(editor) {
     return editor.state.doc;
   }
 
-  // get first line number
+  // get first line number(numeber)
   firstLineNum() {
     return 1;
   }
 
-  // get last line number
+  // get last line number(numeber)
   lastLineNum(editor) {
     return this.doc(editor).lines;
   }
 
-  // get cursor line
-  cursorLine(editor) {
+  // get cursor line(line)
+  getCursorLine(editor) {
     return this.doc(editor).lineAt(this.curPos(editor));
   }
 
-  // get line
+  // get line(line)
   getLine(editor, lineNum) {
     return this.doc(editor).line(lineNum);
   }
@@ -45,12 +45,12 @@ class MarkdownDrawioUtil {
    * (If the BOD is not found after the cursor or the EOD is found before the BOD, return null)
    */
   getBod(editor) {
-    if (this.lineBeginPartOfDrawioRE.test(this.cursorLine(editor)).text) {
+    if (this.lineBeginPartOfDrawioRE.test(this.getCursorLine(editor).text)) {
       // get the beginning of the line where the cursor is located
-      return this.cursorLine(editor).from;
+      return this.getCursorLine(editor).from;
     }
 
-    let line = this.cursorLine(editor).number - 1;
+    let line = this.getCursorLine(editor).number - 1;
     let isFound = false;
     for (; line >= this.firstLineNum(); line--) {
       const strLine = this.getLine(editor, line).text;
@@ -78,12 +78,12 @@ class MarkdownDrawioUtil {
    * (If the EOD is not found after the cursor or the BOD is found before the EOD, return null)
    */
   getEod(editor) {
-    if (this.lineEndPartOfDrawioRE.test(this.cursorLine(editor)).text) {
+    if (this.lineEndPartOfDrawioRE.test(this.getCursorLine(editor).text)) {
       // get the end of the line where the cursor is located
-      return this.cursorLine(editor).to;
+      return this.getCursorLine(editor).to;
     }
 
-    let line = this.cursorLine(editor).number + 1;
+    let line = this.getCursorLine(editor).number + 1;
     let isFound = false;
     for (; line <= this.lastLineNum(editor); line++) {
       const strLine = this.getLine(editor, line).text;
@@ -149,8 +149,8 @@ class MarkdownDrawioUtil {
       endPos = this.getEod(editor);
     }
     else {
-      beginPos = this.cursorLine(editor).from;
-      endPos = this.cursorLine(editor).to;
+      beginPos = this.getCursorLine(editor).from;
+      endPos = this.getCursorLine(editor).to;
     }
 
     editor.dispatch({

--- a/apps/app/src/components/PageEditor/MarkdownDrawioUtil.js
+++ b/apps/app/src/components/PageEditor/MarkdownDrawioUtil.js
@@ -113,12 +113,12 @@ class MarkdownDrawioUtil {
 
       // skip block begin sesion("``` drawio")
       const bodLineNum = this.doc(editor).lineAt(bod).number + 1;
-      const bodLine = this.doc(editor).line(bodLineNum);
+      const bodLine = this.doc(editor).line(bodLineNum).from;
       // skip block end sesion("```")
       const eodLineNum = this.doc(editor).lineAt(eod).number - 1;
-      const eodLine = this.doc(editor).line(eodLineNum);
+      const eodLine = this.doc(editor).line(eodLineNum).to;
 
-      return editor.state.sliceDoc(bodLine.from, eodLine.to);
+      return editor.state.sliceDoc(bodLine, eodLine);
     }
     return null;
   }

--- a/apps/app/src/components/PageEditor/MarkdownDrawioUtil.js
+++ b/apps/app/src/components/PageEditor/MarkdownDrawioUtil.js
@@ -47,7 +47,7 @@ class MarkdownDrawioUtil {
 
     let line = this.doc(editor).lineAt(this.curPos(editor)).number - 1;
     let isFound = false;
-    for (; line >= this.firstLine; line--) {
+    for (; line >= this.firstLine(); line--) {
       const strLine = this.getLine(editor, line).text;
       if (this.lineBeginPartOfDrawioRE.test(strLine)) {
         isFound = true;
@@ -64,8 +64,8 @@ class MarkdownDrawioUtil {
       return null;
     }
 
-    const botLine = Math.max(this.firstLine, line);
-    return this.getLineText(editor, botLine).from;
+    const botLine = Math.max(this.firstLine(), line);
+    return this.getLine(editor, botLine).from;
   }
 
   /**
@@ -189,7 +189,7 @@ class MarkdownDrawioUtil {
   findAllDrawioSection(editor) {
     const lineNumbers = [];
     const lastLine = this.lastLine(editor);
-    let firstLine = this.firstLine;
+    let firstLine = this.firstLine();
     // refs: https://github.com/codemirror/CodeMirror/blob/5.64.0/addon/fold/foldcode.js#L106-L111
     for (firstLine, lastLine; firstLine <= lastLine; firstLine++) {
       const lineText = this.getLine(editor, firstLine + 1).text;

--- a/apps/app/src/components/PageEditor/MarkdownDrawioUtil.js
+++ b/apps/app/src/components/PageEditor/MarkdownDrawioUtil.js
@@ -20,12 +20,12 @@ class MarkdownDrawioUtil {
     return editor.state.doc;
   }
 
-  // get first line number(numeber)
+  // get first line number(number)
   firstLineNum() {
     return 1;
   }
 
-  // get last line number(numeber)
+  // get last line number(number)
   lastLineNum(editor) {
     return this.doc(editor).lines;
   }
@@ -151,8 +151,8 @@ class MarkdownDrawioUtil {
       endPos = this.getEod(editor);
     }
     else {
-      beginPos = this.getCursorLine(editor).from;
-      endPos = this.getCursorLine(editor).to;
+      beginPos = this.curPos(editor);
+      endPos = this.curPos(editor);
     }
 
     editor.dispatch({

--- a/apps/app/src/components/PageEditor/MarkdownDrawioUtil.js
+++ b/apps/app/src/components/PageEditor/MarkdownDrawioUtil.js
@@ -69,7 +69,8 @@ class MarkdownDrawioUtil {
       return null;
     }
 
-    const botLine = Math.max(this.firstLineNum(), line);
+    const firstLineNum = this.firstLineNum();
+    const botLine = Math.max(firstLineNum, line);
     return this.getLine(editor, botLine).from;
   }
 
@@ -102,7 +103,8 @@ class MarkdownDrawioUtil {
       return null;
     }
 
-    const eodLine = Math.min(line, this.lastLineNum(editor));
+    const lastLineNum = this.lastLineNum(editor);
+    const eodLine = Math.min(line, lastLineNum);
     return this.getLine(editor, eodLine).to;
   }
 
@@ -195,7 +197,7 @@ class MarkdownDrawioUtil {
     const lineNumbers = [];
     // refs: https://github.com/codemirror/CodeMirror/blob/5.64.0/addon/fold/foldcode.js#L106-L111
     for (let i = this.firstLineNum(), e = this.lastLineNum(editor); i <= e; i++) {
-      const lineText = this.getLine(editor, i + 1).text;
+      const lineText = this.getLine(editor, i).text;
       const match = this.lineBeginPartOfDrawioRE.exec(lineText);
       if (match) {
         lineNumbers.push(i);

--- a/apps/app/src/components/PageEditor/MarkdownDrawioUtil.js
+++ b/apps/app/src/components/PageEditor/MarkdownDrawioUtil.js
@@ -178,11 +178,11 @@ class MarkdownDrawioUtil {
   findAllDrawioSection(editor) {
     const lineNumbers = [];
     // refs: https://github.com/codemirror/CodeMirror/blob/5.64.0/addon/fold/foldcode.js#L106-L111
-    for (let i = 1, e = this.doc(editor).lines; i <= e; i++) {
-      const line = this.doc(editor).line(i + 1).text;
-      const match = this.lineBeginPartOfDrawioRE.exec(line);
+    for (let firstLine = 1, lastLine = this.doc(editor).lines; firstLine <= lastLine; firstLine++) {
+      const lineText = this.doc(editor).line(firstLine + 1).text;
+      const match = this.lineBeginPartOfDrawioRE.exec(lineText);
       if (match) {
-        lineNumbers.push(i);
+        lineNumbers.push(firstLine);
       }
     }
     return lineNumbers;

--- a/apps/app/src/components/PageEditor/MarkdownDrawioUtil.js
+++ b/apps/app/src/components/PageEditor/MarkdownDrawioUtil.js
@@ -14,13 +14,13 @@ class MarkdownDrawioUtil {
    */
   getBod(editor) {
     const curPos = editor.state.selection.main.head;
+    const doc = editor.state.doc;
     const firstLine = 1;
 
-    if (this.lineBeginPartOfDrawioRE.test(editor.getDoc().getLine(curPos.line))) {
-      return { line: curPos.line, ch: 0 };
+    if (this.lineBeginPartOfDrawioRE.test(doc.lineAt(curPos)).text) {
+      return doc.lineAt(curPos).from;
     }
 
-    const doc = editor.state.doc;
     let line = doc.lineAt(curPos(editor)).number - 1;
     let isFound = false;
     for (; line >= firstLine; line--) {
@@ -53,8 +53,8 @@ class MarkdownDrawioUtil {
     const doc = editor.state.doc;
     const lastLine = doc.lines;
 
-    if (this.lineEndPartOfDrawioRE.test(editor.getDoc().getLine(curPos.line))) {
-      return { line: curPos.line, ch: editor.getDoc().getLine(curPos.line).length };
+    if (this.lineEndPartOfDrawioRE.test(doc.lineAt(curPos)).text) {
+      return doc.lineAt(curPos).to;
     }
 
     let line = doc.lineAt(curPos(editor)).number + 1;

--- a/apps/app/src/components/PageEditor/MarkdownDrawioUtil.js
+++ b/apps/app/src/components/PageEditor/MarkdownDrawioUtil.js
@@ -112,11 +112,13 @@ class MarkdownDrawioUtil {
       const eod = this.getEod(editor);
 
       // skip block begin sesion("``` drawio")
-      this.doc(editor).lineAt(bod).number++;
+      const bodLineNum = this.doc(editor).lineAt(bod).number + 1;
+      const bodLine = this.doc(editor).line(bodLineNum);
       // skip block end sesion("```")
-      this.doc(editor).lineAt(eod).number--;
+      const eodLineNum = this.doc(editor).lineAt(eod).number - 1;
+      const eodLine = this.doc(editor).line(eodLineNum);
 
-      return editor.state.sliceDoc(bod, eod);
+      return editor.state.sliceDoc(bodLine.from, eodLine.to);
     }
     return null;
   }

--- a/apps/app/src/components/PageEditor/MarkdownDrawioUtil.js
+++ b/apps/app/src/components/PageEditor/MarkdownDrawioUtil.js
@@ -13,17 +13,18 @@ class MarkdownDrawioUtil {
    * (If the BOD is not found after the cursor or the EOD is found before the BOD, return null)
    */
   getBod(editor) {
-    const curPos = editor.getCursor();
-    const firstLine = editor.getDoc().firstLine();
+    const curPos = editor.state.selection.main.head;
+    const firstLine = 1;
 
     if (this.lineBeginPartOfDrawioRE.test(editor.getDoc().getLine(curPos.line))) {
       return { line: curPos.line, ch: 0 };
     }
 
-    let line = curPos.line - 1;
+    const doc = editor.state.doc;
+    let line = doc.lineAt(curPos(editor)).number - 1;
     let isFound = false;
     for (; line >= firstLine; line--) {
-      const strLine = editor.getDoc().getLine(line);
+      const strLine = doc.line(line).text;
       if (this.lineBeginPartOfDrawioRE.test(strLine)) {
         isFound = true;
         break;
@@ -39,8 +40,8 @@ class MarkdownDrawioUtil {
       return null;
     }
 
-    const bodLine = Math.max(firstLine, line);
-    return { line: bodLine, ch: 0 };
+    const botLine = Math.max(firstLine, line);
+    return doc.line(botLine).from;
   }
 
   /**

--- a/apps/app/src/components/PageEditor/MarkdownDrawioUtil.js
+++ b/apps/app/src/components/PageEditor/MarkdownDrawioUtil.js
@@ -50,9 +50,10 @@ class MarkdownDrawioUtil {
       return this.getCursorLine(editor).from;
     }
 
+    const firstLineNum = this.firstLineNum();
     let line = this.getCursorLine(editor).number - 1;
     let isFound = false;
-    for (; line >= this.firstLineNum(); line--) {
+    for (; line >= firstLineNum; line--) {
       const strLine = this.getLine(editor, line).text;
       if (this.lineBeginPartOfDrawioRE.test(strLine)) {
         isFound = true;
@@ -69,7 +70,6 @@ class MarkdownDrawioUtil {
       return null;
     }
 
-    const firstLineNum = this.firstLineNum();
     const botLine = Math.max(firstLineNum, line);
     return this.getLine(editor, botLine).from;
   }
@@ -84,9 +84,10 @@ class MarkdownDrawioUtil {
       return this.getCursorLine(editor).to;
     }
 
+    const lastLineNum = this.lastLineNum(editor);
     let line = this.getCursorLine(editor).number + 1;
     let isFound = false;
-    for (; line <= this.lastLineNum(editor); line++) {
+    for (; line <= lastLineNum; line++) {
       const strLine = this.getLine(editor, line).text;
       if (this.lineEndPartOfDrawioRE.test(strLine)) {
         isFound = true;
@@ -103,7 +104,6 @@ class MarkdownDrawioUtil {
       return null;
     }
 
-    const lastLineNum = this.lastLineNum(editor);
     const eodLine = Math.min(line, lastLineNum);
     return this.getLine(editor, eodLine).to;
   }


### PR DESCRIPTION
# 概要
MarkdownDrawioUtil.js で codemirror6へのマイグレーション対応をした。

# やったこと
https://codemirror.net/docs/migration/
codemirrorのマイグレーションガイドに従って、MarkdownDrawioUtil.jsを修正しました。

# task
https://redmine.weseek.co.jp/issues/135426

# 後続タスク
(MarkdownDrawioUtil の TS化・関数コンポーネント化)
https://redmine.weseek.co.jp/issues/135842
(モーダルからdrawioをエディタに挿入)
https://redmine.weseek.co.jp/issues/135845
(エディタからdrawioを取得してモーダルで編集できる)
https://redmine.weseek.co.jp/issues/136228