### PR TITLE
fix: Page tree indentation of the bottom page

### DIFF
--- a/apps/app/src/components/ItemsTree/ItemsTree.module.scss
+++ b/apps/app/src/components/ItemsTree/ItemsTree.module.scss
@@ -68,10 +68,6 @@ $grw-pagetree-item-container-height: 40px;
         min-width: 35px;
         height: $grw-pagetree-item-container-height;
       }
-
-      .grw-pagetree-current-page-item {
-        background-color: var(--grw-primary-100);
-      }
     }
   }
   &:global{

--- a/apps/app/src/components/ItemsTree/ItemsTree.module.scss
+++ b/apps/app/src/components/ItemsTree/ItemsTree.module.scss
@@ -65,9 +65,7 @@ $grw-pagetree-item-container-height: 40px;
 
     .grw-pagetree-item-container {
       .grw-triangle-container {
-        // TODO: ignore width frickering
-        // https://redmine.weseek.co.jp/issues/130828
-        // min-width: 35px;
+        min-width: 35px;
         height: $grw-pagetree-item-container-height;
       }
     }

--- a/apps/app/src/components/ItemsTree/ItemsTree.module.scss
+++ b/apps/app/src/components/ItemsTree/ItemsTree.module.scss
@@ -68,6 +68,10 @@ $grw-pagetree-item-container-height: 40px;
         min-width: 35px;
         height: $grw-pagetree-item-container-height;
       }
+
+      .grw-pagetree-current-page-item {
+        background-color: var(--grw-primary-100);
+      }
     }
   }
   &:global{

--- a/apps/app/src/components/TreeItem/SimpleItem.tsx
+++ b/apps/app/src/components/TreeItem/SimpleItem.tsx
@@ -208,8 +208,6 @@ export const SimpleItem: FC<SimpleItemProps> = (props) => {
           )}
         </div>
 
-        {!hasDescendants && <span className="d-flex justify-content-center ms-5" />}
-
         <SimpleItemContent page={page} />
 
         {EndComponents.map((EndComponent, index) => (

--- a/apps/app/src/components/TreeItem/SimpleItem.tsx
+++ b/apps/app/src/components/TreeItem/SimpleItem.tsx
@@ -208,6 +208,8 @@ export const SimpleItem: FC<SimpleItemProps> = (props) => {
           )}
         </div>
 
+        {!hasDescendants && <span className="d-flex justify-content-center ms-5" />}
+
         <SimpleItemContent page={page} />
 
         {EndComponents.map((EndComponent, index) => (


### PR DESCRIPTION
## Task
[#139421](https://redmine.weseek.co.jp/issues/139421) [v7] ページツリーにおいて最下層ページのインデントが崩れる
┗ [#139596](https://redmine.weseek.co.jp/issues/139596) 修正

[#132737](https://redmine.weseek.co.jp/issues/132737) [v7] 雑多なリファクタ (その1)
┗ [#130828](https://redmine.weseek.co.jp/issues/130828) .grw-triangle-container のマージンを修正する