### PR TITLE
imprv: Unable to push Diagram Button when receive  editorKey as null

### DIFF
--- a/apps/app/src/components/PageEditor/DrawioModal.tsx
+++ b/apps/app/src/components/PageEditor/DrawioModal.tsx
@@ -50,16 +50,12 @@ export const DrawioModal = (): JSX.Element => {
   });
 
   const { data: drawioModalData, close: closeDrawioModal } = useDrawioModal();
-  const { data: drawioModalDataInEditor, close: closeDrawioModalInEdior } = useDrawioModalForEditor();
-  const isOpened = drawioModalData?.isOpened ?? false;
-  const isOpendInEditor = drawioModalDataInEditor?.isOpened ?? false;
+  const { data: drawioModalDataInEditor, close: closeDrawioModalInEditor } = useDrawioModalForEditor();
   const editorKey = drawioModalDataInEditor?.editorKey ?? null;
   const { data: codeMirrorEditor } = useCodeMirrorEditorIsolated(editorKey);
   const editor = codeMirrorEditor?.view;
-
-  if (isOpendInEditor && editor == null) {
-    closeDrawioModalInEdior();
-  }
+  const isOpenedInEditor = (drawioModalDataInEditor?.isOpened ?? false) && (editor != null);
+  const isOpened = drawioModalData?.isOpened ?? false;
 
   const drawioUriWithParams = useMemo(() => {
     if (rendererConfig == null) {
@@ -97,9 +93,9 @@ export const DrawioModal = (): JSX.Element => {
     return new DrawioCommunicationHelper(
       rendererConfig.drawioUri,
       drawioConfig,
-      { onClose: closeDrawioModal, onSave: save },
+      { onClose: isOpened ? closeDrawioModal : closeDrawioModalInEditor, onSave: save },
     );
-  }, [closeDrawioModal, drawioModalData?.onSave, editor, rendererConfig]);
+  }, [closeDrawioModal, closeDrawioModalInEditor, drawioModalData?.onSave, editor, isOpened, rendererConfig]);
 
   const receiveMessageHandler = useCallback((event: MessageEvent) => {
     if (drawioModalData == null) {
@@ -111,7 +107,7 @@ export const DrawioModal = (): JSX.Element => {
   }, [drawioCommunicationHelper, drawioModalData, editor]);
 
   useEffect(() => {
-    if (isOpened) {
+    if (isOpened || isOpenedInEditor) {
       window.addEventListener('message', receiveMessageHandler);
     }
     else {
@@ -122,12 +118,13 @@ export const DrawioModal = (): JSX.Element => {
     return function() {
       window.removeEventListener('message', receiveMessageHandler);
     };
-  }, [isOpened, receiveMessageHandler]);
+  }, [isOpened, isOpenedInEditor, receiveMessageHandler]);
+
 
   return (
     <Modal
-      isOpen={isOpened || isOpendInEditor}
-      toggle={() => closeDrawioModal()}
+      isOpen={isOpened || isOpenedInEditor}
+      toggle={() => (isOpened ? closeDrawioModal() : closeDrawioModalInEditor())}
       backdrop="static"
       className="drawio-modal grw-body-only-modal-expanded"
       size="xl"
@@ -143,7 +140,7 @@ export const DrawioModal = (): JSX.Element => {
         {/* iframe */}
         { drawioUriWithParams != null && (
           <div className="w-100 h-100 position-absolute d-flex">
-            { isOpened && (
+            { (isOpened || isOpenedInEditor) && (
               <iframe
                 src={drawioUriWithParams.href}
                 className="border-0 flex-grow-1"

--- a/apps/app/src/components/PageEditor/DrawioModal.tsx
+++ b/apps/app/src/components/PageEditor/DrawioModal.tsx
@@ -50,12 +50,16 @@ export const DrawioModal = (): JSX.Element => {
   });
 
   const { data: drawioModalData, close: closeDrawioModal } = useDrawioModal();
-  const { data: drawioModalDataInEditor } = useDrawioModalForEditor();
+  const { data: drawioModalDataInEditor, close: closeDrawioModalInEdior } = useDrawioModalForEditor();
   const isOpened = drawioModalData?.isOpened ?? false;
   const isOpendInEditor = drawioModalDataInEditor?.isOpened ?? false;
   const editorKey = drawioModalDataInEditor?.editorKey ?? null;
   const { data: codeMirrorEditor } = useCodeMirrorEditorIsolated(editorKey);
   const editor = codeMirrorEditor?.view;
+
+  if ((isOpened || isOpendInEditor) && editorKey == null && drawioModalData?.onSave == null) {
+    closeDrawioModalInEdior();
+  }
 
   const drawioUriWithParams = useMemo(() => {
     if (rendererConfig == null) {

--- a/apps/app/src/components/PageEditor/DrawioModal.tsx
+++ b/apps/app/src/components/PageEditor/DrawioModal.tsx
@@ -57,7 +57,7 @@ export const DrawioModal = (): JSX.Element => {
   const { data: codeMirrorEditor } = useCodeMirrorEditorIsolated(editorKey);
   const editor = codeMirrorEditor?.view;
 
-  if ((isOpened || isOpendInEditor) && editorKey == null && drawioModalData?.onSave == null) {
+  if (isOpendInEditor && editor == null) {
     closeDrawioModalInEdior();
   }
 

--- a/apps/app/src/components/PageEditor/DrawioModal.tsx
+++ b/apps/app/src/components/PageEditor/DrawioModal.tsx
@@ -120,7 +120,6 @@ export const DrawioModal = (): JSX.Element => {
     };
   }, [isOpened, isOpenedInEditor, receiveMessageHandler]);
 
-
   return (
     <Modal
       isOpen={isOpened || isOpenedInEditor}

--- a/packages/editor/src/components/CodeMirrorEditor/Toolbar/DiagramButton.tsx
+++ b/packages/editor/src/components/CodeMirrorEditor/Toolbar/DiagramButton.tsx
@@ -10,6 +10,9 @@ export const DiagramButton = (props: Props): JSX.Element => {
   const { editorKey } = props;
   const { open: openDrawioModal } = useDrawioModalForEditor();
   const onClickDiagramButton = useCallback(() => {
+    if (editorKey == null) {
+      return;
+    }
     openDrawioModal(editorKey);
   }, [editorKey, openDrawioModal]);
   return (

--- a/packages/editor/src/components/CodeMirrorEditor/Toolbar/DiagramButton.tsx
+++ b/packages/editor/src/components/CodeMirrorEditor/Toolbar/DiagramButton.tsx
@@ -10,9 +10,6 @@ export const DiagramButton = (props: Props): JSX.Element => {
   const { editorKey } = props;
   const { open: openDrawioModal } = useDrawioModalForEditor();
   const onClickDiagramButton = useCallback(() => {
-    if (editorKey == null) {
-      return;
-    }
     openDrawioModal(editorKey);
   }, [editorKey, openDrawioModal]);
   return (

--- a/packages/editor/src/stores/use-drawio.ts
+++ b/packages/editor/src/stores/use-drawio.ts
@@ -3,18 +3,14 @@ import { useCallback } from 'react';
 import { useSWRStatic } from '@growi/core/dist/swr';
 import type { SWRResponse } from 'swr';
 
-type DrawioModalSaveHandler = () => void;
-
 type DrawioModalStatus = {
   isOpened: boolean,
   editorKey: string | undefined,
-  onSave?: DrawioModalSaveHandler,
 }
 
 type DrawioModalStatusUtils = {
   open(
     editorKey: string,
-    onSave?: DrawioModalSaveHandler,
   ): void,
   close(): void,
 }
@@ -28,12 +24,12 @@ export const useDrawioModalForEditor = (status?: DrawioModalStatus): SWRResponse
 
   const { mutate } = swrResponse;
 
-  const open = useCallback((editorKey: string | undefined, onSave?: DrawioModalSaveHandler): void => {
-    mutate({ isOpened: true, editorKey, onSave });
+  const open = useCallback((editorKey: string | undefined): void => {
+    mutate({ isOpened: true, editorKey });
   }, [mutate]);
 
   const close = useCallback((): void => {
-    mutate({ isOpened: false, editorKey: undefined, onSave: undefined });
+    mutate({ isOpened: false, editorKey: undefined });
   }, [mutate]);
 
   return {

--- a/packages/editor/src/stores/use-drawio.ts
+++ b/packages/editor/src/stores/use-drawio.ts
@@ -7,7 +7,7 @@ type DrawioModalSaveHandler = () => void;
 
 type DrawioModalStatus = {
   isOpened: boolean,
-  editorKey: string,
+  editorKey: string | undefined,
   onSave?: DrawioModalSaveHandler,
 }
 
@@ -22,18 +22,18 @@ type DrawioModalStatusUtils = {
 export const useDrawioModalForEditor = (status?: DrawioModalStatus): SWRResponse<DrawioModalStatus, Error> & DrawioModalStatusUtils => {
   const initialData: DrawioModalStatus = {
     isOpened: false,
-    editorKey: '',
+    editorKey: undefined,
   };
   const swrResponse = useSWRStatic<DrawioModalStatus, Error>('drawioModalStatus', status, { fallbackData: initialData });
 
   const { mutate } = swrResponse;
 
-  const open = useCallback((editorKey: string, onSave?: DrawioModalSaveHandler): void => {
+  const open = useCallback((editorKey: string | undefined, onSave?: DrawioModalSaveHandler): void => {
     mutate({ isOpened: true, editorKey, onSave });
   }, [mutate]);
 
   const close = useCallback((): void => {
-    mutate({ isOpened: false, editorKey: '', onSave: undefined });
+    mutate({ isOpened: false, editorKey: undefined, onSave: undefined });
   }, [mutate]);
 
   return {

--- a/packages/editor/src/stores/use-drawio.ts
+++ b/packages/editor/src/stores/use-drawio.ts
@@ -24,7 +24,7 @@ export const useDrawioModalForEditor = (status?: DrawioModalStatus): SWRResponse
     isOpened: false,
     editorKey: undefined,
   };
-  const swrResponse = useSWRStatic<DrawioModalStatus, Error>('drawioModalStatus', status, { fallbackData: initialData });
+  const swrResponse = useSWRStatic<DrawioModalStatus, Error>('drawioModalStatusForEditor', status, { fallbackData: initialData });
 
   const { mutate } = swrResponse;
 


### PR DESCRIPTION
# 概要
edlitorKeyがnullの場合、DiagramButtonを利用不可にし、コンポーネントのレンダリングを極力抑制することにしました。

# やったこと
- DiagramButtonのonClickDiagramButtonハンドラー内で、editorKeyに対してnullガードしました。

# 仕様相談Slack
https://wsgrowi.slack.com/archives/C05LB9T4KR9/p1702524369757009

# Task
https://redmine.weseek.co.jp/issues/136640