### PR TITLE
fix: Default theme color

### DIFF
--- a/packages/preset-themes/src/styles/default.scss
+++ b/packages/preset-themes/src/styles/default.scss
@@ -9,7 +9,7 @@
   @include generate-color-palette('primary', $primary, #000010, white, 22%, 22%);
   @include generate-color-palette('highlight', $highlight);
 
-  $body-color:                #223246;
+  $body-color:                $gray-800;
   $body-bg:                   white;
 
   $body-secondary-color:      rgba($body-color, .75);
@@ -29,8 +29,8 @@
 
   @import '@growi/core/scss/bootstrap/theming/apply-light';
 
-  --grw-wiki-link-color-rgb: var(--grw-highlight-800-rgb);
-  --grw-wiki-link-hover-color-rgb: var(--grw-highlight-900-rgb);
+  --grw-wiki-link-color-rgb: var(--grw-highlight-700-rgb);
+  --grw-wiki-link-hover-color-rgb: var(--grw-highlight-600-rgb);
   --grw-sidebar-nav-btn-color: var(--grw-highlight-600);
 }
 
@@ -43,7 +43,7 @@
   $highlight: #c4c2bd;
 
   @include generate-color-palette('primary', $primary, #000010, white, 22%, 22%);
-  @include generate-color-palette('highlight', $highlight, black, white);
+  @include generate-color-palette('highlight', $highlight, black, white, 22%, 22%);
 
   $body-color-dark:                   $gray-300;
   $body-bg-dark:                      #1c1a1a;
@@ -65,8 +65,8 @@
 
   @import '@growi/core/scss/bootstrap/theming/apply-dark';
 
-  --grw-wiki-link-color-rgb: var(--grw-highlight-500-rgb);
-  --grw-wiki-link-hover-color-rgb: var(--grw-highlight-300-rgb);
+  --grw-wiki-link-color-rgb: var(--grw-highlight-600-rgb);
+  --grw-wiki-link-hover-color-rgb: var(--grw-highlight-400-rgb);
   --grw-sidebar-nav-btn-color: rgba(var(--grw-highlight-400-rgb), 0.8);
 }
 


### PR DESCRIPTION
# タスク
- https://redmine.weseek.co.jp/issues/140014

# XD
- [Light preview](https://xd.adobe.com/view/26f3cef5-06c1-4ed2-9871-b86d5d00adce-73a0/screen/1aa029cd-401e-40a2-b754-ad74589e58be/)
- [Dark preview](https://xd.adobe.com/view/26f3cef5-06c1-4ed2-9871-b86d5d00adce-73a0/screen/d3e5078a-c8b3-4762-ade9-82d42b9a2d83/)
- [light](https://xd.adobe.com/view/26f3cef5-06c1-4ed2-9871-b86d5d00adce-73a0/screen/55f86f5f-0750-4156-a4a1-933e1d98ccb4/)
- [dark](https://xd.adobe.com/view/26f3cef5-06c1-4ed2-9871-b86d5d00adce-73a0/screen/843241f0-e176-47b3-9092-6f4939a56eb9/)

# 概要
- デフォルトテーマにおけるリンクカラー他設計通りになっていない点を修正