### PR TITLE
imprv:  Fix broken layout of search result page 

### DIFF
--- a/apps/app/public/static/locales/en_US/translation.json
+++ b/apps/app/public/static/locales/en_US/translation.json
@@ -538,6 +538,7 @@
     "search_again" : "Search again",
     "number_of_list_to_display" : "Display",
     "page_number_unit" : "pages",
+    "hit_number_unit" : "hit",
     "sort_axis": {
       "relationScore": "Sort by relevance",
       "createdAt": "Creation date",

--- a/apps/app/public/static/locales/ja_JP/translation.json
+++ b/apps/app/public/static/locales/ja_JP/translation.json
@@ -571,6 +571,7 @@
     "search_again" : "再検索",
     "number_of_list_to_display" : "表示件数",
     "page_number_unit" : "件",
+    "hit_number_unit" : "件",
     "sort_axis": {
       "relationScore": "関連度順",
       "createdAt": "作成日時",

--- a/apps/app/public/static/locales/zh_CN/translation.json
+++ b/apps/app/public/static/locales/zh_CN/translation.json
@@ -541,6 +541,7 @@
     "search_again" : "再次搜索",
     "number_of_list_to_display" : "显示器的数量",
     "page_number_unit" : "例",
+    "hit_number_unit" : "例",
     "sort_axis": {
       "relationScore": "按相关性排序",
       "createdAt": "按创建日期排序",

--- a/apps/app/src/components/SearchPage.tsx
+++ b/apps/app/src/components/SearchPage.tsx
@@ -28,8 +28,6 @@ const INITIAL_PAGIONG_SIZE = 20;
 
 type SearchResultListHeadProps = {
   searchResult: IFormattedSearchResult,
-  searchingKeyword: string,
-  offset: number,
   pagingSize: number,
   onPagingSizeChanged: (size: number) => void,
 }
@@ -38,13 +36,10 @@ const SearchResultListHead = React.memo((props: SearchResultListHeadProps): JSX.
   const { t } = useTranslation();
 
   const {
-    searchResult, searchingKeyword, offset, pagingSize,
-    onPagingSizeChanged,
+    searchResult, // pagingSize, onPagingSizeChanged,
   } = props;
 
-  const { took, total, hitsCount } = searchResult.meta;
-  const leftNum = offset + 1;
-  const rightNum = offset + hitsCount;
+  const { took, total } = searchResult.meta;
 
   if (total === 0) {
     return (
@@ -63,6 +58,7 @@ const SearchResultListHead = React.memo((props: SearchResultListHeadProps): JSX.
           <span data-vrt-blackout className="ms-3 text-muted d-inline-block" style={{ minWidth: '70px' }}>({took}ms)</span>
         ) }
       </div>
+      {/* TODO: infinite scroll for search result */}
       {/* <div className="input-group flex-nowrap search-result-select-group ms-auto d-md-flex d-none">
         <div>
           <label className="form-label input-group-text text-muted" htmlFor="inputGroupSelect01">{t('search_result.number_of_list_to_display')}</label>
@@ -183,7 +179,7 @@ export const SearchPage = (): JSX.Element => {
           >
             <button
               type="button"
-              className="btn btn-outline-danger text-nowrap border-0 px-2"
+              className="btn btn-outline-danger text-nowrap border-0 px-2 py-1"
               disabled={isDisabled}
               onClick={deleteAllButtonClickedHandler}
             >
@@ -219,13 +215,11 @@ export const SearchPage = (): JSX.Element => {
     return (
       <SearchResultListHead
         searchResult={data}
-        searchingKeyword={keyword ?? ''}
-        offset={offset}
         pagingSize={limit}
         onPagingSizeChanged={pagingSizeChangedHandler}
       />
     );
-  }, [data, keyword, limit, offset, pagingSizeChangedHandler]);
+  }, [data, limit, pagingSizeChangedHandler]);
 
   const searchPager = useMemo(() => {
     // when pager is not needed

--- a/apps/app/src/components/SearchPage.tsx
+++ b/apps/app/src/components/SearchPage.tsx
@@ -179,11 +179,10 @@ export const SearchPage = (): JSX.Element => {
           >
             <button
               type="button"
-              className="btn btn-outline-danger text-nowrap border-0 px-2 py-1"
+              className="btn"
               disabled={isDisabled}
               onClick={deleteAllButtonClickedHandler}
             >
-              <span className="material-symbols-outlined">delete</span>
               {t('search_result.delete_all_selected_page')}
             </button>
           </OperateAllControl>

--- a/apps/app/src/components/SearchPage.tsx
+++ b/apps/app/src/components/SearchPage.tsx
@@ -57,15 +57,13 @@ const SearchResultListHead = React.memo((props: SearchResultListHeadProps): JSX.
   return (
     <div className="d-flex align-items-center justify-content-between">
       <div className="text-nowrap">
-        {t('search_result.result_meta')}
-        <span className="search-result-keyword ms-2">{`${searchingKeyword}`}</span>
-        <span className="ms-3">{`${leftNum}-${rightNum}`} / {total}</span>
+        <span className="ms-3 fw-bold">{total} {t('search_result.hit_number_unit', 'hit')}</span>
         { took != null && (
           // blackout 70px rectangle in VRT
           <span data-vrt-blackout className="ms-3 text-muted d-inline-block" style={{ minWidth: '70px' }}>({took}ms)</span>
         ) }
       </div>
-      <div className="input-group flex-nowrap search-result-select-group ms-auto d-md-flex d-none">
+      {/* <div className="input-group flex-nowrap search-result-select-group ms-auto d-md-flex d-none">
         <div>
           <label className="form-label input-group-text text-muted" htmlFor="inputGroupSelect01">{t('search_result.number_of_list_to_display')}</label>
         </div>
@@ -79,7 +77,7 @@ const SearchResultListHead = React.memo((props: SearchResultListHeadProps): JSX.
             return <option key={limit} value={limit}>{limit} {t('search_result.page_number_unit')}</option>;
           })}
         </select>
-      </div>
+      </div> */}
     </div>
   );
 });

--- a/apps/app/src/components/SearchPage.tsx
+++ b/apps/app/src/components/SearchPage.tsx
@@ -179,7 +179,7 @@ export const SearchPage = (): JSX.Element => {
           >
             <button
               type="button"
-              className="btn"
+              className="btn border-0 text-danger"
               disabled={isDisabled}
               onClick={deleteAllButtonClickedHandler}
             >

--- a/apps/app/src/components/SearchPage/OperateAllControl.tsx
+++ b/apps/app/src/components/SearchPage/OperateAllControl.tsx
@@ -57,7 +57,7 @@ const OperateAllControlSubstance: ForwardRefRenderFunction<ISelectableAndIndeter
         type="checkbox"
         id="cb-check-all"
         data-testid="cb-select-all"
-        className="ms-2 me-1"
+        className="ms-2"
         innerRef={selectAllCheckboxElm}
         disabled={isCheckboxDisabled}
         onChange={checkboxChangedHandler}

--- a/apps/app/src/components/SearchPage/OperateAllControl.tsx
+++ b/apps/app/src/components/SearchPage/OperateAllControl.tsx
@@ -57,7 +57,7 @@ const OperateAllControlSubstance: ForwardRefRenderFunction<ISelectableAndIndeter
         type="checkbox"
         id="cb-check-all"
         data-testid="cb-select-all"
-        className="me-2"
+        className="ms-2 me-1"
         innerRef={selectAllCheckboxElm}
         disabled={isCheckboxDisabled}
         onChange={checkboxChangedHandler}

--- a/apps/app/src/components/SearchPage/OperateAllControl.tsx
+++ b/apps/app/src/components/SearchPage/OperateAllControl.tsx
@@ -1,11 +1,10 @@
-import React, {
-  ChangeEvent, forwardRef, ForwardRefRenderFunction, useImperativeHandle, useRef,
-} from 'react';
+import type { ChangeEvent, ForwardRefRenderFunction } from 'react';
+import React, { forwardRef, useImperativeHandle, useRef } from 'react';
 
 import { Input } from 'reactstrap';
 
-import { ISelectableAndIndeterminatable } from '~/client/interfaces/selectable-all';
-import { IndeterminateInputElement } from '~/interfaces/indeterminate-input-elm';
+import type { ISelectableAndIndeterminatable } from '~/client/interfaces/selectable-all';
+import type { IndeterminateInputElement } from '~/interfaces/indeterminate-input-elm';
 
 type Props = {
   isCheckboxDisabled?: boolean,
@@ -58,6 +57,7 @@ const OperateAllControlSubstance: ForwardRefRenderFunction<ISelectableAndIndeter
         type="checkbox"
         id="cb-check-all"
         data-testid="cb-select-all"
+        className="me-2"
         innerRef={selectAllCheckboxElm}
         disabled={isCheckboxDisabled}
         onChange={checkboxChangedHandler}

--- a/apps/app/src/components/SearchPage/SearchControl.module.scss
+++ b/apps/app/src/components/SearchPage/SearchControl.module.scss
@@ -1,0 +1,9 @@
+
+@use '@growi/core/scss/bootstrap/init' as bs;
+
+@use '@growi/ui/scss/atoms/btn-muted';
+
+// == Colors
+.btn-delete {
+  @include btn-muted.colorize(bs.$red);
+}

--- a/apps/app/src/components/SearchPage/SearchControl.tsx
+++ b/apps/app/src/components/SearchPage/SearchControl.tsx
@@ -123,7 +123,7 @@ const SearchControl = React.memo((props: Props): JSX.Element => {
               </button>
             </div>
             <div className="d-none d-lg-flex align-items-center ms-auto search-control-include-options">
-              <div className="px-2 py-1 me-3">
+              <div className="px-2 py-1">
                 <div className="form-check form-check-succsess">
                   <input
                     className="form-check-input me-2"

--- a/apps/app/src/components/SearchPage/SearchControl.tsx
+++ b/apps/app/src/components/SearchPage/SearchControl.tsx
@@ -12,6 +12,8 @@ import SearchForm from '../SearchForm';
 import SearchOptionModal from './SearchOptionModal';
 import SortControl from './SortControl';
 
+import styles from './SearchControl.module.scss';
+
 type Props = {
   isSearchServiceReachable: boolean,
   isEnableSort: boolean,
@@ -160,9 +162,9 @@ const SearchControl = React.memo((props: Props): JSX.Element => {
         )}
         <div className="d-flex">
           <div className="btn-group">
-            <button className="btn rounded" type="button" data-bs-toggle="dropdown" aria-expanded="false">
-              <span className="material-symbols-outlined text-secondary">delete</span>
-              <span className="material-symbols-outlined text-secondary">expand_more</span>
+            <button className={`btn btn-sm rounded ${styles['btn-delete']}`} type="button" data-bs-toggle="dropdown" aria-expanded="false">
+              <span className="material-symbols-outlined ">delete</span>
+              <span className="material-symbols-outlined ">expand_more</span>
             </button>
             <ul className="dropdown-menu">
               {allControl}

--- a/apps/app/src/components/SearchPage/SearchControl.tsx
+++ b/apps/app/src/components/SearchPage/SearchControl.tsx
@@ -93,26 +93,12 @@ const SearchControl = React.memo((props: Props): JSX.Element => {
             onSubmit={searchFormSubmittedHandler}
           />
         </div>
-
-        {/* sort option: show when screen is larger than lg */}
-        {isEnableSort && (
-          <div className="me-4 d-lg-flex d-none">
-            <SortControl
-              sort={sort}
-              order={order}
-              onChange={changeSortHandler}
-            />
-          </div>
-        )}
       </div>
       {/* TODO: replace the following elements deleteAll button , relevance button and include specificPath button component */}
       <div className="search-control d-flex align-items-center py-md-2 py-3 px-md-4 px-3 border-bottom border-gray">
-        <div className="d-flex">
-          {allControl}
-        </div>
-        {/* sort option: show when screen is smaller than lg */}
+        {/* sort option */}
         {isEnableSort && (
-          <div className="me-md-4 me-2 d-flex d-lg-none ms-auto">
+          <div className="d-flex me-auto">
             <SortControl
               sort={sort}
               order={order}
@@ -129,7 +115,9 @@ const SearchControl = React.memo((props: Props): JSX.Element => {
                 className="btn"
                 onClick={() => setIsFileterOptionModalShown(true)}
               >
-                <i className="icon-equalizer"></i>
+                <span className="material-symbols-outlined">
+                  tune
+                </span>
               </button>
             </div>
             <div className="d-none d-lg-flex align-items-center ms-auto search-control-include-options">
@@ -170,6 +158,17 @@ const SearchControl = React.memo((props: Props): JSX.Element => {
             </div>
           </>
         )}
+        <div className="d-flex">
+          <div className="btn-group">
+            <button className="btn rounded" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+              <span className="material-symbols-outlined text-secondary">delete</span>
+              <span className="material-symbols-outlined text-secondary">expand_more</span>
+            </button>
+            <ul className="dropdown-menu">
+              {allControl}
+            </ul>
+          </div>
+        </div>
       </div>
 
       <SearchOptionModal

--- a/apps/app/src/components/SearchPage/SearchControl.tsx
+++ b/apps/app/src/components/SearchPage/SearchControl.tsx
@@ -100,7 +100,7 @@ const SearchControl = React.memo((props: Props): JSX.Element => {
       <div className="search-control d-flex align-items-center py-md-2 py-3 px-md-4 px-3 border-bottom border-gray">
         {/* sort option */}
         {isEnableSort && (
-          <div className="d-flex me-auto">
+          <div className="flex-grow-1">
             <SortControl
               sort={sort}
               order={order}
@@ -122,7 +122,7 @@ const SearchControl = React.memo((props: Props): JSX.Element => {
                 </span>
               </button>
             </div>
-            <div className="d-none d-lg-flex align-items-center ms-auto search-control-include-options">
+            <div className="d-none d-lg-flex align-items-center search-control-include-options">
               <div className="px-2 py-1">
                 <div className="form-check form-check-succsess">
                   <input

--- a/apps/app/src/components/SearchPage/SearchControl.tsx
+++ b/apps/app/src/components/SearchPage/SearchControl.tsx
@@ -162,13 +162,14 @@ const SearchControl = React.memo((props: Props): JSX.Element => {
         )}
         <div className="d-flex">
           <div className="btn-group">
-            <button className={`btn btn-sm rounded ${styles['btn-delete']}`} type="button" data-bs-toggle="dropdown" aria-expanded="false">
+            {/* TODO: imprv to delete all result UI */}
+            {/* <button className={`btn btn-sm rounded ${styles['btn-delete']}`} type="button" data-bs-toggle="dropdown" aria-expanded="false">
               <span className="material-symbols-outlined ">delete</span>
               <span className="material-symbols-outlined ">expand_more</span>
-            </button>
-            <ul className="dropdown-menu">
-              {allControl}
-            </ul>
+            </button> */}
+            {/* <ul className="dropdown-menu"> */}
+            {allControl}
+            {/* </ul> */}
           </div>
         </div>
       </div>

--- a/apps/app/src/components/SearchPage/SearchControl.tsx
+++ b/apps/app/src/components/SearchPage/SearchControl.tsx
@@ -5,7 +5,7 @@ import React, {
 import { useTranslation } from 'next-i18next';
 
 import { SORT_AXIS, SORT_ORDER } from '~/interfaces/search';
-import { ISearchConditions, ISearchConfigurations } from '~/stores/search';
+import type { ISearchConditions, ISearchConfigurations } from '~/stores/search';
 
 import SearchForm from '../SearchForm';
 
@@ -133,7 +133,7 @@ const SearchControl = React.memo((props: Props): JSX.Element => {
               </button>
             </div>
             <div className="d-none d-lg-flex align-items-center ms-auto search-control-include-options">
-              <div className="border rounded px-2 py-1 me-3">
+              <div className="px-2 py-1 me-3">
                 <div className="form-check form-check-succsess">
                   <input
                     className="form-check-input me-2"
@@ -150,7 +150,7 @@ const SearchControl = React.memo((props: Props): JSX.Element => {
                   </label>
                 </div>
               </div>
-              <div className="border rounded px-2 py-1">
+              <div className="px-2 py-1">
                 <div className="form-check form-check-succsess">
                   <input
                     className="form-check-input me-2"
@@ -160,7 +160,7 @@ const SearchControl = React.memo((props: Props): JSX.Element => {
                     onChange={e => changeIncludeTrashPagesHandler(e.target.checked)}
                   />
                   <label
-                    className="form-label form-check-label d-flex align-items-center text-secondary with-no-font-weight"
+                    className="form-label form-check-label mb-0 d-flex align-items-center text-secondary with-no-font-weight"
                     htmlFor="flexCheckChecked"
                   >
                     {t('Include Subordinated Target Page', { target: '/trash' })}

--- a/apps/app/src/components/SearchPage/SearchOptionModal.tsx
+++ b/apps/app/src/components/SearchPage/SearchOptionModal.tsx
@@ -1,4 +1,5 @@
-import React, { FC } from 'react';
+import type { FC } from 'react';
+import React from 'react';
 
 import { useTranslation } from 'next-i18next';
 import {
@@ -51,7 +52,7 @@ const SearchOptionModal: FC<Props> = (props: Props) => {
       </ModalHeader>
       <ModalBody>
         <div className="d-flex p-2">
-          <div className="border border-gray me-3">
+          <div className="me-3">
             <label className="form-label px-3 py-2 mb-0 d-flex align-items-center">
               <input
                 className="me-2"
@@ -62,7 +63,7 @@ const SearchOptionModal: FC<Props> = (props: Props) => {
               {t('Include Subordinated Target Page', { target: '/user' })}
             </label>
           </div>
-          <div className="border border-gray">
+          <div className="">
             <label className="form-label px-3 py-2 mb-0 d-flex align-items-center">
               <input
                 className="me-2"

--- a/apps/app/src/components/SearchPage/SortControl.module.scss
+++ b/apps/app/src/components/SearchPage/SortControl.module.scss
@@ -1,0 +1,3 @@
+.sort-control {
+  width: 250px;
+}

--- a/apps/app/src/components/SearchPage/SortControl.module.scss
+++ b/apps/app/src/components/SearchPage/SortControl.module.scss
@@ -1,3 +1,3 @@
 .sort-control {
-  width: 180px;
+  min-width: 180px;
 }

--- a/apps/app/src/components/SearchPage/SortControl.module.scss
+++ b/apps/app/src/components/SearchPage/SortControl.module.scss
@@ -1,3 +1,3 @@
 .sort-control {
-  width: 250px;
+  width: 180px;
 }

--- a/apps/app/src/components/SearchPage/SortControl.tsx
+++ b/apps/app/src/components/SearchPage/SortControl.tsx
@@ -1,5 +1,8 @@
-import React, { FC } from 'react';
+import type { FC } from 'react';
+import React from 'react';
+
 import { useTranslation } from 'next-i18next';
+
 import { SORT_AXIS, SORT_ORDER } from '../../interfaces/search';
 
 const { DESC, ASC } = SORT_ORDER;
@@ -30,10 +33,8 @@ const SortControl: FC <Props> = (props: Props) => {
   return (
     <>
       <div className="input-group flex-nowrap">
-        <div>
-          <div className="input-group-text border text-muted" id="btnGroupAddon">
-            {renderOrderIcon()}
-          </div>
+        <div className="input-group-text text-muted border rounded-start" id="btnGroupAddon">
+          {renderOrderIcon()}
         </div>
         <div className="border rounded-end">
           <button

--- a/apps/app/src/components/SearchPage/SortControl.tsx
+++ b/apps/app/src/components/SearchPage/SortControl.tsx
@@ -5,6 +5,8 @@ import { useTranslation } from 'next-i18next';
 
 import { SORT_AXIS, SORT_ORDER } from '../../interfaces/search';
 
+import styles from './SortControl.module.scss';
+
 const { DESC, ASC } = SORT_ORDER;
 
 type Props = {
@@ -28,29 +30,32 @@ const SortControl: FC <Props> = (props: Props) => {
 
   return (
     <>
-      <div className="d-flex">
-        <div className="btn-group">
-          <button className="d-flex btn btn-sm btn-outline-neutral-secondary rounded-pill" type="button" data-bs-toggle="dropdown" aria-expanded="false">
-            <span className="material-symbols-outlined text-secondary">sort</span>
-            <span className="ms-2 me-6 text-secondary">{t(`search_result.sort_axis.${sort}`)}</span>
-            <span className="material-symbols-outlined text-secondary">expand_more</span>
-          </button>
-          <ul className="dropdown-menu">
-            {Object.values(SORT_AXIS).map((sortAxis) => {
-              const nextOrder = (sort !== sortAxis || order === ASC) ? DESC : ASC;
-              return (
-                <button
-                  key={sortAxis}
-                  className="dropdown-item"
-                  type="button"
-                  onClick={() => { onClickChangeSort(sortAxis, nextOrder) }}
-                >
-                  <span>{t(`search_result.sort_axis.${sortAxis}`)}</span>
-                </button>
-              );
-            })}
-          </ul>
-        </div>
+      <div className={`btn-group ${styles['sort-control']}`}>
+        <button
+          className="d-flex align-items-center btn btn-sm btn-outline-neutral-secondary rounded-pill"
+          type="button"
+          data-bs-toggle="dropdown"
+          aria-expanded="false"
+        >
+          <span className="material-symbols-outlined py-0">sort</span>
+          <span className="ms-2 me-auto">{t(`search_result.sort_axis.${sort}`)}</span>
+          <span className="material-symbols-outlined py-0">expand_more</span>
+        </button>
+        <ul className="dropdown-menu">
+          {Object.values(SORT_AXIS).map((sortAxis) => {
+            const nextOrder = (sort !== sortAxis || order === ASC) ? DESC : ASC;
+            return (
+              <button
+                key={sortAxis}
+                className="dropdown-item"
+                type="button"
+                onClick={() => { onClickChangeSort(sortAxis, nextOrder) }}
+              >
+                <span>{t(`search_result.sort_axis.${sortAxis}`)}</span>
+              </button>
+            );
+          })}
+        </ul>
       </div>
     </>
   );

--- a/apps/app/src/components/SearchPage/SortControl.tsx
+++ b/apps/app/src/components/SearchPage/SortControl.tsx
@@ -25,26 +25,17 @@ const SortControl: FC <Props> = (props: Props) => {
     }
   };
 
-  const renderOrderIcon = () => {
-    const iconClassName = ASC === order ? 'fa fa-sort-amount-asc' : 'fa fa-sort-amount-desc';
-    return <i className={iconClassName} aria-hidden="true" />;
-  };
 
   return (
     <>
-      <div className="input-group flex-nowrap">
-        <div className="input-group-text text-muted border rounded-start" id="btnGroupAddon">
-          {renderOrderIcon()}
-        </div>
-        <div className="border rounded-end">
-          <button
-            type="button"
-            className="btn dropdown-toggle py-1"
-            data-bs-toggle="dropdown"
-          >
-            <span className="me-2 text-secondary">{t(`search_result.sort_axis.${sort}`)}</span>
+      <div className="d-flex">
+        <div className="btn-group">
+          <button className="d-flex btn btn-sm btn-outline-neutral-secondary rounded-pill" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+            <span className="material-symbols-outlined text-secondary">sort</span>
+            <span className="ms-2 me-6 text-secondary">{t(`search_result.sort_axis.${sort}`)}</span>
+            <span className="material-symbols-outlined text-secondary">expand_more</span>
           </button>
-          <div className="dropdown-menu dropdown-menu-right">
+          <ul className="dropdown-menu">
             {Object.values(SORT_AXIS).map((sortAxis) => {
               const nextOrder = (sort !== sortAxis || order === ASC) ? DESC : ASC;
               return (
@@ -58,7 +49,7 @@ const SortControl: FC <Props> = (props: Props) => {
                 </button>
               );
             })}
-          </div>
+          </ul>
         </div>
       </div>
     </>


### PR DESCRIPTION
# 概要
- 検索結果ページにおいて、検索した単語を表示しないように
- 検索結果ページにおけるレイアウト崩れの修正、XDに寄せる

## 変更前
<img width="622" alt="image" src="https://github.com/weseek/growi/assets/132258880/ecacd6f9-ead7-42f0-8c1d-1805c8605e83">


## 変更後
<img width="620" alt="image" src="https://github.com/weseek/growi/assets/132258880/8cec4ce0-dbfd-46a4-9456-9a638d3bd7df">


# Task
- https://redmine.weseek.co.jp/issues/139438
  - https://redmine.weseek.co.jp/issues/140577
- https://redmine.weseek.co.jp/issues/139433
  - https://redmine.weseek.co.jp/issues/140576
# 後続予定
- 検索結果の infinite scroll
  - https://redmine.weseek.co.jp/issues/140672
- 検索欄にフォーカスした際に、useSearchModal を使用したモーダル検索を開けるようにする。
  - https://redmine.weseek.co.jp/issues/140673