### PR TITLE
fix: 139350 fix paste operation in editor

### DIFF
--- a/packages/editor/src/components/CodeMirrorEditor/CodeMirrorEditor.tsx
+++ b/packages/editor/src/components/CodeMirrorEditor/CodeMirrorEditor.tsx
@@ -10,7 +10,7 @@ import type { ReactCodeMirrorProps } from '@uiw/react-codemirror';
 import { GlobalCodeMirrorEditorKey, AcceptedUploadFileType } from '../../consts';
 import { useFileDropzone, FileDropzoneOverlay, AllEditorTheme } from '../../services';
 import {
-  getLineToCursor, adjustPasteData,
+  adjustPasteData, getStrFromBol,
 } from '../../services/list-util/markdown-list-util';
 import { useCodeMirrorEditorIsolated } from '../../stores';
 
@@ -88,7 +88,7 @@ export const CodeMirrorEditor = (props: Props): JSX.Element => {
 
         const textData = event.clipboardData.getData('text/plain');
 
-        const strFromBol = getLineToCursor(editor);
+        const strFromBol = getStrFromBol(editor);
 
         const adjusted = adjustPasteData(strFromBol, textData);
 

--- a/packages/editor/src/components/CodeMirrorEditor/CodeMirrorEditor.tsx
+++ b/packages/editor/src/components/CodeMirrorEditor/CodeMirrorEditor.tsx
@@ -11,7 +11,6 @@ import { GlobalCodeMirrorEditorKey, AcceptedUploadFileType } from '../../consts'
 import { useFileDropzone, FileDropzoneOverlay, AllEditorTheme } from '../../services';
 import {
   getLineToCursor, adjustPasteData,
-  useNewlineAndIndentContinueMarkdownList,
 } from '../../services/list-util/markdown-list-util';
 import { useCodeMirrorEditorIsolated } from '../../stores';
 
@@ -55,28 +54,6 @@ export const CodeMirrorEditor = (props: Props): JSX.Element => {
     };
   }, [onChange]);
   const { data: codeMirrorEditor } = useCodeMirrorEditorIsolated(editorKey, containerRef.current, cmProps);
