### PR TITLE
fix: Parent group selection dropdown does not work

### DIFF
--- a/apps/app/src/components/Admin/UserGroup/UserGroupForm.tsx
+++ b/apps/app/src/components/Admin/UserGroup/UserGroupForm.tsx
@@ -21,8 +21,6 @@ export const UserGroupForm: FC<Props> = (props: Props) => {
   const {
     userGroup, parentUserGroup, selectableParentUserGroups, submitButtonLabel, onSubmit, isExternalGroup = false,
   } = props;
-
-  console.log('selectableParentUserGroups', selectableParentUserGroups);
   /*
    * State
    */
@@ -51,8 +49,6 @@ export const UserGroupForm: FC<Props> = (props: Props) => {
   }, [parentUserGroup]);
 
   const isSelectableParentUserGroups = selectableParentUserGroups != null && selectableParentUserGroups.length > 0;
-
-  console.log('isSelectableParentUserGroups', isSelectableParentUserGroups);
 
   const isChildUserGroup = parentUserGroup !== undefined;
   const messageAtReleaseParentGroup = isChildUserGroup ? t('user_group_management.release_parent_group') : t('user_group_management.select_parent_group');

--- a/apps/app/src/components/Admin/UserGroup/UserGroupForm.tsx
+++ b/apps/app/src/components/Admin/UserGroup/UserGroupForm.tsx
@@ -21,6 +21,8 @@ export const UserGroupForm: FC<Props> = (props: Props) => {
   const {
     userGroup, parentUserGroup, selectableParentUserGroups, submitButtonLabel, onSubmit, isExternalGroup = false,
   } = props;
+
+  console.log('selectableParentUserGroups', selectableParentUserGroups);
   /*
    * State
    */
@@ -49,6 +51,8 @@ export const UserGroupForm: FC<Props> = (props: Props) => {
   }, [parentUserGroup]);
 
   const isSelectableParentUserGroups = selectableParentUserGroups != null && selectableParentUserGroups.length > 0;
+
+  console.log('isSelectableParentUserGroups', isSelectableParentUserGroups);
 
   const isChildUserGroup = parentUserGroup !== undefined;
   const messageAtReleaseParentGroup = isChildUserGroup ? t('user_group_management.release_parent_group') : t('user_group_management.select_parent_group');
@@ -116,7 +120,7 @@ export const UserGroupForm: FC<Props> = (props: Props) => {
             <button
               type="button"
               id="dropdownMenuButton"
-              data-toggle="dropdown"
+              data-bs-toggle="dropdown"
               className="btn btn-outline-secondary dropdown-toggle mb-3"
               disabled={isExternalGroup || !isSelectableParentUserGroups}
             >


### PR DESCRIPTION
## Task
[#144684](https://redmine.weseek.co.jp/issues/144684) [v7] 管理画面_グループ管理にて子グループを作成した際に親グループの指定のプルダウンが反応しない件の修正
┗ [#145168](https://redmine.weseek.co.jp/issues/145168) 修正