### PR TITLE
support: Create github actions to automatically release RC at scheduled times

### DIFF
--- a/.github/workflows/create-rc-release-branch-scheduler-for-v7.yml
+++ b/.github/workflows/create-rc-release-branch-scheduler-for-v7.yml
@@ -22,7 +22,7 @@ jobs:
           run: echo "CURRENT_DATETIME=$(date +'%Y%m%d%H%M%S')" >> $GITHUB_OUTPUT
 
         - name: Checkout target branch
-          uses: actions/checkout@v4
+          uses: actions/checkout@v
           with:
             ref: dev/7.0.x
 
@@ -32,7 +32,7 @@ jobs:
             git config user.email github-actions@github.com
             git checkout -b rc/${{ steps.set-current-datetime.outputs.CURRENT_DATETIME }}
             git commit --allow-empty -m "empty commit to run release-rc.yml"
-            git push
+            git push --set-upstream origin rc/${{ steps.set-current-datetime.outputs.CURRENT_DATETIME }}
           env:
             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/create-rc-release-branch-scheduler-for-v7.yml
+++ b/.github/workflows/create-rc-release-branch-scheduler-for-v7.yml
@@ -28,20 +28,22 @@ jobs:
 
         - name: Create RC release branch
           run: |
-            git config --local user.email "github-actions[bot]@users.noreply.github.com"
-            git config --local user.name "github-actions[bot]"
+            git config user.name github-actions
+            git config user.email github-actions@github.com
             git commit --allow-empty -m "empty commit to run release-rc.yml"
             git checkout -b rc/${{ steps.set-current-datetime.outputs.CURRENT_DATETIME }}
             git push --set-upstream origin rc/${{ steps.set-current-datetime.outputs.CURRENT_DATETIME }}
+          env:
+            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-        - name: Retrieve information from package.json
-          uses: myrotvorets/info-from-package-json-action@1.2.0
-          id: package-json
+        # - name: Retrieve information from package.json
+        #   uses: myrotvorets/info-from-package-json-action@1.2.0
+        #   id: package-json
 
-        - name: Create PR
-          uses: repo-sync/pull-request@v2
-          with:
-            source_branch: rc/${{ steps.set-current-datetime.outputs.CURRENT_DATETIME }}
-            destination_branch: dev/7.0.x
-            pr_title: Release ${{ steps.package-json.outputs.packageVersion }}-${{ steps.set-current-datetime.outputs.CURRENT_DATETIME }}
-            github_token: ${{ secrets.GITHUB_TOKEN }}
+        # - name: Create PR
+        #   uses: repo-sync/pull-request@v2
+        #   with:
+        #     source_branch: rc/${{ steps.set-current-datetime.outputs.CURRENT_DATETIME }}
+        #     destination_branch: dev/7.0.x
+        #     pr_title: Release ${{ steps.package-json.outputs.packageVersion }}-${{ steps.set-current-datetime.outputs.CURRENT_DATETIME }}
+        #     github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/create-rc-release-branch-scheduler-for-v7.yml
+++ b/.github/workflows/create-rc-release-branch-scheduler-for-v7.yml
@@ -1,4 +1,4 @@
-name: Create RC Release Branche with the Scheduler (for dev/7.0.x)
+name: Create RC release Branche with the Scheduler (for dev/7.0.x)
 
 on:
   schedule:
@@ -21,6 +21,6 @@ jobs:
           with:
             ref: dev/7.0.x
 
-        - name: Create checkout rc branch
+        - name: Create RC release branch
           run: |
             git checkout -b rc/${{ steps.set-current-datetime.outputs.CURRENT_DATETIME }}

--- a/.github/workflows/create-rc-release-branch-scheduler-for-v7.yml
+++ b/.github/workflows/create-rc-release-branch-scheduler-for-v7.yml
@@ -27,11 +27,21 @@ jobs:
             ref: dev/7.0.x
 
         - name: Create RC release branch
