### PR TITLE
fix: Admin users badge color in /admin/users

### DIFF
--- a/apps/app/src/components/Admin/UserManagement.tsx
+++ b/apps/app/src/components/Admin/UserManagement.tsx
@@ -167,11 +167,11 @@ const UserManagement = (props: UserManagementProps) => {
 
           <div className="offset-md-1 col-md-6 my-2">
             <div>
-              {renderCheckbox('all', 'All', 'secondary')}
+              {renderCheckbox('all', 'All', 'primary')}
               {renderCheckbox('registered', 'Approval Pending', 'info')}
               {renderCheckbox('active', 'Active', 'success')}
               {renderCheckbox('suspended', 'Suspended', 'warning')}
-              {renderCheckbox('invited', 'Invited', 'warning')}
+              {renderCheckbox('invited', 'Invited', 'secondary')}
             </div>
             <div>
               { isNotifyCommentShow && <span className="text-warning">{t('admin:user_management.click_twice_same_checkbox')}</span> }

--- a/apps/app/src/components/Admin/UserManagement.tsx
+++ b/apps/app/src/components/Admin/UserManagement.tsx
@@ -90,7 +90,7 @@ const UserManagement = (props: UserManagementProps) => {
           onChange={() => clickHandler(status)}
         />
         <label className="form-label form-check-label" htmlFor={`c_${status}`}>
-          <span className={`badge rounded-pill bg-${statusColor} d-inline-block vt mt-1`}>
+          <span className={`badge text-bg-${statusColor} d-inline-block vt mt-1`}>
             {statusLabel}
           </span>
         </label>
@@ -170,8 +170,8 @@ const UserManagement = (props: UserManagementProps) => {
               {renderCheckbox('all', 'All', 'secondary')}
               {renderCheckbox('registered', 'Approval Pending', 'info')}
               {renderCheckbox('active', 'Active', 'success')}
-              {renderCheckbox('suspended', 'Suspended', 'warning text-dark')}
-              {renderCheckbox('invited', 'Invited', 'pink')}
+              {renderCheckbox('suspended', 'Suspended', 'warning')}
+              {renderCheckbox('invited', 'Invited', 'warning')}
             </div>
             <div>
               { isNotifyCommentShow && <span className="text-warning">{t('admin:user_management.click_twice_same_checkbox')}</span> }

--- a/apps/app/src/components/Admin/Users/UserTable.tsx
+++ b/apps/app/src/components/Admin/Users/UserTable.tsx
@@ -43,7 +43,7 @@ const UserTable = (props: UserTableProps) => {
         text = 'Deleted';
         break;
       case 5:
-        additionalClassName = 'text-bg-warning';
+        additionalClassName = 'text-bg-secondary';
         text = 'Invited';
         break;
     }

--- a/apps/app/src/components/Admin/Users/UserTable.tsx
+++ b/apps/app/src/components/Admin/Users/UserTable.tsx
@@ -22,34 +22,34 @@ const UserTable = (props: UserTableProps) => {
   const { adminUsersContainer } = props;
 
   const getUserStatusLabel = (userStatus: number) => {
-    let additionalClassName = 'bg-info';
+    let additionalClassName = 'text-bg-info';
     let text = 'Approval Pending';
 
     switch (userStatus) {
       case 1:
-        additionalClassName = 'bg-info';
+        additionalClassName = 'text-bg-info';
         text = 'Approval Pending';
         break;
       case 2:
-        additionalClassName = 'bg-success';
+        additionalClassName = 'text-bg-success';
         text = 'Active';
         break;
       case 3:
-        additionalClassName = 'bg-warning text-dark';
+        additionalClassName = 'text-bg-warning';
         text = 'Suspended';
         break;
       case 4:
-        additionalClassName = 'bg-danger';
+        additionalClassName = 'text-bg-danger';
         text = 'Deleted';
         break;
       case 5:
-        additionalClassName = 'bg-pink';
+        additionalClassName = 'text-bg-warning';
         text = 'Invited';
         break;
     }
 
     return (
-      <span className={`badge rounded-pill ${additionalClassName}`}>
+      <span className={`badge ${additionalClassName}`}>
         {text}
       </span>
     );
@@ -153,12 +153,12 @@ const UserTable = (props: UserTableProps) => {
                 <td>
                   {getUserStatusLabel(user.status)}
                   {(user.admin) && (
-                    <span className="badge bg-indigo rounded-pill ms-2">
+                    <span className="badge text-bg-secondary ms-2">
                       {t('admin:user_management.user_table.administrator')}
                     </span>
                   )}
                   {(user.readOnly) && (
-                    <span className="badge bg-light text-dark rounded-pill ms-2">
+                    <span className="badge text-bg-light ms-2">
                       {t('admin:user_management.user_table.read_only')}
                     </span>
                   )}


### PR DESCRIPTION
# Task
https://redmine.weseek.co.jp/issues/143846

# 概要
- `/admin/users` の badge を最新のバージョンに修正
- 一部 badge の配色を見直し

# Screenshot
<img width="628" alt="image" src="https://github.com/weseek/growi/assets/113958844/c3955be3-3d1f-4f15-97b1-fd37669195f2">
<img width="539" alt="image" src="https://github.com/weseek/growi/assets/113958844/34f97e53-58bb-4516-916f-083315d6f97d">
