### PR TITLE
remove async grant related logic from grant update loop

### DIFF
--- a/apps/app/src/server/service/page/index.ts
+++ b/apps/app/src/server/service/page/index.ts
@@ -4058,11 +4058,7 @@ class PageService implements IPageService {
    * @param user The operator
    * @returns The new GrantedGroups array to be set to the page
    */
-  async getNewGrantedGroups(
-      userRelatedGrantedGroups: IGrantedGroup[],
-      page: PageDocument,
-      user,
-  ): Promise<IGrantedGroup[]> {
+  async getNewGrantedGroups(userRelatedGrantedGroups: IGrantedGroup[], page: PageDocument, user): Promise<IGrantedGroup[]> {
     const userRelatedGroups = await this.pageGrantService.getUserRelatedGroups(user);
     return this.getNewGrantedGroupsSyncronously(userRelatedGroups, userRelatedGrantedGroups, page);
   }
@@ -4071,11 +4067,7 @@ class PageService implements IPageService {
    * Use when you do not want to use getNewGrantedGroups with async/await (e.g inside loops that process a large amount of pages)
    * Specification of userRelatedGroups is necessary to avoid the cost of fetching userRelatedGroups from DB every time.
    */
-  getNewGrantedGroupsSyncronously(
-      userRelatedGroups: PopulatedGrantedGroup[],
-      userRelatedGrantedGroups: IGrantedGroup[],
-      page: PageDocument,
-  ): IGrantedGroup[] {
+  getNewGrantedGroupsSyncronously(userRelatedGroups: PopulatedGrantedGroup[], userRelatedGrantedGroups: IGrantedGroup[], page: PageDocument): IGrantedGroup[] {
     const previousGrantedGroups = page.grantedGroups;
     const userRelatedPreviousGrantedGroups = this.pageGrantService.getUserRelatedGrantedGroupsSyncronously(
       userRelatedGroups, page,


### PR DESCRIPTION
## 概要
- 子孫ページの権限更新ループでの async 処理をなるべく減らすために、各メソッドに `Syncronously` バージョンを追加
- ページ削除のストーリーで同様の実装をした際、メソッド名を `filterGrantedGroupsByIds` としていたが、`getUserRelatedGrantedGroupsSyncronously` に変更

## task
https://redmine.weseek.co.jp/issues/138864