### PR TITLE
fix: CopyDropdown protrudes from the screen issue

### DIFF
--- a/apps/app/src/components/Common/CopyDropdown/CopyDropdown.jsx
+++ b/apps/app/src/components/Common/CopyDropdown/CopyDropdown.jsx
@@ -155,7 +155,6 @@ export const CopyDropdown = (props) => {
                 title={t('copy_to_clipboard.Page path')}
                 contents={pagePathWithParams}
                 className="text-truncate d-block"
-                // style={{ direction: 'rtl' }}
               />
             </DropdownItem>
           </CopyToClipboard>
@@ -169,7 +168,6 @@ export const CopyDropdown = (props) => {
                 title={t('copy_to_clipboard.Page URL')}
                 contents={pagePathUrl}
                 className="text-truncate d-block"
-                // style={{ direction: 'rtl' }}
               />
             </DropdownItem>
           </CopyToClipboard>
@@ -183,7 +181,6 @@ export const CopyDropdown = (props) => {
                   title={t('copy_to_clipboard.Permanent link')}
                   contents={permalink}
                   className="text-truncate d-block"
-                  // style={{ direction: 'rtl' }}
                 />
               </DropdownItem>
             </CopyToClipboard>

--- a/apps/app/src/components/Common/CopyDropdown/CopyDropdown.jsx
+++ b/apps/app/src/components/Common/CopyDropdown/CopyDropdown.jsx
@@ -110,7 +110,12 @@ export const CopyDropdown = (props) => {
 
   return (
     <>
-      <Dropdown className={`${styles['grw-copy-dropdown']} grw-copy-dropdown d-print-none`} isOpen={dropdownOpen} size="sm" toggle={toggleDropdown}>
+      <Dropdown
+        className={`${styles['grw-copy-dropdown']} grw-copy-dropdown d-print-none`}
+        isOpen={dropdownOpen}
+        size="sm"
+        toggle={toggleDropdown}
+      >
         <DropdownToggle
           caret={isShareLinkMode}
           className={`btn-copy ${dropdownToggleClassName}`}
@@ -143,7 +148,7 @@ export const CopyDropdown = (props) => {
 
           {/* Page path */}
           <CopyToClipboard text={pagePathWithParams} onCopy={showToolTip}>
-            <DropdownItem className="px-3">
+            <DropdownItem className="px-3 text-wrap">
               <DropdownItemContents title={t('copy_to_clipboard.Page path')} contents={pagePathWithParams} />
             </DropdownItem>
           </CopyToClipboard>
@@ -152,7 +157,7 @@ export const CopyDropdown = (props) => {
 
           {/* Page path URL */}
           <CopyToClipboard text={pagePathUrl} onCopy={showToolTip}>
-            <DropdownItem className="px-3">
+            <DropdownItem className="px-3 text-wrap">
               <DropdownItemContents title={t('copy_to_clipboard.Page URL')} contents={pagePathUrl} />
             </DropdownItem>
           </CopyToClipboard>
@@ -161,7 +166,7 @@ export const CopyDropdown = (props) => {
           {/* Permanent Link */}
           { pageId && (
             <CopyToClipboard text={permalink} onCopy={showToolTip}>
-              <DropdownItem className="px-3">
+              <DropdownItem className="px-3 text-wrap">
                 <DropdownItemContents title={t('copy_to_clipboard.Permanent link')} contents={permalink} />
               </DropdownItem>
             </CopyToClipboard>
@@ -172,7 +177,7 @@ export const CopyDropdown = (props) => {
           {/* Page path + Permanent Link */}
           { pageId && (
             <CopyToClipboard text={`${pagePathWithParams}\n${permalink}`} onCopy={showToolTip}>
-              <DropdownItem className="px-3">
+              <DropdownItem className="px-3 text-wrap">
                 <DropdownItemContents
                   title={t('copy_to_clipboard.Page path and permanent link')}
                   contents={<>{pagePathWithParams}<br />{permalink}</>}

--- a/apps/app/src/components/Common/CopyDropdown/CopyDropdown.jsx
+++ b/apps/app/src/components/Common/CopyDropdown/CopyDropdown.jsx
@@ -16,10 +16,12 @@ import styles from './CopyDropdown.module.scss';
 const { encodeSpaces } = pagePathUtils;
 
 /* eslint-disable react/prop-types */
-const DropdownItemContents = ({ title, contents }) => (
+const DropdownItemContents = ({
+  title, contents, className, style,
+}) => (
   <>
     <div className="h6 mt-1 mb-2"><strong>{title}</strong></div>
-    <div className="card custom-card mb-1 p-2">{contents}</div>
+    <div className={`card custom-card mb-1 p-2 ${className}`} style={style}>{contents}</div>
   </>
 );
 /* eslint-enable react/prop-types */
@@ -148,8 +150,13 @@ export const CopyDropdown = (props) => {
 
           {/* Page path */}
           <CopyToClipboard text={pagePathWithParams} onCopy={showToolTip}>
-            <DropdownItem className="px-3 text-wrap">
-              <DropdownItemContents title={t('copy_to_clipboard.Page path')} contents={pagePathWithParams} />
+            <DropdownItem className="px-3">
+              <DropdownItemContents
+                title={t('copy_to_clipboard.Page path')}
+                contents={pagePathWithParams}
+                className="text-truncate d-block"
+                // style={{ direction: 'rtl' }}
+              />
             </DropdownItem>
           </CopyToClipboard>
 
@@ -157,8 +164,13 @@ export const CopyDropdown = (props) => {
 
           {/* Page path URL */}
           <CopyToClipboard text={pagePathUrl} onCopy={showToolTip}>
-            <DropdownItem className="px-3 text-wrap">
-              <DropdownItemContents title={t('copy_to_clipboard.Page URL')} contents={pagePathUrl} />
+            <DropdownItem className="px-3">
+              <DropdownItemContents
+                title={t('copy_to_clipboard.Page URL')}
+                contents={pagePathUrl}
+                className="text-truncate d-block"
+                // style={{ direction: 'rtl' }}
+              />
             </DropdownItem>
           </CopyToClipboard>
           <DropdownItem divider className="my-0"></DropdownItem>
@@ -166,8 +178,13 @@ export const CopyDropdown = (props) => {
           {/* Permanent Link */}
           { pageId && (
             <CopyToClipboard text={permalink} onCopy={showToolTip}>
-              <DropdownItem className="px-3 text-wrap">
-                <DropdownItemContents title={t('copy_to_clipboard.Permanent link')} contents={permalink} />
+              <DropdownItem className="px-3">
+                <DropdownItemContents
+                  title={t('copy_to_clipboard.Permanent link')}
+                  contents={permalink}
+                  className="text-truncate d-block"
+                  // style={{ direction: 'rtl' }}
+                />
               </DropdownItem>
             </CopyToClipboard>
           )}
@@ -177,10 +194,12 @@ export const CopyDropdown = (props) => {
           {/* Page path + Permanent Link */}
           { pageId && (
             <CopyToClipboard text={`${pagePathWithParams}\n${permalink}`} onCopy={showToolTip}>
-              <DropdownItem className="px-3 text-wrap">
+              <DropdownItem className="px-3">
                 <DropdownItemContents
                   title={t('copy_to_clipboard.Page path and permanent link')}
                   contents={<>{pagePathWithParams}<br />{permalink}</>}
+                  className="text-truncate"
+                  style={{ direction: 'rtl' }}
                 />
               </DropdownItem>
             </CopyToClipboard>

--- a/apps/app/src/components/Common/CopyDropdown/CopyDropdown.module.scss
+++ b/apps/app/src/components/Common/CopyDropdown/CopyDropdown.module.scss
@@ -9,6 +9,11 @@
 
   .dropdown-menu {
     min-width: 310px;
+    max-width: 375px;
+
+    @include bs.media-breakpoint-up(md) {
+      max-width: 600px;
+    }
 
     .dropdown-header {
       margin-bottom: 0.5em;


### PR DESCRIPTION
## タスク
https://redmine.weseek.co.jp/issues/144765
## 概要
- ページ名が長い場合にCopyDropdownがサイドバーの後ろに隠れたり、画面外にはみ出してしまう問題を解決しました。

## 変更点
- DropdownItemContentsに新たにpropsを設定しました。
- .dropdown-menu にbreakpointを設定し、新たにスタイルを設定しました。

## デザインについての詳細仕様
以下の仕様は全てfumiya-sと合意済みです。
https://wsgrowi.slack.com/archives/C05HK5SA8CC/p1713347696195269
- 「ページ名」、「ページURL」は後ろをtruncateする
- 「ページ名とパーマリンク」は前をtruncateする
- それ以外はtruncateしない
- Dropdownのmax-widthはmd以上で600px、md未満で375px

## スクリーンショット
![image (2)](https://github.com/weseek/growi/assets/83588003/e529c0f6-100c-46fc-ac1a-280b7ae2d375)
![image (1)](https://github.com/weseek/growi/assets/83588003/2e084058-5ae4-4cfe-853d-a80b5204ce3e)


## セルフチェック
- [x] コンフリクト解消したか
- [x] 余計なコードは残っていないか
- [x] 適切にメモ化したか
- [x] 責務の問題はクリアしているか
- [x] CIは通っているか
- [x] PRの内容は適切にかけているか