### PR TITLE
support: Add light and dark badge color

### DIFF
--- a/packages/core/scss/bootstrap/override/helpers/_color-bg.scss
+++ b/packages/core/scss/bootstrap/override/helpers/_color-bg.scss
@@ -1,8 +1,24 @@
 // All-caps `RGBA()` function used because of this Sass bug: https://github.com/sass/node-sass/issues/2251
 @each $color, $value in $theme-colors {
-  .text-bg-#{$color} {
-    color: var(--#{$prefix}#{$color}) if($enable-important-utilities, !important, null);
-    background-color: var(--#{$prefix}#{$color}-bg-subtle) if($enable-important-utilities, !important, null);
-    border: 1px solid var(--#{$prefix}#{$color}-border-subtle) if($enable-important-utilities, !important, null);
+  @if $color == 'light' {
+    .text-bg-#{$color} {
+      color: $gray-500 if($enable-important-utilities, !important, null);
+      background-color: var(--bs-light) if($enable-important-utilities, !important, null);
+      border: 1px solid var(--bs-light-border-subtle) if($enable-important-utilities, !important, null);
+    }
+  }
+  @else if $color == 'dark' {
+    .text-bg-#{$color} {
+      color: $gray-600 if($enable-important-utilities, !important, null);
+      background-color: var(--bs-dark);
+      border: 1px solid var(--bs-dark-border-subtle);
+    }
+  }
+  @else {
+    .text-bg-#{$color} {
+      color: var(--#{$prefix}#{$color}) if($enable-important-utilities, !important, null);
+      background-color: var(--#{$prefix}#{$color}-bg-subtle) if($enable-important-utilities, !important, null);
+      border: 1px solid var(--#{$prefix}#{$color}-border-subtle) if($enable-important-utilities, !important, null);
+    }
   }
 }


### PR DESCRIPTION
# Task
https://redmine.weseek.co.jp/issues/143725

# 概要
- `.badge` の light / dark の色を修正
  - `text-light/dark-bg` を figma 通りに設定

# Figma
- https://www.figma.com/file/ZiEcjZ8sYt6YvowboA5Um6/GROWI-v7?type=design&node-id=0%3A1&mode=design&t=ahkBpdVyoOdWmL4O-1

# Screen Shot
<img width="338" alt="image" src="https://github.com/weseek/growi/assets/113958844/8dc7f4a2-4f41-4237-9678-7e9c4ac504ba">
<img width="365" alt="image" src="https://github.com/weseek/growi/assets/113958844/8c813e9b-0e7e-4642-9c27-24e933aae8d6">
