### PR TITLE
fix: Fix Dropup menu style

### DIFF
--- a/packages/core/scss/bootstrap/_variables.scss
+++ b/packages/core/scss/bootstrap/_variables.scss
@@ -115,6 +115,7 @@ $font-family-base: $font-family-sans-serif;
 // $dropdown-link-disabled-color: $gray-500;
 // $dropdown-header-color: $gray-500;
 // $dropdown-box-shadow: 0 0.5rem 0.7rem rgba(black, 0.1);
+$dropdown-header-padding-y:         0 !default;
 
 //== Popovers
 // $popover-border-radius: $border-radius;

--- a/packages/editor/src/components/CodeMirrorEditor/Toolbar/AttachmentsButton.tsx
+++ b/packages/editor/src/components/CodeMirrorEditor/Toolbar/AttachmentsButton.tsx
@@ -16,7 +16,7 @@ export const AttachmentsButton = (props: Props): JSX.Element => {
   if (acceptedFileType === AcceptedUploadFileType.ALL) {
     return (
       <>
-        <DropdownItem className="d-flex gap-1 align-items-center" onClick={onFileOpen}>
+        <DropdownItem className="d-flex gap-2 align-items-center" onClick={onFileOpen}>
           <span className="material-symbols-outlined fs-5">attach_file</span>
           Files
         </DropdownItem>
@@ -26,7 +26,7 @@ export const AttachmentsButton = (props: Props): JSX.Element => {
   if (acceptedFileType === AcceptedUploadFileType.IMAGE) {
     return (
       <>
-        <DropdownItem className="d-flex gap-1 align-items-center" onClick={onFileOpen}>
+        <DropdownItem className="d-flex gap-2 align-items-center" onClick={onFileOpen}>
           <span className="material-symbols-outlined fs-5">image</span>
           Images
         </DropdownItem>

--- a/packages/editor/src/components/CodeMirrorEditor/Toolbar/AttachmentsDropup.tsx
+++ b/packages/editor/src/components/CodeMirrorEditor/Toolbar/AttachmentsDropup.tsx
@@ -27,8 +27,7 @@ export const AttachmentsDropup = (props: Props): JSX.Element => {
           <span className="material-symbols-outlined fs-6">add</span>
         </DropdownToggle>
         <DropdownMenu>
-          <DropdownItem className="d-flex gap-1 align-items-center" header>
-            <span className="material-symbols-outlined fs-5">add_circle_outline</span>
+          <DropdownItem className="mt-1" header>
             Attachments
           </DropdownItem>
           <DropdownItem divider />

--- a/packages/override/_dropdown.scss
+++ b/packages/override/_dropdown.scss
@@ -1,0 +1,11 @@
+:root[data-bs-theme='light'] {
+  .dropdown-menu {
+    --#{$prefix}dropdown-header-color: var(--grw-gray-500);
+  }
+}
+
+:root[data-bs-theme='dark'] {
+  .dropdown-menu {
+    --#{$prefix}dropdown-header-color: var(--grw-gray-600);
+  }
+}


### PR DESCRIPTION
# Task
https://redmine.weseek.co.jp/issues/140059

# XD
- https://xd.adobe.com/view/26f3cef5-06c1-4ed2-9871-b86d5d00adce-73a0/screen/5b928f9d-ea54-430f-9516-6b07f98c40e5/

# 内容
- ドロップアップのスタイル修正
- ドロップダウン(アップも共通)ヘッダーの色の調整