### PR TITLE
fix: Tags are unintentionally created when a conversion is finalized

### DIFF
--- a/apps/app/src/components/PageTags/TagsInput.tsx
+++ b/apps/app/src/components/PageTags/TagsInput.tsx
@@ -42,6 +42,12 @@ export const TagsInput: FC<Props> = (props: Props) => {
     if (event.key === ' ') {
       event.preventDefault();
 
+      // fix: https://redmine.weseek.co.jp/issues/140689
+      const isComposing = event.nativeEvent.isComposing;
+      if (isComposing) {
+        return;
+      }
+
       const initialItem = tagsInputRef?.current?.state?.initialItem;
       const handleMenuItemSelect = tagsInputRef?.current?._handleMenuItemSelect;
 


### PR DESCRIPTION
## Task
[#140689](https://redmine.weseek.co.jp/issues/140689) [v7] タグ作成時 日本語入力でスペースを打つと変換中にタグが確定してしまう
┗ [#144023](https://redmine.weseek.co.jp/issues/144023) 修正

## ScreenRecord
https://github.com/weseek/growi/assets/34241526/78db5dfb-b4dd-41c0-8cbb-d6af30870556




