### PR TITLE
fix: Custom logo style

### DIFF
--- a/apps/app/src/components/Sidebar/SidebarBrandLogo.tsx
+++ b/apps/app/src/components/Sidebar/SidebarBrandLogo.tsx
@@ -12,7 +12,7 @@ export const SidebarBrandLogo = memo((props: SidebarBrandLogoProps) => {
   return isDefaultLogo
     ? <GrowiLogo />
     // eslint-disable-next-line @next/next/no-img-element
-    : (<img src="/attachment/brand-logo" alt="custom logo" className="picture picture-lg p-2 mx-2" id="settingBrandLogo" width="32" />);
+    : (<div><img src="/attachment/brand-logo" alt="custom logo" className="picture picture-lg p-2" id="settingBrandLogo" /></div>);
 });
 
 SidebarBrandLogo.displayName = 'SidebarBrandLogo';


### PR DESCRIPTION
# Task
https://redmine.weseek.co.jp/issues/143848

# 概要
- カスタムロゴを設定したときのレイアウト崩れを修正

# Screenshot
<img width="286" alt="image" src="https://github.com/weseek/growi/assets/113958844/cf73a3e6-b1ba-45ed-a9d6-08c01528fdc3">
<img width="278" alt="image" src="https://github.com/weseek/growi/assets/113958844/28e21a0d-947d-425c-8b84-7517d48d9003">