-          env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           run: |
             git config --local user.email "github-actions[bot]@users.noreply.github.com"
             git config --local user.name "github-actions[bot]"
             git commit --allow-empty -m "empty commit to run release-rc.yml"
             git checkout -b rc/${{ steps.set-current-datetime.outputs.CURRENT_DATETIME }}
             git push --set-upstream origin rc/${{ steps.set-current-datetime.outputs.CURRENT_DATETIME }}
+
+        - name: Retrieve information from package.json
+          uses: myrotvorets/info-from-package-json-action@1.2.0
+          id: package-json
+
+        - name: Create PR
+          uses: repo-sync/pull-request@v2
+          with:
+            source_branch: rc/${{ steps.set-current-datetime.outputs.CURRENT_DATETIME }}
+            destination_branch: dev/7.0.x
+            pr_title: Release ${{ steps.package-json.outputs.packageVersion }}-${{ steps.set-current-datetime.outputs.CURRENT_DATETIME }}
+            github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/create-rc-release-branch-scheduler-for-v7.yml
+++ b/.github/workflows/create-rc-release-branch-scheduler-for-v7.yml
@@ -26,17 +26,12 @@ jobs:
           with:
             ref: dev/7.0.x
 
-        - name: Commit
-          uses: actions-x/commit@v6
-          with:
-            name: GitHub Actions Autocommitter
-            token: ${{ secrets.GITHUB_TOKEN }}
-            branch: rc/${{ steps.set-current-datetime.outputs.CURRENT_DATETIME }}
-            message: 'empty commit to run Github actions'
-
         - name: Create RC release branch
           env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           run: |
+          	git config --local user.email "github-actions[bot]@users.noreply.github.com"
+	          git config --local user.name "github-actions[bot]"
+            git commit --allow-empty -m "empty commit to run release-rc.yml"
             git checkout -b rc/${{ steps.set-current-datetime.outputs.CURRENT_DATETIME }}
             git push --set-upstream origin rc/${{ steps.set-current-datetime.outputs.CURRENT_DATETIME }}

--- a/.github/workflows/create-rc-release-branch-scheduler-for-v7.yml
+++ b/.github/workflows/create-rc-release-branch-scheduler-for-v7.yml
@@ -27,7 +27,7 @@ jobs:
             ref: dev/7.0.x
 
         - name: Commit
-          uses: github-actions-x/commit@6
+          uses: actions-x/commit@v6
           with:
             name: GitHub Actions Autocommitter
             token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/create-rc-release-branch-scheduler-for-v7.yml
+++ b/.github/workflows/create-rc-release-branch-scheduler-for-v7.yml
@@ -22,7 +22,7 @@ jobs:
           run: echo "CURRENT_DATETIME=$(date +'%Y%m%d%H%M%S')" >> $GITHUB_OUTPUT
 
         - name: Checkout target branch
-          uses: actions/checkout@v3
+          uses: actions/checkout@v4
           with:
             ref: dev/7.0.x
 

--- a/.github/workflows/create-rc-release-branch-scheduler-for-v7.yml
+++ b/.github/workflows/create-rc-release-branch-scheduler-for-v7.yml
@@ -30,9 +30,9 @@ jobs:
           run: |
             git config user.name github-actions
             git config user.email github-actions@github.com
-            git commit --allow-empty -m "empty commit to run release-rc.yml"
             git checkout -b rc/${{ steps.set-current-datetime.outputs.CURRENT_DATETIME }}
-            git push --set-upstream origin rc/${{ steps.set-current-datetime.outputs.CURRENT_DATETIME }}
+            git commit --allow-empty -m "empty commit to run release-rc.yml"
+            git push
           env:
             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/create-rc-release-branch-scheduler-for-v7.yml
