### PR TITLE
fix: Error on today's memo create from hotkey when memo exists

### DIFF
--- a/apps/app/src/server/routes/apiv3/page/check-page-existence.ts
+++ b/apps/app/src/server/routes/apiv3/page/check-page-existence.ts
@@ -1,5 +1,6 @@
 import type { IPage, IUserHasId } from '@growi/core';
 import { ErrorV3 } from '@growi/core/dist/models';
+import { normalizePath } from '@growi/core/dist/utils/path-utils';
 import type { Request, RequestHandler } from 'express';
 import type { ValidationChain } from 'express-validator';
 import { query } from 'express-validator';
@@ -44,10 +45,11 @@ export const checkPageExistenceHandlersFactory: CreatePageHandlersFactory = (cro
       const { path } = req.query;
 
       if (path == null || Array.isArray(path)) {
-        return res.apiv3Err(new ErrorV3('The param "path" must be an page id'));
+        return res.apiv3Err(new ErrorV3('The param "path" must be a string'));
       }
 
-      const count = await Page.countByPathAndViewer(path.toString(), req.user);
+      const normalizedPath = normalizePath(path.toString());
+      const count = await Page.countByPathAndViewer(normalizedPath, req.user);
       res.apiv3({ isExist: count > 0 });
     },
   ];


### PR DESCRIPTION
## task
https://redmine.weseek.co.jp/issues/144854

## 方針
hotkey からの今日のメモ作成で、ページ名を空にしていると最後に '/' がついてしまうため、それが原因で正確にページの存在の有無を判断できていなかった。
https://github.com/weseek/growi/blob/bff088d2ab0b40b49c235d355348b0dd96f0774f/apps/app/src/components/PageCreateModal.tsx#L96
これを取り除くために、API 側で normalize する (ページ作成 API と同じ挙動)。