### PR TITLE
fix: Always autofocus when moving to the Editor

### DIFF
--- a/apps/app/src/components/PageEditor/PageEditor.tsx
+++ b/apps/app/src/components/PageEditor/PageEditor.tsx
@@ -273,26 +273,10 @@ export const PageEditor = React.memo((props: Props): JSX.Element => {
     };
   }, [saveAndReturnToViewHandler]);
 
-
-  // TODO: https://redmine.weseek.co.jp/issues/142729
-  // https://regex101.com/r/Wg2Hh6/1
-  // initial caret line
-  useEffect(() => {
-    const untitledPageRegex = /^Untitled-\d+$/;
-    const isNewlyCreatedPage = (
-      currentPage?.wip && currentPage?.latestRevision == null && untitledPageRegex.test(nodePath.basename(currentPage?.path ?? ''))
-    ) ?? false;
-    if (!isNewlyCreatedPage) {
-      codeMirrorEditor?.setCaretLine();
-    }
-  }, [codeMirrorEditor, currentPage]);
-
   // set handler to focus
   useLayoutEffect(() => {
-    if (editorMode === EditorMode.Editor) {
-      codeMirrorEditor?.focus();
-    }
-  }, [codeMirrorEditor, editorMode]);
+    codeMirrorEditor?.focus();
+  }, [codeMirrorEditor, currentPage, editorMode]);
 
   // Detect indent size from contents (only when users are allowed to change it)
   useEffect(() => {

--- a/apps/app/src/components/PageEditor/PageEditor.tsx
+++ b/apps/app/src/components/PageEditor/PageEditor.tsx
@@ -275,7 +275,9 @@ export const PageEditor = React.memo((props: Props): JSX.Element => {
 
   // set handler to focus
   useLayoutEffect(() => {
-    codeMirrorEditor?.focus();
+    if (editorMode === EditorMode.Editor) {
+      codeMirrorEditor?.focus();
+    }
   }, [codeMirrorEditor, currentPage, editorMode]);
 
   // Detect indent size from contents (only when users are allowed to change it)

--- a/apps/app/src/components/PageHeader/PageTitleHeader.tsx
+++ b/apps/app/src/components/PageHeader/PageTitleHeader.tsx
@@ -84,11 +84,13 @@ export const PageTitleHeader: FC<Props> = (props) => {
     setRenameInputShown(true);
   }, [currentPagePath, isMovable]);
 
-  useEffect(() => {
-    if (isNewlyCreatedPage) {
-      setRenameInputShown(true);
-    }
-  }, [currentPage._id, isNewlyCreatedPage]);
+  // TODO: auto focus when create new page
+  // https://redmine.weseek.co.jp/issues/136128
+  // useEffect(() => {
+  //   if (isNewlyCreatedPage) {
+  //     setRenameInputShown(true);
+  //   }
+  // }, [currentPage._id, isNewlyCreatedPage]);
 
   return (
     <div className={`d-flex ${moduleClass} ${props.className ?? ''} position-relative`}>


### PR DESCRIPTION
# Summary
- Editor に遷移した際、どのような遷移の仕方であっても Editor にオートフォーカスするようにする。

# Task
- https://redmine.weseek.co.jp/issues/144674
  - https://redmine.weseek.co.jp/issues/144679