### PR TITLE
imprv: Hide the page creation button for users without editing permissions

### DIFF
--- a/apps/app/src/components/Sidebar/SidebarNav/SidebarNav.tsx
+++ b/apps/app/src/components/Sidebar/SidebarNav/SidebarNav.tsx
@@ -1,8 +1,9 @@
-import React, { memo } from 'react';
+import React, { memo, useMemo } from 'react';
 
 import type { SidebarContentsType } from '~/interfaces/ui';
 import { useIsGuestUser, useIsReadOnlyUser } from '~/stores/context';
 
+import { NotAvailableForReadOnlyUser } from '../../NotAvailableForReadOnlyUser';
 import { PageCreateButton } from '../PageCreateButton';
 
 import { PrimaryItems } from './PrimaryItems';
@@ -20,9 +21,26 @@ export const SidebarNav = memo((props: SidebarNavProps) => {
   const { data: isGuestUser } = useIsGuestUser();
   const { data: isReadOnlyUser } = useIsReadOnlyUser();
 
+  const renderedPageCreateButton = useMemo(() => {
+    if (isGuestUser) {
+      return <></>;
+    }
+
+    if (isReadOnlyUser) {
+      return (
+        <NotAvailableForReadOnlyUser>
+          <PageCreateButton />
+        </NotAvailableForReadOnlyUser>
+      );
+    }
+
+    return <PageCreateButton />;
+  }, [isGuestUser, isReadOnlyUser]);
+
   return (
     <div className={`grw-sidebar-nav ${styles['grw-sidebar-nav']}`}>
-      {!(isGuestUser || isReadOnlyUser) && <PageCreateButton />}
+
+      {renderedPageCreateButton}
 
       <div className="grw-sidebar-nav-primary-container" data-vrt-blackout-sidebar-nav>
         <PrimaryItems onItemHover={onPrimaryItemHover} />

--- a/apps/app/src/components/Sidebar/SidebarNav/SidebarNav.tsx
+++ b/apps/app/src/components/Sidebar/SidebarNav/SidebarNav.tsx
@@ -1,6 +1,7 @@
 import React, { memo } from 'react';
 
 import type { SidebarContentsType } from '~/interfaces/ui';
+import { useIsGuestUser, useIsReadOnlyUser } from '~/stores/context';
 
 import { PageCreateButton } from '../PageCreateButton';
 
@@ -16,9 +17,12 @@ export type SidebarNavProps = {
 export const SidebarNav = memo((props: SidebarNavProps) => {
   const { onPrimaryItemHover } = props;
 
+  const { data: isGuestUser } = useIsGuestUser();
+  const { data: isReadOnlyUser } = useIsReadOnlyUser();
+
   return (
     <div className={`grw-sidebar-nav ${styles['grw-sidebar-nav']}`}>
-      <PageCreateButton />
+      {!(isGuestUser || isReadOnlyUser) && <PageCreateButton />}
 
       <div className="grw-sidebar-nav-primary-container" data-vrt-blackout-sidebar-nav>
         <PrimaryItems onItemHover={onPrimaryItemHover} />


### PR DESCRIPTION
## Task
[#144139](https://redmine.weseek.co.jp/issues/144139) [v7][issue] ゲストユーザーや編集のみ権限のユーザーのアクセス時に「記事の新規作成」のアイコンが表示される件の修正
┗ [#146019](https://redmine.weseek.co.jp/issues/146019) 改善

## XD
https://xd.adobe.com/view/26f3cef5-06c1-4ed2-9871-b86d5d00adce-73a0/screen/9f52318d-2291-41b6-92e0-b4157a6a128b/

## Screenshot
### GuestMode
<img width="1262" alt="スクリーンショット 2024-05-15 11 12 32" src="https://github.com/weseek/growi/assets/34241526/77c01fd2-8ce4-4373-a51e-f49b68242f5e">

### ReadOnlyUserMode
<img width="1264" alt="スクリーンショット 2024-05-15 11 13 04" src="https://github.com/weseek/growi/assets/34241526/5081ff15-5dfb-4ba6-ad75-85553957c9d6">

