### PR TITLE
fix: Editor theme active line (material, nord)

### DIFF
--- a/packages/editor/src/services/editor-theme/material.ts
+++ b/packages/editor/src/services/editor-theme/material.ts
@@ -35,6 +35,8 @@ const tooltipBackground = base01;
 const selection = base01;
 // Change color
 const cursor = base05;
+// Create New color
+const activeLineBackground = '#00000020';
 
 // / The editor theme styles for Material Dark.
 export const materialDarkTheme = EditorView.theme(
@@ -64,7 +66,8 @@ export const materialDarkTheme = EditorView.theme(
       backgroundColor: highlightBackground,
     },
 
-    '.cm-activeLine': { backgroundColor: highlightBackground },
+    // Custom
+    '.cm-activeLine': { backgroundColor: activeLineBackground },
     '.cm-selectionMatch': {
       backgroundColor: darkBackground,
       outline: `1px solid ${base_teal}`,
@@ -85,8 +88,9 @@ export const materialDarkTheme = EditorView.theme(
       color: base02,
     },
 
+    // Custom
     '.cm-activeLineGutter': {
-      backgroundColor: highlightBackground,
+      backgroundColor: activeLineBackground,
       color: base07,
     },
 

--- a/packages/editor/src/services/editor-theme/material.ts
+++ b/packages/editor/src/services/editor-theme/material.ts
@@ -66,7 +66,7 @@ export const materialDarkTheme = EditorView.theme(
       backgroundColor: highlightBackground,
     },
 
-    // Custom
+    // Customize
     '.cm-activeLine': { backgroundColor: activeLineBackground },
     '.cm-selectionMatch': {
       backgroundColor: darkBackground,
@@ -88,7 +88,7 @@ export const materialDarkTheme = EditorView.theme(
       color: base02,
     },
 
-    // Custom
+    // Customize
     '.cm-activeLineGutter': {
       backgroundColor: activeLineBackground,
       color: base07,

--- a/packages/editor/src/services/editor-theme/nord.ts
+++ b/packages/editor/src/services/editor-theme/nord.ts
@@ -40,7 +40,7 @@ const tooltipBackground = base01;
 const selection = base03;
 // Customize
 const cursor = base06;
-// Create
+// Create New color
 const activeLineBackground = '#00000020';
 
 // / The editor theme styles for Nord.

--- a/packages/editor/src/services/editor-theme/nord.ts
+++ b/packages/editor/src/services/editor-theme/nord.ts
@@ -60,8 +60,8 @@ export const nordTheme = EditorView.theme(
       { backgroundColor: selection },
 
     '.cm-panels': { backgroundColor: darkBackground, color: base03 },
-    // '.cm-panels.cm-panels-top': { borderBottom: '2px solid black' },
-    // '.cm-panels.cm-panels-bottom': { borderTop: '2px solid black' },
+    '.cm-panels.cm-panels-top': { borderBottom: '2px solid black' },
+    '.cm-panels.cm-panels-bottom': { borderTop: '2px solid black' },
 
     '.cm-searchMatch': {
       backgroundColor: 'transparent',

--- a/packages/editor/src/services/editor-theme/nord.ts
+++ b/packages/editor/src/services/editor-theme/nord.ts
@@ -72,6 +72,7 @@ export const nordTheme = EditorView.theme(
       color: base00,
     },
 
+    // Custom
     '.cm-activeLine': { backgroundColor: activeLineBackground },
     '.cm-selectionMatch': {
       backgroundColor: base05,
@@ -95,6 +96,7 @@ export const nordTheme = EditorView.theme(
       border: 'none',
     },
 
+    // Custom
     '.cm-activeLineGutter': {
       backgroundColor: activeLineBackground,
       color: base04,

--- a/packages/editor/src/services/editor-theme/nord.ts
+++ b/packages/editor/src/services/editor-theme/nord.ts
@@ -33,13 +33,15 @@ const base0F = '#b48ead'; // purple
 
 const invalid = '#d30102';
 const darkBackground = '#252a33';
-// Cutomize
+// Customize
 const highlightBackground = base02;
 const background = base00;
 const tooltipBackground = base01;
 const selection = base03;
-// Cutomize
+// Customize
 const cursor = base06;
+// Create
+const activeLineBackground = '#00000020';
 
 // / The editor theme styles for Nord.
 export const nordTheme = EditorView.theme(
@@ -58,8 +60,8 @@ export const nordTheme = EditorView.theme(
       { backgroundColor: selection },
 
     '.cm-panels': { backgroundColor: darkBackground, color: base03 },
-    '.cm-panels.cm-panels-top': { borderBottom: '2px solid black' },
-    '.cm-panels.cm-panels-bottom': { borderTop: '2px solid black' },
+    // '.cm-panels.cm-panels-top': { borderBottom: '2px solid black' },
+    // '.cm-panels.cm-panels-bottom': { borderTop: '2px solid black' },
 
     '.cm-searchMatch': {
       backgroundColor: 'transparent',
@@ -70,7 +72,7 @@ export const nordTheme = EditorView.theme(
       color: base00,
     },
 
-    '.cm-activeLine': { backgroundColor: highlightBackground },
+    '.cm-activeLine': { backgroundColor: activeLineBackground },
     '.cm-selectionMatch': {
       backgroundColor: base05,
       color: base01,
@@ -82,7 +84,7 @@ export const nordTheme = EditorView.theme(
     },
 
     '&.cm-focused .cm-matchingBracket': {
-      // Cutomize
+      // Customize
       backgroundColor: base02,
       color: base02,
     },
@@ -94,7 +96,7 @@ export const nordTheme = EditorView.theme(
     },
 
     '.cm-activeLineGutter': {
-      backgroundColor: highlightBackground,
+      backgroundColor: activeLineBackground,
       color: base04,
     },
 


### PR DESCRIPTION
# Task
- https://redmine.weseek.co.jp/issues/145247

# Summary
- #8748 の修正漏れ
- `アクティブ行をハイライト`をONにしている時にアクティブ行においてテキストの選択の色を見えるようにした

# ScreenShot
<img width="562" alt="image" src="https://github.com/weseek/growi/assets/113958844/d427e53f-6efb-43a5-a932-1eb05da1f7dd">
<img width="567" alt="image" src="https://github.com/weseek/growi/assets/113958844/2e57edd6-73fe-46a7-8d4b-a65a870308ba">
