### PR TITLE
fix: Duplicate root pages are created unintentionally

### DIFF
--- a/packages/core/src/utils/page-path-utils/index.ts
+++ b/packages/core/src/utils/page-path-utils/index.ts
@@ -100,7 +100,7 @@ export const isSharedPage = (path: string): boolean => {
 };
 
 const restrictedPatternsToCreate: Array<RegExp> = [
-  /\^|\$|\*|\+|#|%|\?/,
+  /\^|\$|\*|\+|#|<|>|%|\?/,
   /^\/-\/.*/,
   /^\/_r\/.*/,
   /^\/_apix?(\/.*)?/,


### PR DESCRIPTION
## Task
[#137388](https://redmine.weseek.co.jp/issues/137388) [bug][isuue] 重複する root ページ (/) が作成できてしまう 
┗ [#139081](https://redmine.weseek.co.jp/issues/139081) 修正

## Issue
https://github.com/weseek/growi/issues/8337

## cause
this.crowi.xss.process によって入力された文字列が  `<` が含まれていた場合 `<`  以降がエスケープされてしまっていた。
https://github.com/weseek/growi/blob/b8b7ff5e73bf7b3b8fbcaae3f25becf4494047e2/apps/app/src/server/service/page/index.ts#L517