### PR TITLE
fix: Cannot display error when page path is duplicated

### DIFF
--- a/apps/app/src/components/TreeItem/NewPageInput/NewPageInput.tsx
+++ b/apps/app/src/components/TreeItem/NewPageInput/NewPageInput.tsx
@@ -40,7 +40,7 @@ export const NewPageInput: FC<Props> = (props) => {
     }
 
     try {
-      onSubmit?.(newPagePath);
+      await onSubmit?.(newPagePath);
       toastSuccess(t('successfully_saved_the_page'));
     }
     catch (err) {


### PR DESCRIPTION
### Task
- https://redmine.weseek.co.jp/issues/143751

### About the changes
Add await to wait for an exception thrown by an async process.

