### PR TITLE
feat: 137726 page side contents layout

### DIFF
--- a/apps/app/src/components/Common/PageViewLayout.module.scss
+++ b/apps/app/src/components/Common/PageViewLayout.module.scss
@@ -45,6 +45,11 @@ $page-view-layout-margin-top: 32px;
       min-width: 250px;
       margin-left: 30px;
     }
+
+    @include bs.media-breakpoint-down(sm) {
+      position: fixed;
+      right: 1rem;
+    }
   }
 }
 

--- a/apps/app/src/components/PageSideContents/PageAccessoriesControl.module.scss
+++ b/apps/app/src/components/PageSideContents/PageAccessoriesControl.module.scss
@@ -12,6 +12,12 @@
   }
 }
 
+@include bs.media-breakpoint-down(sm) {
+  .btn-page-accessories :global {
+    box-shadow: 0px 3px 6px rgba(black, 0.15);
+  }
+}
+
 // apply larger font when smaller than lg
 @include bs.media-breakpoint-down(lg) {
   .btn-page-accessories :global {

--- a/apps/app/src/components/PageTags/TagLabels.module.scss
+++ b/apps/app/src/components/PageTags/TagLabels.module.scss
@@ -22,4 +22,7 @@ $grw-tag-label-font-size: 12px;
 
 .grw-tag-icon-button {
   padding: 6px 8px;
+  @include bs.media-breakpoint-down(sm) {
+    box-shadow: 0px 3px 6px rgba(black, 0.15);
+  }
 }


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/138222

 # やったこと
- 画面サイズがsm以下の場合、`PageSideContens`の`position`を`fixed`で表示するようにした
- 画面サイズがsm以下の場合、`PageSideContens`のボタンに影をつけるようにした

画面サイズがmdの場合
<img width="741" alt="スクリーンショット 2024-01-12 14 41 49" src="https://github.com/weseek/growi/assets/65263895/a553ec84-6df0-4f0c-998d-0b4d76bb25ba">

画面サイズがsmの場合（今回実装したスタイル）
<img width="598" alt="スクリーンショット 2024-01-12 14 42 30" src="https://github.com/weseek/growi/assets/65263895/c79a01ac-a113-4343-8734-8c677b071d47">


動作確認ずみ

