### PR TITLE
feat: Enable multi group grant in grant fix

### DIFF
--- a/apps/app/src/server/routes/apiv3/page/index.js
+++ b/apps/app/src/server/routes/apiv3/page/index.js
@@ -678,11 +678,6 @@ module.exports = (crowi) => {
     const { pageId } = req.params;
     const { grant, userRelatedGrantedGroups } = req.body;
 
-    // TODO: remove in https://redmine.weseek.co.jp/issues/136137
-    if (userRelatedGrantedGroups != null && userRelatedGrantedGroups.length > 1) {
-      return res.apiv3Err('Cannot grant multiple groups to page at the moment');
-    }
-
     const Page = crowi.model('Page');
 
     const page = await Page.findByIdAndViewer(pageId, req.user, null, false);


### PR DESCRIPTION
## task
https://redmine.weseek.co.jp/issues/140991

## やったこと
権限が壊れている場合の修正における multi group grant を有効にするのを忘れていたため、有効化