### PR TITLE
imprv: Sm size dropdown menu

### DIFF
--- a/apps/app/src/components/PageControls/PageControls.tsx
+++ b/apps/app/src/components/PageControls/PageControls.tsx
@@ -292,7 +292,6 @@ const PageControlsSubstance = (props: PageControlsSubstanceProps): JSX.Element =
       ) }
       { showPageControlDropdown && _isIPageInfoForOperation && (
         <PageItemControl
-          alignEnd
           pageId={pageId}
           pageInfo={pageInfo}
           isEnableActions={!isGuestUser}


### PR DESCRIPTION
# Task
- https://redmine.weseek.co.jp/issues/144386

# 概要
- smサイズでドロップダウンの一部が画面の外に表示されてしまう問題の解決

# スクリーンショット
- ![image](https://github.com/weseek/growi/assets/113958844/1f48b6b3-5b3d-42e1-8910-9c310d175bc2)
- <img width="395" alt="image" src="https://github.com/weseek/growi/assets/113958844/f8a53f8f-9977-4583-93d8-395eccef1cf9">

- ![image](https://github.com/weseek/growi/assets/113958844/9ccceb06-ecff-471b-8b12-461fc59793c0)

