### PR TITLE
imprv: Fix paste operation of markdown

### DIFF
--- a/packages/editor/src/services/paste-util/paste-markdown-util.ts
+++ b/packages/editor/src/services/paste-util/paste-markdown-util.ts
@@ -20,28 +20,30 @@ export const adjustPasteData = (strFromBol: string, text: string): string => {
 
   let adjusted = text;
 
-  if (text.match(indentAndMarkRE) && strFromBol.match(indentAndMarkRE)) {
-    const matchResult = strFromBol.match(indentAndMarkRE);
-    const indent = matchResult ? matchResult[1] : '';
+  if (indentAndMarkOnlyRE.test(strFromBol)) {
+    if (text.match(indentAndMarkRE)) {
+      const matchResult = strFromBol.match(indentAndMarkRE);
+      const indent = matchResult ? matchResult[1] : '';
 
-    const lines = text.match(/[^\r\n]+/g);
+      const lines = text.match(/[^\r\n]+/g);
 
-    const replacedLines = lines?.map((line, index) => {
+      const replacedLines = lines?.map((line, index) => {
 
-      if (index === 0 && strFromBol.match(indentAndMarkOnlyRE)) {
-        return line.replace(indentAndMarkRE, '');
-      }
+        if (index === 0 && strFromBol.match(indentAndMarkOnlyRE)) {
+          return line.replace(indentAndMarkRE, '');
+        }
 
-      return indent + line;
-    });
+        return indent + line;
+      });
 
-    adjusted = replacedLines ? replacedLines.join('\n') : '';
-  }
+      adjusted = replacedLines ? replacedLines.join('\n') : '';
+    }
 
-  else if (strFromBol.match(indentAndMarkRE)) {
-    const replacedText = text.replace(/(\r\n|\r|\n)/g, `$1${strFromBol}`);
+    else {
+      const replacedText = text.replace(/(\r\n|\r|\n)/g, `$1${strFromBol}`);
 
-    adjusted = replacedText;
+      adjusted = replacedText;
+    }
   }
 
   return adjusted;

--- a/packages/editor/src/services/paste-util/paste-markdown-util.ts
+++ b/packages/editor/src/services/paste-util/paste-markdown-util.ts
@@ -38,7 +38,7 @@ export const adjustPasteData = (strFromBol: string, text: string): string => {
     if (replacedLines == null) {
       adjusted = '';
     }
-    else if (replacedLines.length === 1 && !matchResult) {
+    else if (!matchResult) {
       adjusted = `${replacedLines.join('')}\n`;
     }
     else {

--- a/packages/editor/src/services/paste-util/paste-markdown-util.ts
+++ b/packages/editor/src/services/paste-util/paste-markdown-util.ts
@@ -20,7 +20,7 @@ export const adjustPasteData = (strFromBol: string, text: string): string => {
 
   let adjusted = text;
 
-  if (text.match(indentAndMarkRE)) {
+  if (text.match(indentAndMarkRE) && strFromBol.match(indentAndMarkRE)) {
     const matchResult = strFromBol.match(indentAndMarkRE);
     const indent = matchResult ? matchResult[1] : '';
 
@@ -35,15 +35,7 @@ export const adjustPasteData = (strFromBol: string, text: string): string => {
       return indent + line;
     });
 
-    if (replacedLines == null) {
-      adjusted = '';
-    }
-    else if (!matchResult) {
-      adjusted = `${replacedLines.join('')}\n`;
-    }
-    else {
-      adjusted = replacedLines.join('\n');
-    }
+    adjusted = replacedLines ? replacedLines.join('\n') : '';
   }
 
   else if (strFromBol.match(indentAndMarkRE)) {

--- a/packages/editor/src/services/paste-util/paste-markdown-util.ts
+++ b/packages/editor/src/services/paste-util/paste-markdown-util.ts
@@ -35,7 +35,15 @@ export const adjustPasteData = (strFromBol: string, text: string): string => {
       return indent + line;
     });
 
-    adjusted = replacedLines ? replacedLines.join('\n') : '';
+    if (replacedLines == null) {
+      adjusted = '';
+    }
+    else if (replacedLines.length === 1 && !matchResult) {
+      adjusted = `${replacedLines.join('')}\n`;
+    }
+    else {
+      adjusted = replacedLines.join('\n');
+    }
   }
 
   else if (strFromBol.match(indentAndMarkRE)) {


### PR DESCRIPTION
## タスク
https://redmine.weseek.co.jp/issues/142716
## 概要
>## 症状
>- Markdown のリストをコピーし、リスト内でのペーストを試みた際に、行が挿入されずに既存の行に追加された状態でリストが追加される
>    - v6 では行が挿入（追加）されて、ペーストした内容のみの行が生成される
>    - リスト形式ではないテキストであれば、v7 でも挿入（追加）されて、ペーストした内容のみの行が生成される
>
>## 再現状況（＆期待される動作）
>1. エディタ内の markdown_リストに対して `Shift + ↓` で行を選択
>2. 選択した markdown_リストを含む行をコピー
>3. コピーした行を、別の行にペースト
>
>このときに、行が挿入（追加）された状態で
>ペーストした行の内容のみが表示されている行が生成される状態にする
## 変更点
- adjutedの内容を変更する条件を1つ追加しました。
## セルフチェック
- [x] コンフリクト解消したか
- [x] 余計なコードは残っていないか
- [x] 適切にメモ化したか
- [x] 責務の問題はクリアしているか
- [x] CIは通っているか
- [x] PRの内容は適切にかけているか