### PR TITLE
fix: Add filePath to the schema of attachement for backward compatibility for v3.3 or earlier (v6.3.x)

### DIFF
--- a/apps/app/src/server/models/attachment.ts
+++ b/apps/app/src/server/models/attachment.ts
@@ -38,6 +38,7 @@ export interface IAttachmentModel extends Model<IAttachmentDocument> {
 const attachmentSchema = new Schema({
   page: { type: Types.ObjectId, ref: 'Page', index: true },
   creator: { type: Types.ObjectId, ref: 'User', index: true },
+  filePath: { type: String }, // DEPRECATED: remains for backward compatibility for v3.3.x or below
   fileName: { type: String, required: true, unique: true },
   fileFormat: { type: String, required: true },
   fileSize: { type: Number, default: 0 },

--- a/apps/app/src/server/service/file-uploader/aws.ts
+++ b/apps/app/src/server/service/file-uploader/aws.ts
@@ -79,7 +79,7 @@ const S3Factory = (): S3Client => {
 };
 
 const getFilePathOnStorage = (attachment) => {
-  if (attachment.filePath != null) {
+  if (attachment.filePath != null) { // DEPRECATED: remains for backward compatibility for v3.3.x or below
     return attachment.filePath;
   }
 


### PR DESCRIPTION
fix #8674