### PR TITLE
enable page grant/body update

### DIFF
--- a/apps/app/src/server/routes/page.js
+++ b/apps/app/src/server/routes/page.js
@@ -463,11 +463,6 @@ module.exports = function(crowi, app) {
     const isSyncRevisionToHackmd = !!req.body.isSyncRevisionToHackmd; // cast to boolean
     const pageTags = req.body.pageTags || undefined;
 
-    // TODO: remove in https://redmine.weseek.co.jp/issues/136140
-    if (grantUserGroupIds != null && grantUserGroupIds.length > 1) {
-      return res.apiv3Err('Cannot grant multiple groups to page at the moment');
-    }
-
     if (pageId === null || pageBody === null || revisionId === null) {
       return res.json(ApiResponse.error('page_id, body and revision_id are required.'));
     }


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/136533

## やったこと
- page grant/revision 更新 API (page.update) で複数グループ grant を有効化
    - 元々仕様を満たしていたため、validation を取り除く以外の変更はなし。
- [rename](https://github.com/weseek/growi/blob/4f7791b7dacdcd47279cb5392e12ac7cbb1211c8/apps/app/src/server/routes/apiv3/pages.js#L524) では grant の更新がないため、create や update で弾けていれば良いものとして、元々複数グループ grant のバリデーションを入れていなかった。また、元々仕様を満たしていたため、何も変更はない。

## base branch
https://github.com/weseek/growi/pull/8309
https://redmine.weseek.co.jp/issues/129126 を再度有効化したもの。
