### PR TITLE
fix: File dialog works correctly

### DIFF
--- a/packages/editor/src/components/CodeMirrorEditor/Toolbar/AttachmentsDropdownItem.tsx
+++ b/packages/editor/src/components/CodeMirrorEditor/Toolbar/AttachmentsDropdownItem.tsx
@@ -11,6 +11,7 @@ type Props = {
   acceptedUploadFileType: AcceptedUploadFileType,
   children?: ReactNode,
   onUpload?: (files: File[]) => void,
+  onClose?: () => void,
 }
 
 export const AttachmentsDropdownItem = (props: Props): JSX.Element => {
@@ -19,6 +20,7 @@ export const AttachmentsDropdownItem = (props: Props): JSX.Element => {
     acceptedUploadFileType,
     children,
     onUpload,
+    onClose,
   } = props;
 
   const {
@@ -26,10 +28,13 @@ export const AttachmentsDropdownItem = (props: Props): JSX.Element => {
     getInputProps,
     open,
   } = useFileDropzone({
-    onUpload,
+    onUpload: (files: File[]) => { onUpload?.(files); onClose?.() },
     acceptedUploadFileType,
     dropzoneOpts: {
-      noClick: true, noDrag: true, noKeyboard: true,
+      noClick: true,
+      noDrag: true,
+      noKeyboard: true,
+      onFileDialogCancel: onClose,
     },
   });
 

--- a/packages/editor/src/components/CodeMirrorEditor/Toolbar/AttachmentsDropdownItem.tsx
+++ b/packages/editor/src/components/CodeMirrorEditor/Toolbar/AttachmentsDropdownItem.tsx
@@ -36,7 +36,7 @@ export const AttachmentsDropdownItem = (props: Props): JSX.Element => {
   return (
     <div {...getRootProps()} className="dropzone">
       <input {...getInputProps()} />
-      <DropdownItem className="d-flex gap-2 align-items-center" onClick={open}>
+      <DropdownItem toggle={false} className="d-flex gap-2 align-items-center" onClick={open}>
         {children}
       </DropdownItem>
     </div>

--- a/packages/editor/src/components/CodeMirrorEditor/Toolbar/AttachmentsDropup.tsx
+++ b/packages/editor/src/components/CodeMirrorEditor/Toolbar/AttachmentsDropup.tsx
@@ -38,14 +38,14 @@ export const AttachmentsDropup = (props: Props): JSX.Element => {
           <DropdownItem divider />
 
           { acceptedUploadFileType === AcceptedUploadFileType.ALL && (
-            <AttachmentsDropdownItem acceptedUploadFileType={AcceptedUploadFileType.ALL} onUpload={onUpload}>
+            <AttachmentsDropdownItem acceptedUploadFileType={AcceptedUploadFileType.ALL} onUpload={onUpload} onClose={() => setOpen(false)}>
               <span className="material-symbols-outlined fs-5">attach_file</span>
               Files
             </AttachmentsDropdownItem>
           ) }
 
           { acceptedUploadFileType !== AcceptedUploadFileType.NONE && (
-            <AttachmentsDropdownItem acceptedUploadFileType={AcceptedUploadFileType.IMAGE} onUpload={onUpload}>
+            <AttachmentsDropdownItem acceptedUploadFileType={AcceptedUploadFileType.IMAGE} onUpload={onUpload} onClose={() => setOpen(false)}>
               <span className="material-symbols-outlined fs-5">image</span>
               Images
             </AttachmentsDropdownItem>


### PR DESCRIPTION
# 概要
- `AttachmentsDropdownItem` で `FileDialog` は開けるが、ファイルを添付することができない問題の修正。

# 解決方法について
`React-Dropzone` における `FileDialog` は `<input {...getInputProps()>` によって管理されており、これがないと出てこない + `onDrop` も発火しない。

`AttachmentsDropdownIem` はドロップダウン内のボタンであり、修正前の状態では、押下すると`FileDialog` を呼び出し、消える。

つまり、`FileDialog` が出てくると同時に、`AttachmentsDropdownItem`内の`<input {...getInputProps()>`が消える。これによりファイル選択後の `onDrop` が発火しない今回のバグが発生した。

解決策として、`FileDialog` が消えるまで `AttachmentsDropdownItem`が消えないようにする。`Upload` 後か、`FileDialog`がキャンセルされた後に `close` する方法をとった。

# Task 
- https://redmine.weseek.co.jp/issues/141652
  - https://redmine.weseek.co.jp/issues/141811