### PR TITLE
imprv: 139425-140982 & fix-sidbar-fontsize&margin

### DIFF
--- a/apps/app/src/components/ItemsTree/ItemsTree.tsx
+++ b/apps/app/src/components/ItemsTree/ItemsTree.tsx
@@ -274,7 +274,7 @@ export const ItemsTree = (props: ItemsTreeProps): JSX.Element => {
 
   if (initialItemNode != null) {
     return (
-      <ul className={`grw-pagetree ${styles['grw-pagetree']} list-group py-3`} ref={rootElemRef}>
+      <ul className={`grw-pagetree ${styles['grw-pagetree']} list-group py-4`} ref={rootElemRef}>
         <CustomTreeItem
           key={initialItemNode.page.path}
           targetPathOrId={targetPathOrId}

--- a/apps/app/src/components/Sidebar/Bookmarks.tsx
+++ b/apps/app/src/components/Sidebar/Bookmarks.tsx
@@ -12,11 +12,9 @@ export const Bookmarks = () : JSX.Element => {
   const { data: isGuestUser } = useIsGuestUser();
 
   return (
-    <>
-      {/* TODO : #139425 Match the space specification method to others */}
-      {/* ref.  https://redmine.weseek.co.jp/issues/139425 */}
-      <div className="grw-sidebar-content-header p-3">
-        <h4 className="mb-0">{t('Bookmarks')}</h4>
+    <div className="px-3">
+      <div className="grw-sidebar-content-header">
+        <h4 className="mb-0 py-4">{t('Bookmarks')}</h4>
       </div>
       {isGuestUser ? (
         <h4 className="ps-3">
@@ -25,6 +23,6 @@ export const Bookmarks = () : JSX.Element => {
       ) : (
         <BookmarkContents />
       )}
-    </>
+    </div>
   );
 };

--- a/apps/app/src/components/Sidebar/Bookmarks.tsx
+++ b/apps/app/src/components/Sidebar/Bookmarks.tsx
@@ -16,7 +16,7 @@ export const Bookmarks = () : JSX.Element => {
       {/* TODO : #139425 Match the space specification method to others */}
       {/* ref.  https://redmine.weseek.co.jp/issues/139425 */}
       <div className="grw-sidebar-content-header p-3">
-        <h3 className="mb-0">{t('Bookmarks')}</h3>
+        <h4 className="mb-0">{t('Bookmarks')}</h4>
       </div>
       {isGuestUser ? (
         <h4 className="ps-3">

--- a/apps/app/src/components/Sidebar/Custom/CustomSidebar.tsx
+++ b/apps/app/src/components/Sidebar/Custom/CustomSidebar.tsx
@@ -22,10 +22,10 @@ export const CustomSidebar = (): JSX.Element => {
     // ref.  https://redmine.weseek.co.jp/issues/139425
     <div className="px-3">
       <div className="grw-sidebar-content-header py-3 d-flex">
-        <h3 className="mb-0">
+        <h4 className="mb-0">
           {t('CustomSidebar')}
           { !isLoading && <Link href="/Sidebar#edit" className="h6 ms-2"><span className="material-symbols-outlined">edit</span></Link> }
-        </h3>
+        </h4>
         { !isLoading && <SidebarHeaderReloadButton onClick={() => mutate()} /> }
       </div>
 

--- a/apps/app/src/components/Sidebar/Custom/CustomSidebar.tsx
+++ b/apps/app/src/components/Sidebar/Custom/CustomSidebar.tsx
@@ -18,10 +18,8 @@ export const CustomSidebar = (): JSX.Element => {
   const { mutate, isLoading } = useSWRxPageByPath('/Sidebar');
 
   return (
-    // TODO : #139425 Match the space specification method to others
-    // ref.  https://redmine.weseek.co.jp/issues/139425
-    <div className="px-3">
-      <div className="grw-sidebar-content-header py-3 d-flex">
+    <div className="pt-4 pb-3 px-3">
+      <div className="grw-sidebar-content-header d-flex">
         <h4 className="mb-0">
           {t('CustomSidebar')}
           { !isLoading && <Link href="/Sidebar#edit" className="h6 ms-2"><span className="material-symbols-outlined">edit</span></Link> }

--- a/apps/app/src/components/Sidebar/Custom/CustomSidebarSubstance.tsx
+++ b/apps/app/src/components/Sidebar/Custom/CustomSidebarSubstance.tsx
@@ -22,7 +22,7 @@ export const CustomSidebarSubstance = (): JSX.Element => {
   const markdown = page?.revision.body;
 
   return (
-    <div className={`py-3 grw-custom-sidebar-content ${styles['grw-custom-sidebar-content']}`}>
+    <div className={`py-4 grw-custom-sidebar-content ${styles['grw-custom-sidebar-content']}`}>
       { markdown == null
         ? <SidebarNotFound />
         : (

--- a/apps/app/src/components/Sidebar/InAppNotification/InAppNotification.tsx
+++ b/apps/app/src/components/Sidebar/InAppNotification/InAppNotification.tsx
@@ -19,9 +19,9 @@ export const InAppNotification = (): JSX.Element => {
     // ref.  https://redmine.weseek.co.jp/issues/139425
     <div className="px-3">
       <div className="grw-sidebar-content-header py-3 d-flex">
-        <h3 className="mb-0">
+        <h4 className="mb-0">
           {t('In-App Notification')}
-        </h3>
+        </h4>
       </div>
 
       <InAppNotificationForms

--- a/apps/app/src/components/Sidebar/InAppNotification/InAppNotification.tsx
+++ b/apps/app/src/components/Sidebar/InAppNotification/InAppNotification.tsx
@@ -15,10 +15,8 @@ export const InAppNotification = (): JSX.Element => {
   const [isUnopendNotificationsVisible, setUnopendNotificationsVisible] = useState(false);
 
   return (
-    // TODO : #139425 Match the space specification method to others
-    // ref.  https://redmine.weseek.co.jp/issues/139425
     <div className="px-3">
-      <div className="grw-sidebar-content-header py-3 d-flex">
+      <div className="grw-sidebar-content-header py-4 d-flex">
         <h4 className="mb-0">
           {t('In-App Notification')}
         </h4>

--- a/apps/app/src/components/Sidebar/PageTree/PageTree.tsx
+++ b/apps/app/src/components/Sidebar/PageTree/PageTree.tsx
@@ -17,8 +17,6 @@ export const PageTree = (): JSX.Element => {
   const { t } = useTranslation();
 
   return (
-    // TODO : #139425 Match the space specification method to others
-    // ref.  https://redmine.weseek.co.jp/issues/139425
     <div className="pt-4 pb-3 px-3">
       <div className="grw-sidebar-content-header d-flex">
         <h4 className="mb-0">{t('Page Tree')}</h4>

--- a/apps/app/src/components/Sidebar/PageTree/PageTree.tsx
+++ b/apps/app/src/components/Sidebar/PageTree/PageTree.tsx
@@ -4,6 +4,7 @@ import dynamic from 'next/dynamic';
 import { useTranslation } from 'react-i18next';
 
 import ItemsTreeContentSkeleton from '../../ItemsTree/ItemsTreeContentSkeleton';
+
 import { PageTreeHeader } from './PageTreeSubstance';
 
 const PageTreeContent = dynamic(
@@ -20,7 +21,7 @@ export const PageTree = (): JSX.Element => {
     // ref.  https://redmine.weseek.co.jp/issues/139425
     <div className="pt-4 pb-3 px-3">
       <div className="grw-sidebar-content-header d-flex">
-        <h3 className="mb-0">{t('Page Tree')}</h3>
+        <h4 className="mb-0">{t('Page Tree')}</h4>
         <Suspense>
           <PageTreeHeader />
         </Suspense>

--- a/apps/app/src/components/Sidebar/RecentChanges/RecentChanges.tsx
+++ b/apps/app/src/components/Sidebar/RecentChanges/RecentChanges.tsx
@@ -18,10 +18,8 @@ export const RecentChanges = (): JSX.Element => {
   const [isSmall, setIsSmall] = useState(false);
 
   return (
-    // TODO : #139425 Match the space specification method to others
-    // ref.  https://redmine.weseek.co.jp/issues/139425
     <div className="px-3" data-testid="grw-recent-changes">
-      <div className="grw-sidebar-content-header py-3 d-flex">
+      <div className="grw-sidebar-content-header py-4 d-flex">
         <h4 className="mb-0 text-nowrap">{t('Recent Changes')}</h4>
         <Suspense>
           <RecentChangesHeader isSmall={isSmall} onSizeChange={setIsSmall} />

--- a/apps/app/src/components/Sidebar/RecentChanges/RecentChanges.tsx
+++ b/apps/app/src/components/Sidebar/RecentChanges/RecentChanges.tsx
@@ -22,7 +22,7 @@ export const RecentChanges = (): JSX.Element => {
     // ref.  https://redmine.weseek.co.jp/issues/139425
     <div className="px-3" data-testid="grw-recent-changes">
       <div className="grw-sidebar-content-header py-3 d-flex">
-        <h3 className="mb-0 text-nowrap">{t('Recent Changes')}</h3>
+        <h4 className="mb-0 text-nowrap">{t('Recent Changes')}</h4>
         <Suspense>
           <RecentChangesHeader isSmall={isSmall} onSizeChange={setIsSmall} />
         </Suspense>

--- a/apps/app/src/components/Sidebar/RecentChanges/RecentChangesSubstance.tsx
+++ b/apps/app/src/components/Sidebar/RecentChanges/RecentChangesSubstance.tsx
@@ -199,7 +199,7 @@ export const RecentChangesContent = ({ isSmall }: ContentProps): JSX.Element => 
   const isReachingEnd = isEmpty || (data != null && data[data.length - 1]?.pages.length < PER_PAGE);
 
   return (
-    <div className="grw-recent-changes py-3">
+    <div className="grw-recent-changes">
       <ul className="list-group list-group-flush">
         <InfiniteScroll
           swrInifiniteResponse={swrInifinitexRecentlyUpdated}

--- a/apps/app/src/components/Sidebar/Tag.tsx
+++ b/apps/app/src/components/Sidebar/Tag.tsx
@@ -1,9 +1,10 @@
-import React, { FC, useState, useCallback } from 'react';
+import type { FC } from 'react';
+import React, { useState, useCallback } from 'react';
 
 import { useTranslation } from 'next-i18next';
 import { useRouter } from 'next/router';
 
-import { IDataTagCount } from '~/interfaces/tag';
+import type { IDataTagCount } from '~/interfaces/tag';
 import { useSWRxTagsList } from '~/stores/tag';
 
 import TagCloudBox from '../TagCloudBox';
@@ -48,7 +49,7 @@ const Tag: FC = () => {
     // ref.  https://redmine.weseek.co.jp/issues/139425
     <div className="container-lg px-4 mb-5 pb-5" data-testid="grw-sidebar-content-tags">
       <div className="grw-sidebar-content-header py-3 d-flex">
-        <h3 className="mb-0">{t('Tags')}</h3>
+        <h4 className="mb-0">{t('Tags')}</h4>
         <SidebarHeaderReloadButton onClick={() => onReload()} />
       </div>
 

--- a/apps/app/src/components/Sidebar/Tag.tsx
+++ b/apps/app/src/components/Sidebar/Tag.tsx
@@ -45,7 +45,7 @@ const Tag: FC = () => {
 
   // todo: adjust design by XD
   return (
-    <div className="container-lg px-4 mb-5 pb-5" data-testid="grw-sidebar-content-tags">
+    <div className="container-lg px-3 mb-5 pb-5" data-testid="grw-sidebar-content-tags">
       <div className="grw-sidebar-content-header py-3 d-flex">
         <h4 className="mb-0">{t('Tags')}</h4>
         <SidebarHeaderReloadButton onClick={() => onReload()} />

--- a/apps/app/src/components/Sidebar/Tag.tsx
+++ b/apps/app/src/components/Sidebar/Tag.tsx
@@ -45,15 +45,13 @@ const Tag: FC = () => {
 
   // todo: adjust design by XD
   return (
-    // TODO : #139425 Match the space specification method to others
-    // ref.  https://redmine.weseek.co.jp/issues/139425
     <div className="container-lg px-4 mb-5 pb-5" data-testid="grw-sidebar-content-tags">
       <div className="grw-sidebar-content-header py-3 d-flex">
         <h4 className="mb-0">{t('Tags')}</h4>
         <SidebarHeaderReloadButton onClick={() => onReload()} />
       </div>
 
-      <h3 className="my-3">{t('tag_list')}</h3>
+      <h6 className="my-3 pb-1 border-bottom">{t('tag_list')}</h6>
 
       { isLoading
         ? (
@@ -82,7 +80,7 @@ const Tag: FC = () => {
         </button>
       </div>
 
-      <h3 className="my-3">{t('popular_tags')}</h3>
+      <h6 className="my-3 pb-1 border-bottom">{t('popular_tags')}</h6>
 
       <TagCloudBox tags={tagCloudData} />
     </div>

--- a/apps/app/src/components/TagList.tsx
+++ b/apps/app/src/components/TagList.tsx
@@ -53,7 +53,7 @@ const TagList: FC<TagListProps> = (props:(TagListProps & typeof defaultProps)) =
   }, [pushState]);
 
   if (!isTagExist) {
-    return <h3>{ t('You have no tag, You can set tags on pages') }</h3>;
+    return <h6>{ t('You have no tag, You can set tags on pages') }</h6>;
   }
 
   return (


### PR DESCRIPTION
## Task

- [#139425](https://redmine.weseek.co.jp/issues/139425) [v7][design] サイドバーのヘッダーにおけるデザイン崩れの修正
  - [#141029](https://redmine.weseek.co.jp/issues/141029) サイドバーの余白を修正
  - [#140982](https://redmine.weseek.co.jp/issues/140982) 各種サイドバーの見出し修正

### Note
- サイドバータグ画面においてXDには存在する 「タグ一覧」「人気のタグ」の下線がなかったため追加。

## ScreenShot
![image](https://github.com/weseek/growi/assets/130130573/d12d4a61-e4cb-4245-aa9e-173d31809b62)
[参考元XD](https://xd.adobe.com/view/26f3cef5-06c1-4ed2-9871-b86d5d00adce-73a0/screen/02f976ba-5719-471f-8d1c-1a823784a0c2/variables/)
![image](https://github.com/weseek/growi/assets/130130573/c0b5d9ab-5da6-49a1-aa34-c8992ce9405b)
[参考元XD](https://xd.adobe.com/view/26f3cef5-06c1-4ed2-9871-b86d5d00adce-73a0/screen/80929244-cad4-4332-8858-f1a8de143fab/variables/)
![image](https://github.com/weseek/growi/assets/130130573/71d884a2-33e7-4769-926f-2fe787e4d344)
[参考元XD](https://xd.adobe.com/view/26f3cef5-06c1-4ed2-9871-b86d5d00adce-73a0/screen/04623570-34c6-45c7-8812-9c9ec057ab13/variables/)
![image](https://github.com/weseek/growi/assets/130130573/877613cb-3eb0-4467-ad65-adcec35aa0a4)
[参考元XD](https://xd.adobe.com/view/26f3cef5-06c1-4ed2-9871-b86d5d00adce-73a0/screen/a9f9a2c7-ff54-43d8-bf83-7c499c93a473/variables/)
![image](https://github.com/weseek/growi/assets/130130573/564d642e-81da-4407-aa43-c71d67ad4773)
[参考元XD](https://xd.adobe.com/view/26f3cef5-06c1-4ed2-9871-b86d5d00adce-73a0/screen/a9f9a2c7-ff54-43d8-bf83-7c499c93a473/)
![image](https://github.com/weseek/growi/assets/130130573/35b7b969-58f4-49c7-a320-9095249fa1a9)
[参考元XD](https://xd.adobe.com/view/26f3cef5-06c1-4ed2-9871-b86d5d00adce-73a0/screen/1d78c9a3-8a12-43c8-8da5-5beaaad105c5/variables/)

### 後続タスク
- [#139425](https://redmine.weseek.co.jp/issues/139425) [v7][design] サイドバーのヘッダーにおけるデザイン崩れの修正
  - [#141028](https://redmine.weseek.co.jp/issues/141028) 「最新の変更」のスイッチ修正