### PR TITLE
feat: Automatic deletion of wip pages using TTL index

### DIFF
--- a/apps/app/src/server/crowi/index.js
+++ b/apps/app/src/server/crowi/index.js
@@ -725,6 +725,7 @@ Crowi.prototype.setupPageService = async function() {
   // initialize after pageGrantService since pageService uses pageGrantService in constructor
   if (this.pageService == null) {
     this.pageService = new PageService(this);
+    await this.pageService.createTtlIndex();
   }
   if (this.pageOperationService == null) {
     this.pageOperationService = new PageOperationService(this);

--- a/apps/app/src/server/models/page.ts
+++ b/apps/app/src/server/models/page.ts
@@ -140,7 +140,7 @@ const schema = new Schema<PageDocument, PageModel>({
   commentCount: { type: Number, default: 0 },
   expandContentWidth: { type: Boolean },
   wip: { type: Boolean },
-  wipExpiredAt: { type: Date, index: true },
+  ttlTimestamp: { type: Date, index: true },
   updatedAt: { type: Date, default: Date.now }, // Do not use timetamps for updatedAt because it breaks 'updateMetadata: false' option
   deleteUser: { type: ObjectId, ref: 'User' },
   deletedAt: { type: Date },
@@ -1055,17 +1055,17 @@ schema.methods.calculateAndUpdateLatestRevisionBodyLength = async function(this:
 
 schema.methods.publish = function() {
   this.wip = undefined;
-  this.wipExpiredAt = undefined;
+  this.ttlTimestamp = undefined;
 };
 
 schema.methods.unpublish = function() {
   this.wip = true;
-  this.wipExpiredAt = undefined;
+  this.ttlTimestamp = undefined;
 };
 
 schema.methods.makeWip = function() {
   this.wip = true;
-  this.wipExpiredAt = new Date();
+  this.ttlTimestamp = new Date();
 };
 
 /*

--- a/apps/app/src/server/models/page.ts
+++ b/apps/app/src/server/models/page.ts
@@ -140,7 +140,7 @@ const schema = new Schema<PageDocument, PageModel>({
   commentCount: { type: Number, default: 0 },
   expandContentWidth: { type: Boolean },
   wip: { type: Boolean },
-  wipExpiredAt: { type: Date },
+  wipExpiredAt: { type: Date, index: true },
   updatedAt: { type: Date, default: Date.now }, // Do not use timetamps for updatedAt because it breaks 'updateMetadata: false' option
   deleteUser: { type: ObjectId, ref: 'User' },
   deletedAt: { type: Date },

--- a/apps/app/src/server/models/page.ts
+++ b/apps/app/src/server/models/page.ts
@@ -1063,9 +1063,12 @@ schema.methods.unpublish = function() {
   this.ttlTimestamp = undefined;
 };
 
-schema.methods.makeWip = function() {
+schema.methods.makeWip = function(disableTtl: boolean) {
   this.wip = true;
-  this.ttlTimestamp = new Date();
+
+  if (!disableTtl) {
+    this.ttlTimestamp = new Date();
+  }
 };
 
 /*

--- a/apps/app/src/server/service/config-loader.ts
+++ b/apps/app/src/server/service/config-loader.ts
@@ -711,9 +711,9 @@ const ENV_VAR_NAME_TO_CONFIG_INFO = {
     type: ValueType.NUMBER,
     default: 30000,
   },
-  PAGE_EXPIRATION_SECONDS: {
+  WIP_PAGE_EXPIRATION_SECONDS: {
     ns: 'crowi',
-    key: 'app:pageExpirationSeconds',
+    key: 'app:wipPageExpirationSeconds',
     type: ValueType.NUMBER,
     default: 172800, // 2 days
   },

--- a/apps/app/src/server/service/config-loader.ts
+++ b/apps/app/src/server/service/config-loader.ts
@@ -4,9 +4,8 @@ import { parseISO } from 'date-fns';
 import { GrowiServiceType } from '~/features/questionnaire/interfaces/growi-info';
 import loggerFactory from '~/utils/logger';
 
-import ConfigModel, {
-  Config, defaultCrowiConfigs, defaultMarkdownConfigs, defaultNotificationConfigs,
-} from '../models/config';
+import type { Config } from '../models/config';
+import ConfigModel, { defaultCrowiConfigs, defaultMarkdownConfigs, defaultNotificationConfigs } from '../models/config';
 
 
 const logger = loggerFactory('growi:service:ConfigLoader');
@@ -711,6 +710,12 @@ const ENV_VAR_NAME_TO_CONFIG_INFO = {
     key: 'app:ssrMaxRevisionBodyLength',
     type: ValueType.NUMBER,
     default: 30000,
+  },
+  PAGE_EXPIRATION_SECONDS: {
+    ns: 'crowi',
+    key: 'app:pageExpirationSeconds',
+    type: ValueType.NUMBER,
+    default: 172800, // 2 days
   },
 };
 

--- a/apps/app/src/server/service/page/index.ts
+++ b/apps/app/src/server/service/page/index.ts
@@ -3954,7 +3954,6 @@ class PageService implements IPageService {
       { $project: { _id: 1 } },
     ]);
 
-    // const ancestorPageIds = ancestorPages.map(page => page._id);
     await Page.updateMany({ _id: { $in: ancestorPageIds } }, { $unset: { ttlTimestamp: true } });
   }
 

--- a/apps/app/src/server/service/page/index.ts
+++ b/apps/app/src/server/service/page/index.ts
@@ -3816,9 +3816,8 @@ class PageService implements IPageService {
 
     // Make WIP
     if (options.wip) {
-      const childrenCount = await Page.count({ parent: page._id });
-      const disableTtl = childrenCount > 0;
-      page.makeWip(disableTtl);
+      const hasChildren = await Page.exists({ parent: page._id });
+      page.makeWip(hasChildren != null); // disableTtl = hasChildren != null
     }
 
     // Save

--- a/apps/app/src/server/service/page/index.ts
+++ b/apps/app/src/server/service/page/index.ts
@@ -4409,7 +4409,7 @@ class PageService implements IPageService {
   }
 
   async createTtlIndex(): Promise<void> {
-    const pageExpirationSeconds = 60; // TODO: Allow to retrieve from environment variables
+    const pageExpirationSeconds = configManager.getConfig('crowi', 'app:pageExpirationSeconds') ?? 172800;
     const collection = mongoose.connection.collection('pages');
 
     try {

--- a/apps/app/src/server/service/page/index.ts
+++ b/apps/app/src/server/service/page/index.ts
@@ -3814,10 +3814,10 @@ class PageService implements IPageService {
       page.parent = parent._id;
     }
 
-    // Set wip
+    // Make WIP
     if (options.wip) {
-      const children = await Page.find({ parent: page._id });
-      const disableTtl = children.length > 0;
+      const childrenCount = await Page.count({ parent: page._id });
+      const disableTtl = childrenCount > 0;
       page.makeWip(disableTtl);
     }
 

--- a/apps/app/src/server/service/page/index.ts
+++ b/apps/app/src/server/service/page/index.ts
@@ -3957,7 +3957,7 @@ class PageService implements IPageService {
       .exec();
 
     const nonEmptyAncestorIds = nonEmptyAncestors.map(page => page._id);
-    await Page.updateMany({ _id: { $in: nonEmptyAncestorIds } }, { $set: { ttlTimestamp: null } });
+    await Page.updateMany({ _id: { $in: nonEmptyAncestorIds } }, { $unset: { ttlTimestamp: true } });
   }
 
   /**

--- a/apps/app/src/server/service/page/index.ts
+++ b/apps/app/src/server/service/page/index.ts
@@ -3955,8 +3955,8 @@ class PageService implements IPageService {
       .query
       .exec();
 
-    const nonEmptyAncestorIds = ancestorPages.map(page => page._id);
-    await Page.updateMany({ _id: { $in: nonEmptyAncestorIds } }, { $unset: { ttlTimestamp: true } });
+    const ancestorPageIds = ancestorPages.map(page => page._id);
+    await Page.updateMany({ _id: { $in: ancestorPageIds } }, { $unset: { ttlTimestamp: true } });
   }
 
   /**

--- a/apps/app/src/server/service/page/index.ts
+++ b/apps/app/src/server/service/page/index.ts
@@ -585,7 +585,7 @@ class PageService implements IPageService {
       this.activityEvent.emit('updated', activity, page, preNotify);
     }
 
-    this.disableAncestorPagesTTL(newPagePath);
+    this.disableAncestorPagesTtl(newPagePath);
     return renamedPage;
   }
 
@@ -3851,7 +3851,7 @@ class PageService implements IPageService {
       throw err;
     }
 
-    this.disableAncestorPagesTTL(path);
+    this.disableAncestorPagesTtl(path);
     this.createSubOperation(savedPage, user, options, pageOp._id);
 
     return savedPage;
@@ -3945,18 +3945,18 @@ class PageService implements IPageService {
     return this.canProcessCreate(path, grantData, false);
   }
 
-  private async disableAncestorPagesTTL(path: string): Promise<void> {
+  private async disableAncestorPagesTtl(path: string): Promise<void> {
     const Page = mongoose.model<PageDocument, PageModel>('Page');
 
     const ancestorPaths = collectAncestorPaths(path);
-    const builder = new PageQueryBuilder(Page.find()); // includeEmpty false
-    const nonEmptyAncestors = await builder
+    const builder = new PageQueryBuilder(Page.find());
+    const ancestorPages = await builder
       .addConditionAsNonRootPage()
       .addConditionToListByPathsArray(ancestorPaths)
       .query
       .exec();
 
-    const nonEmptyAncestorIds = nonEmptyAncestors.map(page => page._id);
+    const nonEmptyAncestorIds = ancestorPages.map(page => page._id);
     await Page.updateMany({ _id: { $in: nonEmptyAncestorIds } }, { $unset: { ttlTimestamp: true } });
   }
 

--- a/apps/app/src/server/service/page/index.ts
+++ b/apps/app/src/server/service/page/index.ts
@@ -584,6 +584,8 @@ class PageService implements IPageService {
 
       this.activityEvent.emit('updated', activity, page, preNotify);
     }
+
+    this.disableAncestorPagesTTL(newPagePath);
     return renamedPage;
   }
 
@@ -3756,6 +3758,7 @@ class PageService implements IPageService {
    * Set options.isSynchronously to true to await all process when you want to run this method multiple times at short intervals.
    */
   async create(_path: string, body: string, user: HasObjectId, options: IOptionsForCreate = {}): Promise<PageDocument> {
+    console.log('呼ばれた！');
     // Switch method
     const isV5Compatible = this.crowi.configManager.getConfig('crowi', 'app:isV5Compatible');
     if (!isV5Compatible) {

--- a/apps/app/src/server/service/page/index.ts
+++ b/apps/app/src/server/service/page/index.ts
@@ -3758,7 +3758,6 @@ class PageService implements IPageService {
    * Set options.isSynchronously to true to await all process when you want to run this method multiple times at short intervals.
    */
   async create(_path: string, body: string, user: HasObjectId, options: IOptionsForCreate = {}): Promise<PageDocument> {
-    console.log('呼ばれた！');
     // Switch method
     const isV5Compatible = this.crowi.configManager.getConfig('crowi', 'app:isV5Compatible');
     if (!isV5Compatible) {

--- a/apps/app/src/server/service/page/index.ts
+++ b/apps/app/src/server/service/page/index.ts
@@ -4413,7 +4413,7 @@ class PageService implements IPageService {
     const collection = mongoose.connection.collection('pages');
 
     try {
-      const targetField = 'wipExpiredAt_1';
+      const targetField = 'ttlTimestamp_1';
 
       const indexes = await collection.indexes();
       const foundTargetField = indexes.find(i => i.name === targetField);
@@ -4427,7 +4427,7 @@ class PageService implements IPageService {
       }
 
       if (shoudCreateIndex) {
-        await collection.createIndex({ wipExpiredAt: 1 }, { expireAfterSeconds: pageExpirationSeconds });
+        await collection.createIndex({ ttlTimestamp: 1 }, { expireAfterSeconds: pageExpirationSeconds });
       }
     }
     catch (err) {

--- a/packages/core/src/interfaces/page.ts
+++ b/packages/core/src/interfaces/page.ts
@@ -40,7 +40,7 @@ export type IPage = {
   latestRevisionBodyLength?: number,
   expandContentWidth?: boolean,
   wip?: boolean,
-  wipExpiredAt?: Date
+  ttlTimestamp?: Date
 }
 
 export type IPagePopulatedToList = Omit<IPageHasId, 'lastUpdateUser'> & {


### PR DESCRIPTION
## Task
[#136303](https://redmine.weseek.co.jp/issues/136303) [WIP page] WIP ページを自動削除できる
┗ [#140684](https://redmine.weseek.co.jp/issues/140684) 実装

## 戦略

### 削除方法
- ttlTimestamp が付与されている Page を TTL によって自動削除する

### 削除対象
- 子ページを抱えるページは TTL によって削除されないようにする
   - ttlTimestamp が付与されている Page 配下にページが存在する場合
     - ex: `/A/B` というページを作成した後に `/A` を作成した場合は `/A` は自動削除の対象にはならない
   - ttlTimesramp が付与されている Page より上の階層に削除対象ページがある場合
     - ex: `/A` を作成した後に `/A/B` を作成した場合 `/A` は自動削除の対象だったとしても対象外となる