### PR TITLE
fix: implement dropdown using reactstrap

### DIFF
--- a/apps/app/src/components/Sidebar/PageCreateButton/DropendMenu.tsx
+++ b/apps/app/src/components/Sidebar/PageCreateButton/DropendMenu.tsx
@@ -72,7 +72,10 @@ export const DropendMenu = React.memo((props: DropendMenuProps): JSX.Element => 
         </li>
       </ul> */}
 
-      <DropdownMenu container="body">
+      <DropdownMenu
+        container="body"
+        style={{ zIndex: 1055 }}
+      >
         <DropdownItem
           onClick={onClickCreateNewPageButtonHandler}
         >

--- a/apps/app/src/components/Sidebar/PageCreateButton/DropendMenu.tsx
+++ b/apps/app/src/components/Sidebar/PageCreateButton/DropendMenu.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 
 import { useTranslation } from 'react-i18next';
+import { DropdownMenu, DropdownItem } from 'reactstrap';
 
 import { LabelType } from '~/interfaces/template';
+
 
 type DropendMenuProps = {
   onClickCreateNewPageButtonHandler: () => Promise<void>
@@ -22,52 +24,85 @@ export const DropendMenu = React.memo((props: DropendMenuProps): JSX.Element => 
   const { t } = useTranslation('commons');
 
   return (
-    <ul className="dropdown-menu">
-      <li>
-        <button
-          className="dropdown-item"
+    <>
+      {/* <ul className="dropdown-menu">
+        <li>
+          <button
+            className="dropdown-item"
+            onClick={onClickCreateNewPageButtonHandler}
+            type="button"
+          >
+            {t('create_page_dropdown.new_page')}
+          </button>
+        </li>
+        {todaysPath != null && (
+          <>
+            <li><hr className="dropdown-divider" /></li>
+            <li><span className="text-muted px-3">{t('create_page_dropdown.todays.desc')}</span></li>
+            <li>
+              <button
+                className="dropdown-item"
+                onClick={onClickCreateTodaysButtonHandler}
+                type="button"
+              >
+                {todaysPath}
+              </button>
+            </li>
+          </>
+        )}
+        <li><hr className="dropdown-divider" /></li>
+        <li><span className="text-muted text-nowrap px-3">{t('create_page_dropdown.template.desc')}</span></li>
+        <li>
+          <button
+            className="dropdown-item"
+            onClick={() => onClickTemplateButtonHandler('_template')}
+            type="button"
+          >
+            {t('create_page_dropdown.template.children')}
+          </button>
+        </li>
+        <li>
+          <button
+            className="dropdown-item"
+            onClick={() => onClickTemplateButtonHandler('__template')}
+            type="button"
+          >
+            {t('create_page_dropdown.template.descendants')}
+          </button>
+        </li>
+      </ul> */}
+
+      <DropdownMenu container="body">
+        <DropdownItem
           onClick={onClickCreateNewPageButtonHandler}
-          type="button"
         >
           {t('create_page_dropdown.new_page')}
-        </button>
-      </li>
-      {todaysPath != null && (
-        <>
-          <li><hr className="dropdown-divider" /></li>
-          <li><span className="text-muted px-3">{t('create_page_dropdown.todays.desc')}</span></li>
-          <li>
-            <button
-              className="dropdown-item"
+        </DropdownItem>
+        {todaysPath != null && (
+          <>
+            <DropdownItem divider />
+            <li><span className="text-muted px-3">{t('create_page_dropdown.todays.desc')}</span></li>
+            <DropdownItem
               onClick={onClickCreateTodaysButtonHandler}
-              type="button"
             >
               {todaysPath}
-            </button>
-          </li>
-        </>
-      )}
-      <li><hr className="dropdown-divider" /></li>
-      <li><span className="text-muted text-nowrap px-3">{t('create_page_dropdown.template.desc')}</span></li>
-      <li>
-        <button
-          className="dropdown-item"
+            </DropdownItem>
+          </>
+        )}
+        <DropdownItem divider />
+        <li><span className="text-muted text-nowrap px-3">{t('create_page_dropdown.template.desc')}</span></li>
+        <DropdownItem
           onClick={() => onClickTemplateButtonHandler('_template')}
-          type="button"
         >
           {t('create_page_dropdown.template.children')}
-        </button>
-      </li>
-      <li>
-        <button
-          className="dropdown-item"
+        </DropdownItem>
+        <DropdownItem
           onClick={() => onClickTemplateButtonHandler('__template')}
-          type="button"
         >
           {t('create_page_dropdown.template.descendants')}
-        </button>
-      </li>
-    </ul>
+        </DropdownItem>
+      </DropdownMenu>
+    </>
   );
 });
 DropendMenu.displayName = 'DropendMenu';

