### PR TITLE
imprv: Add config to toggle ACL between public_read and private on PutObject when using S3 with FileUploader

### DIFF
--- a/apps/app/src/server/models/config.ts
+++ b/apps/app/src/server/models/config.ts
@@ -110,7 +110,6 @@ export const defaultCrowiConfigs: { [key: string]: any } = {
   'aws:s3AccessKeyId'     : undefined,
   'aws:s3SecretAccessKey' : undefined,
   'aws:s3CustomEndpoint'  : undefined,
-  'aws:s3PutObjectAcl'    : 'public-read',
 
   'mail:from'         : undefined,
   'mail:smtpHost'     : undefined,

--- a/apps/app/src/server/models/config.ts
+++ b/apps/app/src/server/models/config.ts
@@ -109,6 +109,7 @@ export const defaultCrowiConfigs: { [key: string]: any } = {
   'aws:s3AccessKeyId'     : undefined,
   'aws:s3SecretAccessKey' : undefined,
   'aws:s3CustomEndpoint'  : undefined,
+  'aws:s3PutObjectAcl'    : 'public-read',
 
   'mail:from'         : undefined,
   'mail:smtpHost'     : undefined,

--- a/apps/app/src/server/service/config-loader.ts
+++ b/apps/app/src/server/service/config-loader.ts
@@ -471,6 +471,12 @@ const ENV_VAR_NAME_TO_CONFIG_INFO = {
     type:    ValueType.NUMBER,
     default: 120,
   },
+  S3_BUCKET_ACLS_DISABLE: {
+    ns:      'crowi',
+    key:     'aws:s3BucketAclsDisable',
+    type:    ValueType.BOOLEAN,
+    default: false,
+  },
   GCS_API_KEY_JSON_PATH: {
     ns:      'crowi',
     key:     'gcs:apiKeyJsonPath',

--- a/apps/app/src/server/service/file-uploader/aws.ts
+++ b/apps/app/src/server/service/file-uploader/aws.ts
@@ -232,7 +232,7 @@ class AwsFileUploader extends AbstractFileUploader {
 }
 
 module.exports = (crowi) => {
-  const lib          = new AwsFileUploader(crowi);
+  const lib = new AwsFileUploader(crowi);
 
   lib.isValidUploadSettings = function() {
     return configManager.getConfig('crowi', 'aws:s3AccessKeyId') != null


### PR DESCRIPTION
ref: https://github.com/weseek/growi/discussions/8747#discussioncomment-9182746

## 概要
FileUploaderのバックエンドにS3を利用する際にPutObjectのオプションでACLを`public_read`固定から`private`に切り替えられるよう設定を追加しました。
`crowi:aws:S3PutObject`を設定することで切り替えられます、
デフォルトは後方互換をもつため`public_read`です。

## 動作確認

Growi,mongoを手元で建て、AWS S3 BucketとIAMアクセスキーを指定して以下の動作を確認しました

- `public_read`指定時、ACL有効のS3 Bucketをバックエンドで画像アップロードに成功すること
- `public_read`指定時、ACL無効のprivateなS3 Bucketに画像をアップロードしようとすると失敗すること
- `private`指定時、ACL無効のS3 Bucketに画像のアップロードに成功すること

## このPRで対応しないこと
オプションの変更方法に関して、自分の理解が浅いこと、PRを小さくしたいことからこのPRでは対応していません

## 確認してほしい点
- オプションの変更方法の追加に関しての対応要望をコードにコメントで追加したほうがよいか
- Config`crowi:aws:S3PutObject`の命名は適切か
    - Crowiから引き継いだと思われるConfigに新規で追加するのは不適切かもしれない