### PR TITLE
fix: Non-admin user cannot rename pages

### DIFF
--- a/apps/app/src/components/Common/Dropdown/PageItemControl.tsx
+++ b/apps/app/src/components/Common/Dropdown/PageItemControl.tsx
@@ -86,8 +86,7 @@ const PageItemControlDropdownMenu = React.memo((props: DropdownMenuProps): JSX.E
     if (onClickRenameMenuItem == null) {
       return;
     }
-
-    if (!pageInfo?.isDeletable) {
+    if (!pageInfo?.isMovable) {
       logger.warn('This page could not be renamed.');
       return;
     }
@@ -178,10 +177,9 @@ const PageItemControlDropdownMenu = React.memo((props: DropdownMenuProps): JSX.E
         ) }
 
         {/* Move/Rename */}
-        { !forceHideMenuItems?.includes(MenuItemType.RENAME) && isEnableActions && !isReadOnlyUser && (
+        { !forceHideMenuItems?.includes(MenuItemType.RENAME) && isEnableActions && !isReadOnlyUser && pageInfo.isMovable && (
           <DropdownItem
             onClick={renameItemClickedHandler}
-            disabled={!pageInfo.isDeletable}
             data-testid="open-page-move-rename-modal-btn"
             className="grw-page-control-dropdown-item"
           >
@@ -233,7 +231,7 @@ const PageItemControlDropdownMenu = React.memo((props: DropdownMenuProps): JSX.E
 
         {/* divider */}
         {/* Delete */}
-        { !forceHideMenuItems?.includes(MenuItemType.DELETE) && isEnableActions && !isReadOnlyUser && (
+        { !forceHideMenuItems?.includes(MenuItemType.DELETE) && isEnableActions && !isReadOnlyUser && pageInfo.isMovable && (
           <>
             { showDeviderBeforeDelete && <DropdownItem divider /> }
             <DropdownItem

--- a/apps/app/src/components/Common/Dropdown/PageItemControl.tsx
+++ b/apps/app/src/components/Common/Dropdown/PageItemControl.tsx
@@ -231,7 +231,7 @@ const PageItemControlDropdownMenu = React.memo((props: DropdownMenuProps): JSX.E
 
         {/* divider */}
         {/* Delete */}
-        { !forceHideMenuItems?.includes(MenuItemType.DELETE) && isEnableActions && !isReadOnlyUser && pageInfo.isMovable && (
+        { !forceHideMenuItems?.includes(MenuItemType.DELETE) && isEnableActions && !isReadOnlyUser && pageInfo.isDeletable && (
           <>
             { showDeviderBeforeDelete && <DropdownItem divider /> }
             <DropdownItem

--- a/apps/app/src/server/service/page.ts
+++ b/apps/app/src/server/service/page.ts
@@ -313,6 +313,7 @@ class PageService {
         meta: {
           isV5Compatible: isTopPage(page.path) || page.parent != null,
           isEmpty: page.isEmpty,
+          isMovable: false,
           isDeletable: false,
           isAbleToDeleteCompletely: false,
           isRevertible: false,
@@ -2463,12 +2464,13 @@ class PageService {
   }
 
   constructBasicPageInfo(page: PageDocument, isGuestUser?: boolean): IPageInfo | IPageInfoForEntity {
-    const isDeletable = !(isGuestUser || isTopPage(page.path) || isUsersTopPage(page.path));
+    const isMovable = isGuestUser ? false : isMovablePage(page.path);
 
     if (page.isEmpty) {
       return {
         isV5Compatible: true,
         isEmpty: true,
+        isMovable,
         isDeletable: false,
         isAbleToDeleteCompletely: false,
         isRevertible: false,
@@ -2485,7 +2487,8 @@ class PageService {
       likerIds: this.extractStringIds(likers),
       seenUserIds: this.extractStringIds(seenUsers),
       sumOfSeenUsers: page.seenUsers.length,
-      isDeletable,
+      isMovable,
+      isDeletable: isMovable,
       isAbleToDeleteCompletely: false,
       isRevertible: isTrashPage(page.path),
       contentAge: page.getContentAge(),

--- a/apps/app/src/server/service/page.ts
+++ b/apps/app/src/server/service/page.ts
@@ -2465,6 +2465,7 @@ class PageService {
 
   constructBasicPageInfo(page: PageDocument, isGuestUser?: boolean): IPageInfo | IPageInfoForEntity {
     const isMovable = isGuestUser ? false : isMovablePage(page.path);
+    const isDeletable = !(isGuestUser || isTopPage(page.path) || isUsersTopPage(page.path));
 
     if (page.isEmpty) {
       return {
@@ -2488,7 +2489,7 @@ class PageService {
       seenUserIds: this.extractStringIds(seenUsers),
       sumOfSeenUsers: page.seenUsers.length,
       isMovable,
-      isDeletable: isMovable,
+      isDeletable,
       isAbleToDeleteCompletely: false,
       isRevertible: isTrashPage(page.path),
       contentAge: page.getContentAge(),

--- a/packages/core/src/interfaces/page.ts
+++ b/packages/core/src/interfaces/page.ts
@@ -74,6 +74,7 @@ export type IPageHasId = IPage & HasObjectId;
 export type IPageInfo = {
   isV5Compatible: boolean,
   isEmpty: boolean,
+  isMovable: boolean,
   isDeletable: boolean,
   isAbleToDeleteCompletely: boolean,
   isRevertible: boolean,


### PR DESCRIPTION
This reverts commit 39efb0bf10e6f6155099cf78d2838f3eefa0b877.

## task
https://redmine.weseek.co.jp/issues/138838
- [x] [ストーリー](https://redmine.weseek.co.jp/issues/138836)の症状を直す
- [x] user homepage 削除機能にデグレがないこと
  - [x] 削除されたユーザーのユーザーホームページを削除できる
  - [x] ページの削除権限 設定と併用できる
  - [x] ユーザーホームぺージの削除を有効化しても user homepage は rename/move はできない仕様
  - [x] /admin からユーザーホームぺージの削除を無効化すると、削除できない
  
## 概要
- 原因は v6.2.4 より pageInfo の isMovable を廃止し、代わりにそのページを削除できるかどうかを rename/move できるかどうかの条件にしていたため. https://github.com/weseek/growi/pull/8224
- isMovablePage を前後のバージョンで確認
- pageInfo の isMovale を前後のバージョンで確認