### PR TITLE
feat: Add a button to open PageCreateModal in the new page creation lead

### DIFF
--- a/apps/app/public/static/locales/en_US/commons.json
+++ b/apps/app/public/static/locales/en_US/commons.json
@@ -77,6 +77,7 @@
 
   "create_page_dropdown": {
     "new_page": "Create New Page",
+    "open_page_create_modal": "Open Page Create Modal",
     "todays": {
       "desc": "Create today's memo",
       "memo": "memo"

--- a/apps/app/public/static/locales/en_US/commons.json
+++ b/apps/app/public/static/locales/en_US/commons.json
@@ -77,7 +77,7 @@
 
   "create_page_dropdown": {
     "new_page": "Create New Page",
-    "open_page_create_modal": "Open Page Create Modal",
+    "open_page_create_modal": "Open new page create modal",
     "todays": {
       "desc": "Create today's memo",
       "memo": "memo"

--- a/apps/app/public/static/locales/fr_FR/commons.json
+++ b/apps/app/public/static/locales/fr_FR/commons.json
@@ -77,7 +77,7 @@
 
   "create_page_dropdown": {
     "new_page": "Créer nouvelle page",
-    "open_page_create_modal": "Afficher la modalité de création d'une nouvelle page",
+    "open_page_create_modal": "Ouvrir une nouvelle page créer une fenêtre modale",
     "todays": {
       "desc": "Créer le mémo du jour",
       "memo": "mémo"

--- a/apps/app/public/static/locales/fr_FR/commons.json
+++ b/apps/app/public/static/locales/fr_FR/commons.json
@@ -77,6 +77,7 @@
 
   "create_page_dropdown": {
     "new_page": "Créer nouvelle page",
+    "open_page_create_modal": "Afficher la modalité de création d'une nouvelle page",
     "todays": {
       "desc": "Créer le mémo du jour",
       "memo": "mémo"

--- a/apps/app/public/static/locales/ja_JP/commons.json
+++ b/apps/app/public/static/locales/ja_JP/commons.json
@@ -79,6 +79,7 @@
 
   "create_page_dropdown": {
     "new_page": "新規ページ作成",
+    "open_page_create_modal": "新規ページ作成モーダルを表示",
     "todays": {
       "desc": "今日のメモを作成",
       "memo": "メモ"

--- a/apps/app/public/static/locales/zh_CN/commons.json
+++ b/apps/app/public/static/locales/zh_CN/commons.json
@@ -80,6 +80,7 @@
 
   "create_page_dropdown": {
     "new_page": "新页面",
+    "open_page_create_modal": "显示新页面创建模式",
     "todays": {
       "desc": "Create today's memo",
       "memo": "memo"

--- a/apps/app/public/static/locales/zh_CN/commons.json
+++ b/apps/app/public/static/locales/zh_CN/commons.json
@@ -80,7 +80,7 @@
 
   "create_page_dropdown": {
     "new_page": "新页面",
-    "open_page_create_modal": "显示新页面创建模式",
+    "open_page_create_modal": "打开新页面创建模式",
     "todays": {
       "desc": "Create today's memo",
       "memo": "memo"

--- a/apps/app/src/components/Sidebar/PageCreateButton/DropendMenu.tsx
+++ b/apps/app/src/components/Sidebar/PageCreateButton/DropendMenu.tsx
@@ -39,7 +39,7 @@ export const DropendMenu = React.memo((props: DropendMenuProps): JSX.Element => 
       <DropdownItem
         onClick={onClickOpenPageCreateModal}
       >
-        新規ページ作成モーダルの表示
+        {t('create_page_dropdown.open_page_create_modal')}
       </DropdownItem>
 
 

--- a/apps/app/src/components/Sidebar/PageCreateButton/DropendMenu.tsx
+++ b/apps/app/src/components/Sidebar/PageCreateButton/DropendMenu.tsx
@@ -8,6 +8,7 @@ import type { LabelType } from '~/interfaces/template';
 
 type DropendMenuProps = {
   onClickCreateNewPage: () => Promise<void>
+  onClickOpenPageCreateModal: () => void
   onClickCreateTodaysMemo: () => Promise<void>
   onClickCreateTemplate?: (label: LabelType) => Promise<void>
   todaysPath: string | null,
@@ -16,6 +17,7 @@ type DropendMenuProps = {
 export const DropendMenu = React.memo((props: DropendMenuProps): JSX.Element => {
   const {
     onClickCreateNewPage,
+    onClickOpenPageCreateModal,
     onClickCreateTodaysMemo,
     onClickCreateTemplate,
     todaysPath,
@@ -33,6 +35,13 @@ export const DropendMenu = React.memo((props: DropendMenuProps): JSX.Element => 
       >
         {t('create_page_dropdown.new_page')}
       </DropdownItem>
+
+      <DropdownItem
+        onClick={onClickOpenPageCreateModal}
+      >
+        新規ページ作成モーダルの表示
+      </DropdownItem>
+
 
       { todaysPath != null && (
         <>

--- a/apps/app/src/components/Sidebar/PageCreateButton/PageCreateButton.tsx
+++ b/apps/app/src/components/Sidebar/PageCreateButton/PageCreateButton.tsx
@@ -4,6 +4,8 @@ import { Dropdown } from 'reactstrap';
 
 import { useCreateTemplatePage } from '~/client/services/create-page';
 import { useToastrOnError } from '~/client/services/use-toastr-on-error';
+import { usePageCreateModal } from '~/stores/modal';
+import { useCurrentPagePath } from '~/stores/page';
 
 import { CreateButton } from './CreateButton';
 import { DropendMenu } from './DropendMenu';
@@ -15,6 +17,9 @@ export const PageCreateButton = React.memo((): JSX.Element => {
   const [isHovered, setIsHovered] = useState(false);
 
   const [dropdownOpen, setDropdownOpen] = useState(false);
+
+  const { open: openPageCreateModal } = usePageCreateModal();
+  const { data: currentPagePath } = useCurrentPagePath();
 
   const { createNewPage, isCreating: isNewPageCreating } = useCreateNewPage();
   // TODO: https://redmine.weseek.co.jp/issues/138806
@@ -64,6 +69,7 @@ export const PageCreateButton = React.memo((): JSX.Element => {
           <DropendToggle />
           <DropendMenu
             onClickCreateNewPage={createNewPageWithToastr}
+            onClickOpenPageCreateModal={() => openPageCreateModal(currentPagePath)}
             onClickCreateTodaysMemo={createTodaysMemoWithToastr}
             onClickCreateTemplate={isTemplatePageCreatable ? createTemplateWithToastr : undefined}
             todaysPath={todaysPath}


### PR DESCRIPTION
##  Task
[#141772](https://redmine.weseek.co.jp/issues/141772) [v7] 新規ページ作成導線のドロップダウンメニュー内に Page Create Modal への導線を追加する
┗ [#145461](https://redmine.weseek.co.jp/issues/145461) 実装

## Demo
https://github.com/weseek/growi/assets/34241526/1dfa98ae-caae-4211-8a78-1d209f382fb4