### PR TITLE
fix: list markdown not pasting properly

### DIFF
--- a/packages/editor/src/services/list-util/markdown-list-util.ts
+++ b/packages/editor/src/services/list-util/markdown-list-util.ts
@@ -1,7 +1,9 @@
 import type { EditorView } from '@codemirror/view';
 
-// https://regex101.com/r/7BN2fR/5
-const indentAndMarkRE = /^(\s*)(>[> ]*|[*+-] \[[x ]\]\s|[*+-]\s|(\d+)([.)]))(\s*)/;
+// https://regex101.com/r/r9plEA/1
+const indentAndMarkRE = /^(\s*)(>[> ]*|[*+-] \[[x ]\]\s|[*+-]\s|(\d+)([.)]\s))(\s*)/;
+// https://regex101.com/r/HFYoFN/1
+const indentAndMarkOnlyRE = /^(\s*)(>[> ]*|[*+-] \[[x ]\]|[*+-]|(\d+)[.)])(\s*)$/;
 
 const getBol = (editor: EditorView) => {
   const curPos = editor.state.selection.main.head;
@@ -26,7 +28,7 @@ export const adjustPasteData = (strFromBol: string, text: string): string => {
 
     const replacedLines = lines?.map((line, index) => {
 
-      if (index === 0 && strFromBol.match(indentAndMarkRE)) {
+      if (index === 0 && strFromBol.match(indentAndMarkOnlyRE)) {
         return line.replace(indentAndMarkRE, '');
       }
 


### PR DESCRIPTION
## タスク
https://redmine.weseek.co.jp/issues/140930

## slackのリンク
https://wsgrowi.slack.com/archives/C06DZ74MC2V/p1708061163421689

## 概要
- 「- test」などのマークダウン記号を含む文字列を「- test」などのマークダウン記号を含む文字列の後ろにペーストすると
「test」がペーストされてしまう問題の解決
- 「2.3.4」などの文字列をマークダウン記号を含む文字列の後ろにペーストすると、「2.」の部分が消えてしまう問題の解決
## 変更点
- markdown-list-util.ts内のindnetAndMarkReを修正しました。
- markdown-list-util.ts内にindentAndMarkOnlyReを加え、条件分岐を変更しました。

## 後続ストーリー
https://redmine.weseek.co.jp/issues/141097
こちらのストーリーはこのPR内で修正したregular expressionを使用することで解決します。

## セルフチェック
- [x] コンフリクト解消したか
- [x] 余計なコードは残っていないか
- [x] 適切にメモ化したか
- [x] 責務の問題はクリアしているか
- [x] CIは通っているか
- [x] PRの内容は適切にかけているか