### PR TITLE
imprv: Allow plugin that contain slashes in the branch name to be installed

### DIFF
--- a/apps/app/src/features/growi-plugin/server/models/vo/github-url.spec.ts
+++ b/apps/app/src/features/growi-plugin/server/models/vo/github-url.spec.ts
@@ -69,19 +69,38 @@ describe('archiveUrl()', () => {
 
 describe('extractedArchiveDirName()', () => {
 
-  it.concurrent.each`
-    branchName
-    ${'a"\'!,;-=@`]<>|&{}()$%+#/b'}
-    ${'a---b'}
-  `("'$branchName'", ({ branchName }) => {
-    // setup
-    const githubUrl = new GitHubUrl('https://github.com/org/repos', branchName);
+  describe('certain characters in the branch name are converted to slashes, and if they are consecutive, they become a single hyphen', () => {
+    it.concurrent.each`
+      branchName
+      ${'a"\'!,;-=@`]<>|&{}()$%+#/b'}
+      ${'a---b'}
+    `("'$branchName'", ({ branchName }) => {
+      // setup
+      const githubUrl = new GitHubUrl('https://github.com/org/repos', branchName);
 
-    // when
-    const { extractedArchiveDirName } = githubUrl;
+      // when
+      const { extractedArchiveDirName } = githubUrl;
 
-    // then
-    expect(extractedArchiveDirName).toEqual('a-b');
+      // then
+      expect(extractedArchiveDirName).toEqual('a-b');
+    });
+  });
+
+  describe('when no certain characters in the branch name', () => {
+    it.concurrent.each`
+      branchName
+      ${'a.b'}
+      ${'a_b'}
+    `("'$branchName'", ({ branchName }) => {
+      // setup
+      const githubUrl = new GitHubUrl('https://github.com/org/repos', branchName);
+
+      // when
+      const { extractedArchiveDirName } = githubUrl;
+
+      // then
+      expect(extractedArchiveDirName).toEqual(branchName);
+    });
   });
 
 });

--- a/apps/app/src/features/growi-plugin/server/models/vo/github-url.spec.ts
+++ b/apps/app/src/features/growi-plugin/server/models/vo/github-url.spec.ts
@@ -63,6 +63,25 @@ describe('archiveUrl()', () => {
     const { archiveUrl } = githubUrl;
 
     // then
-    expect(archiveUrl).toEqual('https://github.com/org/repos/archive/refs/heads/fix/bug.zip');
+    expect(archiveUrl).toEqual('https://github.com/org/repos/archive/refs/heads/fix%2Fbug.zip');
   });
+});
+
+describe('extractedArchiveDirName()', () => {
+
+  it.concurrent.each`
+    branchName
+    ${'a"\'!,;-=@`]<>|&{}()$%+#/b'}
+    ${'a---b'}
+  `("'$branchName'", ({ branchName }) => {
+    // setup
+    const githubUrl = new GitHubUrl('https://github.com/org/repos', branchName);
+
+    // when
+    const { extractedArchiveDirName } = githubUrl;
+
+    // then
+    expect(extractedArchiveDirName).toEqual('a-b');
+  });
+
 });

--- a/apps/app/src/features/growi-plugin/server/models/vo/github-url.ts
+++ b/apps/app/src/features/growi-plugin/server/models/vo/github-url.ts
@@ -2,8 +2,8 @@ import sanitize from 'sanitize-filename';
 
 // https://regex101.com/r/fK2rV3/1
 const githubReposIdPattern = new RegExp(/^\/([^/]+)\/([^/]+)$/);
-// https://regex101.com/r/DOVpOT/1
-const sanitizeChars = new RegExp(/[/|"'<>]+/g);
+// https://regex101.com/r/YhZVsj/1
+const sanitizeChars = new RegExp(/[^a-zA-Z_.]+/g);
 
 export class GitHubUrl {
 
@@ -26,7 +26,8 @@ export class GitHubUrl {
   }
 
   get archiveUrl(): string {
-    const ghUrl = new URL(`/${this.organizationName}/${this.reposName}/archive/refs/heads/${this.branchName}.zip`, 'https://github.com');
+    const encodedBranchName = encodeURIComponent(this.branchName);
+    const ghUrl = new URL(`/${this.organizationName}/${this.reposName}/archive/refs/heads/${encodedBranchName}.zip`, 'https://github.com');
     return ghUrl.toString();
   }
 

--- a/apps/app/src/features/growi-plugin/server/models/vo/github-url.ts
+++ b/apps/app/src/features/growi-plugin/server/models/vo/github-url.ts
@@ -2,6 +2,8 @@ import sanitize from 'sanitize-filename';
 
 // https://regex101.com/r/fK2rV3/1
 const githubReposIdPattern = new RegExp(/^\/([^/]+)\/([^/]+)$/);
+// https://regex101.com/r/DOVpOT/1
+const sanitizeChars = new RegExp(/[/|"'<>]+/g);
 
 export class GitHubUrl {
 
@@ -26,6 +28,10 @@ export class GitHubUrl {
   get archiveUrl(): string {
     const ghUrl = new URL(`/${this.organizationName}/${this.reposName}/archive/refs/heads/${this.branchName}.zip`, 'https://github.com');
     return ghUrl.toString();
+  }
+
+  get archiveFileName(): string {
+    return this._branchName.replaceAll(sanitizeChars, '-');
   }
 
   constructor(url: string, branchName = 'main') {

--- a/apps/app/src/features/growi-plugin/server/models/vo/github-url.ts
+++ b/apps/app/src/features/growi-plugin/server/models/vo/github-url.ts
@@ -31,7 +31,7 @@ export class GitHubUrl {
     return ghUrl.toString();
   }
 
-  get archiveFileName(): string {
+  get extractedArchiveDirName(): string {
     return this._branchName.replaceAll(sanitizeChars, '-');
   }
 

--- a/apps/app/src/features/growi-plugin/server/services/growi-plugin/growi-plugin.ts
+++ b/apps/app/src/features/growi-plugin/server/services/growi-plugin/growi-plugin.ts
@@ -76,11 +76,11 @@ export class GrowiPluginService implements IGrowiPluginService {
 
           // TODO: imprv Document version and repository version possibly different.
           const ghUrl = new GitHubUrl(growiPlugin.origin.url, growiPlugin.origin.ghBranch);
-          const { reposName, archiveUrl, archiveFileName } = ghUrl;
+          const { reposName, archiveUrl, extractedArchiveDirName } = ghUrl;
 
-          const zipFilePath = path.join(PLUGIN_STORING_PATH, `${archiveFileName}.zip`);
+          const zipFilePath = path.join(PLUGIN_STORING_PATH, `${extractedArchiveDirName}.zip`);
           const unzippedPath = PLUGIN_STORING_PATH;
-          const unzippedReposPath = path.join(PLUGIN_STORING_PATH, `${reposName}-${archiveFileName}`);
+          const unzippedReposPath = path.join(PLUGIN_STORING_PATH, `${reposName}-${extractedArchiveDirName}`);
 
           try {
             // download github repository to local file system
@@ -110,14 +110,14 @@ export class GrowiPluginService implements IGrowiPluginService {
   async install(origin: IGrowiPluginOrigin): Promise<string> {
     const ghUrl = new GitHubUrl(origin.url, origin.ghBranch);
     const {
-      organizationName, reposName, archiveUrl, archiveFileName,
+      organizationName, reposName, archiveUrl, extractedArchiveDirName,
     } = ghUrl;
 
     const installedPath = `${organizationName}/${reposName}`;
 
     const organizationPath = path.join(PLUGIN_STORING_PATH, organizationName);
-    const zipFilePath = path.join(organizationPath, `${reposName}-${archiveFileName}.zip`);
-    const temporaryReposPath = path.join(organizationPath, `${reposName}-${archiveFileName}`);
+    const zipFilePath = path.join(organizationPath, `${reposName}-${extractedArchiveDirName}.zip`);
+    const temporaryReposPath = path.join(organizationPath, `${reposName}-${extractedArchiveDirName}`);
     const reposPath = path.join(organizationPath, reposName);
 
     if (!fs.existsSync(organizationPath)) fs.mkdirSync(organizationPath);

--- a/apps/app/src/features/growi-plugin/server/services/growi-plugin/growi-plugin.ts
+++ b/apps/app/src/features/growi-plugin/server/services/growi-plugin/growi-plugin.ts
@@ -77,11 +77,11 @@ export class GrowiPluginService implements IGrowiPluginService {
 
           // TODO: imprv Document version and repository version possibly different.
           const ghUrl = new GitHubUrl(growiPlugin.origin.url, growiPlugin.origin.ghBranch);
-          const { reposName, branchName, archiveUrl } = ghUrl;
+          const { reposName, archiveUrl, archiveFileName } = ghUrl;
 
-          const zipFilePath = path.join(PLUGIN_STORING_PATH, `${branchName}.zip`);
+          const zipFilePath = path.join(PLUGIN_STORING_PATH, `${archiveFileName}.zip`);
           const unzippedPath = PLUGIN_STORING_PATH;
-          const unzippedReposPath = path.join(PLUGIN_STORING_PATH, `${reposName}-${branchName}`);
+          const unzippedReposPath = path.join(PLUGIN_STORING_PATH, `${reposName}-${archiveFileName}`);
 
           try {
             // download github repository to local file system
@@ -111,16 +111,14 @@ export class GrowiPluginService implements IGrowiPluginService {
   async install(origin: IGrowiPluginOrigin): Promise<string> {
     const ghUrl = new GitHubUrl(origin.url, origin.ghBranch);
     const {
-      organizationName, reposName, branchName, archiveUrl,
+      organizationName, reposName, archiveUrl, archiveFileName,
     } = ghUrl;
-
-    const sanitizedBranchName = sanitize(branchName);
 
     const installedPath = `${organizationName}/${reposName}`;
 
     const organizationPath = path.join(PLUGIN_STORING_PATH, organizationName);
-    const zipFilePath = path.join(organizationPath, `${reposName}-${sanitizedBranchName}.zip`);
-    const temporaryReposPath = path.join(organizationPath, `${reposName}-${sanitizedBranchName}`);
+    const zipFilePath = path.join(organizationPath, `${reposName}-${archiveFileName}.zip`);
+    const temporaryReposPath = path.join(organizationPath, `${reposName}-${archiveFileName}`);
     const reposPath = path.join(organizationPath, reposName);
 
     if (!fs.existsSync(organizationPath)) fs.mkdirSync(organizationPath);

--- a/apps/app/src/features/growi-plugin/server/services/growi-plugin/growi-plugin.ts
+++ b/apps/app/src/features/growi-plugin/server/services/growi-plugin/growi-plugin.ts
@@ -8,7 +8,6 @@ import { importPackageJson, validateGrowiDirective } from '@growi/pluginkit/dist
 // eslint-disable-next-line no-restricted-imports
 import axios from 'axios';
 import mongoose from 'mongoose';
-import sanitize from 'sanitize-filename';
 import streamToPromise from 'stream-to-promise';
 import unzipper from 'unzipper';
 


### PR DESCRIPTION
This PR improves the ability to install  plug-ins even when the branch name contains characters that are removed by the [sanitize-filename](https://www.npmjs.com/package/sanitize-filename) library.

For example, users will be able to install plugin the following branch names.

- ex1. branch name: `slash/slash`
- ex2. branch name: `repeat<>chars`
- ex3. branch name: `pipe|pipe`
- ex4. branch name: `a"b"c`
- ex5. branch name: `a'b'c`
- ex6. branch name: `per%per`
- ex7. branch name: `sharp#sharp`

These letters can be used in the git branch. ref: https://git-scm.com/docs/git-check-ref-format


The "growi-plugin" service can download plugins with the above branch names, but the unzipped files are extracted into a directory with certain characters converted to hyphens.

However, the "growi-plugin" service searches the path with the specific characters removed, so the plugin is not found and the installation fails.

ex. If branch name is `slash/slash`, "growi-plugin" service will looks up "slashslash" directory. The correct path is the "slash-slash" directory.

This PR allows GROWI to search for the correct directory name corresponding to the branch name.
(Note that this rule does not seem to be described in the documentation published by github, so it is an assumption based on my testing with several branch names)

Rules:

* ```!#$%&'()+,/;<=>@]`{|}``` is replaced with `-`
* If above characters are repeated, these characters replaced with single `-`
