### PR TITLE
imprv: Add left margin in edit mode preview

### DIFF
--- a/apps/app/src/components/PageEditor/Preview.module.scss
+++ b/apps/app/src/components/PageEditor/Preview.module.scss
@@ -3,6 +3,7 @@
 .page-editor-preview-body :global {
   .wiki {
     max-width: 980px;
+    padding: 0px 15px;
     margin: 0 auto;
   }
 }


### PR DESCRIPTION
# 概要
Edit mode 時の Preview に左右の padding を追加


<img width="1186" alt="image" src="https://github.com/weseek/growi/assets/132258880/67f47b66-f9c4-476d-b938-fc665803d08c">


# Task
- https://redmine.weseek.co.jp/issues/140676
  - https://redmine.weseek.co.jp/issues/141378