### PR TITLE
fix: Display share page date

### DIFF
--- a/apps/app/src/components/ShareLinkPageView.tsx
+++ b/apps/app/src/components/ShareLinkPageView.tsx
@@ -15,6 +15,7 @@ import { PagePathNavSticky } from './Common/PagePathNav';
 import { PageViewLayout } from './Common/PageViewLayout';
 import RevisionRenderer from './Page/RevisionRenderer';
 import ShareLinkAlert from './Page/ShareLinkAlert';
+import { PageContentFooter } from './PageContentFooter';
 import type { PageSideContentsProps } from './PageSideContents';
 
 
@@ -66,6 +67,12 @@ export const ShareLinkPageView = (props: Props): JSX.Element => {
     : null;
 
 
+  const footerContents = !isNotFound
+    ? (
+      <PageContentFooter page={page} />
+    )
+    : null;
+
   const Contents = () => {
     if (isNotFound || page.revision == null) {
       return <></>;
@@ -97,6 +104,7 @@ export const ShareLinkPageView = (props: Props): JSX.Element => {
       headerContents={headerContents}
       sideContents={sideContents}
       expandContentWidth={shouldExpandContent}
+      footerContents={footerContents}
     >
       { specialContents }
       { specialContents == null && (


### PR DESCRIPTION
## task
- https://redmine.weseek.co.jp/issues/145698
- Add footer content that existed in v6 to v7

## view image
### shared page
![image](https://github.com/weseek/growi/assets/8895367/966c3b4a-f1bf-47ce-b3ad-27cc8de7577f)

### shared page not found
![image](https://github.com/weseek/growi/assets/8895367/ca1f27dc-6f59-4abb-ad92-2478a7f7f736)

### normal page view
![image](https://github.com/weseek/growi/assets/8895367/b4f698f5-638a-4737-bee4-2a0df6fa70a6)
