### PR TITLE
imprv: 139427 140551 adjustment space

### DIFF
--- a/apps/app/src/components/PageDuplicateModal.tsx
+++ b/apps/app/src/components/PageDuplicateModal.tsx
@@ -160,10 +160,10 @@ const PageDuplicateModal = (): JSX.Element => {
 
     return (
       <>
-        <div><label className="form-label">{t('modal_duplicate.label.Current page name')}</label><br />
+        <div className="mt-3"><label className="form-label">{t('modal_duplicate.label.Current page name')}</label><br />
           <code>{path}</code>
         </div>
-        <div>
+        <div className="mt-3">
           <label className="form-label" htmlFor="duplicatePageName">{ t('modal_duplicate.label.New page name') }</label><br />
           <div className="input-group">
             <div>
@@ -196,7 +196,7 @@ const PageDuplicateModal = (): JSX.Element => {
           <p className="text-danger">Error: Target path is duplicated.</p>
         ) }
 
-        <div className="form-check form-check-warning">
+        <div className="form-check form-check-warning mt-3">
           <input
             className="form-check-input"
             name="recursively"
@@ -210,7 +210,7 @@ const PageDuplicateModal = (): JSX.Element => {
             <p className="form-text text-muted my-0">{ t('modal_duplicate.help.recursive') }</p>
           </label>
 
-          <div>
+          <div className="mt-3">
             {isDuplicateRecursively && existingPaths.length !== 0 && (
               <div className="form-check form-check-warning">
                 <input

--- a/apps/app/src/components/PageDuplicateModal.tsx
+++ b/apps/app/src/components/PageDuplicateModal.tsx
@@ -230,7 +230,7 @@ const PageDuplicateModal = (): JSX.Element => {
           </div>
         </div>
 
-        <div className="form-check form-check-warning mb-3">
+        <div className="form-check form-check-warning mt-2">
           <input
             className="form-check-input"
             id="cbOnlyDuplicateUserRelatedResources"
@@ -243,7 +243,7 @@ const PageDuplicateModal = (): JSX.Element => {
             <p className="form-text text-muted my-0">{ t('modal_duplicate.help.only_user_related_resources') }</p>
           </label>
         </div>
-        <div>
+        <div className="mt-3">
           {isDuplicateRecursively && existingPaths.length !== 0 && (
             <DuplicatePathsTable existingPaths={existingPaths} fromPath={path} toPath={pageNameInput} />
           ) }


### PR DESCRIPTION
## What
- ページの複製時に表示されるモーダル内の各項目上下の余白が調整されていなく項目と内容が紐づいているように見えないので修正する

## ScreenShot
### Before
<img width="479" alt="image" src="https://github.com/weseek/growi/assets/130130573/15ecb532-f4a7-4b10-8fda-6449f31d1c45">

### After
<img width="476" alt="image" src="https://github.com/weseek/growi/assets/130130573/a67bac8e-edd0-4241-b59c-28b29ff1ed90">

## Task
- https://redmine.weseek.co.jp/issues/139427
  -  https://redmine.weseek.co.jp/issues/140551