### PR TITLE
imprv: Fold drawio in Editor

### DIFF
--- a/apps/app/src/components/PageEditor/markdown-drawio-util-for-editor.ts
+++ b/apps/app/src/components/PageEditor/markdown-drawio-util-for-editor.ts
@@ -131,5 +131,4 @@ export const replaceFocusedDrawioWithEditor = (editor: EditorView, drawioData: s
       insert: drawioBlock,
     },
   });
-  // foldDrawioSection(editor);
 };

--- a/apps/app/src/components/PageEditor/markdown-drawio-util-for-editor.ts
+++ b/apps/app/src/components/PageEditor/markdown-drawio-util-for-editor.ts
@@ -1,4 +1,3 @@
-import { foldEffect } from '@codemirror/language';
 import { EditorView } from '@codemirror/view';
 
 const lineBeginPartOfDrawioRE = /^```(\s.*)drawio$/;
@@ -115,36 +114,6 @@ export const getMarkdownDrawioMxfile = (editor: EditorView): string | null => {
 
   return editor.state.sliceDoc(bodLine, eodLine);
 };
-
-// /**
-//  * return an array of the starting line numbers of the drawio sections found in markdown
-//  */
-// const findAllDrawioSection = (editor: EditorView): number[] => {
-//   const lineNumbers: number[] = [];
-//   for (let i = firstLineNum, e = lastLineNum(editor); i <= e; i++) {
-//     const lineTxt = getLine(editor, i).text;
-//     const match = lineBeginPartOfDrawioRE.exec(lineTxt);
-//     if (match) {
-//       lineNumbers.push(i);
-//     }
-//   }
-//   return lineNumbers;
-// };
-
-// // fold draw.io section (``` drawio ~ ```)
-// export const foldDrawioSection = (editor: EditorView): void => {
-//   const lineNumbers = findAllDrawioSection(editor);
-//   console.log(lineNumbers);
-//   lineNumbers.forEach((lineNumber) => {
-//     const from = getLine(editor, lineNumber).to;
-//     const to = getLine(editor, lineNumber + 2).to;
-//     editor.dispatch({
-//       effects: foldEffect.of({
-//         from, to,
-//       }),
-//     });
-//   });
-// };
 
 export const replaceFocusedDrawioWithEditor = (editor: EditorView, drawioData: string): void => {
   const drawioBlock = ['``` drawio', drawioData.toString(), '```'].join('\n');

--- a/apps/app/src/components/PageEditor/markdown-drawio-util-for-editor.ts
+++ b/apps/app/src/components/PageEditor/markdown-drawio-util-for-editor.ts
@@ -1,3 +1,4 @@
+import { foldEffect } from '@codemirror/language';
 import { EditorView } from '@codemirror/view';
 
 const lineBeginPartOfDrawioRE = /^```(\s.*)drawio$/;
@@ -115,6 +116,36 @@ export const getMarkdownDrawioMxfile = (editor: EditorView): string | null => {
   return editor.state.sliceDoc(bodLine, eodLine);
 };
 
+// /**
+//  * return an array of the starting line numbers of the drawio sections found in markdown
+//  */
+// const findAllDrawioSection = (editor: EditorView): number[] => {
+//   const lineNumbers: number[] = [];
+//   for (let i = firstLineNum, e = lastLineNum(editor); i <= e; i++) {
+//     const lineTxt = getLine(editor, i).text;
+//     const match = lineBeginPartOfDrawioRE.exec(lineTxt);
+//     if (match) {
+//       lineNumbers.push(i);
+//     }
+//   }
+//   return lineNumbers;
+// };
+
+// // fold draw.io section (``` drawio ~ ```)
+// export const foldDrawioSection = (editor: EditorView): void => {
+//   const lineNumbers = findAllDrawioSection(editor);
+//   console.log(lineNumbers);
+//   lineNumbers.forEach((lineNumber) => {
+//     const from = getLine(editor, lineNumber).to;
+//     const to = getLine(editor, lineNumber + 2).to;
+//     editor.dispatch({
+//       effects: foldEffect.of({
+//         from, to,
+//       }),
+//     });
+//   });
+// };
+
 export const replaceFocusedDrawioWithEditor = (editor: EditorView, drawioData: string): void => {
   const drawioBlock = ['``` drawio', drawioData.toString(), '```'].join('\n');
   let bod = getBod(editor);
@@ -131,21 +162,5 @@ export const replaceFocusedDrawioWithEditor = (editor: EditorView, drawioData: s
       insert: drawioBlock,
     },
   });
+  // foldDrawioSection(editor);
 };
