### PR TITLE
imprv: Truncate page path title in view

### DIFF
--- a/apps/app/src/components/Common/CopyDropdown/CopyDropdown.jsx
+++ b/apps/app/src/components/Common/CopyDropdown/CopyDropdown.jsx
@@ -120,6 +120,7 @@ export const CopyDropdown = (props) => {
 
         <DropdownMenu
           strategy="fixed"
+          container="body"
         >
           <div className="d-flex align-items-center justify-content-between">
             <DropdownItem header className="px-3">

--- a/apps/app/src/components/Common/PagePathNav/PagePathNav.module.scss
+++ b/apps/app/src/components/Common/PagePathNav/PagePathNav.module.scss
@@ -20,15 +20,6 @@
       font-size: 1.75rem !important;
     }
   }
-  // avoid sticky-top nav to turnate page path
-  .is-collapse-with-top {
-    @include bs.media-breakpoint-down(md) {
-      max-width: calc(100% - 350px);
-    }
-    @include bs.media-breakpoint-up(md) {
-      max-width: calc(100% - 500px);
-    }
-  }
 }
 
 .grw-page-path-nav :global {

--- a/apps/app/src/components/Common/PagePathNav/PagePathNav.tsx
+++ b/apps/app/src/components/Common/PagePathNav/PagePathNav.tsx
@@ -5,6 +5,7 @@ import React, {
 
 import { DevidedPagePath } from '@growi/core/dist/models';
 import { pagePathUtils } from '@growi/core/dist/utils';
+import { useRect } from '@growi/ui/dist/utils';
 import dynamic from 'next/dynamic';
 import Sticky from 'react-stickynode';
 
@@ -115,16 +116,17 @@ export const PagePathNavSticky = (props: PagePathNavStickyProps): JSX.Element =>
   const { data: sidebarWidth } = useCurrentProductNavWidth();
   const { data: sidebarMode } = useSidebarMode();
   const pagePathNavRef = useRef<HTMLDivElement>(null);
+  const [pagePathNavRect] = useRect(pagePathNavRef);
 
   const navMaxWidth: CSSProperties | undefined = useMemo(() => {
-    if (pageControlsX == null || pagePathNavRef.current == null || sidebarWidth == null || sidebarMode == null) {
+    if (pageControlsX == null || pagePathNavRef.current == null || sidebarWidth == null || sidebarMode == null || pagePathNavRect == null) {
       return;
     }
     // console.log('sideBarMode: ', sidebarMode, pagePathNavRef.current.getBoundingClientRect().x);
-    console.log(' sideBarWidth: ', sidebarWidth, ' pageControsX: ', pageControlsX, ' pagePathNavRef current x: ',
-      pagePathNavRef.current.getBoundingClientRect().x);
+    console.log(' sideBarWidth: ', sidebarWidth, ' pageControsX: ', pageControlsX, ' pagePathNavRef.x: ',
+      pagePathNavRef.current.getBoundingClientRect().x, ' pagePathNavRect.x: ', pagePathNavRect.x);
     return { maxWidth: `calc(${pageControlsX}px - ${pagePathNavRef.current.getBoundingClientRect().x}px - 10px)` };
-  }, [pageControlsX, pagePathNavRef, sidebarWidth, sidebarMode]);
+  }, [pageControlsX, pagePathNavRef, sidebarWidth, sidebarMode, pagePathNavRect]);
 
   return (
     // Controlling pointer-events

--- a/apps/app/src/components/Common/PagePathNav/PagePathNav.tsx
+++ b/apps/app/src/components/Common/PagePathNav/PagePathNav.tsx
@@ -1,5 +1,5 @@
-import type { FC } from 'react';
-import React from 'react';
+import type { CSSProperties, FC } from 'react';
+import React, { useMemo } from 'react';
 
 import { DevidedPagePath } from '@growi/core/dist/models';
 import { pagePathUtils } from '@growi/core/dist/utils';
@@ -7,6 +7,7 @@ import dynamic from 'next/dynamic';
 import Sticky from 'react-stickynode';
 
 import { useIsNotFound } from '~/stores/page';
+import { usePageControlsX } from '~/stores/ui';
 
 import LinkedPagePath from '../../../models/linked-page-path';
 import { PagePathHierarchicalLink } from '../PagePathHierarchicalLink';
@@ -107,6 +108,14 @@ export const PagePathNav: FC<Props> = (props: Props) => {
 type PagePathNavStickyProps = Omit<Props, 'isCollapseParents'>;
 
 export const PagePathNavSticky = (props: PagePathNavStickyProps): JSX.Element => {
+
+  const { data: pageControlsX } = usePageControlsX();
+  const maxWidth: CSSProperties | undefined = useMemo(() => {
+    if (pageControlsX == null) {
+      return;
+    }
+    return { maxWidth: `1000px - ${pageControlsX}` };
+  }, [pageControlsX]);
   return (
     // Controlling pointer-events
     //  1. disable pointer-events with 'pe-none'
@@ -117,7 +126,7 @@ export const PagePathNavSticky = (props: PagePathNavStickyProps): JSX.Element =>
           // Controlling pointer-events
           //  2. enable pointer-events with 'pe-auto' only against the children
           //      which width is minimized by 'd-inline-block'
-          <div className={`d-inline-block pe-auto ${isCollapseParents ? 'is-collapse-with-top' : ''}`}>
+          <div className="d-inline-block pe-auto" style={isCollapseParents ? maxWidth : {}}>
             <PagePathNav {...props} isCollapseParents={isCollapseParents} latterLinkClassName={isCollapseParents ? 'fs-3  text-truncate' : 'fs-2'} />
           </div>
         );

--- a/apps/app/src/components/Common/PagePathNav/PagePathNav.tsx
+++ b/apps/app/src/components/Common/PagePathNav/PagePathNav.tsx
@@ -1,8 +1,9 @@
 import type { CSSProperties, FC } from 'react';
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 
 import { DevidedPagePath } from '@growi/core/dist/models';
 import { pagePathUtils } from '@growi/core/dist/utils';
+import { useRect } from '@growi/ui/dist/utils';
 import dynamic from 'next/dynamic';
 import Sticky from 'react-stickynode';
 
@@ -110,12 +111,16 @@ type PagePathNavStickyProps = Omit<Props, 'isCollapseParents'>;
 export const PagePathNavSticky = (props: PagePathNavStickyProps): JSX.Element => {
 
   const { data: pageControlsX } = usePageControlsX();
-  const maxWidth: CSSProperties | undefined = useMemo(() => {
-    if (pageControlsX == null) {
+  const pagePathNavRef = useRef<HTMLDivElement>(null);
+  const [pagePathNavRect] = useRect(pagePathNavRef);
+
+  const navMaxWidth: CSSProperties | undefined = useMemo(() => {
+    if (pageControlsX == null || pagePathNavRect?.x == null) {
       return;
     }
-    return { maxWidth: `1000px - ${pageControlsX}` };
-  }, [pageControlsX]);
+    return { maxWidth: `calc(${pageControlsX}px - ${pagePathNavRect.x}px - 10px)` };
+  }, [pageControlsX, pagePathNavRect?.x]);
+
   return (
     // Controlling pointer-events
     //  1. disable pointer-events with 'pe-none'
@@ -126,7 +131,7 @@ export const PagePathNavSticky = (props: PagePathNavStickyProps): JSX.Element =>
           // Controlling pointer-events
           //  2. enable pointer-events with 'pe-auto' only against the children
           //      which width is minimized by 'd-inline-block'
-          <div className="d-inline-block pe-auto" style={isCollapseParents ? maxWidth : {}}>
+          <div className="d-inline-block pe-auto" style={isCollapseParents ? navMaxWidth : {}} ref={pagePathNavRef}>
             <PagePathNav {...props} isCollapseParents={isCollapseParents} latterLinkClassName={isCollapseParents ? 'fs-3  text-truncate' : 'fs-2'} />
           </div>
         );

--- a/apps/app/src/components/Common/PagePathNav/PagePathNav.tsx
+++ b/apps/app/src/components/Common/PagePathNav/PagePathNav.tsx
@@ -5,7 +5,6 @@ import React, {
 
 import { DevidedPagePath } from '@growi/core/dist/models';
 import { pagePathUtils } from '@growi/core/dist/utils';
-import { useRect } from '@growi/ui/dist/utils';
 import dynamic from 'next/dynamic';
 import Sticky from 'react-stickynode';
 
@@ -116,17 +115,16 @@ export const PagePathNavSticky = (props: PagePathNavStickyProps): JSX.Element =>
   const { data: sidebarWidth } = useCurrentProductNavWidth();
   const { data: sidebarMode } = useSidebarMode();
   const pagePathNavRef = useRef<HTMLDivElement>(null);
-  const [pagePathNavRect] = useRect(pagePathNavRef);
 
   const navMaxWidth: CSSProperties | undefined = useMemo(() => {
-    if (pageControlsX == null || pagePathNavRef.current == null || sidebarWidth == null || sidebarMode == null || pagePathNavRect == null) {
+    if (pageControlsX == null || pagePathNavRef.current == null || sidebarWidth == null || sidebarMode == null) {
       return;
     }
     // console.log('sideBarMode: ', sidebarMode, pagePathNavRef.current.getBoundingClientRect().x);
     console.log(' sideBarWidth: ', sidebarWidth, ' pageControsX: ', pageControlsX, ' pagePathNavRef.x: ',
-      pagePathNavRef.current.getBoundingClientRect().x, ' pagePathNavRect.x: ', pagePathNavRect.x);
+      pagePathNavRef.current.getBoundingClientRect().x);
     return { maxWidth: `calc(${pageControlsX}px - ${pagePathNavRef.current.getBoundingClientRect().x}px - 10px)` };
-  }, [pageControlsX, pagePathNavRef, sidebarWidth, sidebarMode, pagePathNavRect]);
+  }, [pageControlsX, pagePathNavRef, sidebarWidth, sidebarMode]);
 
   return (
     // Controlling pointer-events

--- a/apps/app/src/components/Common/PagePathNav/PagePathNav.tsx
+++ b/apps/app/src/components/Common/PagePathNav/PagePathNav.tsx
@@ -1,7 +1,6 @@
-import type { FC } from 'react';
 import React, {
   useEffect,
-  useMemo, useRef,
+  useRef,
   useState,
 } from 'react';
 
@@ -41,7 +40,7 @@ const Separator = ({ className }: {className?: string}): JSX.Element => {
   return <span className={`separator ${className ?? ''} ${styles['grw-mx-02em']}`}>/</span>;
 };
 
-export const PagePathNav: FC<Props> = (props: Props) => {
+export const PagePathNav = (props: Props): JSX.Element => {
   const {
     pageId, pagePath, isWipPage, isSingleLineMode, isCollapseParents,
     formerLinkClassName, latterLinkClassName, maxWidth,
@@ -111,6 +110,8 @@ export const PagePathNav: FC<Props> = (props: Props) => {
   );
 };
 
+PagePathNav.displayName = 'PagePathNav';
+
 
 type PagePathNavStickyProps = Omit<Props, 'isCollapseParents'>;
 
@@ -156,3 +157,5 @@ export const PagePathNavSticky = (props: PagePathNavStickyProps): JSX.Element =>
     </div>
   );
 };
+
+PagePathNavSticky.displayName = 'PagePathNavSticky';

--- a/apps/app/src/components/Common/PagePathNav/PagePathNav.tsx
+++ b/apps/app/src/components/Common/PagePathNav/PagePathNav.tsx
@@ -1,14 +1,15 @@
 import type { CSSProperties, FC } from 'react';
-import React, { useEffect, useMemo, useRef } from 'react';
+import React, {
+  useMemo, useRef,
+} from 'react';
 
 import { DevidedPagePath } from '@growi/core/dist/models';
 import { pagePathUtils } from '@growi/core/dist/utils';
-import { useRect } from '@growi/ui/dist/utils';
 import dynamic from 'next/dynamic';
 import Sticky from 'react-stickynode';
 
 import { useIsNotFound } from '~/stores/page';
-import { usePageControlsX } from '~/stores/ui';
+import { usePageControlsX, useCurrentProductNavWidth, useSidebarMode } from '~/stores/ui';
 
 import LinkedPagePath from '../../../models/linked-page-path';
 import { PagePathHierarchicalLink } from '../PagePathHierarchicalLink';
@@ -111,15 +112,19 @@ type PagePathNavStickyProps = Omit<Props, 'isCollapseParents'>;
 export const PagePathNavSticky = (props: PagePathNavStickyProps): JSX.Element => {
 
   const { data: pageControlsX } = usePageControlsX();
+  const { data: sidebarWidth } = useCurrentProductNavWidth();
+  const { data: sidebarMode } = useSidebarMode();
   const pagePathNavRef = useRef<HTMLDivElement>(null);
-  const [pagePathNavRect] = useRect(pagePathNavRef);
 
   const navMaxWidth: CSSProperties | undefined = useMemo(() => {
-    if (pageControlsX == null || pagePathNavRect?.x == null) {
+    if (pageControlsX == null || pagePathNavRef.current == null || sidebarWidth == null || sidebarMode == null) {
       return;
     }
-    return { maxWidth: `calc(${pageControlsX}px - ${pagePathNavRect.x}px - 10px)` };
-  }, [pageControlsX, pagePathNavRect?.x]);
+    // console.log('sideBarMode: ', sidebarMode, pagePathNavRef.current.getBoundingClientRect().x);
+    console.log(' sideBarWidth: ', sidebarWidth, ' pageControsX: ', pageControlsX, ' pagePathNavRef current x: ',
+      pagePathNavRef.current.getBoundingClientRect().x);
+    return { maxWidth: `calc(${pageControlsX}px - ${pagePathNavRef.current.getBoundingClientRect().x}px - 10px)` };
+  }, [pageControlsX, pagePathNavRef, sidebarWidth, sidebarMode]);
 
   return (
     // Controlling pointer-events

--- a/apps/app/src/components/Common/PagePathNav/PagePathNav.tsx
+++ b/apps/app/src/components/Common/PagePathNav/PagePathNav.tsx
@@ -123,19 +123,10 @@ export const PagePathNavSticky = (props: PagePathNavStickyProps): JSX.Element =>
 
   const [navMaxWidth, setNavMaxWidth] = useState<number | undefined>();
 
-  // const navMaxWidth: CSSProperties | undefined = useMemo(() => {
-  //   if (pageControlsX == null || pagePathNavRef.current == null || sidebarWidth == null || sidebarMode == null || isPreferCollapsedMode == null) {
-  //     return;
-  //   }
-  //   return { maxWidth: `calc(${pageControlsX}px - ${pagePathNavRef.current.getBoundingClientRect().x}px - 10px)` };
-  // }, [pageControlsX, pagePathNavRef, sidebarWidth, sidebarMode, isPreferCollapsedMode]);
-
-
   useEffect(() => {
     if (pageControlsX == null || pagePathNavRef.current == null || sidebarWidth == null || sidebarMode == null) {
       return;
     }
-    console.log(pagePathNavRef.current.getBoundingClientRect());
     setNavMaxWidth(pageControlsX - pagePathNavRef.current.getBoundingClientRect().x - 10);
   }, [pageControlsX, pagePathNavRef, sidebarWidth, sidebarMode]);
 

--- a/apps/app/src/components/Common/PagePathNav/PagePathNav.tsx
+++ b/apps/app/src/components/Common/PagePathNav/PagePathNav.tsx
@@ -120,15 +120,23 @@ export const PagePathNavSticky = (props: PagePathNavStickyProps): JSX.Element =>
   const { data: pageControlsX } = usePageControlsX();
   const { data: sidebarWidth } = useCurrentProductNavWidth();
   const { data: sidebarMode } = useSidebarMode();
-  const pagePathNavRef = useRef<HTMLDivElement | null>(null);
+  const pagePathNavRef = useRef<HTMLDivElement>(null);
 
   const [navMaxWidth, setNavMaxWidth] = useState<number | undefined>();
 
   useEffect(() => {
-    if (pageControlsX == null || pagePathNavRef.current == null || sidebarWidth == null || sidebarMode == null) {
-      return;
-    }
-    setNavMaxWidth(pageControlsX - pagePathNavRef.current.getBoundingClientRect().x - 10);
+
+    // wait for the end of the animation of the opening and closing of the sidebar
+    const timeout = setTimeout(() => {
+      if (pageControlsX == null || pagePathNavRef.current == null || sidebarWidth == null || sidebarMode == null) {
+        return;
+      }
+      setNavMaxWidth(pageControlsX - pagePathNavRef.current.getBoundingClientRect().x - 10);
+    }, 200);
+
+    return () => {
+      clearTimeout(timeout);
+    };
   }, [pageControlsX, pagePathNavRef, sidebarWidth, sidebarMode]);
 
   return (

--- a/apps/app/src/components/Common/PagePathNav/PagePathNav.tsx
+++ b/apps/app/src/components/Common/PagePathNav/PagePathNav.tsx
@@ -125,19 +125,24 @@ export const PagePathNavSticky = (props: PagePathNavStickyProps): JSX.Element =>
   const [navMaxWidth, setNavMaxWidth] = useState<number | undefined>();
 
   useEffect(() => {
+    if (pageControlsX == null || pagePathNavRef.current == null || sidebarWidth == null) {
+      return;
+    }
+    setNavMaxWidth(pageControlsX - pagePathNavRef.current.getBoundingClientRect().x - 10);
+  }, [pageControlsX, pagePathNavRef, sidebarWidth]);
 
+  useEffect(() => {
     // wait for the end of the animation of the opening and closing of the sidebar
     const timeout = setTimeout(() => {
-      if (pageControlsX == null || pagePathNavRef.current == null || sidebarWidth == null || sidebarMode == null) {
+      if (pageControlsX == null || pagePathNavRef.current == null || sidebarMode == null) {
         return;
       }
       setNavMaxWidth(pageControlsX - pagePathNavRef.current.getBoundingClientRect().x - 10);
     }, 200);
-
     return () => {
       clearTimeout(timeout);
     };
-  }, [pageControlsX, pagePathNavRef, sidebarWidth, sidebarMode]);
+  }, [pageControlsX, pagePathNavRef, sidebarMode]);
 
   return (
     // Controlling pointer-events

--- a/apps/app/src/components/PageControls/PageControls.tsx
+++ b/apps/app/src/components/PageControls/PageControls.tsx
@@ -1,4 +1,6 @@
-import React, { memo, useCallback, useMemo } from 'react';
+import React, {
+  memo, useCallback, useEffect, useMemo, useRef,
+} from 'react';
 
 import type {
   IPageInfoForOperation, IPageToDeleteWithMeta, IPageToRenameWithMeta,
@@ -6,6 +8,7 @@ import type {
 import {
   isIPageInfoForEntity, isIPageInfoForOperation,
 } from '@growi/core';
+import { useRect } from '@growi/ui/dist/utils';
 import { useTranslation } from 'next-i18next';
 import { DropdownItem } from 'reactstrap';
 
@@ -15,7 +18,9 @@ import {
 import { toastError } from '~/client/util/toastr';
 import { useIsGuestUser, useIsReadOnlyUser } from '~/stores/context';
 import { useTagEditModal, type IPageForPageDuplicateModal } from '~/stores/modal';
-import { EditorMode, useEditorMode, useIsDeviceLargerThanMd } from '~/stores/ui';
+import {
+  EditorMode, useEditorMode, useIsDeviceLargerThanMd, usePageControlsX,
+} from '~/stores/ui';
 import loggerFactory from '~/utils/logger';
 
 import { useSWRxPageInfo, useSWRxTagsInfo } from '../../stores/page';
@@ -131,6 +136,18 @@ const PageControlsSubstance = (props: PageControlsSubstanceProps): JSX.Element =
 
   const likerIds = isIPageInfoForEntity(pageInfo) ? (pageInfo.likerIds ?? []).slice(0, 15) : [];
   const seenUserIds = isIPageInfoForEntity(pageInfo) ? (pageInfo.seenUserIds ?? []).slice(0, 15) : [];
+
+  const { mutate: mutatePageControlsX } = usePageControlsX();
+  const pageControlsRef = useRef<HTMLDivElement>(null);
+  const [pageControlsRect] = useRect(pageControlsRef);
+
+  useEffect(() => {
+    if (pageControlsRect == null) {
+      return;
+    }
+    mutatePageControlsX(pageControlsRect.x);
+  }, [pageControlsRect, mutatePageControlsX]);
+
 
   // Put in a mixture of seenUserIds and likerIds data to make the cache work
   const { data: usersList } = useSWRxUsersList([...likerIds, ...seenUserIds]);
@@ -253,7 +270,7 @@ const PageControlsSubstance = (props: PageControlsSubstanceProps): JSX.Element =
   const isViewMode = editorMode === EditorMode.View;
 
   return (
-    <div className={`grw-page-controls ${styles['grw-page-controls']} d-flex`} style={{ gap: '2px' }}>
+    <div className={`grw-page-controls ${styles['grw-page-controls']} d-flex`} style={{ gap: '2px' }} ref={pageControlsRef}>
       { isDeviceLargerThanMd && (
         <SearchButton />
       )}

--- a/apps/app/src/components/PageControls/PageControls.tsx
+++ b/apps/app/src/components/PageControls/PageControls.tsx
@@ -137,16 +137,17 @@ const PageControlsSubstance = (props: PageControlsSubstanceProps): JSX.Element =
   const likerIds = isIPageInfoForEntity(pageInfo) ? (pageInfo.likerIds ?? []).slice(0, 15) : [];
   const seenUserIds = isIPageInfoForEntity(pageInfo) ? (pageInfo.seenUserIds ?? []).slice(0, 15) : [];
 
-  const { mutate: mutatePageControlsX } = usePageControlsX();
+  const { mutateAndSave: mutatePageControlsX } = usePageControlsX();
+
   const pageControlsRef = useRef<HTMLDivElement>(null);
   const [pageControlsRect] = useRect(pageControlsRef);
 
   useEffect(() => {
-    if (pageControlsRect == null) {
+    if (pageControlsRect?.x == null) {
       return;
     }
     mutatePageControlsX(pageControlsRect.x);
-  }, [pageControlsRect, mutatePageControlsX]);
+  }, [pageControlsRect?.x, mutatePageControlsX]);
 
 
   // Put in a mixture of seenUserIds and likerIds data to make the cache work

--- a/apps/app/src/interfaces/user-ui-settings.ts
+++ b/apps/app/src/interfaces/user-ui-settings.ts
@@ -1,7 +1,8 @@
-import { SidebarContentsType } from './ui';
+import type { SidebarContentsType } from './ui';
 
 export interface IUserUISettings {
   currentSidebarContents: SidebarContentsType,
+  currentPageControlsRect: DOMRect,
   currentProductNavWidth: number,
   preferCollapsedModeByUser: boolean,
 }

--- a/apps/app/src/interfaces/user-ui-settings.ts
+++ b/apps/app/src/interfaces/user-ui-settings.ts
@@ -2,7 +2,7 @@ import type { SidebarContentsType } from './ui';
 
 export interface IUserUISettings {
   currentSidebarContents: SidebarContentsType,
-  currentPageControlsRect: DOMRect,
+  currentPageControlsX: number,
   currentProductNavWidth: number,
   preferCollapsedModeByUser: boolean,
 }

--- a/apps/app/src/server/models/user-ui-settings.ts
+++ b/apps/app/src/server/models/user-ui-settings.ts
@@ -1,6 +1,7 @@
 import type { Ref, IUser } from '@growi/core';
+import type { Model, Document } from 'mongoose';
 import {
-  Schema, Model, Document,
+  Schema,
 } from 'mongoose';
 
 
@@ -21,6 +22,9 @@ const schema = new Schema<UserUISettingsDocument, UserUISettingsModel>({
     type: String,
     enum: SidebarContentsType,
     default: SidebarContentsType.RECENT,
+  },
+  currentPageControlsRect: {
+    type: DOMRect,
   },
   currentProductNavWidth: { type: Number },
   preferCollapsedModeByUser: { type: Boolean, default: false },

--- a/apps/app/src/server/models/user-ui-settings.ts
+++ b/apps/app/src/server/models/user-ui-settings.ts
@@ -23,8 +23,8 @@ const schema = new Schema<UserUISettingsDocument, UserUISettingsModel>({
     enum: SidebarContentsType,
     default: SidebarContentsType.RECENT,
   },
-  currentPageControlsRect: {
-    type: DOMRect,
+  currentPageControlsX: {
+    type: Number,
   },
   currentProductNavWidth: { type: Number },
   preferCollapsedModeByUser: { type: Boolean, default: false },

--- a/apps/app/src/stores/ui.tsx
+++ b/apps/app/src/stores/ui.tsx
@@ -271,15 +271,15 @@ export const useCurrentSidebarContents = (
   return withUtils(swrResponse, { mutateAndSave });
 };
 
-export const usePageControlsRect = (
-    initialData?: DOMRect,
-): SWRResponseWithUtils<MutateAndSaveUserUISettingsUtils<DOMRect>, DOMRect> => {
-  const swrResponse = useSWRStatic('pageControlsRect', initialData, { fallbackData: new DOMRect() });
+export const usePageControlsX = (
+    initialData?: number,
+): SWRResponseWithUtils<MutateAndSaveUserUISettingsUtils<number>, number> => {
+  const swrResponse = useSWRStatic('pageControlsX', initialData, { fallbackData: 1000 });
 
   const { mutate } = swrResponse;
 
-  const mutateAndSave: MutateAndSaveUserUISettings<DOMRect> = useCallback((data, opt?) => {
-    scheduleToPut({ currentPageControlsRect: data });
+  const mutateAndSave: MutateAndSaveUserUISettings<number> = useCallback((data, opt?) => {
+    scheduleToPut({ currentPageControlsX: data });
     return mutate(data, opt);
   }, [mutate]);
 

--- a/apps/app/src/stores/ui.tsx
+++ b/apps/app/src/stores/ui.tsx
@@ -271,6 +271,21 @@ export const useCurrentSidebarContents = (
   return withUtils(swrResponse, { mutateAndSave });
 };
 
+export const usePageControlsRect = (
+    initialData?: DOMRect,
+): SWRResponseWithUtils<MutateAndSaveUserUISettingsUtils<DOMRect>, DOMRect> => {
+  const swrResponse = useSWRStatic('pageControlsRect', initialData, { fallbackData: new DOMRect() });
+
+  const { mutate } = swrResponse;
+
+  const mutateAndSave: MutateAndSaveUserUISettings<DOMRect> = useCallback((data, opt?) => {
+    scheduleToPut({ currentPageControlsRect: data });
+    return mutate(data, opt);
+  }, [mutate]);
+
+  return withUtils(swrResponse, { mutateAndSave });
+};
+
 export const useCurrentProductNavWidth = (initialData?: number): SWRResponseWithUtils<MutateAndSaveUserUISettingsUtils<number>, number> => {
   const swrResponse = useSWRStatic('productNavWidth', initialData, { fallbackData: 320 });
 


### PR DESCRIPTION
# Summary
- View におけるページタイトルが Sticky になったときに正常に省略されるようにする。
- 正常にとは、Sidebar の開閉、ドラッグ時にその広さに対応した長さにできるようにすることである。

# Task 
- https://redmine.weseek.co.jp/issues/143964
  - https://redmine.weseek.co.jp/issues/144048