### PR TITLE
imprv: wip Improved white space

### DIFF
--- a/apps/app/src/components/Sidebar/PageTree/PageTreeSubstance.tsx
+++ b/apps/app/src/components/Sidebar/PageTree/PageTreeSubstance.tsx
@@ -50,7 +50,7 @@ export const PageTreeHeader = memo(({ isWipPageShown, onWipPageShownChange }: He
                 checked={isWipPageShown}
                 onChange={() => {}}
               />
-              <label className="form-label form-check-label text-muted" htmlFor="wipPageVisibility">
+              <label className="form-label form-check-label text-muted mb-0" htmlFor="wipPageVisibility">
                 {t('sidebar_header.show_wip_page')}
               </label>
             </div>

--- a/apps/app/src/features/search/client/components/SearchModal.tsx
+++ b/apps/app/src/features/search/client/components/SearchModal.tsx
@@ -94,6 +94,7 @@ const SearchModal = (): JSX.Element => {
                   searchKeyword={searchKeyword}
                   getItemProps={getItemProps}
                 />
+                <div className="border-top mt-2 mb-2" />
                 <SearchResultMenuItem
                   activeIndex={highlightedIndex}
                   searchKeyword={searchKeyword}

--- a/apps/app/src/features/search/client/components/SearchModal.tsx
+++ b/apps/app/src/features/search/client/components/SearchModal.tsx
@@ -94,7 +94,6 @@ const SearchModal = (): JSX.Element => {
                   searchKeyword={searchKeyword}
                   getItemProps={getItemProps}
                 />
-                <div className="border-top mt-2 mb-2" />
                 <SearchResultMenuItem
                   activeIndex={highlightedIndex}
                   searchKeyword={searchKeyword}


### PR DESCRIPTION
サイドバー_pagetree の switch 下部の不要なスペースを削除。wipの余白を修正しました。

## TASK 
https://redmine.weseek.co.jp/issues/142769
┗ https://redmine.weseek.co.jp/issues/143036