-
-/**
- * return an array of the starting line numbers of the drawio sections found in markdown
- */
-// TODO: https://redmine.weseek.co.jp/issues/136473
-// export const findAllDrawioSection = (editor: EditorView): number[] => {
-//   const lineNumbers: number[] = [];
-//   // refs: https://github.com/codemirror/CodeMirror/blob/5.64.0/addon/fold/foldcode.js#L106-L111
-//   for (let i = firstLineNum, e = lastLineNum(editor); i <= e; i++) {
-//     const lineTxt = getLine(editor, i).text;
-//     const match = lineBeginPartOfDrawioRE.exec(lineTxt);
-//     if (match) {
-//       lineNumbers.push(i);
-//     }
-//   }
-//   return lineNumbers;
-// };

--- a/packages/editor/src/services/codemirror-editor/use-codemirror-editor/use-codemirror-editor.ts
+++ b/packages/editor/src/services/codemirror-editor/use-codemirror-editor/use-codemirror-editor.ts
@@ -14,6 +14,7 @@ import { emojiAutocompletionSettings } from '../../extensions/emojiAutocompletio
 
 import { useAppendExtensions, type AppendExtensions } from './utils/append-extensions';
 import { useFocus, type Focus } from './utils/focus';
+import { FoldDrawio, useFoldDrawio } from './utils/fold-drawio';
 import { useGetDoc, type GetDoc } from './utils/get-doc';
 import { useInitDoc, type InitDoc } from './utils/init-doc';
 import { useInsertMarkdownElements, type InsertMarkdowElements } from './utils/insert-markdown-elements';
@@ -41,6 +42,7 @@ type UseCodeMirrorEditorUtils = {
   replaceText: ReplaceText,
   insertMarkdownElements: InsertMarkdowElements,
   insertPrefix: InsertPrefix,
+  foldDrawio: FoldDrawio,
 }
 export type UseCodeMirrorEditor = {
   state: EditorState | undefined;
@@ -95,6 +97,7 @@ export const useCodeMirrorEditor = (props?: UseCodeMirror): UseCodeMirrorEditor 
   const replaceText = useReplaceText(view);
   const insertMarkdownElements = useInsertMarkdownElements(view);
   const insertPrefix = useInsertPrefix(view);
+  const foldDrawio = useFoldDrawio(view);
 
   return {
     state,
@@ -108,5 +111,6 @@ export const useCodeMirrorEditor = (props?: UseCodeMirror): UseCodeMirrorEditor 
     replaceText,
     insertMarkdownElements,
     insertPrefix,
+    foldDrawio,
   };
 };

