### PR TITLE
imprv: change sidebar input positions

### DIFF
--- a/apps/app/src/components/Sidebar/Bookmarks/BookmarkContents.tsx
+++ b/apps/app/src/components/Sidebar/Bookmarks/BookmarkContents.tsx
@@ -45,11 +45,8 @@ export const BookmarkContents = (): JSX.Element => {
           className="btn btn-outline-secondary rounded-pill d-flex justify-content-start align-middle"
           onClick={onClickNewBookmarkFolder}
         >
-
-          <div className="d-flex align-items-center">
-            <FolderPlusIcon />
-            <span className="ms-2">{t('bookmark_folder.new_folder')}</span>
-          </div>
+          <FolderPlusIcon />
+          <span className="mx-2 ">{t('bookmark_folder.new_folder')}</span>
         </button>
       </div>
       {isCreateAction && (

--- a/apps/app/src/components/Sidebar/Bookmarks/BookmarkContents.tsx
+++ b/apps/app/src/components/Sidebar/Bookmarks/BookmarkContents.tsx
@@ -45,8 +45,11 @@ export const BookmarkContents = (): JSX.Element => {
           className="btn btn-outline-secondary rounded-pill d-flex justify-content-start align-middle"
           onClick={onClickNewBookmarkFolder}
         >
-          <FolderPlusIcon />
-          <span className="mx-2 ">{t('bookmark_folder.new_folder')}</span>
+
+          <div className="d-flex align-items-center">
+            <FolderPlusIcon />
+            <span className="ms-2">{t('bookmark_folder.new_folder')}</span>
+          </div>
         </button>
       </div>
       {isCreateAction && (

--- a/apps/app/src/components/Sidebar/PageTreeItem/Ellipsis.tsx
+++ b/apps/app/src/components/Sidebar/PageTreeItem/Ellipsis.tsx
@@ -126,10 +126,12 @@ export const Ellipsis: FC<TreeItemToolProps> = (props) => {
     }
   };
 
+  const hasChildren = page.descendantCount ? page.descendantCount > 0 : false;
+
   return (
     <>
       {isRenameInputShown ? (
-        <div className="position-absolute ms-5">
+        <div className={`position-absolute ${hasChildren ? 'ms-5' : 'ms-4'}`}>
           <NotDraggableForClosableTextInput>
             <ClosableTextInput
               value={nodePath.basename(page.path ?? '')}

--- a/apps/app/src/components/Sidebar/PageTreeItem/Ellipsis.tsx
+++ b/apps/app/src/components/Sidebar/PageTreeItem/Ellipsis.tsx
@@ -1,5 +1,6 @@
+import type { FC } from 'react';
 import React, {
-  useCallback, useState, FC,
+  useCallback, useState,
 } from 'react';
 
 import nodePath from 'path';
@@ -128,7 +129,7 @@ export const Ellipsis: FC<TreeItemToolProps> = (props) => {
   return (
     <>
       {isRenameInputShown ? (
-        <div className="flex-fill">
+        <div className="position-absolute ms-5">
           <NotDraggableForClosableTextInput>
             <ClosableTextInput
               value={nodePath.basename(page.path ?? '')}


### PR DESCRIPTION
## task
[#140336](https://redmine.weseek.co.jp/issues/140336) [v7]サイドバーでリネームの際にinputが現在のページ名の隣に出現してしまう
┗ [#140569](https://redmine.weseek.co.jp/issues/140569) inputの位置を調整

## Screenshot
### Before
<img width="248" alt="image" src="https://github.com/weseek/growi/assets/130130573/6ae6dc45-bffd-44fe-8ad4-f868316e1127">

### After
<img width="250" alt="image" src="https://github.com/weseek/growi/assets/130130573/d02535ec-948f-49ae-810f-382e17f5eb6e">