+++ b/.github/workflows/create-rc-release-branch-scheduler-for-v7.yml
@@ -22,7 +22,7 @@ jobs:
           run: echo "CURRENT_DATETIME=$(date +'%Y%m%d%H%M%S')" >> $GITHUB_OUTPUT
 
         - name: Checkout target branch
-          uses: actions/checkout@v
+          uses: actions/checkout@v4
           with:
             ref: dev/7.0.x
 

--- a/.github/workflows/create-rc-release-branch-scheduler-for-v7.yml
+++ b/.github/workflows/create-rc-release-branch-scheduler-for-v7.yml
@@ -26,6 +26,10 @@ jobs:
           with:
             ref: dev/7.0.x
 
+        - name: Retrieve information from package.json
+          uses: myrotvorets/info-from-package-json-action@1.2.0
+          id: package-json
+
         - name: Create RC release branch
           run: |
             git config user.name github-actions
@@ -33,13 +37,10 @@ jobs:
             git checkout -b rc/${{ steps.set-current-datetime.outputs.CURRENT_DATETIME }}
             git commit --allow-empty -m "empty commit to run release-rc.yml"
             git push --set-upstream origin rc/${{ steps.set-current-datetime.outputs.CURRENT_DATETIME }}
-            gh pr create --title "Release ${{ steps.package-json.outputs.packageVersion }}-${{ steps.set-current-datetime.outputs.CURRENT_DATETIME }}" --body "test"
+            gh pr create --title "Release ${{ steps.package-json.outputs.packageVersion }}-${{ steps.set-current-datetime.outputs.CURRENT_DATETIME }}" --body "test" --base dev/7.0.x
           env:
             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-        # - name: Retrieve information from package.json
-        #   uses: myrotvorets/info-from-package-json-action@1.2.0
-        #   id: package-json
 
         # - name: Create PR
         #   uses: repo-sync/pull-request@v2

--- a/.github/workflows/create-rc-release-branch-scheduler-for-v7.yml
+++ b/.github/workflows/create-rc-release-branch-scheduler-for-v7.yml
@@ -33,6 +33,7 @@ jobs:
             git checkout -b rc/${{ steps.set-current-datetime.outputs.CURRENT_DATETIME }}
             git commit --allow-empty -m "empty commit to run release-rc.yml"
             git push --set-upstream origin rc/${{ steps.set-current-datetime.outputs.CURRENT_DATETIME }}
+            gh pr create --title "Release ${{ steps.package-json.outputs.packageVersion }}-${{ steps.set-current-datetime.outputs.CURRENT_DATETIME }}"
           env:
             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/create-rc-release-branch-scheduler-for-v7.yml
+++ b/.github/workflows/create-rc-release-branch-scheduler-for-v7.yml
@@ -1,8 +1,13 @@
 name: Create RC release Branche with the Scheduler (for dev/7.0.x)
 
+# on:
+#   schedule:
+#     - cron: '0 0 * * *'
+
 on:
-  schedule:
-    - cron: '0 0 * * *'
+  pull_request:
+    branches:
+      - master
 
 jobs:
     create-rc-branch:

--- a/.github/workflows/create-rc-release-branch-scheduler-for-v7.yml
+++ b/.github/workflows/create-rc-release-branch-scheduler-for-v7.yml
@@ -33,7 +33,7 @@ jobs:
             git checkout -b rc/${{ steps.set-current-datetime.outputs.CURRENT_DATETIME }}
             git commit --allow-empty -m "empty commit to run release-rc.yml"
             git push --set-upstream origin rc/${{ steps.set-current-datetime.outputs.CURRENT_DATETIME }}
-            gh pr create --title "Release ${{ steps.package-json.outputs.packageVersion }}-${{ steps.set-current-datetime.outputs.CURRENT_DATETIME }} --body "test"
+            gh pr create --title "Release ${{ steps.package-json.outputs.packageVersion }}-${{ steps.set-current-datetime.outputs.CURRENT_DATETIME }}" --body "test"
           env:
             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/create-rc-release-branch-scheduler-for-v7.yml
