### PR TITLE
imprv: Behavior of dropdown toggle in groundglassbar

### DIFF
--- a/apps/app/src/components/PageControls/PageControls.tsx
+++ b/apps/app/src/components/PageControls/PageControls.tsx
@@ -87,7 +87,6 @@ const WideViewMenuItem = (props: WideViewMenuItemProps): JSX.Element => {
           className="form-check-input"
           type="checkbox"
           checked={expandContentWidth}
-          onChange={onClickMenuItem}
         />
         <label className="form-label form-check-label">
           { t('wide_view') }

--- a/apps/app/src/components/PageControls/PageControls.tsx
+++ b/apps/app/src/components/PageControls/PageControls.tsx
@@ -66,7 +66,7 @@ const Tags = (props: TagsProps): JSX.Element => {
 };
 
 type WideViewMenuItemProps = AdditionalMenuItemsRendererProps & {
-  onClickMenuItem: (e: React.MouseEvent<HTMLInputElement>) => void,
+  onClickMenuItem: () => void,
   expandContentWidth?: boolean,
 }
 
@@ -77,10 +77,15 @@ const WideViewMenuItem = (props: WideViewMenuItemProps): JSX.Element => {
     onClickMenuItem, expandContentWidth,
   } = props;
 
+  const menuItemClickedHandler = useCallback((e: React.MouseEvent<HTMLInputElement>) => {
+    e.preventDefault();
+    onClickMenuItem();
+  }, [onClickMenuItem]);
+
   return (
     <div
       className="grw-page-control-dropdown-item dropdown-item"
-      onClick={onClickMenuItem}
+      onClick={menuItemClickedHandler}
     >
       <div className="form-check form-switch ms-1">
         <input
@@ -222,8 +227,7 @@ const PageControlsSubstance = (props: PageControlsSubstanceProps): JSX.Element =
     onClickDeleteMenuItem(pageToDelete);
   }, [onClickDeleteMenuItem, pageId, pageInfo, path, revisionId]);
 
-  const switchContentWidthClickHandler = useCallback((e: React.MouseEvent<HTMLInputElement>) => {
-    e.preventDefault();
+  const switchContentWidthClickHandler = useCallback(() => {
 
     const newValue = !expandContentWidth;
     if (onClickSwitchContentWidth == null || (isGuestUser ?? true) || (isReadOnlyUser ?? true)) {

--- a/apps/app/src/components/PageControls/PageControls.tsx
+++ b/apps/app/src/components/PageControls/PageControls.tsx
@@ -66,7 +66,7 @@ const Tags = (props: TagsProps): JSX.Element => {
 };
 
 type WideViewMenuItemProps = AdditionalMenuItemsRendererProps & {
-  onClickMenuItem: (newValue: boolean) => void,
+  onClickMenuItem: (e:any) => void,
   expandContentWidth?: boolean,
 }
 
@@ -78,23 +78,22 @@ const WideViewMenuItem = (props: WideViewMenuItemProps): JSX.Element => {
   } = props;
 
   return (
-    <DropdownItem
-      onClick={() => onClickMenuItem(!(expandContentWidth))}
-      className="grw-page-control-dropdown-item"
+    <div
+      className="grw-page-control-dropdown-item dropdown-item"
+      onClick={onClickMenuItem}
     >
       <div className="form-check form-switch ms-1">
         <input
-          id="switchContentWidth"
           className="form-check-input"
           type="checkbox"
           checked={expandContentWidth}
-          onChange={() => {}}
+          onChange={onClickMenuItem}
         />
-        <label className="form-label form-check-label" htmlFor="switchContentWidth">
+        <label className="form-label form-check-label">
           { t('wide_view') }
         </label>
       </div>
-    </DropdownItem>
+    </div>
   );
 };
 
@@ -224,7 +223,10 @@ const PageControlsSubstance = (props: PageControlsSubstanceProps): JSX.Element =
     onClickDeleteMenuItem(pageToDelete);
   }, [onClickDeleteMenuItem, pageId, pageInfo, path, revisionId]);
 
-  const switchContentWidthClickHandler = useCallback(async(newValue: boolean) => {
+  const switchContentWidthClickHandler = useCallback(async(e:any) => {
+    e.preventDefault();
+
+    const newValue = !expandContentWidth;
     if (onClickSwitchContentWidth == null || (isGuestUser ?? true) || (isReadOnlyUser ?? true)) {
       logger.warn('Could not switch content width', {
         onClickSwitchContentWidth: onClickSwitchContentWidth == null ? 'null' : 'not null',
@@ -242,7 +244,7 @@ const PageControlsSubstance = (props: PageControlsSubstanceProps): JSX.Element =
     catch (err) {
       toastError(err);
     }
-  }, [isGuestUser, isReadOnlyUser, onClickSwitchContentWidth, pageId, pageInfo]);
+  }, [expandContentWidth, isGuestUser, isReadOnlyUser, onClickSwitchContentWidth, pageId, pageInfo]);
 
   const additionalMenuItemOnTopRenderer = useMemo(() => {
     if (!isIPageInfoForEntity(pageInfo)) {

--- a/apps/app/src/components/PageControls/PageControls.tsx
+++ b/apps/app/src/components/PageControls/PageControls.tsx
@@ -222,7 +222,7 @@ const PageControlsSubstance = (props: PageControlsSubstanceProps): JSX.Element =
     onClickDeleteMenuItem(pageToDelete);
   }, [onClickDeleteMenuItem, pageId, pageInfo, path, revisionId]);
 
-  const switchContentWidthClickHandler = useCallback(async(e: React.MouseEvent<HTMLInputElement>) => {
+  const switchContentWidthClickHandler = useCallback((e: React.MouseEvent<HTMLInputElement>) => {
     e.preventDefault();
 
     const newValue = !expandContentWidth;

--- a/apps/app/src/components/PageControls/PageControls.tsx
+++ b/apps/app/src/components/PageControls/PageControls.tsx
@@ -66,7 +66,7 @@ const Tags = (props: TagsProps): JSX.Element => {
 };
 
 type WideViewMenuItemProps = AdditionalMenuItemsRendererProps & {
-  onClickMenuItem: (e:any) => void,
+  onClickMenuItem: (e: React.MouseEvent<HTMLInputElement>) => void,
   expandContentWidth?: boolean,
 }
 
@@ -223,7 +223,7 @@ const PageControlsSubstance = (props: PageControlsSubstanceProps): JSX.Element =
     onClickDeleteMenuItem(pageToDelete);
   }, [onClickDeleteMenuItem, pageId, pageInfo, path, revisionId]);
 
-  const switchContentWidthClickHandler = useCallback(async(e:any) => {
+  const switchContentWidthClickHandler = useCallback(async(e: React.MouseEvent<HTMLInputElement>) => {
     e.preventDefault();
 
     const newValue = !expandContentWidth;


### PR DESCRIPTION
[#145795](https://redmine.weseek.co.jp/issues/145795): [v7] 上部の GroundGlassBar 内の三点リーダー内ドロップダウンのトグル押下後の挙動の修正
┗ [#145917](https://redmine.weseek.co.jp/issues/145917): 実装

- 切り替え後、dropdown が閉じないままになる
- input (switch) クリックで切り替えができる
- label クリックでも切り替えができる