--- a/packages/editor/src/services/codemirror-editor/use-codemirror-editor/utils/fold-drawio.ts
+++ b/packages/editor/src/services/codemirror-editor/use-codemirror-editor/utils/fold-drawio.ts
@@ -1,0 +1,46 @@
+import { useEffect } from 'react';
+
+import { foldEffect } from '@codemirror/language';
+import { EditorView } from '@codemirror/view';
+
+export type FoldDrawio = void;
+
+const findAllDrawioSection = (view?: EditorView) => {
+  if (view == null) {
+    return;
+  }
+  const lineBeginPartOfDrawioRE = /^```(\s.*)drawio$/;
+  const lineNumbers: number[] = [];
+  for (let i = 1, e = view.state.doc.lines; i <= e; i++) {
+    const lineTxt = view.state.doc.line(i).text;
+    const match = lineBeginPartOfDrawioRE.exec(lineTxt);
+    if (match) {
+      lineNumbers.push(i);
+    }
+  }
+  return lineNumbers;
+};
+
+const foldDrawioSection = (lineNumbers?: number[], view?: EditorView) => {
+  if (view == null || lineNumbers == null) {
+    return;
+  }
+  lineNumbers.forEach((lineNumber) => {
+    const from = view.state.doc.line(lineNumber).to;
+    const to = view.state.doc.line(lineNumber + 2).to;
+    view?.dispatch({
+      effects: foldEffect.of({
+        from,
+        to,
+      }),
+    });
+  });
+};
+
+export const useFoldDrawio = (view?: EditorView): FoldDrawio => {
+  const lineNumbers = findAllDrawioSection(view);
+
+  useEffect(() => {
+    foldDrawioSection(lineNumbers, view);
+  }, [view, lineNumbers]);
+};

--- a/packages/editor/src/services/codemirror-editor/use-codemirror-editor/utils/fold-drawio.ts
+++ b/packages/editor/src/services/codemirror-editor/use-codemirror-editor/utils/fold-drawio.ts
@@ -11,7 +11,9 @@ const findAllDrawioSection = (view?: EditorView) => {
   }
   const lineBeginPartOfDrawioRE = /^```(\s.*)drawio$/;
   const lineNumbers: number[] = [];
+  // repeat the process in each line from the top to the bottom in the editor
   for (let i = 1, e = view.state.doc.lines; i <= e; i++) {
+    // get each line text
     const lineTxt = view.state.doc.line(i).text;
     const match = lineBeginPartOfDrawioRE.exec(lineTxt);
     if (match) {
@@ -26,7 +28,9 @@ const foldDrawioSection = (lineNumbers?: number[], view?: EditorView) => {
     return;
   }
   lineNumbers.forEach((lineNumber) => {
+    // get the end of the lines containing '''drawio
     const from = view.state.doc.line(lineNumber).to;
+    // get the end of the lines containing '''
     const to = view.state.doc.line(lineNumber + 2).to;
     view?.dispatch({
       effects: foldEffect.of({

--- a/packages/editor/src/services/codemirror-editor/use-codemirror-editor/utils/init-doc.ts
+++ b/packages/editor/src/services/codemirror-editor/use-codemirror-editor/utils/init-doc.ts
@@ -1,46 +1,11 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback } from 'react';
 
-import { foldEffect } from '@codemirror/language';
 import { Transaction } from '@codemirror/state';
 import { EditorView } from '@codemirror/view';
 
 export type InitDoc = (doc?: string) => void;
 
 export const useInitDoc = (view?: EditorView): InitDoc => {
-  useEffect(() => {
-    if (view != null) {
-      /**
-       * return an array of the starting line numbers of the drawio sections found in markdown
-       */
-      const findAllDrawioSection = (editor: EditorView): number[] => {
-        const lineBeginPartOfDrawioRE = /^```(\s.*)drawio$/;
-        const lineNumbers: number[] = [];
-        for (let i = 1, e = editor.state.doc.lines; i <= e; i++) {
-          const lineTxt = editor.state.doc.line(i).text;
-          const match = lineBeginPartOfDrawioRE.exec(lineTxt);
-          if (match) {
-            lineNumbers.push(i);
-          }
-        }
-        return lineNumbers;
-      };
-
-      // fold draw.io section (``` drawio ~ ```)
-      const foldDrawioSection = (editor: EditorView): void => {
-        const lineNumbers = findAllDrawioSection(editor);
-        lineNumbers.forEach((lineNumber) => {
-          const from = editor.state.doc.line(lineNumber).to;
-          const to = editor.state.doc.line(lineNumber + 2).to;
-          editor.dispatch({
-            effects: foldEffect.of({
-              from, to,
-            }),
-          });
-        });
-      };
-      foldDrawioSection(view);
-    }
-  });
 
   return useCallback((doc) => {
     view?.dispatch({

--- a/packages/editor/src/services/codemirror-editor/use-codemirror-editor/utils/init-doc.ts
+++ b/packages/editor/src/services/codemirror-editor/use-codemirror-editor/utils/init-doc.ts
@@ -1,11 +1,46 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 
+import { foldEffect } from '@codemirror/language';
 import { Transaction } from '@codemirror/state';
 import { EditorView } from '@codemirror/view';
 
 export type InitDoc = (doc?: string) => void;
 
 export const useInitDoc = (view?: EditorView): InitDoc => {
+  useEffect(() => {
+    if (view != null) {
+      /**
+       * return an array of the starting line numbers of the drawio sections found in markdown
+       */
+      const findAllDrawioSection = (editor: EditorView): number[] => {
+        const lineBeginPartOfDrawioRE = /^```(\s.*)drawio$/;
+        const lineNumbers: number[] = [];
+        for (let i = 1, e = editor.state.doc.lines; i <= e; i++) {
+          const lineTxt = editor.state.doc.line(i).text;
+          const match = lineBeginPartOfDrawioRE.exec(lineTxt);
+          if (match) {
+            lineNumbers.push(i);
+          }
+        }
+        return lineNumbers;
+      };
+
+      // fold draw.io section (``` drawio ~ ```)
+      const foldDrawioSection = (editor: EditorView): void => {
+        const lineNumbers = findAllDrawioSection(editor);
+        lineNumbers.forEach((lineNumber) => {
+          const from = editor.state.doc.line(lineNumber).to;
+          const to = editor.state.doc.line(lineNumber + 2).to;
+          editor.dispatch({
+            effects: foldEffect.of({
+              from, to,
+            }),
+          });
+        });
+      };
+      foldDrawioSection(view);
+    }
+  });
 
   return useCallback((doc) => {
     view?.dispatch({


### PR DESCRIPTION
# 概要
エディタ上にdrawioブロックが存在する場合はdrawioブロックのみ折りたたむようにしました。

# やったこと
- init-doc.tsでエディタ画面の初期状態を設定していたので、エディタ画面にある'`'' drawio`を含む行番号を取得し、その行の行末から二行したの行末に対して`foldEffect.of`することで、drawioブロックのみ折りたたむことができる状態になりました。

# task
https://redmine.weseek.co.jp/issues/136958

# 参考
https://codemirror.net/docs/ref/#language.foldEffect

# ScreenShot
<img width="248" alt="スクリーンショット 2023-12-22 17 10 52" src="https://github.com/weseek/growi/assets/112812878/1a08ca9e-4e5a-43be-8752-cc6e03e8970a">