+++ b/.github/workflows/create-rc-release-branch-scheduler-for-v7.yml
@@ -10,7 +10,7 @@ on:
       - master
 
 jobs:
-    create-rc-branch:
+    create-rc-release-branch:
 
       runs-on: ubuntu-latest
 
@@ -31,4 +31,5 @@ jobs:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           run: |
             git checkout -b rc/${{ steps.set-current-datetime.outputs.CURRENT_DATETIME }}
+            git commit --allow-empty -m "empty commit"
             git push --set-upstream origin rc/${{ steps.set-current-datetime.outputs.CURRENT_DATETIME }}

--- a/.github/workflows/create-rc-release-branch-scheduler-for-v7.yml
+++ b/.github/workflows/create-rc-release-branch-scheduler-for-v7.yml
@@ -31,3 +31,4 @@ jobs:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           run: |
             git checkout -b rc/${{ steps.set-current-datetime.outputs.CURRENT_DATETIME }}
+            git push

--- a/.github/workflows/create-rc-release-branch-scheduler-for-v7.yml
+++ b/.github/workflows/create-rc-release-branch-scheduler-for-v7.yml
@@ -31,4 +31,4 @@ jobs:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           run: |
             git checkout -b rc/${{ steps.set-current-datetime.outputs.CURRENT_DATETIME }}
-            git push
+            git push --set-upstream origin rc/${{ steps.set-current-datetime.outputs.CURRENT_DATETIME }}

--- a/.github/workflows/create-rc-release-branch-scheduler-for-v7.yml
+++ b/.github/workflows/create-rc-release-branch-scheduler-for-v7.yml
@@ -33,7 +33,7 @@ jobs:
             git checkout -b rc/${{ steps.set-current-datetime.outputs.CURRENT_DATETIME }}
             git commit --allow-empty -m "empty commit to run release-rc.yml"
             git push --set-upstream origin rc/${{ steps.set-current-datetime.outputs.CURRENT_DATETIME }}
-            gh pr create --title "Release ${{ steps.package-json.outputs.packageVersion }}-${{ steps.set-current-datetime.outputs.CURRENT_DATETIME }}"
+            gh pr create --title "Release ${{ steps.package-json.outputs.packageVersion }}-${{ steps.set-current-datetime.outputs.CURRENT_DATETIME }} --body "test"
           env:
             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/create-rc-release-branch-scheduler-for-v7.yml
+++ b/.github/workflows/create-rc-release-branch-scheduler-for-v7.yml
@@ -18,7 +18,7 @@ jobs:
         - name: Set current datetime as env variable
           id: set-current-datetime
           env:
-          TZ: 'Asia/Tokyo'
+            TZ: 'Asia/Tokyo'
           run: echo "CURRENT_DATETIME=$(date +'%Y%m%d%H%M%S')" >> $GITHUB_OUTPUT
 
         - name: Checkout target branch
@@ -27,5 +27,7 @@ jobs:
             ref: dev/7.0.x
 
         - name: Create RC release branch
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           run: |
             git checkout -b rc/${{ steps.set-current-datetime.outputs.CURRENT_DATETIME }}

--- a/.github/workflows/create-rc-release-branch-scheduler-for-v7.yml
+++ b/.github/workflows/create-rc-release-branch-scheduler-for-v7.yml
@@ -30,8 +30,8 @@ jobs:
           env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           run: |
-          	git config --local user.email "github-actions[bot]@users.noreply.github.com"
-	          git config --local user.name "github-actions[bot]"
+            git config --local user.email "github-actions[bot]@users.noreply.github.com"
+            git config --local user.name "github-actions[bot]"
             git commit --allow-empty -m "empty commit to run release-rc.yml"
             git checkout -b rc/${{ steps.set-current-datetime.outputs.CURRENT_DATETIME }}
             git push --set-upstream origin rc/${{ steps.set-current-datetime.outputs.CURRENT_DATETIME }}

