### PR TITLE
fix: Visibility of PageViewReadOnly

### DIFF
--- a/apps/app/src/components/PageEditor/PageEditorReadOnly.tsx
+++ b/apps/app/src/components/PageEditor/PageEditorReadOnly.tsx
@@ -11,7 +11,11 @@ import { EditorNavbar } from './EditorNavbar';
 import Preview from './Preview';
 import { useScrollSync } from './ScrollSyncHelper';
 
-export const PageEditorReadOnly = react.memo((): JSX.Element => {
+type Props = {
+  visibility?: boolean,
+}
+
+export const PageEditorReadOnly = react.memo(({ visibility }: Props): JSX.Element => {
   const previewRef = useRef<HTMLDivElement>(null);
 
   const { data: currentPage } = useSWRxCurrentPage();
@@ -30,7 +34,7 @@ export const PageEditorReadOnly = react.memo((): JSX.Element => {
   }
 
   return (
-    <div id="page-editor" className="flex-expand-vert">
+    <div id="page-editor" className={`flex-expand-vert ${visibility ? '' : 'd-none'}`}>
       <EditorNavbar />
 
       <div className="flex-expand-horiz">


### PR DESCRIPTION
## Task
[#140132](https://redmine.weseek.co.jp/issues/140132) [v7][collab] History から過去の revision を選択してエディター画面を開くと最新の revision が表示されてしまう
┗ [#143061](https://redmine.weseek.co.jp/issues/143061) View 画面を開いている時に View 画面下部 PageViewReadOnly が表示されてしまう

## Screenshot
以下のような状態になっていた
<img width="1470" alt="スクリーンショット 2024-03-22 13 53 28" src="https://github.com/weseek/growi/assets/34241526/714e331f-6403-43fa-b52b-e72ad1c061f2">