-
-  const editor = codeMirrorEditor?.view;
-
-  const newlineAndIndentContinueMarkdownList = useNewlineAndIndentContinueMarkdownList(editor);
-
-  useEffect(() => {
-    const handleEnterKey = (event: KeyboardEvent) => {
-      if (event.key === 'Enter') {
-        event.preventDefault();
-        if (editor == null) {
-          return;
-        }
-        newlineAndIndentContinueMarkdownList?.(editor);
-      }
-    };
-
-    editor?.dom.addEventListener('keydown', handleEnterKey);
-
-    return () => {
-      editor?.dom.removeEventListener('keydown', handleEnterKey);
-    };
-  }, [codeMirrorEditor, editor, newlineAndIndentContinueMarkdownList]);
 
   useEffect(() => {
     if (indentSize == null) {

--- a/packages/editor/src/services/codemirror-editor/use-codemirror-editor/utils/insert-text.ts
+++ b/packages/editor/src/services/codemirror-editor/use-codemirror-editor/utils/insert-text.ts
@@ -1,24 +1,20 @@
 import { useCallback } from 'react';
 
-import { type EditorView } from '@codemirror/view';
+import { EditorView } from '@codemirror/view';
 
-export type InsertText = (text: string, from?: number, to?: number) => void;
+export type InsertText = (text: string) => void;
 
 
 export const useInsertText = (view?: EditorView): InsertText => {
-  return useCallback((text, from?, to?) => {
+  return useCallback((text) => {
     if (view == null) {
       return;
     }
     const insertPos = view.state.selection.main.head;
-
-    const fromPos = from ?? insertPos;
-    const toPos = to ?? insertPos;
-
     view.dispatch({
       changes: {
-        from: fromPos,
-        to: toPos,
+        from: insertPos,
+        to: insertPos,
         insert: text,
       },
       selection: { anchor: insertPos },

--- a/packages/editor/src/services/codemirror-editor/use-codemirror-editor/utils/insert-text.ts
+++ b/packages/editor/src/services/codemirror-editor/use-codemirror-editor/utils/insert-text.ts
@@ -4,8 +4,8 @@ import { EditorView } from '@codemirror/view';
 
 export type InsertText = (text: string) => void;
 
-
 export const useInsertText = (view?: EditorView): InsertText => {
+
   return useCallback((text) => {
     if (view == null) {
       return;

--- a/packages/editor/src/services/list-util/markdown-list-util.ts
+++ b/packages/editor/src/services/list-util/markdown-list-util.ts
@@ -16,6 +16,8 @@ export const getStrFromBol = (editor: EditorView): string => {
 
 export const adjustPasteData = (indentAndMark: string, text: string): string => {
 
+  let adjusted;
+
   if (text.match(indentAndMarkRE)) {
     const matchResult = indentAndMark.match(indentAndMarkRE);
     const indent = matchResult ? matchResult[1] : '';
@@ -31,10 +33,14 @@ export const adjustPasteData = (indentAndMark: string, text: string): string => 
       return indent + line;
     });
 
-    const adjusted = replacedLines ? replacedLines.join('\n') : '';
-
-    return adjusted;
+    adjusted = replacedLines ? replacedLines.join('\n') : '';
   }
 
-  return text;
+  else {
+    const replacedText = text.replace(/(\r\n|\r|\n)/g, `$1${indentAndMark}`);
+
+    adjusted = replacedText;
+  }
+
+  return adjusted;
 };

--- a/packages/editor/src/services/list-util/markdown-list-util.ts
+++ b/packages/editor/src/services/list-util/markdown-list-util.ts
@@ -1,9 +1,4 @@
-import { useCallback } from 'react';
-
 import { EditorView } from '@codemirror/view';
-
-import { useInsertText } from '../codemirror-editor/use-codemirror-editor/utils/insert-text';
-
 
 export type NewlineAndIndentContinueMarkdownList = ((editor: EditorView) => void) | undefined;
 
@@ -19,31 +14,6 @@ export const getLineToCursor = (editor: EditorView, lineNumBeforeCursor = 0): st
   const firstLineToGet = editor.state.doc.line(fixedFirstLineNumToGet).from;
 
   return editor.state.sliceDoc(firstLineToGet, curPos);
-};
-
-export const useNewlineAndIndentContinueMarkdownList = (editor?: EditorView): NewlineAndIndentContinueMarkdownList => {
-  const insertText = useInsertText(editor);
-
-  const NewlineAndIndentContinueMarkdownList = useCallback((view: EditorView) => {
-
-    const curPos = view?.state.selection.main.head;
-    const lineStartPos = view?.state.doc.lineAt(curPos).from;
-
-    const getStrFromAboveLine = getLineToCursor(view, 1);
-
-    const matchResult = getStrFromAboveLine.match(indentAndMarkRE);
-
-    if (matchResult != null) {
-      const indentAndMark = matchResult[0];
-      insertText(indentAndMark, lineStartPos, curPos);
-    }
-  }, [insertText]);
-
-  if (editor == null) {
-    return;
-  }
-
-  return () => { NewlineAndIndentContinueMarkdownList(editor) };
 };
 
 export const adjustPasteData = (strFromBol: string, text: string): string => {

--- a/packages/editor/src/services/list-util/markdown-list-util.ts
+++ b/packages/editor/src/services/list-util/markdown-list-util.ts
@@ -3,17 +3,6 @@ import { EditorView } from '@codemirror/view';
 // https://regex101.com/r/7BN2fR/5
 const indentAndMarkRE = /^(\s*)(>[> ]*|[*+-] \[[x ]\]\s|[*+-]\s|(\d+)([.)]))(\s*)/;
 
-// export const getLineToCursor = (editor: EditorView, lineNumBeforeCursor = 0): string => {
-//   const curPos = editor.state.selection.main.head;
-//   const firstLineNumToGet = editor.state.doc.lineAt(curPos).number - lineNumBeforeCursor;
-
-//   const fixedFirstLineNumToGet = Math.max(firstLineNumToGet, 0);
-
-//   const firstLineToGet = editor.state.doc.line(fixedFirstLineNumToGet).from;
-
-//   return editor.state.sliceDoc(firstLineToGet, curPos);
-// };
-
 const getBol = (editor: EditorView) => {
   const curPos = editor.state.selection.main.head;
   const aboveLine = editor.state.doc.lineAt(curPos).number;

--- a/packages/editor/src/services/list-util/markdown-list-util.ts
+++ b/packages/editor/src/services/list-util/markdown-list-util.ts
@@ -46,19 +46,19 @@ export const useNewlineAndIndentContinueMarkdownList = (editor?: EditorView): Ne
   return () => { NewlineAndIndentContinueMarkdownList(editor) };
 };
 
-export const adjustPasteData = (indentAndMark: string, text: string): string => {
+export const adjustPasteData = (strFromBol: string, text: string): string => {
 
-  let adjusted;
+  let adjusted = text;
 
   if (text.match(indentAndMarkRE)) {
-    const matchResult = indentAndMark.match(indentAndMarkRE);
+    const matchResult = strFromBol.match(indentAndMarkRE);
     const indent = matchResult ? matchResult[1] : '';
 
     const lines = text.match(/[^\r\n]+/g);
 
     const replacedLines = lines?.map((line, index) => {
 
-      if (index === 0 && indentAndMark.match(indentAndMarkRE)) {
+      if (index === 0 && strFromBol.match(indentAndMarkRE)) {
         return line.replace(indentAndMarkRE, '');
       }
 
@@ -68,8 +68,8 @@ export const adjustPasteData = (indentAndMark: string, text: string): string => 
     adjusted = replacedLines ? replacedLines.join('\n') : '';
   }
 
-  else {
-    const replacedText = text.replace(/(\r\n|\r|\n)/g, `$1${indentAndMark}`);
+  else if (strFromBol.match(indentAndMarkRE)) {
+    const replacedText = text.replace(/(\r\n|\r|\n)/g, `$1${strFromBol}`);
 
     adjusted = replacedText;
   }

--- a/packages/editor/src/services/list-util/markdown-list-util.ts
+++ b/packages/editor/src/services/list-util/markdown-list-util.ts
@@ -16,8 +16,6 @@ export const getStrFromBol = (editor: EditorView): string => {
 
 export const adjustPasteData = (indentAndMark: string, text: string): string => {
 
-  let adjusted;
-
   if (text.match(indentAndMarkRE)) {
     const matchResult = indentAndMark.match(indentAndMarkRE);
     const indent = matchResult ? matchResult[1] : '';
@@ -33,14 +31,10 @@ export const adjustPasteData = (indentAndMark: string, text: string): string => 
       return indent + line;
     });
 
-    adjusted = replacedLines ? replacedLines.join('\n') : '';
+    const adjusted = replacedLines ? replacedLines.join('\n') : '';
+
+    return adjusted;
   }
 
-  else {
-    const replacedText = text.replace(/(\r\n|\r|\n)/g, `$1${indentAndMark}`);
-
-    adjusted = indentAndMark + replacedText;
-  }
-
-  return adjusted;
+  return text;
 };

--- a/packages/editor/src/services/list-util/markdown-list-util.ts
+++ b/packages/editor/src/services/list-util/markdown-list-util.ts
@@ -1,7 +1,5 @@
 import { EditorView } from '@codemirror/view';
 
-export type NewlineAndIndentContinueMarkdownList = ((editor: EditorView) => void) | undefined;
-
 // https://regex101.com/r/7BN2fR/5
 const indentAndMarkRE = /^(\s*)(>[> ]*|[*+-] \[[x ]\]\s|[*+-]\s|(\d+)([.)]))(\s*)/;
 

--- a/packages/editor/src/services/list-util/markdown-list-util.ts
+++ b/packages/editor/src/services/list-util/markdown-list-util.ts
@@ -3,15 +3,26 @@ import { EditorView } from '@codemirror/view';
 // https://regex101.com/r/7BN2fR/5
 const indentAndMarkRE = /^(\s*)(>[> ]*|[*+-] \[[x ]\]\s|[*+-]\s|(\d+)([.)]))(\s*)/;
 
-export const getLineToCursor = (editor: EditorView, lineNumBeforeCursor = 0): string => {
+// export const getLineToCursor = (editor: EditorView, lineNumBeforeCursor = 0): string => {
+//   const curPos = editor.state.selection.main.head;
+//   const firstLineNumToGet = editor.state.doc.lineAt(curPos).number - lineNumBeforeCursor;
+
+//   const fixedFirstLineNumToGet = Math.max(firstLineNumToGet, 0);
+
+//   const firstLineToGet = editor.state.doc.line(fixedFirstLineNumToGet).from;
+
+//   return editor.state.sliceDoc(firstLineToGet, curPos);
+// };
+
+const getBol = (editor: EditorView) => {
   const curPos = editor.state.selection.main.head;
-  const firstLineNumToGet = editor.state.doc.lineAt(curPos).number - lineNumBeforeCursor;
+  const aboveLine = editor.state.doc.lineAt(curPos).number;
+  return editor.state.doc.line(aboveLine).from;
+};
 
-  const fixedFirstLineNumToGet = Math.max(firstLineNumToGet, 0);
-
-  const firstLineToGet = editor.state.doc.line(fixedFirstLineNumToGet).from;
-
-  return editor.state.sliceDoc(firstLineToGet, curPos);
+export const getStrFromBol = (editor: EditorView): string => {
+  const curPos = editor.state.selection.main.head;
+  return editor.state.sliceDoc(getBol(editor), curPos);
 };
 
 export const adjustPasteData = (strFromBol: string, text: string): string => {


### PR DESCRIPTION
## タスク
https://redmine.weseek.co.jp/issues/139353

## 概要
v7で実装されたペースト操作が正しく動作しない問題を解決しました。

## 実装内容
ペーストする直前に発火するadjustPasteData()内でのペースト対象のテキストを調整する操作を修正しました。