### PR TITLE
feat: Mark to check for the presence of drafts

### DIFF
--- a/apps/app/src/components/Navbar/PageEditorModeManager.tsx
+++ b/apps/app/src/components/Navbar/PageEditorModeManager.tsx
@@ -68,6 +68,9 @@ export const PageEditorModeManager = (props: Props): JSX.Element => {
 
   const { isCreating, createAndTransit } = useCreatePageAndTransit();
 
+  // TODO: https://redmine.weseek.co.jp/issues/132775
+  const hasDraft = false;
+
   const editButtonClickedHandler = useCallback(async() => {
     if (isNotFound == null || isNotFound === false) {
       mutateEditorMode(EditorMode.Editor);
@@ -113,6 +116,7 @@ export const PageEditorModeManager = (props: Props): JSX.Element => {
             onClick={editButtonClickedHandler}
           >
             <span className="material-symbols-outlined me-1 fs-5">edit_square</span>{t('Edit')}
+            { hasDraft && <span className="position-absolute top-0 start-100 translate-middle p-1 bg-primary border border-light rounded-circle" />}
           </PageEditorModeButton>
         )}
       </div>

--- a/apps/app/src/components/Navbar/PageEditorModeManager.tsx
+++ b/apps/app/src/components/Navbar/PageEditorModeManager.tsx
@@ -69,7 +69,7 @@ export const PageEditorModeManager = (props: Props): JSX.Element => {
   const { isCreating, createAndTransit } = useCreatePageAndTransit();
 
   // TODO: https://redmine.weseek.co.jp/issues/132775
-  const hasYjsDraft = false;
+  const hasYjsDraft = true;
 
   const editButtonClickedHandler = useCallback(async() => {
     if (isNotFound == null || isNotFound === false) {
@@ -116,7 +116,7 @@ export const PageEditorModeManager = (props: Props): JSX.Element => {
             onClick={editButtonClickedHandler}
           >
             <span className="material-symbols-outlined me-1 fs-5">edit_square</span>{t('Edit')}
-            { hasYjsDraft && <span className="position-absolute top-0 start-100 translate-middle p-1 bg-primary border border-light rounded-circle" />}
+            { hasYjsDraft && <span className="position-absolute top-0 start-100 translate-middle p-1 bg-primary rounded-circle" />}
           </PageEditorModeButton>
         )}
       </div>

--- a/apps/app/src/components/Navbar/PageEditorModeManager.tsx
+++ b/apps/app/src/components/Navbar/PageEditorModeManager.tsx
@@ -69,7 +69,7 @@ export const PageEditorModeManager = (props: Props): JSX.Element => {
   const { isCreating, createAndTransit } = useCreatePageAndTransit();
 
   // TODO: https://redmine.weseek.co.jp/issues/132775
-  const hasDraft = false;
+  const hasYjsDraft = false;
 
   const editButtonClickedHandler = useCallback(async() => {
     if (isNotFound == null || isNotFound === false) {
@@ -116,7 +116,7 @@ export const PageEditorModeManager = (props: Props): JSX.Element => {
             onClick={editButtonClickedHandler}
           >
             <span className="material-symbols-outlined me-1 fs-5">edit_square</span>{t('Edit')}
-            { hasDraft && <span className="position-absolute top-0 start-100 translate-middle p-1 bg-primary border border-light rounded-circle" />}
+            { hasYjsDraft && <span className="position-absolute top-0 start-100 translate-middle p-1 bg-primary border border-light rounded-circle" />}
           </PageEditorModeButton>
         )}
       </div>


### PR DESCRIPTION
## Task
[#132775](https://redmine.weseek.co.jp/issues/132775) [v7][New Editor][collab] Editor で編集中またはドラフトが存在することを subnav から確認できる
┗ [#141357](https://redmine.weseek.co.jp/issues/141357) デザイン実装

## XD
- Viewer
  - https://xd.adobe.com/view/26f3cef5-06c1-4ed2-9871-b86d5d00adce-73a0/screen/fc4bb8e1-4e44-4123-a2ef-c982859df6fb/
- Editor
  - https://xd.adobe.com/view/26f3cef5-06c1-4ed2-9871-b86d5d00adce-73a0/screen/fcd4d51c-090b-4c02-94d3-4cc26bab1464/

## Screenshot
<img width="262" alt="スクリーンショット 2024-04-04 18 32 54" src="https://github.com/weseek/growi/assets/34241526/c79d0720-9145-4f82-a254-74bb3c6fae63">
