### PR TITLE
fix: EditingUserList shows user icons even when the user is not opening the editor

### DIFF
--- a/apps/app/src/components/PageEditor/PageEditor.tsx
+++ b/apps/app/src/components/PageEditor/PageEditor.tsx
@@ -353,6 +353,7 @@ export const PageEditor = React.memo((props: Props): JSX.Element => {
       <div className={`flex-expand-horiz ${props.visibility ? '' : 'd-none'}`}>
         <div className="page-editor-editor-container flex-expand-vert border-end">
           <CodeMirrorEditorMain
+            isEditorMode={editorMode === EditorMode.Editor}
             onChange={markdownChangedHandler}
             onSave={saveWithShortcut}
             onUpload={uploadHandler}

--- a/packages/editor/src/components/CodeMirrorEditorMain.tsx
+++ b/packages/editor/src/components/CodeMirrorEditorMain.tsx
@@ -21,18 +21,19 @@ type Props = CodeMirrorEditorProps & {
   user?: IUserHasId,
   pageId?: string,
   initialValue?: string,
+  isEditorMode: boolean,
   onEditorsUpdated?: (userList: IUserHasId[]) => void,
 }
 
 export const CodeMirrorEditorMain = (props: Props): JSX.Element => {
   const {
-    user, pageId, initialValue,
+    user, pageId, initialValue, isEditorMode,
     onSave, onEditorsUpdated, ...otherProps
   } = props;
 
   const { data: codeMirrorEditor } = useCodeMirrorEditorIsolated(GlobalCodeMirrorEditorKey.MAIN);
 
-  useCollaborativeEditorMode(user, pageId, initialValue, onEditorsUpdated, codeMirrorEditor);
+  useCollaborativeEditorMode(isEditorMode, user, pageId, initialValue, onEditorsUpdated, codeMirrorEditor);
 
   // setup additional extensions
   useEffect(() => {

--- a/packages/editor/src/components/playground/Playground.tsx
+++ b/packages/editor/src/components/playground/Playground.tsx
@@ -70,6 +70,7 @@ export const Playground = (): JSX.Element => {
       <div className="flex-expand-horiz">
         <div className="flex-expand-vert">
           <CodeMirrorEditorMain
+            isEditorMode
             onSave={saveHandler}
             onChange={setMarkdownToPreview}
             onUpload={uploadHandler}

--- a/packages/editor/src/stores/use-collaborative-editor-mode.ts
+++ b/packages/editor/src/stores/use-collaborative-editor-mode.ts
@@ -18,7 +18,7 @@ type UserLocalState = {
 }
 
 export const useCollaborativeEditorMode = (
-    isEditorMode: boolean,
+    isEnabled: boolean,
     user?: IUserHasId,
     pageId?: string,
     initialValue?: string,
@@ -32,7 +32,7 @@ export const useCollaborativeEditorMode = (
   const { data: socket } = useGlobalSocket();
 
   const cleanupYDoc = () => {
-    if (cPageId === pageId && isEditorMode) {
+    if (cPageId === pageId && isEnabled) {
       return;
     }
 
@@ -53,7 +53,7 @@ export const useCollaborativeEditorMode = (
   };
 
   const setupYDoc = () => {
-    if (ydoc != null || !isEditorMode) {
+    if (ydoc != null || !isEnabled) {
       return;
     }
 
@@ -130,8 +130,8 @@ export const useCollaborativeEditorMode = (
     };
   };
 
-  useEffect(cleanupYDoc, [cPageId, isEditorMode, onEditorsUpdated, pageId, provider, socket, ydoc]);
-  useEffect(setupYDoc, [isEditorMode, provider, ydoc]);
+  useEffect(cleanupYDoc, [cPageId, isEnabled, onEditorsUpdated, pageId, provider, socket, ydoc]);
+  useEffect(setupYDoc, [isEnabled, provider, ydoc]);
   useEffect(setupProvider, [initialValue, onEditorsUpdated, pageId, provider, socket, user, ydoc]);
   useEffect(setupYDocExtensions, [codeMirrorEditor, provider, ydoc]);
 };

--- a/packages/editor/src/stores/use-collaborative-editor-mode.ts
+++ b/packages/editor/src/stores/use-collaborative-editor-mode.ts
@@ -31,7 +31,8 @@ export const useCollaborativeEditorMode = (
 
   const { data: socket } = useGlobalSocket();
 
-  const cleanupYDoc = () => {
+  // Cleanup Ydoc
+  useEffect(() => {
     if (cPageId === pageId && isEnabled) {
       return;
     }
@@ -50,9 +51,10 @@ export const useCollaborativeEditorMode = (
 
     // reset editors
     onEditorsUpdated?.([]);
-  };
+  }, [cPageId, isEnabled, onEditorsUpdated, pageId, provider?.awareness, socket, ydoc]);
 
-  const setupYDoc = () => {
+  // Setup Ydoc
+  useEffect(() => {
     if (ydoc != null || !isEnabled) {
       return;
     }
@@ -64,9 +66,10 @@ export const useCollaborativeEditorMode = (
 
     const _ydoc = new Y.Doc();
     setYdoc(_ydoc);
-  };
+  }, [isEnabled, provider, ydoc]);
 
-  const setupProvider = () => {
+  // Setup provider
+  useEffect(() => {
     if (provider != null || ydoc == null || socket == null || onEditorsUpdated == null) {
       return;
     }
@@ -105,9 +108,10 @@ export const useCollaborativeEditorMode = (
     });
 
     setProvider(socketIOProvider);
-  };
+  }, [initialValue, onEditorsUpdated, pageId, provider, socket, user, ydoc]);
 
-  const setupYDocExtensions = () => {
+  // Setup Ydoc Extensions
+  useEffect(() => {
     if (ydoc == null || provider == null || codeMirrorEditor == null) {
       return;
     }
@@ -128,10 +132,5 @@ export const useCollaborativeEditorMode = (
       cleanupYUndoManagerKeymap?.();
       cleanupYCollab?.();
     };
-  };
-
-  useEffect(cleanupYDoc, [cPageId, isEnabled, onEditorsUpdated, pageId, provider, socket, ydoc]);
-  useEffect(setupYDoc, [isEnabled, provider, ydoc]);
-  useEffect(setupProvider, [initialValue, onEditorsUpdated, pageId, provider, socket, user, ydoc]);
-  useEffect(setupYDocExtensions, [codeMirrorEditor, provider, ydoc]);
+  }, [codeMirrorEditor, provider, ydoc]);
 };

--- a/packages/editor/src/stores/use-collaborative-editor-mode.ts
+++ b/packages/editor/src/stores/use-collaborative-editor-mode.ts
@@ -18,6 +18,7 @@ type UserLocalState = {
 }
 
 export const useCollaborativeEditorMode = (
+    isEditorMode: boolean,
     user?: IUserHasId,
     pageId?: string,
     initialValue?: string,
@@ -31,7 +32,7 @@ export const useCollaborativeEditorMode = (
   const { data: socket } = useGlobalSocket();
 
   const cleanupYDoc = () => {
-    if (cPageId === pageId) {
+    if (cPageId === pageId && isEditorMode) {
       return;
     }
 
@@ -52,7 +53,7 @@ export const useCollaborativeEditorMode = (
   };
 
   const setupYDoc = () => {
-    if (ydoc != null) {
+    if (ydoc != null || !isEditorMode) {
       return;
     }
 
@@ -129,8 +130,8 @@ export const useCollaborativeEditorMode = (
     };
   };
 
-  useEffect(cleanupYDoc, [cPageId, onEditorsUpdated, pageId, provider, socket, ydoc]);
-  useEffect(setupYDoc, [provider, ydoc]);
+  useEffect(cleanupYDoc, [cPageId, isEditorMode, onEditorsUpdated, pageId, provider, socket, ydoc]);
+  useEffect(setupYDoc, [isEditorMode, provider, ydoc]);
   useEffect(setupProvider, [initialValue, onEditorsUpdated, pageId, provider, socket, user, ydoc]);
   useEffect(setupYDocExtensions, [codeMirrorEditor, provider, ydoc]);
 };


### PR DESCRIPTION
## Task
[#141939](https://redmine.weseek.co.jp/issues/141939) [v7] View 画面を開いている時にそのユーザーが Editor 画面の執筆中アイコンに表示されてしまう
┗ [#144321](https://redmine.weseek.co.jp/issues/144321) 修正

## ScreenRecord
https://github.com/weseek/growi/assets/34241526/9f6b2627-b0d5-4f00-8f04-8b9e92a002df

