### PR TITLE
feat: Apply grant data when new button clicked

### DIFF
--- a/apps/app/src/components/Sidebar/PageCreateButton/PageCreateButton.tsx
+++ b/apps/app/src/components/Sidebar/PageCreateButton/PageCreateButton.tsx
@@ -35,7 +35,9 @@ export const PageCreateButton = React.memo((): JSX.Element => {
     ? null
     : generateTodaysPath(currentUser, t('create_page_dropdown.todays.memo'));
 
-  const { onClickHandler: onClickNewButton, isPageCreating: isNewPageCreating } = useOnNewButtonClicked(currentPage, isLoading);
+  const { onClickHandler: onClickNewButton, isPageCreating: isNewPageCreating } = useOnNewButtonClicked(
+    currentPage?.path, currentPage?.grant, currentPage?.grantedGroups, isLoading,
+  );
   // TODO: https://redmine.weseek.co.jp/issues/138806
   const { onClickHandler: onClickTodaysButton, isPageCreating: isTodaysPageCreating } = useOnTodaysButtonClicked(todaysPath);
   // TODO: https://redmine.weseek.co.jp/issues/138805

--- a/apps/app/src/components/Sidebar/PageCreateButton/PageCreateButton.tsx
+++ b/apps/app/src/components/Sidebar/PageCreateButton/PageCreateButton.tsx
@@ -9,7 +9,7 @@ import { useOnTemplateButtonClicked } from '~/client/services/use-on-template-bu
 import { toastError } from '~/client/util/toastr';
 import { LabelType } from '~/interfaces/template';
 import { useCurrentUser } from '~/stores/context';
-import { useCurrentPagePath } from '~/stores/page';
+import { useSWRxCurrentPage } from '~/stores/page';
 
 import { CreateButton } from './CreateButton';
 import { DropendMenu } from './DropendMenu';
@@ -25,7 +25,7 @@ const generateTodaysPath = (currentUser: IUserHasId, parentDirName: string) => {
 export const PageCreateButton = React.memo((): JSX.Element => {
   const { t } = useTranslation('commons');
 
-  const { data: currentPagePath, isLoading } = useCurrentPagePath();
+  const { data: currentPage, isLoading } = useSWRxCurrentPage();
   const { data: currentUser } = useCurrentUser();
 
   const [isHovered, setIsHovered] = useState(false);
@@ -34,7 +34,7 @@ export const PageCreateButton = React.memo((): JSX.Element => {
     ? null
     : generateTodaysPath(currentUser, t('create_page_dropdown.todays.memo'));
 
-  const { onClickHandler: onClickNewButton, isPageCreating: isNewPageCreating } = useOnNewButtonClicked(currentPagePath, isLoading);
+  const { onClickHandler: onClickNewButton, isPageCreating: isNewPageCreating } = useOnNewButtonClicked(currentPage, isLoading);
   const { onClickHandler: onClickTodaysButton, isPageCreating: isTodaysPageCreating } = useOnTodaysButtonClicked(todaysPath);
   const { onClickHandler: onClickTemplateButton, isPageCreating: isTemplatePageCreating } = useOnTemplateButtonClicked(currentPagePath, isLoading);
 

--- a/apps/app/src/components/Sidebar/PageCreateButton/PageCreateButton.tsx
+++ b/apps/app/src/components/Sidebar/PageCreateButton/PageCreateButton.tsx
@@ -9,7 +9,7 @@ import { useOnTemplateButtonClicked } from '~/client/services/use-on-template-bu
 import { toastError } from '~/client/util/toastr';
 import { LabelType } from '~/interfaces/template';
 import { useCurrentUser } from '~/stores/context';
-import { useSWRxCurrentPage } from '~/stores/page';
+import { useCurrentPagePath, useSWRxCurrentPage } from '~/stores/page';
 
 import { CreateButton } from './CreateButton';
 import { DropendMenu } from './DropendMenu';
@@ -25,6 +25,7 @@ const generateTodaysPath = (currentUser: IUserHasId, parentDirName: string) => {
 export const PageCreateButton = React.memo((): JSX.Element => {
   const { t } = useTranslation('commons');
 
+  const { data: currentPagePath, isLoading: isLoadingPagePath } = useCurrentPagePath();
   const { data: currentPage, isLoading } = useSWRxCurrentPage();
   const { data: currentUser } = useCurrentUser();
 
@@ -35,8 +36,10 @@ export const PageCreateButton = React.memo((): JSX.Element => {
     : generateTodaysPath(currentUser, t('create_page_dropdown.todays.memo'));
 
   const { onClickHandler: onClickNewButton, isPageCreating: isNewPageCreating } = useOnNewButtonClicked(currentPage, isLoading);
+  // TODO: https://redmine.weseek.co.jp/issues/138806
   const { onClickHandler: onClickTodaysButton, isPageCreating: isTodaysPageCreating } = useOnTodaysButtonClicked(todaysPath);
-  const { onClickHandler: onClickTemplateButton, isPageCreating: isTemplatePageCreating } = useOnTemplateButtonClicked(currentPagePath, isLoading);
+  // TODO: https://redmine.weseek.co.jp/issues/138805
+  const { onClickHandler: onClickTemplateButton, isPageCreating: isTemplatePageCreating } = useOnTemplateButtonClicked(currentPagePath, isLoadingPagePath);
 
   const onClickTemplateButtonHandler = useCallback(async(label: LabelType) => {
     try {

--- a/apps/app/src/components/Sidebar/PageCreateButton/hooks.tsx
+++ b/apps/app/src/components/Sidebar/PageCreateButton/hooks.tsx
@@ -22,10 +22,11 @@ export const useOnNewButtonClicked = (
     try {
       setIsPageCreating(true);
 
-      // !! NOTICE !!
-      // Verification of page createable or not is done on the server side.
-      // Since the new page path is not generated on the client side.
-      // Need shouldGeneratePath flag.
+      /**
+       * !! NOTICE !! - Verification of page createable or not is checked on the server side.
+       * since the new page path is not generated on the client side.
+       * need shouldGeneratePath flag.
+       */
       const shouldUseRootPath = currentPage?.path == null;
       const parentPath = shouldUseRootPath
         ? '/'
@@ -39,8 +40,7 @@ export const useOnNewButtonClicked = (
         shouldGeneratePath: true,
       };
 
-      // !! NOTICE !!
-      // If shouldGeneratePath is flagged, send the parent page path
+      // !! NOTICE !! - if shouldGeneratePath is flagged, send the parent page path
       const response = await createPage(parentPath, '', params);
 
       router.push(`/${response.page.id}#edit`);

--- a/apps/app/src/components/Sidebar/PageCreateButton/hooks.tsx
+++ b/apps/app/src/components/Sidebar/PageCreateButton/hooks.tsx
@@ -36,7 +36,7 @@ export const useOnNewButtonClicked = (
         isSlackEnabled: false,
         slackChannels: '',
         grant: shouldUseRootPath ? 1 : currentPage.grant,
-        grantUserGroupId: shouldUseRootPath ? undefined : currentPage.grantedGroups,
+        grantUserGroupIds: shouldUseRootPath ? undefined : currentPage.grantedGroups,
         shouldGeneratePath: true,
       };
 

--- a/apps/app/src/components/Sidebar/PageCreateButton/hooks.tsx
+++ b/apps/app/src/components/Sidebar/PageCreateButton/hooks.tsx
@@ -1,13 +1,15 @@
 import { useCallback, useState } from 'react';
 
-import type { IPagePopulatedToShowRevision } from '@growi/core';
+import type { PageGrant, IGrantedGroup } from '@growi/core';
 import { useRouter } from 'next/router';
 
 import { createPage, exist } from '~/client/services/page-operation';
 import { toastError } from '~/client/util/toastr';
 
 export const useOnNewButtonClicked = (
-    currentPage?: IPagePopulatedToShowRevision | null,
+    currentPagePath?: string,
+    currentPageGrant?: PageGrant,
+    currentPageGrantedGroups?: IGrantedGroup[],
     isLoading?: boolean,
 ): {
   onClickHandler: () => Promise<void>,
@@ -27,16 +29,16 @@ export const useOnNewButtonClicked = (
        * since the new page path is not generated on the client side.
        * need shouldGeneratePath flag.
        */
-      const shouldUseRootPath = currentPage?.path == null;
+      const shouldUseRootPath = currentPagePath == null || currentPageGrant == null;
       const parentPath = shouldUseRootPath
         ? '/'
-        : currentPage.path;
+        : currentPagePath;
 
       const params = {
         isSlackEnabled: false,
         slackChannels: '',
-        grant: shouldUseRootPath ? 1 : currentPage.grant,
-        grantUserGroupIds: shouldUseRootPath ? undefined : currentPage.grantedGroups,
+        grant: shouldUseRootPath ? 1 : currentPageGrant,
+        grantUserGroupIds: shouldUseRootPath ? undefined : currentPageGrantedGroups,
         shouldGeneratePath: true,
       };
 
@@ -51,7 +53,7 @@ export const useOnNewButtonClicked = (
     finally {
       setIsPageCreating(false);
     }
-  }, [currentPage, isLoading, router]);
+  }, [currentPageGrant, currentPageGrantedGroups, currentPagePath, isLoading, router]);
 
   return { onClickHandler, isPageCreating };
 };

--- a/apps/app/src/server/routes/apiv3/pages.js
+++ b/apps/app/src/server/routes/apiv3/pages.js
@@ -327,10 +327,10 @@ module.exports = (crowi) => {
         const basePath = path === rootPath ? defaultTitle : path + defaultTitle;
         path = await generateUniquePath(basePath);
 
-        // If the generated path is not creatable, create the path under the root path.
+        // if the generated path is not creatable, create the path under the root path
         if (!isCreatablePage(path)) {
           path = await generateUniquePath(defaultTitle);
-          // Initialize grant data when creating under root
+          // initialize grant data
           grant = 1;
           grantUserGroupIds = null;
         }

--- a/apps/app/src/server/routes/apiv3/pages.js
+++ b/apps/app/src/server/routes/apiv3/pages.js
@@ -307,15 +307,15 @@ module.exports = (crowi) => {
   router.post('/', accessTokenParser, loginRequiredStrictly, excludeReadOnlyUser, addActivity, validator.createPage, apiV3FormValidator, async(req, res) => {
     const {
       // body, grant, grantUserGroupId, overwriteScopesOfDescendants, isSlackEnabled, slackChannels, pageTags, shouldGeneratePath,
-      body, grant, grantUserGroupIds, overwriteScopesOfDescendants, isSlackEnabled, slackChannels, pageTags, shouldGeneratePath,
+      body, overwriteScopesOfDescendants, isSlackEnabled, slackChannels, pageTags, shouldGeneratePath,
     } = req.body;
+
+    let { path, grant, grantUserGroupIds } = req.body;
 
     // TODO: remove in https://redmine.weseek.co.jp/issues/136136
     if (grantUserGroupIds != null && grantUserGroupIds.length > 1) {
       return res.apiv3Err('Cannot grant multiple groups to page at the moment');
     }
-
-    let { path } = req.body;
 
     // check whether path starts slash
     path = addHeadingSlash(path);
@@ -327,8 +327,12 @@ module.exports = (crowi) => {
         const basePath = path === rootPath ? defaultTitle : path + defaultTitle;
         path = await generateUniquePath(basePath);
 
+        // If the generated path is not creatable, create the path under the root path.
         if (!isCreatablePage(path)) {
           path = await generateUniquePath(defaultTitle);
+          // Initialize grant data when creating under root
+          grant = 1;
+          grantUserGroupIds = null;
         }
       }
       catch (err) {

--- a/apps/app/src/server/routes/apiv3/pages.js
+++ b/apps/app/src/server/routes/apiv3/pages.js
@@ -332,7 +332,7 @@ module.exports = (crowi) => {
           path = await generateUniquePath(defaultTitle);
           // initialize grant data
           grant = 1;
-          grantUserGroupIds = null;
+          grantUserGroupIds = undefined;
         }
       }
       catch (err) {


### PR DESCRIPTION
## task
- https://redmine.weseek.co.jp/issues/138765

## 概要
- useOnNewButtonClicked の処理で親ページから grant 情報を引き継げるようにする
- クライアント側で親ページの grant 情報を取得するようにします。以下は後続タスクとストーリーです
  - https://redmine.weseek.co.jp/issues/138805
  - https://redmine.weseek.co.jp/issues/138806
  - https://redmine.weseek.co.jp/issues/138816
- futa-a さんと相談して, [本ストーリー](https://redmine.weseek.co.jp/issues/137028)ではサーバーサイドに渡す grant 情報は `grant` に親ページの `grant`, `grantUserGroupIds` に 親ページの`grantedGroups` で統一します