### PR TITLE
fix: CopyDropdown hidden behind modal issue

### DIFF
--- a/apps/app/src/components/Common/CopyDropdown/CopyDropdown.jsx
+++ b/apps/app/src/components/Common/CopyDropdown/CopyDropdown.jsx
@@ -120,7 +120,6 @@ export const CopyDropdown = (props) => {
 
         <DropdownMenu
           strategy="fixed"
-          container="body"
         >
           <div className="d-flex align-items-center justify-content-between">
             <DropdownItem header className="px-3">


### PR DESCRIPTION
## タスク
https://redmine.weseek.co.jp/issues/144644
## 概要
- CopyDropdown がモーダルの後ろに隠れる問題を修正しました。
## 変更点
- DropdownMenuに指定されていたcontainer="body"というpropsを消去しました。
- これによって、Dropdownがbody配下にレンダリングされなくなりました。

## 後続タスク
https://redmine.weseek.co.jp/issues/144765

## セルフチェック
- [x] コンフリクト解消したか
- [x] 余計なコードは残っていないか
- [x] 適切にメモ化したか
- [x] 責務の問題はクリアしているか
- [x] CIは通っているか
- [x] PRの内容は適切にかけているか