### PR TITLE
fix: When the revision body is empty no differences are detected

### DIFF
--- a/apps/app/src/components/PageHistory/RevisionDiff.tsx
+++ b/apps/app/src/components/PageHistory/RevisionDiff.tsx
@@ -3,7 +3,8 @@ import React from 'react';
 import type { IRevisionHasPageId } from '@growi/core';
 import { returnPathForURL } from '@growi/core/dist/utils/path-utils';
 import { createPatch } from 'diff';
-import { html, Diff2HtmlConfig } from 'diff2html';
+import type { Diff2HtmlConfig } from 'diff2html';
+import { html } from 'diff2html';
 import { useTranslation } from 'next-i18next';
 import Link from 'next/link';
 import urljoin from 'url-join';
@@ -43,7 +44,7 @@ export const RevisionDiff = (props: RevisioinDiffProps): JSX.Element => {
     drawFileList: false,
   };
 
-  const diffViewHTML = (currentRevision.body && previousRevision.body && revisionDiffOpened) ? html(patch, option) : '';
+  const diffViewHTML = revisionDiffOpened ? html(patch, option) : '';
 
   const diffView = { __html: diffViewHTML };
 


### PR DESCRIPTION
## Task
[#139845](https://redmine.weseek.co.jp/issues/139845) [v7] ページの更新履歴で一番古いリビジョンとのページの差分が表示されない件の修正
┗ [#140308](https://redmine.weseek.co.jp/issues/140308) 修正

## Detail 
ストーリー記載の症状、再現条件ではなかった為追記しています

### 症状
revision.body が空文字列になっている revision を History の比較対象 (source or target) にした時にページの差分が表示されない

### 再現条件
1. 適当なページを作成して空文字列の body を持つ revision を作成する
2. 1で作成した revision を History の比較対象とする

### 期待する動作
差分が表示される
