### PR TITLE
feat: 137722 137982 onclick handler

### DIFF
--- a/apps/app/src/components/PageTags/PageTags.tsx
+++ b/apps/app/src/components/PageTags/PageTags.tsx
@@ -34,7 +34,7 @@ export const PageTags:FC<Props> = (props: Props) => {
         <button
           type="button"
           className={`btn btn-sm btn-outline-secondary rounded-pill mb-2 d-flex d-lg-none ${styles['grw-tag-icon-button']}`}
-          onClick={() => {}} // TODO: add a handler
+          onClick={onClickEditTagsButton}
         >
           <span className="material-symbols-outlined">local_offer</span>
         </button>


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/137982

タグボタンタップ時の処理を実装

<img width="112" alt="スクリーンショット 2024-01-09 21 49 07" src="https://github.com/weseek/growi/assets/65263895/8ee5fbce-8bc6-4dfa-8bd8-6051f7771270">

<img width="270" alt="スクリーンショット 2024-01-09 21 49 32" src="https://github.com/weseek/growi/assets/65263895/440b4ca8-f584-45a0-a627-2bbf1e57460c">


タグアイコンをタップした時の挙動を、下画像のプラスアイコンをタップした時の挙動と同じにして、下のモーダルが出るようにしました。

<img width="604" alt="スクリーンショット 2024-01-09 13 37 13" src="https://github.com/weseek/growi/assets/65263895/6c922bc6-1654-4c4b-b4f8-3ede46804e99">