### PR TITLE
imprv: Remove skip to run cypress in 23-editor

### DIFF
--- a/apps/app/test/cypress/e2e/23-editor/23-editor--with-navigation.cy.ts
+++ b/apps/app/test/cypress/e2e/23-editor/23-editor--with-navigation.cy.ts
@@ -106,7 +106,7 @@ context('Editor while uploading to a new page', () => {
 
 });
 
-context.skip('Editor while navigation', () => {
+context('Editor while navigation', () => {
 
   const ssPrefix = 'editor-while-navigation-';
 


### PR DESCRIPTION
# やったこと
`23-editor--with-navigation.cy.ts`で`context.skip('Editor while navigation', () => {`としている箇所があったが、.skipを消してcypressを回してもエラーがないことを確認できたので、`context('Editor while navigation', () => {`に変更した。

# Task
https://redmine.weseek.co.jp/issues/136199