### PR TITLE
fix: Behaviour of table operation by enter key in editor

### DIFF
--- a/packages/editor/src/services/table-util/insert-new-row-to-table-markdown.ts
+++ b/packages/editor/src/services/table-util/insert-new-row-to-table-markdown.ts
@@ -130,14 +130,14 @@ const removeRow = (editor: EditorView) => {
   const bolPos = editor.state.doc.line(curLine).from;
   const eolPos = editor.state.doc.line(curLine).to;
 
-  const nextCurPos = editor.state.doc.lineAt(getCurPos(editor)).to + 1;
-
   editor.dispatch({
     changes: {
       from: bolPos,
       to: eolPos,
     },
   });
+
+  const nextCurPos = editor.state.doc.lineAt(getCurPos(editor)).to + 1;
 
   editor.dispatch({
     selection: { anchor: nextCurPos },


### PR DESCRIPTION
## タスク
https://redmine.weseek.co.jp/issues/144502
## 概要
- editor内でのテーブル操作の挙動を修正しました。
## 変更点
- removeRow関数内で、テーブルの行を削除した後に、カーソルが遷移する場所を決定するようにしました。
- これによって、副作用を適切に扱うことができるようになりました。

## セルフチェック
- [x] コンフリクト解消したか
- [x] 余計なコードは残っていないか
- [x] 適切にメモ化したか
- [x] 責務の問題はクリアしているか
- [x] CIは通っているか
- [x] PRの内容は適切にかけているか