--- a/apps/app/src/components/Sidebar/PageCreateButton/DropendMenu.tsx
+++ b/apps/app/src/components/Sidebar/PageCreateButton/DropendMenu.tsx
@@ -24,88 +24,38 @@ export const DropendMenu = React.memo((props: DropendMenuProps): JSX.Element => 
   const { t } = useTranslation('commons');
 
   return (
-    <>
-      {/* <ul className="dropdown-menu">
-        <li>
-          <button
-            className="dropdown-item"
-            onClick={onClickCreateNewPageButtonHandler}
-            type="button"
-          >
-            {t('create_page_dropdown.new_page')}
-          </button>
-        </li>
-        {todaysPath != null && (
-          <>
-            <li><hr className="dropdown-divider" /></li>
-            <li><span className="text-muted px-3">{t('create_page_dropdown.todays.desc')}</span></li>
-            <li>
-              <button
-                className="dropdown-item"
-                onClick={onClickCreateTodaysButtonHandler}
-                type="button"
-              >
-                {todaysPath}
-              </button>
-            </li>
-          </>
-        )}
-        <li><hr className="dropdown-divider" /></li>
-        <li><span className="text-muted text-nowrap px-3">{t('create_page_dropdown.template.desc')}</span></li>
-        <li>
-          <button
-            className="dropdown-item"
-            onClick={() => onClickTemplateButtonHandler('_template')}
-            type="button"
-          >
-            {t('create_page_dropdown.template.children')}
-          </button>
-        </li>
-        <li>
-          <button
-            className="dropdown-item"
-            onClick={() => onClickTemplateButtonHandler('__template')}
-            type="button"
-          >
-            {t('create_page_dropdown.template.descendants')}
-          </button>
-        </li>
-      </ul> */}
-
-      <DropdownMenu
-        container="body"
-        style={{ zIndex: 1055 }}
+    <DropdownMenu
+      container="body"
+    >
+      <DropdownItem
+        onClick={onClickCreateNewPageButtonHandler}
       >
-        <DropdownItem
-          onClick={onClickCreateNewPageButtonHandler}
-        >
-          {t('create_page_dropdown.new_page')}
-        </DropdownItem>
-        {todaysPath != null && (
-          <>
-            <DropdownItem divider />
-            <li><span className="text-muted px-3">{t('create_page_dropdown.todays.desc')}</span></li>
-            <DropdownItem
-              onClick={onClickCreateTodaysButtonHandler}
-            >
-              {todaysPath}
-            </DropdownItem>
-          </>
-        )}
-        <DropdownItem divider />
-        <li><span className="text-muted text-nowrap px-3">{t('create_page_dropdown.template.desc')}</span></li>
-        <DropdownItem
-          onClick={() => onClickTemplateButtonHandler('_template')}
-        >
-          {t('create_page_dropdown.template.children')}
-        </DropdownItem>
-        <DropdownItem
-          onClick={() => onClickTemplateButtonHandler('__template')}
-        >
-          {t('create_page_dropdown.template.descendants')}
-        </DropdownItem>
-      </DropdownMenu>
-    </>
+        {t('create_page_dropdown.new_page')}
+      </DropdownItem>
+      {todaysPath != null && (
+        <>
+          <DropdownItem divider />
+          <li><span className="text-muted px-3">{t('create_page_dropdown.todays.desc')}</span></li>
+          <DropdownItem
+            onClick={onClickCreateTodaysButtonHandler}
+          >
+            {todaysPath}
+          </DropdownItem>
+        </>
+      )}
+      <DropdownItem divider />
+      <li><span className="text-muted text-nowrap px-3">{t('create_page_dropdown.template.desc')}</span></li>
+      <DropdownItem
+        onClick={() => onClickTemplateButtonHandler('_template')}
+      >
+        {t('create_page_dropdown.template.children')}
+      </DropdownItem>
+      <DropdownItem
+        onClick={() => onClickTemplateButtonHandler('__template')}
+      >
+        {t('create_page_dropdown.template.descendants')}
+      </DropdownItem>
+    </DropdownMenu>
   );
 });
 DropendMenu.displayName = 'DropendMenu';

