### PR TITLE
fix: Tuncate former link in small mode

### DIFF
--- a/apps/app/src/components/Sidebar/RecentChanges/RecentChangesSubstance.tsx
+++ b/apps/app/src/components/Sidebar/RecentChanges/RecentChangesSubstance.tsx
@@ -91,7 +91,7 @@ const PageItem = memo(({ page, isSmall, onClickTag }: PageItemProps): JSX.Elemen
   const linkedPagePathFormer = new LinkedPagePath(dPagePath.former);
   const linkedPagePathLatter = new LinkedPagePath(dPagePath.latter);
   const FormerLink = () => (
-    <div className={`${formerLinkClass} ${isSmall ? 'text-truncate' : ''}`}>
+    <div className={`${formerLinkClass} ${isSmall ? 'text-truncate' : ''} small`}>
       <PagePathHierarchicalLink linkedPagePath={linkedPagePathFormer} />
     </div>
   );

--- a/apps/app/src/components/Sidebar/RecentChanges/RecentChangesSubstance.tsx
+++ b/apps/app/src/components/Sidebar/RecentChanges/RecentChangesSubstance.tsx
@@ -91,7 +91,7 @@ const PageItem = memo(({ page, isSmall, onClickTag }: PageItemProps): JSX.Elemen
   const linkedPagePathFormer = new LinkedPagePath(dPagePath.former);
   const linkedPagePathLatter = new LinkedPagePath(dPagePath.latter);
   const FormerLink = () => (
-    <div className={`${formerLinkClass} small`}>
+    <div className={`${formerLinkClass} ${isSmall ? 'text-truncate' : ''}`}>
       <PagePathHierarchicalLink linkedPagePath={linkedPagePathFormer} />
     </div>
   );


### PR DESCRIPTION
## Task
[#139737](https://redmine.weseek.co.jp/issues/139737) [v7] サイドバー「最新の変更」の「S」サイズ表示時にページ名が改行して表示されてしまっている件の修正
┗ [#140187](https://redmine.weseek.co.jp/issues/140187) 修正

## ScreenRecord

https://github.com/weseek/growi/assets/34241526/84bdfaf7-e4af-4502-a3bb-9a0c9b53f9a7



