### PR TITLE
imprv: Styling adjustments for the login lead

### DIFF
--- a/apps/app/src/components/Navbar/GrowiContextualSubNavigation.tsx
+++ b/apps/app/src/components/Navbar/GrowiContextualSubNavigation.tsx
@@ -322,14 +322,14 @@ const GrowiContextualSubNavigation = (props: GrowiContextualSubNavigationProps):
         )}
 
         { isGuestUser && (
-          <>
-            <Link href="/login#register" className="btn" prefetch={false}>
+          <div className="mt-2">
+            <Link href="/login#register" className="btn me-2" prefetch={false}>
               <span className="material-symbols-outlined me-1">person_add</span>{t('Sign up')}
             </Link>
             <Link href="/login#login" className="btn btn-primary" prefetch={false}>
               <span className="material-symbols-outlined me-1">login</span>{t('Sign in')}
             </Link>
-          </>
+          </div>
         ) }
       </div>
 


### PR DESCRIPTION
## Task
[#140052](https://redmine.weseek.co.jp/issues/140052) [v7] ゲストモードでアクセスした際の /login への導線を追加する
┗ [#141452](https://redmine.weseek.co.jp/issues/141452) スタイルの調整

## Screenshot
### before 
<img width="957" alt="スクリーンショット 2024-02-29 17 08 38" src="https://github.com/weseek/growi/assets/34241526/416d1049-03fd-411a-8f06-9be1d33cb0af">

### after
<img width="947" alt="スクリーンショット 2024-02-29 17 07 58" src="https://github.com/weseek/growi/assets/34241526/96b8acca-da4e-4619-b86f-3ca51cec2043">


