### PR TITLE
imprv: 137433 improve paste operations in markdown

### DIFF
--- a/packages/editor/src/components/CodeMirrorEditor/CodeMirrorEditor.tsx
+++ b/packages/editor/src/components/CodeMirrorEditor/CodeMirrorEditor.tsx
@@ -57,6 +57,7 @@ export const CodeMirrorEditor = (props: Props): JSX.Element => {
 
   }, [codeMirrorEditor, indentSize]);
 
+  // ここのPaste処理を改善！
   useEffect(() => {
     const handlePaste = (event: ClipboardEvent) => {
       event.preventDefault();

--- a/packages/editor/src/components/CodeMirrorEditor/CodeMirrorEditor.tsx
+++ b/packages/editor/src/components/CodeMirrorEditor/CodeMirrorEditor.tsx
@@ -8,9 +8,13 @@ import type { ReactCodeMirrorProps } from '@uiw/react-codemirror';
 
 import { GlobalCodeMirrorEditorKey, AcceptedUploadFileType } from '../../consts';
 import { useFileDropzone, FileDropzoneOverlay } from '../../services';
+import {
+  getStrFromBolToSelectedUpperPos, adjustPasteData,
+} from '../../services/list-util/markdown-list-util';
 import { useCodeMirrorEditorIsolated } from '../../stores';
 
 import { Toolbar } from './Toolbar';
+
 
 import style from './CodeMirrorEditor.module.scss';
 
@@ -62,6 +66,19 @@ export const CodeMirrorEditor = (props: Props): JSX.Element => {
     const handlePaste = (event: ClipboardEvent) => {
       event.preventDefault();
 
+      const editor = codeMirrorEditor?.view;
+
+      if (editor == null) {
+        return;
+      }
+
+      const strFromBol = getStrFromBolToSelectedUpperPos(editor);
+
+      const testVar = strFromBol;
+
+      console.log(testVar);
+      console.log('kohsei');
+
       if (event.clipboardData == null) {
         return;
       }
@@ -71,9 +88,16 @@ export const CodeMirrorEditor = (props: Props): JSX.Element => {
       }
 
       if (event.clipboardData.types.includes('text/plain')) {
+
         const textData = event.clipboardData.getData('text/plain');
-        codeMirrorEditor?.replaceText(textData);
+
+        const adjusted = adjustPasteData(strFromBol, textData);
+
+        if (adjusted != null) {
+          codeMirrorEditor?.replaceText(adjusted);
+        }
       }
+      // console.log('kohsei');
     };
 
     const extension = EditorView.domEventHandlers({

--- a/packages/editor/src/components/CodeMirrorEditor/CodeMirrorEditor.tsx
+++ b/packages/editor/src/components/CodeMirrorEditor/CodeMirrorEditor.tsx
@@ -61,7 +61,6 @@ export const CodeMirrorEditor = (props: Props): JSX.Element => {
 
   }, [codeMirrorEditor, indentSize]);
 
-  // ここのPaste処理を改善！
   useEffect(() => {
     const handlePaste = (event: ClipboardEvent) => {
       event.preventDefault();
@@ -92,7 +91,6 @@ export const CodeMirrorEditor = (props: Props): JSX.Element => {
           codeMirrorEditor?.replaceText(adjusted);
         }
       }
-      // console.log('kohsei');
     };
 
     const extension = EditorView.domEventHandlers({

--- a/packages/editor/src/components/CodeMirrorEditor/CodeMirrorEditor.tsx
+++ b/packages/editor/src/components/CodeMirrorEditor/CodeMirrorEditor.tsx
@@ -9,7 +9,7 @@ import type { ReactCodeMirrorProps } from '@uiw/react-codemirror';
 import { GlobalCodeMirrorEditorKey, AcceptedUploadFileType } from '../../consts';
 import { useFileDropzone, FileDropzoneOverlay } from '../../services';
 import {
-  getStrFromBolToSelectedUpperPos, adjustPasteData,
+  getStrFromBol, adjustPasteData,
 } from '../../services/list-util/markdown-list-util';
 import { useCodeMirrorEditorIsolated } from '../../stores';
 
@@ -72,13 +72,6 @@ export const CodeMirrorEditor = (props: Props): JSX.Element => {
         return;
       }
 
-      const strFromBol = getStrFromBolToSelectedUpperPos(editor);
-
-      const testVar = strFromBol;
-
-      console.log(testVar);
-      console.log('kohsei');
-
       if (event.clipboardData == null) {
         return;
       }
@@ -90,6 +83,8 @@ export const CodeMirrorEditor = (props: Props): JSX.Element => {
       if (event.clipboardData.types.includes('text/plain')) {
 
         const textData = event.clipboardData.getData('text/plain');
+
+        const strFromBol = getStrFromBol(editor);
 
         const adjusted = adjustPasteData(strFromBol, textData);
 

--- a/packages/editor/src/components/CodeMirrorEditor/CodeMirrorEditor.tsx
+++ b/packages/editor/src/components/CodeMirrorEditor/CodeMirrorEditor.tsx
@@ -87,9 +87,7 @@ export const CodeMirrorEditor = (props: Props): JSX.Element => {
 
         const adjusted = adjustPasteData(strFromBol, textData);
 
-        if (adjusted != null) {
-          codeMirrorEditor?.replaceText(adjusted);
-        }
+        codeMirrorEditor?.replaceText(adjusted);
       }
     };
 

--- a/packages/editor/src/services/codemirror-editor/use-codemirror-editor/use-codemirror-editor.ts
+++ b/packages/editor/src/services/codemirror-editor/use-codemirror-editor/use-codemirror-editor.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 
 import { indentWithTab, defaultKeymap } from '@codemirror/commands';
-import { markdown, markdownLanguage, markdownKeymap } from '@codemirror/lang-markdown';
+import { markdown, markdownLanguage } from '@codemirror/lang-markdown';
 import { syntaxHighlighting, HighlightStyle, defaultHighlightStyle } from '@codemirror/language';
 import { languages } from '@codemirror/language-data';
 import { EditorState, Prec, type Extension } from '@codemirror/state';

--- a/packages/editor/src/services/codemirror-editor/use-codemirror-editor/use-codemirror-editor.ts
+++ b/packages/editor/src/services/codemirror-editor/use-codemirror-editor/use-codemirror-editor.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 
 import { indentWithTab, defaultKeymap } from '@codemirror/commands';
-import { markdown, markdownLanguage } from '@codemirror/lang-markdown';
+import { markdown, markdownLanguage, markdownKeymap } from '@codemirror/lang-markdown';
 import { syntaxHighlighting, HighlightStyle, defaultHighlightStyle } from '@codemirror/language';
 import { languages } from '@codemirror/language-data';
 import { EditorState, Prec, type Extension } from '@codemirror/state';

--- a/packages/editor/src/services/list-util/markdown-list-util.ts
+++ b/packages/editor/src/services/list-util/markdown-list-util.ts
@@ -1,0 +1,50 @@
+import { EditorView } from '@codemirror/view';
+
+const indentAndMarkRE = /^(\s*)(>[> ]*|[*+-] \[[x ]\]\s|[*+-]\s|(\d+)([.)]))(\s*)/;
+const indentAndMarkOnlyRE = /^(\s*)(>[> ]*|[*+-] \[[x ]\]|[*+-]|(\d+)[.)])(\s*)$/;
+
+const getBol = (editor: EditorView) => {
+  const curPos = editor.state.selection.main.head;
+  const aboveLine = editor.state.doc.lineAt(curPos).number - 1;
+  return editor.state.doc.line(aboveLine).from;
+};
+
+const getStrFromBol = (editor: EditorView) => {
+  const curPos = editor.state.selection.main.head;
+  return editor.state.sliceDoc(getBol(editor), curPos);
+};
+
+const insertText = (editor: EditorView, text: string) => {
+  const curPos = editor.state.selection.main.head;
+  const line = editor.state.doc.lineAt(curPos).from;
+  editor.dispatch({
+    changes: {
+      from: line,
+      to: curPos,
+      insert: text,
+    },
+  });
+};
+
+export const newlineAndIndentContinueMarkdownList = (editor: EditorView): void => {
+  const strFromBol = getStrFromBol(editor);
+
+  const matchResult = strFromBol.match(indentAndMarkRE);
+
+  if (matchResult != null) {
+    // continue list
+    const indentAndMark = matchResult[0];
+    insertText(editor, indentAndMark);
+  }
+};
+
+
+// ここを作っていこう！
+export const adjustPasteData = (indentAndMark: string, text: string): string | null => {
+
+  if (text.match(indentAndMarkRE)) {
+    const indent = indentAndMark.match(indentAndMarkRE)[1];
+  }
+
+  return '';
+};

--- a/packages/editor/src/services/list-util/markdown-list-util.ts
+++ b/packages/editor/src/services/list-util/markdown-list-util.ts
@@ -13,52 +13,6 @@ export const getStrFromBol = (editor: EditorView): string => {
   return editor.state.sliceDoc(getBol(editor), curPos);
 };
 
-const insertText = (editor: EditorView, text: string) => {
-  const curPos = editor.state.selection.main.head;
-  const line = editor.state.doc.lineAt(curPos).from;
-  editor.dispatch({
-    changes: {
-      from: line,
-      to: curPos,
-      insert: text,
-    },
-  });
-};
-
-export const newlineAndIndentContinueMarkdownList = (editor: EditorView): void => {
-  const strFromBol = getStrFromBol(editor);
-
-  const matchResult = strFromBol.match(indentAndMarkRE);
-
-  if (matchResult != null) {
-    // continue list
-    const indentAndMark = matchResult[0];
-    insertText(editor, indentAndMark);
-  }
-};
-
-const selectUpperPos = (editor: EditorView, pos1: number, pos2: number) => {
-
-  const pos1Line = editor.state.doc.lineAt(pos1);
-  const pos2Line = editor.state.doc.lineAt(pos2);
-
-  const pos1Ch = pos1 - editor.state.doc.lineAt(pos1).from;
-  const pos2Ch = pos2 - editor.state.doc.lineAt(pos2).from;
-
-  if (pos1Line === pos2Line) {
-    return (pos1Ch < pos2Ch) ? pos1 : pos2;
-  }
-  return (pos1Line < pos2Line) ? pos1 : pos2;
-};
-
-export const getStrFromBolToSelectedUpperPos = (editor: EditorView): string => {
-  const pos = selectUpperPos(editor, editor.state.selection.main.from, editor.state.selection.main.to);
-  // ここでエラー起きてそう
-
-  return editor.state.sliceDoc(getBol(editor), pos);
-};
-
-// ここを作っていこう！
 export const adjustPasteData = (indentAndMark: string, text: string): string => {
 
   let adjusted = '';

--- a/packages/editor/src/services/list-util/markdown-list-util.ts
+++ b/packages/editor/src/services/list-util/markdown-list-util.ts
@@ -1,5 +1,6 @@
 import { EditorView } from '@codemirror/view';
 
+// https://regex101.com/r/7BN2fR/5
 const indentAndMarkRE = /^(\s*)(>[> ]*|[*+-] \[[x ]\]\s|[*+-]\s|(\d+)([.)]))(\s*)/;
 
 const getBol = (editor: EditorView) => {

--- a/packages/editor/src/services/list-util/markdown-list-util.ts
+++ b/packages/editor/src/services/list-util/markdown-list-util.ts
@@ -4,11 +4,11 @@ const indentAndMarkRE = /^(\s*)(>[> ]*|[*+-] \[[x ]\]\s|[*+-]\s|(\d+)([.)]))(\s*
 
 const getBol = (editor: EditorView) => {
   const curPos = editor.state.selection.main.head;
-  const aboveLine = editor.state.doc.lineAt(curPos).number - 1;
+  const aboveLine = editor.state.doc.lineAt(curPos).number;
   return editor.state.doc.line(aboveLine).from;
 };
 
-const getStrFromBol = (editor: EditorView) => {
+export const getStrFromBol = (editor: EditorView) => {
   const curPos = editor.state.selection.main.head;
   return editor.state.sliceDoc(getBol(editor), curPos);
 };
@@ -27,6 +27,8 @@ const insertText = (editor: EditorView, text: string) => {
 
 export const newlineAndIndentContinueMarkdownList = (editor: EditorView): void => {
   const strFromBol = getStrFromBol(editor);
+
+  console.log(strFromBol);
 
   const matchResult = strFromBol.match(indentAndMarkRE);
 

--- a/packages/editor/src/services/list-util/markdown-list-util.ts
+++ b/packages/editor/src/services/list-util/markdown-list-util.ts
@@ -8,7 +8,7 @@ const getBol = (editor: EditorView) => {
   return editor.state.doc.line(aboveLine).from;
 };
 
-export const getStrFromBol = (editor: EditorView) => {
+export const getStrFromBol = (editor: EditorView): string => {
   const curPos = editor.state.selection.main.head;
   return editor.state.sliceDoc(getBol(editor), curPos);
 };
@@ -28,8 +28,6 @@ const insertText = (editor: EditorView, text: string) => {
 export const newlineAndIndentContinueMarkdownList = (editor: EditorView): void => {
   const strFromBol = getStrFromBol(editor);
 
-  console.log(strFromBol);
-
   const matchResult = strFromBol.match(indentAndMarkRE);
 
   if (matchResult != null) {
@@ -46,14 +44,6 @@ const selectUpperPos = (editor: EditorView, pos1: number, pos2: number) => {
 
   const pos1Ch = pos1 - editor.state.doc.lineAt(pos1).from;
   const pos2Ch = pos2 - editor.state.doc.lineAt(pos2).from;
-
-  console.log(pos1);
-  console.log(pos2);
-  console.log(pos1Line);
-  console.log(pos2Line);
-  console.log(pos1Ch);
-  console.log(pos2Ch);
-
 
   if (pos1Line === pos2Line) {
     return (pos1Ch < pos2Ch) ? pos1 : pos2;
@@ -79,7 +69,12 @@ export const adjustPasteData = (indentAndMark: string, text: string): string => 
 
     const lines = text.match(/[^\r\n]+/g);
 
-    const replacedLines = lines?.map((line) => {
+    const replacedLines = lines?.map((line, index) => {
+
+      if (index === 0 && indentAndMark.match(indentAndMarkRE)) {
+        return line.replace(indentAndMarkRE, '');
+      }
+
       return indent + line;
     });
 

--- a/packages/editor/src/services/list-util/markdown-list-util.ts
+++ b/packages/editor/src/services/list-util/markdown-list-util.ts
@@ -1,7 +1,6 @@
 import { EditorView } from '@codemirror/view';
 
 const indentAndMarkRE = /^(\s*)(>[> ]*|[*+-] \[[x ]\]\s|[*+-]\s|(\d+)([.)]))(\s*)/;
-const indentAndMarkOnlyRE = /^(\s*)(>[> ]*|[*+-] \[[x ]\]|[*+-]|(\d+)[.)])(\s*)$/;
 
 const getBol = (editor: EditorView) => {
   const curPos = editor.state.selection.main.head;
@@ -38,13 +37,58 @@ export const newlineAndIndentContinueMarkdownList = (editor: EditorView): void =
   }
 };
 
+const selectUpperPos = (editor: EditorView, pos1: number, pos2: number) => {
+
+  const pos1Line = editor.state.doc.lineAt(pos1);
+  const pos2Line = editor.state.doc.lineAt(pos2);
+
+  const pos1Ch = pos1 - editor.state.doc.lineAt(pos1).from;
+  const pos2Ch = pos2 - editor.state.doc.lineAt(pos2).from;
+
+  console.log(pos1);
+  console.log(pos2);
+  console.log(pos1Line);
+  console.log(pos2Line);
+  console.log(pos1Ch);
+  console.log(pos2Ch);
+
+
+  if (pos1Line === pos2Line) {
+    return (pos1Ch < pos2Ch) ? pos1 : pos2;
+  }
+  return (pos1Line < pos2Line) ? pos1 : pos2;
+};
+
+export const getStrFromBolToSelectedUpperPos = (editor: EditorView): string => {
+  const pos = selectUpperPos(editor, editor.state.selection.main.from, editor.state.selection.main.to);
+  // ここでエラー起きてそう
+
+  return editor.state.sliceDoc(getBol(editor), pos);
+};
 
 // ここを作っていこう！
-export const adjustPasteData = (indentAndMark: string, text: string): string | null => {
+export const adjustPasteData = (indentAndMark: string, text: string): string => {
+
+  let adjusted = '';
 
   if (text.match(indentAndMarkRE)) {
-    const indent = indentAndMark.match(indentAndMarkRE)[1];
+    const matchResult = indentAndMark.match(indentAndMarkRE);
+    const indent = matchResult ? matchResult[1] : '';
+
+    const lines = text.match(/[^\r\n]+/g);
+
+    const replacedLines = lines?.map((line) => {
+      return indent + line;
+    });
+
+    adjusted = replacedLines ? replacedLines.join('\n') : '';
   }
 
-  return '';
+  else {
+    const replacedText = text.replace(/(\r\n|\r|\n)/g, `$1${indentAndMark}`);
+
+    adjusted = indentAndMark + replacedText;
+  }
+
+  return adjusted;
 };

--- a/packages/editor/src/services/list-util/markdown-list-util.ts
+++ b/packages/editor/src/services/list-util/markdown-list-util.ts
@@ -1,4 +1,4 @@
-import { EditorView } from '@codemirror/view';
+import type { EditorView } from '@codemirror/view';
 
 // https://regex101.com/r/7BN2fR/5
 const indentAndMarkRE = /^(\s*)(>[> ]*|[*+-] \[[x ]\]\s|[*+-]\s|(\d+)([.)]))(\s*)/;

--- a/packages/editor/src/services/list-util/markdown-list-util.ts
+++ b/packages/editor/src/services/list-util/markdown-list-util.ts
@@ -15,7 +15,7 @@ export const getStrFromBol = (editor: EditorView): string => {
 
 export const adjustPasteData = (indentAndMark: string, text: string): string => {
 
-  let adjusted = '';
+  let adjusted;
 
   if (text.match(indentAndMarkRE)) {
     const matchResult = indentAndMark.match(indentAndMarkRE);


### PR DESCRIPTION
## タスク
https://redmine.weseek.co.jp/issues/137433

## 概要
GROWI V6 のように、階層構造になっているマークダウンリスト(A)を別のマークダウンリスト(B)の階層に挿入しても、マークダウンリスト(A)の階層が崩れないようにする

## 実装内容
マークダウンをペーストする際には、ペーストする前にコピーされたテキストのインデントやprefixを調整するようにしました。