### PR TITLE
fix: Two dropzone file dialog opening.

### DIFF
--- a/packages/editor/src/components/CodeMirrorEditor/Toolbar/AttachmentsDropdownItem.tsx
+++ b/packages/editor/src/components/CodeMirrorEditor/Toolbar/AttachmentsDropdownItem.tsx
@@ -25,7 +25,13 @@ export const AttachmentsDropdownItem = (props: Props): JSX.Element => {
     getRootProps,
     getInputProps,
     open,
-  } = useFileDropzone({ onUpload, acceptedUploadFileType });
+  } = useFileDropzone({
+    onUpload,
+    acceptedUploadFileType,
+    dropzoneOpts: {
+      noClick: true, noDrag: true, noKeyboard: true,
+    },
+  });
 
   return (
     <div {...getRootProps()} className="dropzone">

--- a/packages/editor/src/services/file-dropzone/use-file-dropzone/use-file-dropzone.ts
+++ b/packages/editor/src/services/file-dropzone/use-file-dropzone/use-file-dropzone.ts
@@ -35,11 +35,13 @@ export const useFileDropzone = (props: Props): FileDropzoneState => {
 
   }, [onUpload, setIsUploading, acceptedUploadFileType]);
 
-  const accept: Accept | undefined = acceptedUploadFileType === AcceptedUploadFileType.IMAGE
-    ? {
-      'image/*': [],
-    }
-    : undefined;
+  let accept: Accept | undefined;
+  if (acceptedUploadFileType === AcceptedUploadFileType.ALL) {
+    accept = { 'application/*': [] };
+  }
+  else if (acceptedUploadFileType === AcceptedUploadFileType.IMAGE) {
+    accept = { 'image/*': [] };
+  }
 
   const dzState = useDropzone({
     onDrop: dropHandler,


### PR DESCRIPTION
# 概要
二つファイルドロップゾーンのダイアログができる問題の修正。

# 参考
- https://react-dropzone.js.org/#section-opening-file-dialog-programmatically

# Task
- https://redmine.weseek.co.jp/issues/141034
  - https://redmine.weseek.co.jp/issues/141303

