### PR TITLE
fix: Tags are not created when space key is entered (Firefox)

### DIFF
--- a/apps/app/src/components/PageTags/TagsInput.tsx
+++ b/apps/app/src/components/PageTags/TagsInput.tsx
@@ -39,7 +39,7 @@ export const TagsInput: FC<Props> = (props: Props) => {
   }, [tagsSearch?.tags]);
 
   const keyDownHandler = useCallback((event: KeyboardEvent<HTMLElement>) => {
-    if (event.key === ' ') {
+    if (event.key === ' ' || event.key === '　') {
       event.preventDefault();
 
       // fix: https://redmine.weseek.co.jp/issues/140689

--- a/apps/app/src/components/PageTags/TagsInput.tsx
+++ b/apps/app/src/components/PageTags/TagsInput.tsx
@@ -39,7 +39,7 @@ export const TagsInput: FC<Props> = (props: Props) => {
   }, [tagsSearch?.tags]);
 
   const keyDownHandler = useCallback((event: KeyboardEvent<HTMLElement>) => {
-    if (event.key === ' ' || event.key === '　') {
+    if (event.code === 'Space') {
       event.preventDefault();
 
       // fix: https://redmine.weseek.co.jp/issues/140689


### PR DESCRIPTION
## Task
[#140689](https://redmine.weseek.co.jp/issues/140689) [v7] タグ作成時 日本語入力でスペースを打つと変換中にタグが確定してしまう
┗ [#144840](https://redmine.weseek.co.jp/issues/144840) スペースキーを入力してもタグが作成されない (Firefox)