--- a/apps/app/src/components/Sidebar/PageCreateButton/DropendToggle.tsx
+++ b/apps/app/src/components/Sidebar/PageCreateButton/DropendToggle.tsx
@@ -8,15 +8,12 @@ import styles from './DropendToggle.module.scss';
 const moduleClass = styles['btn-toggle'];
 
 
-type Props = {
-  className?: string
-}
-
-export const DropendToggle = (props: Props): JSX.Element => {
-
+export const DropendToggle = (): JSX.Element => {
   return (
     <DropdownToggle
-      className={`position-absolute ${moduleClass} btn btn-primary ${props.className ?? ''}`}
+      color="primary"
+      className={`position-absolute ${moduleClass}`}
+      aria-expanded={false}
     >
       <Hexagon />
       <div className="hitarea position-absolute" />

--- a/apps/app/src/components/Sidebar/PageCreateButton/DropendToggle.tsx
+++ b/apps/app/src/components/Sidebar/PageCreateButton/DropendToggle.tsx
@@ -1,6 +1,6 @@
 import type { ButtonHTMLAttributes, DetailedHTMLProps } from 'react';
 
-import { DropdownToggle } from 'reactstrap';
+import { Dropdown, DropdownToggle } from 'reactstrap';
 
 import { Hexagon } from './Hexagon';
 
@@ -10,18 +10,28 @@ import styles from './DropendToggle.module.scss';
 const moduleClass = styles['btn-toggle'];
 
 
-type Props = DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>
+type Props = DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>;
 
 export const DropendToggle = (props: Props): JSX.Element => {
+
   return (
-    <button
-      type="button"
-      {...props}
-      className={`${moduleClass} btn btn-primary ${props.className ?? ''}`}
+    <DropdownToggle
+      className={`position-absolute ${moduleClass} btn btn-primary ${props.className ?? ''}`}
     >
       <Hexagon />
       <div className="hitarea position-absolute" />
       <span className="icon material-symbols-outlined position-absolute">chevron_right</span>
-    </button>
+    </DropdownToggle>
+    // <DropdownToggle>
+    //   <button
+    //     type="button"
+    //     {...props}
+    //     className={`${moduleClass} btn btn-primary ${props.className ?? ''}`}
+    //   >
+    //     <Hexagon />
+    //     <div className="hitarea position-absolute" />
+    //     <span className="icon material-symbols-outlined position-absolute">chevron_right</span>
+    //   </button>
+    // </DropdownToggle>
   );
 };

--- a/apps/app/src/components/Sidebar/PageCreateButton/DropendToggle.tsx
+++ b/apps/app/src/components/Sidebar/PageCreateButton/DropendToggle.tsx
@@ -1,6 +1,6 @@
 import type { ButtonHTMLAttributes, DetailedHTMLProps } from 'react';
 
-import { Dropdown, DropdownToggle } from 'reactstrap';
+import { DropdownToggle } from 'reactstrap';
 
 import { Hexagon } from './Hexagon';
 
@@ -22,16 +22,5 @@ export const DropendToggle = (props: Props): JSX.Element => {
       <div className="hitarea position-absolute" />
       <span className="icon material-symbols-outlined position-absolute">chevron_right</span>
     </DropdownToggle>
-    // <DropdownToggle>
-    //   <button
-    //     type="button"
-    //     {...props}
-    //     className={`${moduleClass} btn btn-primary ${props.className ?? ''}`}
-    //   >
-    //     <Hexagon />
-    //     <div className="hitarea position-absolute" />
-    //     <span className="icon material-symbols-outlined position-absolute">chevron_right</span>
-    //   </button>
-    // </DropdownToggle>
   );
 };

--- a/apps/app/src/components/Sidebar/PageCreateButton/DropendToggle.tsx
+++ b/apps/app/src/components/Sidebar/PageCreateButton/DropendToggle.tsx
@@ -1,8 +1,11 @@
 import type { ButtonHTMLAttributes, DetailedHTMLProps } from 'react';
 
+import { DropdownToggle } from 'reactstrap';
+
 import { Hexagon } from './Hexagon';
 
 import styles from './DropendToggle.module.scss';
+
 
 const moduleClass = styles['btn-toggle'];
 

--- a/apps/app/src/components/Sidebar/PageCreateButton/DropendToggle.tsx
+++ b/apps/app/src/components/Sidebar/PageCreateButton/DropendToggle.tsx
@@ -1,5 +1,3 @@
-import type { ButtonHTMLAttributes, DetailedHTMLProps } from 'react';
-
 import { DropdownToggle } from 'reactstrap';
 
 import { Hexagon } from './Hexagon';
@@ -10,7 +8,9 @@ import styles from './DropendToggle.module.scss';
 const moduleClass = styles['btn-toggle'];
 
 
-type Props = DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>;
+type Props = {
+  className?: string
+}
 
 export const DropendToggle = (props: Props): JSX.Element => {
 

--- a/apps/app/src/components/Sidebar/PageCreateButton/PageCreateButton.tsx
+++ b/apps/app/src/components/Sidebar/PageCreateButton/PageCreateButton.tsx
@@ -97,19 +97,6 @@ export const PageCreateButton = React.memo((): JSX.Element => {
           todaysPath={todaysPath}
         />
       </Dropdown>
-      {/* <div className="btn-group dropend position-absolute">
-        <DropendToggle
-          className="dropdown-toggle dropdown-toggle-split"
-          data-bs-toggle="dropdown"
-          aria-expanded="false"
-        />
-        <DropendMenu
-          onClickCreateNewPageButtonHandler={onClickNewButton}
-          onClickCreateTodaysButtonHandler={onClickTodaysButton}
-          onClickTemplateButtonHandler={onClickTemplateButtonHandler}
-          todaysPath={todaysPath}
-        />
-      </div> */}
     </div>
   );
 });

--- a/apps/app/src/components/Sidebar/PageCreateButton/PageCreateButton.tsx
+++ b/apps/app/src/components/Sidebar/PageCreateButton/PageCreateButton.tsx
@@ -4,7 +4,6 @@ import type { IUserHasId } from '@growi/core';
 import { pagePathUtils } from '@growi/core/dist/utils';
 import { format } from 'date-fns';
 import { useTranslation } from 'react-i18next';
-import { Dropdown } from 'reactstrap';
 
 import { useOnTemplateButtonClicked } from '~/client/services/use-on-template-button-clicked';
 import { toastError } from '~/client/util/toastr';
@@ -16,7 +15,6 @@ import { CreateButton } from './CreateButton';
 import { DropendMenu } from './DropendMenu';
 import { DropendToggle } from './DropendToggle';
 import { useOnNewButtonClicked, useOnTodaysButtonClicked } from './hooks';
-
 
 const generateTodaysPath = (currentUser: IUserHasId, parentDirName: string) => {
   const now = format(new Date(), 'yyyy/MM/dd');
@@ -75,11 +73,9 @@ export const PageCreateButton = React.memo((): JSX.Element => {
           disabled={isNewPageCreating || isTodaysPageCreating || isTemplatePageCreating}
         />
       </div>
-      <Dropdown
-        direction="end"
-      >
+      <div className="btn-group dropend position-absolute">
         <DropendToggle
-          // className="dropdown-toggle dropdown-toggle-split"
+          className="dropdown-toggle dropdown-toggle-split"
           data-bs-toggle="dropdown"
           aria-expanded="false"
         />
@@ -89,7 +85,7 @@ export const PageCreateButton = React.memo((): JSX.Element => {
           onClickTemplateButtonHandler={onClickTemplateButtonHandler}
           todaysPath={todaysPath}
         />
-      </Dropdown>
+      </div>
     </div>
   );
 });

--- a/apps/app/src/components/Sidebar/PageCreateButton/PageCreateButton.tsx
+++ b/apps/app/src/components/Sidebar/PageCreateButton/PageCreateButton.tsx
@@ -4,6 +4,7 @@ import type { IUserHasId } from '@growi/core';
 import { pagePathUtils } from '@growi/core/dist/utils';
 import { format } from 'date-fns';
 import { useTranslation } from 'react-i18next';
+import { Dropdown } from 'reactstrap';
 
 import { useOnTemplateButtonClicked } from '~/client/services/use-on-template-button-clicked';
 import { toastError } from '~/client/util/toastr';
@@ -15,6 +16,7 @@ import { CreateButton } from './CreateButton';
 import { DropendMenu } from './DropendMenu';
 import { DropendToggle } from './DropendToggle';
 import { useOnNewButtonClicked, useOnTodaysButtonClicked } from './hooks';
+
 
 const generateTodaysPath = (currentUser: IUserHasId, parentDirName: string) => {
   const now = format(new Date(), 'yyyy/MM/dd');
@@ -73,21 +75,21 @@ export const PageCreateButton = React.memo((): JSX.Element => {
           disabled={isNewPageCreating || isTodaysPageCreating || isTemplatePageCreating}
         />
       </div>
-      { isHovered && (
-        <div className="btn-group dropend position-absolute">
-          <DropendToggle
-            className="dropdown-toggle dropdown-toggle-split"
-            data-bs-toggle="dropdown"
-            aria-expanded="false"
-          />
-          <DropendMenu
-            onClickCreateNewPageButtonHandler={onClickNewButton}
-            onClickCreateTodaysButtonHandler={onClickTodaysButton}
-            onClickTemplateButtonHandler={onClickTemplateButtonHandler}
-            todaysPath={todaysPath}
-          />
-        </div>
-      )}
+      <Dropdown
+        direction="end"
+      >
+        <DropendToggle
+          // className="dropdown-toggle dropdown-toggle-split"
+          data-bs-toggle="dropdown"
+          aria-expanded="false"
+        />
+        <DropendMenu
+          onClickCreateNewPageButtonHandler={onClickNewButton}
+          onClickCreateTodaysButtonHandler={onClickTodaysButton}
+          onClickTemplateButtonHandler={onClickTemplateButtonHandler}
+          todaysPath={todaysPath}
+        />
+      </Dropdown>
     </div>
   );
 });

--- a/apps/app/src/components/Sidebar/PageCreateButton/PageCreateButton.tsx
+++ b/apps/app/src/components/Sidebar/PageCreateButton/PageCreateButton.tsx
@@ -4,6 +4,7 @@ import type { IUserHasId } from '@growi/core';
 import { pagePathUtils } from '@growi/core/dist/utils';
 import { format } from 'date-fns';
 import { useTranslation } from 'react-i18next';
+import { Dropdown } from 'reactstrap';
 
 import { useOnTemplateButtonClicked } from '~/client/services/use-on-template-button-clicked';
 import { toastError } from '~/client/util/toastr';
@@ -16,7 +17,6 @@ import { DropendMenu } from './DropendMenu';
 import { DropendToggle } from './DropendToggle';
 import { useOnNewButtonClicked, useOnTodaysButtonClicked } from './hooks';
 
-import { Dropdown } from 'reactstrap';
 
 const generateTodaysPath = (currentUser: IUserHasId, parentDirName: string) => {
   const now = format(new Date(), 'yyyy/MM/dd');
@@ -87,11 +87,7 @@ export const PageCreateButton = React.memo((): JSX.Element => {
           direction="end"
           className="position-absolute"
         >
-          <DropendToggle
-            className="dropdown-toggle dropdown-toggle-split"
-            data-bs-toggle="dropdown"
-            aria-expanded="false"
-          />
+          <DropendToggle />
           <DropendMenu
             onClickCreateNewPageButtonHandler={onClickNewButton}
             onClickCreateTodaysButtonHandler={onClickTodaysButton}

--- a/apps/app/src/components/Sidebar/PageCreateButton/PageCreateButton.tsx
+++ b/apps/app/src/components/Sidebar/PageCreateButton/PageCreateButton.tsx
@@ -62,6 +62,7 @@ export const PageCreateButton = React.memo((): JSX.Element => {
 
   const onMouseLeaveHandler = () => {
     setIsHovered(false);
+    setDropdownOpen(false);
   };
 
   const toggle = () => setDropdownOpen(!dropdownOpen);
@@ -79,24 +80,26 @@ export const PageCreateButton = React.memo((): JSX.Element => {
           disabled={isNewPageCreating || isTodaysPageCreating || isTemplatePageCreating}
         />
       </div>
-      <Dropdown
-        isOpen={dropdownOpen}
-        toggle={toggle}
-        direction='end'
-        className="position-absolute"
-      >
-        <DropendToggle
-          className="dropdown-toggle dropdown-toggle-split"
-          data-bs-toggle="dropdown"
-          aria-expanded="false"
-        />
-        <DropendMenu
-          onClickCreateNewPageButtonHandler={onClickNewButton}
-          onClickCreateTodaysButtonHandler={onClickTodaysButton}
-          onClickTemplateButtonHandler={onClickTemplateButtonHandler}
-          todaysPath={todaysPath}
-        />
-      </Dropdown>
+      { isHovered && (
+        <Dropdown
+          isOpen={dropdownOpen}
+          toggle={toggle}
+          direction='end'
+          className="position-absolute"
+        >
+          <DropendToggle
+            className="dropdown-toggle dropdown-toggle-split"
+            data-bs-toggle="dropdown"
+            aria-expanded="false"
+          />
+          <DropendMenu
+            onClickCreateNewPageButtonHandler={onClickNewButton}
+            onClickCreateTodaysButtonHandler={onClickTodaysButton}
+            onClickTemplateButtonHandler={onClickTemplateButtonHandler}
+            todaysPath={todaysPath}
+          />
+        </Dropdown>
+      )}
     </div>
   );
 });

--- a/apps/app/src/components/Sidebar/PageCreateButton/PageCreateButton.tsx
+++ b/apps/app/src/components/Sidebar/PageCreateButton/PageCreateButton.tsx
@@ -16,6 +16,8 @@ import { DropendMenu } from './DropendMenu';
 import { DropendToggle } from './DropendToggle';
 import { useOnNewButtonClicked, useOnTodaysButtonClicked } from './hooks';
 
+import { Dropdown } from 'reactstrap';
+
 const generateTodaysPath = (currentUser: IUserHasId, parentDirName: string) => {
   const now = format(new Date(), 'yyyy/MM/dd');
   const userHomepagePath = pagePathUtils.userHomepagePath(currentUser);
@@ -30,6 +32,8 @@ export const PageCreateButton = React.memo((): JSX.Element => {
   const { data: currentUser } = useCurrentUser();
 
   const [isHovered, setIsHovered] = useState(false);
+
+  const [dropdownOpen, setDropdownOpen] = useState(false);
 
   const todaysPath = currentUser == null
     ? null
@@ -60,6 +64,8 @@ export const PageCreateButton = React.memo((): JSX.Element => {
     setIsHovered(false);
   };
 
+  const toggle = () => setDropdownOpen(!dropdownOpen);
+
   return (
     <div
       className="d-flex flex-row"
@@ -73,7 +79,12 @@ export const PageCreateButton = React.memo((): JSX.Element => {
           disabled={isNewPageCreating || isTodaysPageCreating || isTemplatePageCreating}
         />
       </div>
-      <div className="btn-group dropend position-absolute">
+      <Dropdown
+        isOpen={dropdownOpen}
+        toggle={toggle}
+        direction='end'
+        className="position-absolute"
+      >
         <DropendToggle
           className="dropdown-toggle dropdown-toggle-split"
           data-bs-toggle="dropdown"
@@ -85,7 +96,20 @@ export const PageCreateButton = React.memo((): JSX.Element => {
           onClickTemplateButtonHandler={onClickTemplateButtonHandler}
           todaysPath={todaysPath}
         />
-      </div>
+      </Dropdown>
+      {/* <div className="btn-group dropend position-absolute">
+        <DropendToggle
+          className="dropdown-toggle dropdown-toggle-split"
+          data-bs-toggle="dropdown"
+          aria-expanded="false"
+        />
+        <DropendMenu
+          onClickCreateNewPageButtonHandler={onClickNewButton}
+          onClickCreateTodaysButtonHandler={onClickTodaysButton}
+          onClickTemplateButtonHandler={onClickTemplateButtonHandler}
+          todaysPath={todaysPath}
+        />
+      </div> */}
     </div>
   );
 });

--- a/apps/app/src/components/Sidebar/PageCreateButton/PageCreateButton.tsx
+++ b/apps/app/src/components/Sidebar/PageCreateButton/PageCreateButton.tsx
@@ -84,7 +84,7 @@ export const PageCreateButton = React.memo((): JSX.Element => {
         <Dropdown
           isOpen={dropdownOpen}
           toggle={toggle}
-          direction='end'
+          direction="end"
           className="position-absolute"
         >
           <DropendToggle


### PR DESCRIPTION
## タスク
https://redmine.weseek.co.jp/issues/139469

## 概要
v7のサイドバーのPageCreateButtonの横にあるDropendToggleを押すと出てくるDropdownが隠れてしまう問題を解決しました。

## 実装内容
素のbootstrapを用いて作られていたコンポーネントをreact-strapを用いて再構築しました。
DropdownMenuコンポーネントのcontainer propにbodyを指定することでDropdownが隠れないようにしました。

## 現状の問題点
ボタンがサイドバーで切られてしまっているので、ボタンからdropdownにカーソルを移動する途中でonMouseLeaveが発火しdropdownが非表示になってしまう。
※この問題は下記の後続ストーリーで解決します。

## 後続ストーリー
https://redmine.weseek.co.jp/issues/139423