### PR TITLE
imprv: Dynamic import for keymap

### DIFF
--- a/packages/editor/src/components/CodeMirrorEditor/CodeMirrorEditor.tsx
+++ b/packages/editor/src/components/CodeMirrorEditor/CodeMirrorEditor.tsx
@@ -171,6 +171,7 @@ export const CodeMirrorEditor = (props: Props): JSX.Element => {
       setKeymapExtension(await getKeymap(name ?? 'default'));
     };
     settingKeyMap(editorKeymap as KeyMapMode);
+
   }, [codeMirrorEditor, editorKeymap, setKeymapExtension]);
 
   useEffect(() => {
@@ -178,19 +179,8 @@ export const CodeMirrorEditor = (props: Props): JSX.Element => {
       return;
     }
 
-    const handleCtrlN = (event: KeyboardEvent) => {
-      if (event.ctrlKey && event.key === 'n') {
-        event.preventDefault();
-      }
-    };
-
     // Prevent these Keybind from overwriting the originally defined keymap.
-    const cleanupFunction = codeMirrorEditor?.appendExtensions(
-      [
-        Prec.low(keymapExtension),
-        EditorView.domEventHandlers({ keydown: handleCtrlN }),
-      ],
-    );
+    const cleanupFunction = codeMirrorEditor?.appendExtensions(Prec.low(keymapExtension));
     return cleanupFunction;
 
   }, [codeMirrorEditor, keymapExtension, onSave]);

--- a/packages/editor/src/components/CodeMirrorEditor/CodeMirrorEditor.tsx
+++ b/packages/editor/src/components/CodeMirrorEditor/CodeMirrorEditor.tsx
@@ -178,8 +178,19 @@ export const CodeMirrorEditor = (props: Props): JSX.Element => {
       return;
     }
 
+    const handleCtrlN = (event: KeyboardEvent) => {
+      if (event.ctrlKey && event.key === 'n') {
+        event.preventDefault();
+      }
+    };
+
     // Prevent these Keybind from overwriting the originally defined keymap.
-    const cleanupFunction = codeMirrorEditor?.appendExtensions(Prec.low(keymapExtension));
+    const cleanupFunction = codeMirrorEditor?.appendExtensions(
+      [
+        Prec.low(keymapExtension),
+        EditorView.domEventHandlers({ keydown: handleCtrlN }),
+      ],
+    );
     return cleanupFunction;
 
   }, [codeMirrorEditor, keymapExtension, onSave]);

--- a/packages/editor/src/components/CodeMirrorEditor/CodeMirrorEditor.tsx
+++ b/packages/editor/src/components/CodeMirrorEditor/CodeMirrorEditor.tsx
@@ -9,7 +9,7 @@ import type { ReactCodeMirrorProps } from '@uiw/react-codemirror';
 
 import { GlobalCodeMirrorEditorKey, AcceptedUploadFileType } from '../../consts';
 import {
-  useFileDropzone, FileDropzoneOverlay, getEditorTheme, type EditorTheme, getKeyMap, type KeyMapMode,
+  useFileDropzone, FileDropzoneOverlay, getEditorTheme, type EditorTheme, getKeymap, type KeyMapMode,
 } from '../../services';
 import {
   adjustPasteData, getStrFromBol,
@@ -165,15 +165,24 @@ export const CodeMirrorEditor = (props: Props): JSX.Element => {
   }, [codeMirrorEditor, themeExtension]);
 
 
+  const [keymapExtension, setKeymapExtension] = useState<Extension | undefined>(undefined);
   useEffect(() => {
-    const keymap = (editorKeymap ?? 'default') as KeyMapMode;
-    const extension = getKeyMap(keymap, onSave);
+    const settingKeyMap = async(name?: KeyMapMode) => {
+      setKeymapExtension(await getKeymap(name ?? 'default'));
+    };
+    settingKeyMap(editorKeymap as KeyMapMode);
+  }, [codeMirrorEditor, editorKeymap, setKeymapExtension]);
+
+  useEffect(() => {
+    if (keymapExtension == null) {
+      return;
+    }
 
     // Prevent these Keybind from overwriting the originally defined keymap.
-    const cleanupFunction = codeMirrorEditor?.appendExtensions(Prec.low(extension));
+    const cleanupFunction = codeMirrorEditor?.appendExtensions(Prec.low(keymapExtension));
     return cleanupFunction;
 
-  }, [codeMirrorEditor, editorKeymap, onSave]);
+  }, [codeMirrorEditor, keymapExtension, onSave]);
 
   const {
     getRootProps,

--- a/packages/editor/src/services/keymaps/index.ts
+++ b/packages/editor/src/services/keymaps/index.ts
@@ -1,22 +1,17 @@
-import { defaultKeymap } from '@codemirror/commands';
 import { Extension } from '@codemirror/state';
 import { keymap } from '@codemirror/view';
-import { emacs } from '@replit/codemirror-emacs';
-import { vscodeKeymap } from '@replit/codemirror-vscode-keymap';
-
-import { vimKeymap } from './vim';
 
 
-export const getKeyMap = (keyMapName: KeyMapMode, onSave?: () => void): Extension => {
+export const getKeymap = async(keyMapName: KeyMapMode, onSave?: () => void): Promise<Extension> => {
   switch (keyMapName) {
     case 'vim':
-      return vimKeymap(onSave);
+      return (await import('./vim')).vimKeymap(onSave);
     case 'emacs':
-      return emacs();
+      return (await import('@replit/codemirror-emacs')).emacs();
     case 'vscode':
-      return keymap.of(vscodeKeymap);
+      return keymap.of((await import('@replit/codemirror-vscode-keymap')).vscodeKeymap);
     case 'default':
-      return keymap.of(defaultKeymap);
+      return keymap.of((await import('@codemirror/commands')).defaultKeymap);
   }
 };
 


### PR DESCRIPTION
# 概要
- Vim / Emacs / VSCode のキーバインドを動的にインポートできる
- Emacs における Ctrl + N はブラウザによってはブラウザ側で設定されているショートカットキーの影響で使うことができない。

# Task
- https://redmine.weseek.co.jp/issues/139847
  - https://redmine.weseek.co.jp/issues/140200