### PR TITLE
fix: Use default backward keymap

### DIFF
--- a/packages/editor/src/services/codemirror-editor/use-codemirror-editor/use-codemirror-editor.ts
+++ b/packages/editor/src/services/codemirror-editor/use-codemirror-editor/use-codemirror-editor.ts
@@ -1,8 +1,8 @@
 import { useMemo } from 'react';
 
-import { indentWithTab, defaultKeymap } from '@codemirror/commands';
+import { indentWithTab, defaultKeymap, deleteCharBackward } from '@codemirror/commands';
 import {
-  markdown, markdownLanguage, deleteMarkupBackward,
+  markdown, markdownLanguage,
 } from '@codemirror/lang-markdown';
 import { syntaxHighlighting, HighlightStyle, defaultHighlightStyle } from '@codemirror/language';
 import { languages } from '@codemirror/language-data';
@@ -32,11 +32,11 @@ import { useInsertText, type InsertText } from './utils/insert-text';
 import { useReplaceText, type ReplaceText } from './utils/replace-text';
 import { useSetCaretLine, type SetCaretLine } from './utils/set-caret-line';
 
+
 // set new markdownKeymap instead of default one
-// I also bound the deleteMarkupBackward to the backspace key to align with the existing keymap
 // https://github.com/codemirror/lang-markdown/blob/main/src/index.ts#L17
 const markdownKeymap = [
-  { key: 'Backspace', run: deleteMarkupBackward },
+  { key: 'Backspace', run: deleteCharBackward },
   { key: 'Enter', run: insertNewlineContinueMarkup },
 ];
 


### PR DESCRIPTION
# 概要
`@codemirror/lang-markdown` で設定されていたキーマップをデフォルトの Keymap に上書きする。

# Task
- https://redmine.weseek.co.jp/issues/140046
  - https://redmine.weseek.co.jp/issues/140086