### PR TITLE
fix: Page list count is wrong

### DIFF
--- a/apps/app/src/components/Common/CountBadge.tsx
+++ b/apps/app/src/components/Common/CountBadge.tsx
@@ -1,4 +1,5 @@
-import React, { FC } from 'react';
+import type { FC } from 'react';
+import React from 'react';
 
 type CountProps = {
   count?: number,

--- a/apps/app/src/components/PageSideContents/PageAccessoriesControl.tsx
+++ b/apps/app/src/components/PageSideContents/PageAccessoriesControl.tsx
@@ -13,12 +13,13 @@ type Props = {
   icon: ReactNode,
   label: ReactNode,
   count?: number,
+  offset?: number,
   onClick?: () => void,
 }
 
 export const PageAccessoriesControl = memo((props: Props): JSX.Element => {
   const {
-    icon, label, count,
+    icon, label, count, offset,
     className,
     onClick,
   } = props;
@@ -34,7 +35,7 @@ export const PageAccessoriesControl = memo((props: Props): JSX.Element => {
         {label}
         {/* Do not display CountBadge if '/trash/*': https://github.com/weseek/growi/pull/7600 */}
         { count != null
-          ? <CountBadge count={count} />
+          ? <CountBadge count={count} offset={offset} />
           : <div className="px-2"></div>}
       </span>
     </button>

--- a/apps/app/src/components/PageSideContents/PageSideContents.tsx
+++ b/apps/app/src/components/PageSideContents/PageSideContents.tsx
@@ -105,6 +105,7 @@ export const PageSideContents = (props: PageSideContentsProps): JSX.Element => {
               label={t('page_list')}
               // Do not display CountBadge if '/trash/*': https://github.com/weseek/growi/pull/7600
               count={!isTrash && pageInfo != null ? (pageInfo as IPageInfoForOperation).descendantCount : undefined}
+              offset={1}
               onClick={() => openDescendantPageListModal(pagePath)}
             />
           </div>


### PR DESCRIPTION
## Task
[#140327](https://redmine.weseek.co.jp/issues/140327) [v7] View モード_右カラム_ページリストに表示される件数が v6 の表示件数と異なる件の修正
┗ [#140392](https://redmine.weseek.co.jp/issues/140392) 修正