--- a/.github/workflows/create-rc-release-branch-scheduler-for-v7.yml
+++ b/.github/workflows/create-rc-release-branch-scheduler-for-v7.yml
@@ -26,10 +26,17 @@ jobs:
           with:
             ref: dev/7.0.x
 
+        - name: Commit
+          uses: github-actions-x/commit@6
+          with:
+            name: GitHub Actions Autocommitter
+            token: ${{ secrets.GITHUB_TOKEN }}
+            branch: rc/${{ steps.set-current-datetime.outputs.CURRENT_DATETIME }}
+            message: 'empty commit to run Github actions'
+
         - name: Create RC release branch
           env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           run: |
             git checkout -b rc/${{ steps.set-current-datetime.outputs.CURRENT_DATETIME }}
-            git commit --allow-empty -m "empty commit"
             git push --set-upstream origin rc/${{ steps.set-current-datetime.outputs.CURRENT_DATETIME }}

--- a/.github/workflows/release-rc-scheduled.yml
+++ b/.github/workflows/release-rc-scheduled.yml
@@ -1,0 +1,80 @@
+name: Release Docker Images for RC (by Scheduler)
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+
+jobs:
+
+  determine-tags:
+    runs-on: ubuntu-latest
+
+    outputs:
+      TAGS: ${{ steps.meta.outputs.tags }}
+      TAGS_GHCR: ${{ steps.meta-ghcr.outputs.tags }}
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Retrieve information from package.json
+      uses: myrotvorets/info-from-package-json-action@1.2.0
+      id: package-json
+
+    - name: Docker meta for docker.io
+      uses: docker/metadata-action@v4
+      id: meta
+      with:
+        images: docker.io/weseek/growi
+        sep-tags: ','
+        tags: |
+          type=raw,value=${{ steps.package-json.outputs.packageVersion }}
+          type=raw,value=${{ steps.package-json.outputs.packageVersion }}.{{sha}}
+
+    - name: Docker meta for ghcr.io
+      uses: docker/metadata-action@v4
+      id: meta-ghcr
+      with:
+        images: ghcr.io/weseek/growi
+        sep-tags: ','
+        tags: |
+          type=raw,value=${{ steps.package-json.outputs.packageVersion }}
+          type=raw,value=${{ steps.package-json.outputs.packageVersion }}.{{sha}}
+
+
+  build-image-rc:
+    uses: weseek/growi/.github/workflows/reusable-app-build-image.yml@master
+    with:
+      image-name: weseek/growi
+      tag-temporary: latest-rc
+    secrets:
+      AWS_ROLE_TO_ASSUME_FOR_OIDC: ${{ secrets.AWS_ROLE_TO_ASSUME_FOR_OIDC }}
+
+
+  publish-image-rc:
+    needs: [determine-tags, build-image-rc]
+
+    uses: weseek/growi/.github/workflows/reusable-app-create-manifests.yml@master
+    with:
+      tags: ${{ needs.determine-tags.outputs.TAGS }}
+      registry: docker.io
+      image-name: weseek/growi
+      tag-temporary: latest-rc
+    secrets:
+      DOCKER_REGISTRY_PASSWORD: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
+
+  publish-image-rc-ghcr:
+    needs: [determine-tags, build-image-rc]
+
+    uses: weseek/growi/.github/workflows/reusable-app-create-manifests.yml@master
+    with:
+      tags: ${{ needs.determine-tags.outputs.TAGS_GHCR }}
+      registry: ghcr.io
+      image-name: weseek/growi
+      tag-temporary: latest-rc
+    secrets:
+      DOCKER_REGISTRY_PASSWORD: ${{ secrets.DOCKER_REGISTRY_ON_GITHUB_PASSWORD }}

