### PR TITLE
imprv: behavior of dropdown toggle in 'Recent Changes' sidebar

### DIFF
--- a/apps/app/src/components/Sidebar/RecentChanges/RecentChangesSubstance.tsx
+++ b/apps/app/src/components/Sidebar/RecentChanges/RecentChangesSubstance.tsx
@@ -8,7 +8,6 @@ import {
 import { DevidedPagePath } from '@growi/core/dist/models';
 import { UserPicture } from '@growi/ui/dist/components';
 import { useTranslation } from 'react-i18next';
-import { Button } from 'reactstrap';
 
 import { useKeywordManager } from '~/client/services/search-operation';
 import { PagePathHierarchicalLink } from '~/components/Common/PagePathHierarchicalLink';
@@ -181,17 +180,16 @@ export const RecentChangesHeader = ({
       <SidebarHeaderReloadButton onClick={() => mutate()} />
 
       <div className="me-1">
-        <Button
+        <button
           color="transparent"
-          className="btn p-0 border-0 dropdown-toggle"
+          className="btn p-0 border-0"
           type="button"
           data-bs-toggle="dropdown"
           data-bs-auto-close="outside"
           aria-expanded="false"
-          caret={false}
         >
           <span className="material-symbols-outlined">more_horiz</span>
-        </Button>
+        </button>
 
         <ul className="dropdown-menu">
           <li className="dropdown-item" onClick={changeSizeHandler}>

--- a/apps/app/src/components/Sidebar/RecentChanges/RecentChangesSubstance.tsx
+++ b/apps/app/src/components/Sidebar/RecentChanges/RecentChangesSubstance.tsx
@@ -8,9 +8,7 @@ import {
 import { DevidedPagePath } from '@growi/core/dist/models';
 import { UserPicture } from '@growi/ui/dist/components';
 import { useTranslation } from 'react-i18next';
-import {
-  DropdownItem, DropdownMenu, DropdownToggle, UncontrolledButtonDropdown,
-} from 'reactstrap';
+import { Button } from 'reactstrap';
 
 import { useKeywordManager } from '~/client/services/search-operation';
 import { PagePathHierarchicalLink } from '~/components/Common/PagePathHierarchicalLink';
@@ -182,13 +180,21 @@ export const RecentChangesHeader = ({
     <>
       <SidebarHeaderReloadButton onClick={() => mutate()} />
 
-      <UncontrolledButtonDropdown className="me-1">
-        <DropdownToggle color="transparent" className="p-0 border-0">
+      <div className="me-1">
+        <Button
+          color="transparent"
+          className="btn p-0 border-0 dropdown-toggle"
+          type="button"
+          data-bs-toggle="dropdown"
+          data-bs-auto-close="outside"
+          aria-expanded="false"
+          caret={false}
+        >
           <span className="material-symbols-outlined">more_horiz</span>
-        </DropdownToggle>
+        </Button>
 
-        <DropdownMenu container="body">
-          <DropdownItem onClick={changeSizeHandler}>
+        <ul className="dropdown-menu">
+          <li className="dropdown-item" onClick={changeSizeHandler}>
             <div className={`${styles['grw-recent-changes-resize-button']} form-check form-switch mb-0`}>
               <input
                 id="recentChangesResize"
@@ -201,9 +207,9 @@ export const RecentChangesHeader = ({
                 {isSmall ? t('sidebar_header.size_s') : t('sidebar_header.size_l')}
               </label>
             </div>
-          </DropdownItem>
+          </li>
 
-          <DropdownItem onClick={onWipPageShownChange}>
+          <li className="dropdown-item" onClick={onWipPageShownChange}>
             <div className="form-check form-switch mb-0">
               <input
                 id="wipPageVisibility"
@@ -216,9 +222,9 @@ export const RecentChangesHeader = ({
                 {t('sidebar_header.show_wip_page')}
               </label>
             </div>
-          </DropdownItem>
-        </DropdownMenu>
-      </UncontrolledButtonDropdown>
+          </li>
+        </ul>
+      </div>
     </>
   );
 };


### PR DESCRIPTION
## Task
[#141636](https://redmine.weseek.co.jp/issues/141636): サイドバー「最新の変更」の三点リーダー内ドロップダウンのトグル押下後の挙動の修正
┗ [#145347](https://redmine.weseek.co.jp/issues/145347) 実装

## Demo
![demo](https://github.com/weseek/growi/assets/106868314/855994c3-9cb4-4c02-95bb-179c8f4de71d)