### PR TITLE
feat: refactor PageSideContents tag design

### DIFF
--- a/apps/app/src/components/PageTags/PageTags.tsx
+++ b/apps/app/src/components/PageTags/PageTags.tsx
@@ -31,11 +31,19 @@ export const PageTags:FC<Props> = (props: Props) => {
   return (
     <>
       <div className={`${styles['grw-tag-labels']} grw-tag-labels d-flex align-items-center ${printNoneClass}`} data-testid="grw-tag-labels">
-        <RenderTagLabels
-          tags={tags}
-          isTagLabelsDisabled={isTagLabelsDisabled}
-          onClickEditTagsButton={onClickEditTagsButton}
-        />
+        <button
+          type="button"
+          className={`btn btn-sm btn-outline-secondary rounded-pill mb-2 d-flex d-lg-none ${styles['grw-tag-icon-button']}`}
+        >
+          <span className="material-symbols-outlined">local_offer</span>
+        </button>
+        <div className="d-none d-lg-flex">
+          <RenderTagLabels
+            tags={tags}
+            isTagLabelsDisabled={isTagLabelsDisabled}
+            onClickEditTagsButton={onClickEditTagsButton}
+          />
+        </div>
       </div>
     </>
   );

--- a/apps/app/src/components/PageTags/PageTags.tsx
+++ b/apps/app/src/components/PageTags/PageTags.tsx
@@ -34,6 +34,7 @@ export const PageTags:FC<Props> = (props: Props) => {
         <button
           type="button"
           className={`btn btn-sm btn-outline-secondary rounded-pill mb-2 d-flex d-lg-none ${styles['grw-tag-icon-button']}`}
+          onClick={() => {}} // TODO: add a handler
         >
           <span className="material-symbols-outlined">local_offer</span>
         </button>

--- a/apps/app/src/components/PageTags/TagLabels.module.scss
+++ b/apps/app/src/components/PageTags/TagLabels.module.scss
@@ -8,6 +8,9 @@ $grw-tag-label-font-size: 12px;
     font-weight: normal;
     border-radius: bs.$border-radius;
   }
+  .material-symbols-outlined {
+    font-size: 2em;
+  }
 }
 
 
@@ -15,4 +18,8 @@ $grw-tag-label-font-size: 12px;
   width: 137px;
   height: calc(#{$grw-tag-label-font-size} + #{bs.$badge-padding-y} * 2);
   font-size: $grw-tag-label-font-size; // set font-size to use the same em value in bs.$badge-padding-y(https://getbootstrap.jp/docs/5.0/components/badge/#variables)
+}
+
+.grw-tag-icon-button {
+  padding: 6px 8px;
 }


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/137722


# やったこと
https://xd.adobe.com/view/9d2867cd-8f84-4995-9d94-ee27ce04c62d-c87b/screen/2b59f0ad-a630-4e78-9274-ed0947155da2/

上のデザインに従い、ページサイズによりタグのアイコンのみが出るようにした。


before
<img width="480" alt="スクリーンショット 2024-01-06 17 57 03" src="https://github.com/weseek/growi/assets/65263895/c0176f3c-f793-4a6c-b5f6-2d6f78e2d562">


after
<img width="468" alt="スクリーンショット 2024-01-06 17 57 16" src="https://github.com/weseek/growi/assets/65263895/4d350fa7-c3e1-4a58-a12b-0b46e86beb56">


# やっていないこと
- [ストーリーの説明](https://redmine.weseek.co.jp/issues/137722#%E3%82%B9%E3%82%B3%E3%83%BC%E3%83%97%E5%A4%96)にもあるように、md/sm 間の PageSideContents のレイアウト切り替えに関しては別ストーリー([137726](https://redmine.weseek.co.jp/issues/137726))でやります。
- タグボタンを押したときにどのような挙動になるかの詳細がタスクに書いてなかったので、TODOコメントとして残してます。次のPRで着手します。