--- a/.github/workflows/release-rc-scheduled.yml
+++ b/.github/workflows/release-rc-scheduled.yml
@@ -1,80 +1,26 @@
-name: Release Docker Images for RC (by Scheduler)
+name: Create RC Release Branche with the Scheduler (for dev/7.0.x)
 
 on:
   schedule:
     - cron: '0 0 * * *'
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
-
 jobs:
+    create-rc-branch:
 
-  determine-tags:
-    runs-on: ubuntu-latest
+      runs-on: ubuntu-latest
 
-    outputs:
-      TAGS: ${{ steps.meta.outputs.tags }}
-      TAGS_GHCR: ${{ steps.meta-ghcr.outputs.tags }}
+      steps:
+        - name: Set current datetime as env variable
+          id: set-current-datetime
+          env:
+          TZ: 'Asia/Tokyo'
+          run: echo "CURRENT_DATETIME=$(date +'%Y%m%d%H%M%S')" >> $GITHUB_OUTPUT
 
-    steps:
-    - uses: actions/checkout@v3
+        - name: Checkout target branch
+          uses: actions/checkout@v3
+          with:
+            ref: dev/7.0.x
 
-    - name: Retrieve information from package.json
-      uses: myrotvorets/info-from-package-json-action@1.2.0
-      id: package-json
-
-    - name: Docker meta for docker.io
-      uses: docker/metadata-action@v4
-      id: meta
-      with:
-        images: docker.io/weseek/growi
-        sep-tags: ','
-        tags: |
-          type=raw,value=${{ steps.package-json.outputs.packageVersion }}
-          type=raw,value=${{ steps.package-json.outputs.packageVersion }}.{{sha}}
-
-    - name: Docker meta for ghcr.io
-      uses: docker/metadata-action@v4
-      id: meta-ghcr
-      with:
-        images: ghcr.io/weseek/growi
-        sep-tags: ','
-        tags: |
-          type=raw,value=${{ steps.package-json.outputs.packageVersion }}
-          type=raw,value=${{ steps.package-json.outputs.packageVersion }}.{{sha}}
-
-
-  build-image-rc:
-    uses: weseek/growi/.github/workflows/reusable-app-build-image.yml@master
-    with:
-      image-name: weseek/growi
-      tag-temporary: latest-rc
-    secrets:
-      AWS_ROLE_TO_ASSUME_FOR_OIDC: ${{ secrets.AWS_ROLE_TO_ASSUME_FOR_OIDC }}
-
-
-  publish-image-rc:
-    needs: [determine-tags, build-image-rc]
-
-    uses: weseek/growi/.github/workflows/reusable-app-create-manifests.yml@master
-    with:
-      tags: ${{ needs.determine-tags.outputs.TAGS }}
-      registry: docker.io
-      image-name: weseek/growi
-      tag-temporary: latest-rc
-    secrets:
-      DOCKER_REGISTRY_PASSWORD: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
-
-  publish-image-rc-ghcr:
-    needs: [determine-tags, build-image-rc]
-
-    uses: weseek/growi/.github/workflows/reusable-app-create-manifests.yml@master
-    with:
-      tags: ${{ needs.determine-tags.outputs.TAGS_GHCR }}
-      registry: ghcr.io
-      image-name: weseek/growi
-      tag-temporary: latest-rc
-    secrets:
-      DOCKER_REGISTRY_PASSWORD: ${{ secrets.DOCKER_REGISTRY_ON_GITHUB_PASSWORD }}
+        - name: Create checkout rc branch
+          run: |
+            git checkout -b rc/${{ steps.set-current-datetime.outputs.CURRENT_DATETIME }}


### PR DESCRIPTION
## Task
[#136468](https://redmine.weseek.co.jp/issues/136468) v7ブランチのデモ環境をデプロイできる
┗ [#137408](https://redmine.weseek.co.jp/issues/137408) 指定した時間に dev/7.0.x から rc ブランチを切り release-rc.yml をトリガーする Github actions を作成する