### PR TITLE
fix: pages are not displayed in page tree

### DIFF
--- a/apps/app/src/components/TreeItem/NewPageInput/use-new-page-input.tsx
+++ b/apps/app/src/components/TreeItem/NewPageInput/use-new-page-input.tsx
@@ -76,7 +76,6 @@ export const useNewPageInput = (): UseNewPageInput => {
         grantUserGroupIds: undefined,
       });
 
-      mutateChildren();
       mutatePageTree();
 
       if (!hasDescendants) {

--- a/apps/app/src/components/TreeItem/NewPageInput/use-new-page-input.tsx
+++ b/apps/app/src/components/TreeItem/NewPageInput/use-new-page-input.tsx
@@ -1,13 +1,14 @@
 import React, { useState, type FC, useCallback } from 'react';
 
 import { createPage } from '~/client/services/page-operation';
-import { useSWRxPageChildren } from '~/stores/page-listing';
+import { useSWRxPageChildren, mutatePageTree } from '~/stores/page-listing';
 import { usePageTreeDescCountMap } from '~/stores/ui';
 
 import type { TreeItemToolProps } from '../interfaces';
 
 import { NewPageCreateButton } from './NewPageCreateButton';
 import { NewPageInput } from './NewPageInput';
+
 
 type UseNewPageInput = {
   Input: FC<TreeItemToolProps>,
@@ -76,6 +77,7 @@ export const useNewPageInput = (): UseNewPageInput => {
       });
 
       mutateChildren();
+      mutatePageTree();
 
       if (!hasDescendants) {
         stateHandlers?.setIsOpen(true);


### PR DESCRIPTION
## タスク
https://redmine.weseek.co.jp/issues/141305
## 概要
- PageTreeの新規作成導線からページを作成したときにページが表示されない問題を解決しました。
## 変更点
- createPage関数が発火した後に、mutatePageTreeを実行するようにしました。
## セルフチェック
- [x] コンフリクト解消したか
- [x] 余計なコードは残っていないか
- [x] 適切にメモ化したか
- [x] 責務の問題はクリアしているか
- [x] CIは通っているか
- [x] PRの内容は適切にかけているか