### PR TITLE
feat: CollapsedParentsDropdown to display ancestor pathname

### DIFF
--- a/apps/app/src/components/Common/PagePathHierarchicalLink/CollapsedParentsDropdown.tsx
+++ b/apps/app/src/components/Common/PagePathHierarchicalLink/CollapsedParentsDropdown.tsx
@@ -1,12 +1,26 @@
+import { useMemo } from 'react';
+
+import Link from 'next/link';
 import {
   DropdownItem, DropdownMenu, DropdownToggle, UncontrolledDropdown,
 } from 'reactstrap';
 
-import LinkedPagePath from '~/models/linked-page-path';
-
+import type LinkedPagePath from '~/models/linked-page-path';
 
 import styles from './CollapsedParentsDropdown.module.scss';
 
+const getAncestorPathAndPathName = (linkedPagePath: LinkedPagePath) => {
+  const data: Array<{ path: string, pathName: string }> = [];
+  let linkedPagePathTmp = linkedPagePath;
+
+  while (linkedPagePathTmp.parent != null) {
+    data.push({ path: linkedPagePathTmp.path, pathName: linkedPagePathTmp.pathName });
+    linkedPagePathTmp = linkedPagePathTmp.parent;
+  }
+
+  const reversedData = data.reverse();
+  return reversedData;
+};
 
 type Props = {
   linkedPagePath: LinkedPagePath,
@@ -15,20 +29,19 @@ type Props = {
 export const CollapsedParentsDropdown = (props: Props): JSX.Element => {
   const { linkedPagePath } = props;
 
+  const ancestorPathAndPathName = useMemo(() => getAncestorPathAndPathName(linkedPagePath), [linkedPagePath]);
+
   return (
     <UncontrolledDropdown className="d-inline-block">
       <DropdownToggle color="transparent">...</DropdownToggle>
       <DropdownMenu className={`dropdown-menu ${styles['collapsed-parents-dropdown-menu']}`} container="body">
-        {/* TODO: generate DropdownItems */}
-        <DropdownItem>
-          <a role="menuitem">foo</a>
-        </DropdownItem>
-        <DropdownItem>
-          <a role="menuitem">bar</a>
-        </DropdownItem>
-        <DropdownItem>
-          <a role="menuitem">baz</a>
-        </DropdownItem>
+        {ancestorPathAndPathName.map(data => (
+          <DropdownItem key={data.path}>
+            <Link href={data.path} legacyBehavior>
+              <a role="menuitem">{data.pathName}</a>
+            </Link>
+          </DropdownItem>
+        ))}
       </DropdownMenu>
     </UncontrolledDropdown>
   );

--- a/apps/app/src/components/Common/PagePathHierarchicalLink/CollapsedParentsDropdown.tsx
+++ b/apps/app/src/components/Common/PagePathHierarchicalLink/CollapsedParentsDropdown.tsx
@@ -9,17 +9,16 @@ import type LinkedPagePath from '~/models/linked-page-path';
 
 import styles from './CollapsedParentsDropdown.module.scss';
 
-const getAncestorPathAndPathName = (linkedPagePath: LinkedPagePath) => {
-  const data: Array<{ path: string, pathName: string }> = [];
-  let linkedPagePathTmp = linkedPagePath;
+const getAncestorPathAndPathNames = (linkedPagePath: LinkedPagePath) => {
+  const pathAndPathName: Array<{ path: string, pathName: string }> = [];
+  let currentLinkedPagePath = linkedPagePath;
 
-  while (linkedPagePathTmp.parent != null) {
-    data.push({ path: linkedPagePathTmp.path, pathName: linkedPagePathTmp.pathName });
-    linkedPagePathTmp = linkedPagePathTmp.parent;
+  while (currentLinkedPagePath.parent != null) {
+    pathAndPathName.unshift({ path: currentLinkedPagePath.path, pathName: currentLinkedPagePath.pathName });
+    currentLinkedPagePath = currentLinkedPagePath.parent;
   }
 
-  const reversedData = data.reverse();
-  return reversedData;
+  return pathAndPathName;
 };
 
 type Props = {
@@ -29,13 +28,13 @@ type Props = {
 export const CollapsedParentsDropdown = (props: Props): JSX.Element => {
   const { linkedPagePath } = props;
 
-  const ancestorPathAndPathName = useMemo(() => getAncestorPathAndPathName(linkedPagePath), [linkedPagePath]);
+  const ancestorPathAndPathNames = useMemo(() => getAncestorPathAndPathNames(linkedPagePath), [linkedPagePath]);
 
   return (
     <UncontrolledDropdown className="d-inline-block">
       <DropdownToggle color="transparent">...</DropdownToggle>
       <DropdownMenu className={`dropdown-menu ${styles['collapsed-parents-dropdown-menu']}`} container="body">
-        {ancestorPathAndPathName.map(data => (
+        {ancestorPathAndPathNames.map(data => (
           <DropdownItem key={data.path}>
             <Link href={data.path} legacyBehavior>
               <a role="menuitem">{data.pathName}</a>


### PR DESCRIPTION
## Task
[#139613](https://redmine.weseek.co.jp/issues/139613) [v7] サブナビバーでページ名が省略される際の「…」押下で表示されるドロップダウンでページを選択できる
┗ [#140016](https://redmine.weseek.co.jp/issues/140016) 実装