### PR TITLE
fix: Counting comments when removing the thread

### DIFF
--- a/apps/app/src/features/comment/server/models/comment.ts
+++ b/apps/app/src/features/comment/server/models/comment.ts
@@ -1,9 +1,10 @@
 import type { IUser } from '@growi/core/dist/interfaces';
-import {
-  Types, Document, Model, Schema, Query,
+import type {
+  Types, Document, Model, Query,
 } from 'mongoose';
+import { Schema } from 'mongoose';
 
-import { IComment } from '~/interfaces/comment';
+import type { IComment } from '~/interfaces/comment';
 import { getOrCreateModel } from '~/server/util/mongoose-utils';
 import loggerFactory from '~/utils/logger';
 
@@ -111,10 +112,10 @@ commentSchema.statics.countCommentByPageId = async function(page) {
   return this.count({ page });
 };
 
-commentSchema.methods.removeWithReplies = async function(comment) {
-  await this.remove({
-    $or: (
-      [{ replyTo: this._id }, { _id: this._id }]),
+commentSchema.statics.removeWithReplies = async function(comment) {
+  await this.deleteMany({
+    $or:
+      [{ replyTo: comment._id }, { _id: comment._id }],
   });
 };
 

--- a/apps/app/src/server/routes/comment.js
+++ b/apps/app/src/server/routes/comment.js
@@ -475,7 +475,7 @@ module.exports = function(crowi, app) {
         throw new Error('Current user is not operatable to this comment.');
       }
 
-      await comment.removeWithReplies(comment);
+      await Comment.removeWithReplies(comment);
       await Page.updateCommentCount(comment.page);
       commentEvent.emit(CommentEvent.DELETE, comment);
     }


### PR DESCRIPTION
ストーリー: https://redmine.weseek.co.jp/issues/140648

タスク: https://redmine.weseek.co.jp/issues/143310

# やったこと
- リプライとコメントの一括削除処理が`remove`メソッドで書かれていたのを、`deleteMany`に置き換えた