### PR TITLE
feat: Enable and fix page duplication of user unrelated pages

### DIFF
--- a/apps/app/src/server/routes/apiv3/pages.js
+++ b/apps/app/src/server/routes/apiv3/pages.js
@@ -826,11 +826,6 @@ module.exports = (crowi) => {
 
       const page = await Page.findByIdAndViewer(pageId, req.user, null, true);
 
-      // TODO: remove in https://redmine.weseek.co.jp/issues/136139
-      if (page.grantedGroups != null && page.grantedGroups.length > 1) {
-        return res.apiv3Err('Cannot grant multiple groups to page at the moment');
-      }
-
       const isEmptyAndNotRecursively = page?.isEmpty && !isRecursively;
       if (page == null || isEmptyAndNotRecursively) {
         res.code = 'Page is not found';

--- a/apps/app/src/server/routes/page.js
+++ b/apps/app/src/server/routes/page.js
@@ -923,11 +923,6 @@ module.exports = function(crowi, app) {
       return res.json(ApiResponse.error(`Page '${pageId}' is not found or forbidden`, 'notfound_or_forbidden'));
     }
 
-    // TODO: remove in https://redmine.weseek.co.jp/issues/136139
-    if (page.grantedGroups != null && page.grantedGroups.length > 1) {
-      return res.apiv3Err('Cannot grant multiple groups to page at the moment');
-    }
-
     // check whether path starts slash
     newPagePath = pathUtils.addHeadingSlash(newPagePath);
 


### PR DESCRIPTION
## やったこと
- 「ユーザに関連のあるリソースのみを複製する」がチェックされいない時、ユーザが権限を持っていなくてもページの複製がされる。しかし、現状そのページが normalize 対象となっておらず、複製後に parent の設定がされていなかったため、されるように修正
    - 以下の、どちらかの既存バグが存在している気がしています。
        - 既存 (v6 以前) の複製の仕様が「再帰複製の際、ユーザが権限を持たないページは複製しない」の場合: そもそも複製がされるべきではないが、されるようになっていた
            - normalize されていないので、parent が null で、UI からはアクセスできない
            - [複製対象を絞っている箇所](https://github.com/weseek/growi/blame/master/apps/app/src/server/service/page/index.ts#L1348)
        - 既存 (v6 以前) の複製の仕様が「再帰複製の際、ユーザが権限を持たないページは複製する」の場合: ユーザが権限を持たない複製後のページに対し、normalize が正常に行われていない
- 複製 API での multi grant group の有効化が抜けていたため修正

## task
https://redmine.weseek.co.jp/issues/140076

## 備考
テストは実装方針が定まった後、記述します