### PR TITLE
fix: Preventing duplication of `/user/username` pages

### DIFF
--- a/apps/app/src/utils/page-duplicate-utils.ts
+++ b/apps/app/src/utils/page-duplicate-utils.ts
@@ -1,0 +1,3 @@
+const
+
+const isDuplicatablePage = () => {};

--- a/apps/app/src/utils/page-duplicate-utils.ts
+++ b/apps/app/src/utils/page-duplicate-utils.ts
@@ -1,3 +1,0 @@
-const
-
-const isDuplicatablePage = () => {};

--- a/packages/core/src/utils/page-path-utils/index.ts
+++ b/packages/core/src/utils/page-path-utils/index.ts
@@ -114,7 +114,7 @@ const restrictedPatternsToCreate: Array<RegExp> = [
   /\\/, // see: https://github.com/weseek/growi/issues/7241
   /^\/(_search|_private-legacy-pages)(\/.*|$)/,
   /^\/(installer|register|login|logout|admin|me|files|trash|paste|comments|tags|share|attachment)(\/.*|$)/,
-  /^\/user\/[^/]+$/, // see: https://regex101.com/r/utVQct/1
+  /^\/user(\/.*)?$/, // see: https://regex101.com/r/Y6fRvB/1
 ];
 export const isCreatablePage = (path: string): boolean => {
   return !restrictedPatternsToCreate.some(pattern => path.match(pattern));

--- a/packages/core/src/utils/page-path-utils/index.ts
+++ b/packages/core/src/utils/page-path-utils/index.ts
@@ -114,7 +114,7 @@ const restrictedPatternsToCreate: Array<RegExp> = [
   /\\/, // see: https://github.com/weseek/growi/issues/7241
   /^\/(_search|_private-legacy-pages)(\/.*|$)/,
   /^\/(installer|register|login|logout|admin|me|files|trash|paste|comments|tags|share|attachment)(\/.*|$)/,
-  /^\/user(\/.*)?$/, // see: https://regex101.com/r/Y6fRvB/1
+  /^\/user(?:\/[^/]+)?$/, // https://regex101.com/r/9Eh2S1/1
 ];
 export const isCreatablePage = (path: string): boolean => {
   return !restrictedPatternsToCreate.some(pattern => path.match(pattern));


### PR DESCRIPTION
## タスク
https://redmine.weseek.co.jp/issues/139126

## 概要
admin ユーザーでログインする
/user をページツリーの縦三連ボタンから複製を押す
再帰的に複製 にチェックを入れる

上の手順を踏むと、/userページが複製されてしまう。

そのため、/userページが複製されないようにしました。
ただし、/userページと同一の内容を/user以外のパスに複製することは可能です。

## 実装内容
restrictedPatternsToCreateに/userページを含めることで、/userというパスでページを新規作成、および複製できないようにしました。