### PR TITLE
feat: Each user can undo/redo only their own input

### DIFF
--- a/packages/editor/src/services/codemirror-editor/use-codemirror-editor/use-codemirror-editor.ts
+++ b/packages/editor/src/services/codemirror-editor/use-codemirror-editor/use-codemirror-editor.ts
@@ -9,6 +9,10 @@ import { keymap, EditorView } from '@codemirror/view';
 import { tags } from '@lezer/highlight';
 import { useCodeMirror, type UseCodeMirror } from '@uiw/react-codemirror';
 import deepmerge from 'ts-deepmerge';
+// see: https://github.com/yjs/y-codemirror.next#example
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import { yUndoManagerKeymap } from 'y-codemirror.next';
 
 import { emojiAutocompletionSettings } from '../../extensions/emojiAutocompletionSettings';
 
@@ -56,6 +60,7 @@ const defaultExtensions: Extension[] = [
   syntaxHighlighting(markdownHighlighting),
   Prec.lowest(syntaxHighlighting(defaultHighlightStyle)),
   emojiAutocompletionSettings,
+  keymap.of(yUndoManagerKeymap),
 ];
 
 
@@ -78,6 +83,8 @@ export const useCodeMirrorEditor = (props?: UseCodeMirror): UseCodeMirrorEditor 
         basicSetup: {
           defaultKeymap: false,
           dropCursor: false,
+          // Disabled react-codemirror history for Y.UndoManager
+          history: false,
         },
         // ------- End -------
       },

--- a/packages/editor/src/stores/use-collaborative-editor-mode.ts
+++ b/packages/editor/src/stores/use-collaborative-editor-mode.ts
@@ -86,7 +86,7 @@ export const useCollaborativeEditorMode = (
     setProvider(socketIOProvider);
   };
 
-  const attachYDocExtensionsToCodeMirror = () => {
+  const setupYDocExtensions = () => {
     if (ydoc == null || provider == null) {
       return;
     }
@@ -116,6 +116,6 @@ export const useCollaborativeEditorMode = (
   useEffect(cleanupYDocAndProvider, [cPageId, pageId, provider, socket, ydoc]);
   useEffect(setupYDoc, [provider, ydoc]);
   useEffect(setupProvider, [initialValue, pageId, provider, socket, userName, ydoc]);
-  useEffect(attachYDocExtensionsToCodeMirror, [codeMirrorEditor, provider, ydoc]);
+  useEffect(setupYDocExtensions, [codeMirrorEditor, provider, ydoc]);
   useEffect(initializeEditor, [codeMirrorEditor, isInit, onOpenEditor, ydoc]);
 };


### PR DESCRIPTION
task: https://redmine.weseek.co.jp/issues/

### やったこと
react-codemirror の history(undo/redo機能) が悪さしていたので無効化して, history 機能を `Y.UndoManager` に任せるようにしました。