### PR TITLE
imprv: Update user homepage side contents design

### DIFF
--- a/apps/app/src/components/TableOfContents.tsx
+++ b/apps/app/src/components/TableOfContents.tsx
@@ -11,7 +11,7 @@ import { StickyStretchableScroller } from './StickyStretchableScroller';
 
 import styles from './TableOfContents.module.scss';
 
-const { isUserPage: _isUserPage } = pagePathUtils;
+const { isUsersHomepage: _isUsersHomepage } = pagePathUtils;
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const logger = loggerFactory('growi:TableOfContents');
@@ -19,7 +19,7 @@ const logger = loggerFactory('growi:TableOfContents');
 const TableOfContents = (): JSX.Element => {
   const { data: currentPagePath } = useCurrentPagePath();
 
-  const isUserPage = currentPagePath != null && _isUserPage(currentPagePath);
+  const isUsersHomePage = currentPagePath != null && _isUsersHomepage(currentPagePath);
 
   const { data: rendererOptions } = useTocOptions();
 
@@ -41,13 +41,13 @@ const TableOfContents = (): JSX.Element => {
     // get smaller bottom line of window height - .system-version height - margin 5px) and containerTop
     let bottom = Math.min(window.innerHeight - 20 - 5, parentBottom);
 
-    if (isUserPage) {
+    if (isUsersHomePage) {
       // raise the bottom line by the height and margin-top of UserContentLinks
-      bottom -= 45;
+      bottom -= 90;
     }
     // bottom - revisionToc top
     return bottom - (containerTop + containerPaddingTop);
-  }, [isUserPage, rendererOptions]);
+  }, [isUsersHomePage, rendererOptions]);
 
   return (
     <div id="revision-toc" className={`revision-toc ${styles['revision-toc']}`}>


### PR DESCRIPTION
## Description
task: https://redmine.weseek.co.jp/issues/140802
toc が十分長い場合に side contents が version 表記と被る の修正

@yuki-takei 
エッジケースとして、 tag がない user homepage に遷移し side contents の高さが計算された後に side contents から tag を増やすと side contents の高さが変わり、画面右下の version 表示と被る場合があります。
ページ遷移などして side contents の再計算が走ると正しく高さが計算されますが、tag が更新された時もすぐに toc の高さの再計算をされるようにすべきでしょうか？

## Screenshot
### Before
![localhost_3000_65ade4eb91a8b2d2522a232a (7)](https://github.com/weseek/growi/assets/68407388/19f29d28-8e65-4116-83e6-7d1f810a6e9d)

### After
![localhost_3000_65ade4eb91a8b2d2522a232a (6)](https://github.com/weseek/growi/assets/68407388/1cbeae72-b055-4e95-8011-b096e8ad54bf)
