### PR TITLE
fix: Slack notification not sent on page update

### DIFF
--- a/apps/app/src/components/PageEditor/PageEditor.tsx
+++ b/apps/app/src/components/PageEditor/PageEditor.tsx
@@ -68,6 +68,7 @@ declare global {
 export type SaveOptions = {
   wip: boolean,
   slackChannels: string,
+  isSlackEnabled: boolean,
   overwriteScopesOfDescendants?: boolean
 }
 export type Save = (

--- a/apps/app/src/components/SavePageControls.tsx
+++ b/apps/app/src/components/SavePageControls.tsx
@@ -35,30 +35,32 @@ declare global {
 const logger = loggerFactory('growi:SavePageControls');
 
 
-const SavePageButton = (props: {slackChannels: string, isDeviceLargerThanMd?: boolean}) => {
+const SavePageButton = (props: {slackChannels: string, isSlackEnabled?: boolean, isDeviceLargerThanMd?: boolean}) => {
 
   const { t } = useTranslation();
   const { data: _isWaitingSaveProcessing } = useWaitingSaveProcessing();
   const [isSavePageModalShown, setIsSavePageModalShown] = useState<boolean>(false);
 
-  const { slackChannels, isDeviceLargerThanMd } = props;
+  const { slackChannels, isSlackEnabled, isDeviceLargerThanMd } = props;
 
   const isWaitingSaveProcessing = _isWaitingSaveProcessing === true; // ignore undefined
 
   const save = useCallback(async(): Promise<void> => {
     // save
-    globalEmitter.emit('saveAndReturnToView', { wip: false, slackChannels });
-  }, [slackChannels]);
+    globalEmitter.emit('saveAndReturnToView', { wip: false, slackChannels, isSlackEnabled });
+  }, [isSlackEnabled, slackChannels]);
 
   const saveAndOverwriteScopesOfDescendants = useCallback(() => {
     // save
-    globalEmitter.emit('saveAndReturnToView', { wip: false, overwriteScopesOfDescendants: true, slackChannels });
-  }, [slackChannels]);
+    globalEmitter.emit('saveAndReturnToView', {
+      wip: false, overwriteScopesOfDescendants: true, slackChannels, isSlackEnabled,
+    });
+  }, [isSlackEnabled, slackChannels]);
 
   const saveAndMakeWip = useCallback(() => {
     // save
-    globalEmitter.emit('saveAndReturnToView', { wip: true, slackChannels });
-  }, [slackChannels]);
+    globalEmitter.emit('saveAndReturnToView', { wip: true, slackChannels, isSlackEnabled });
+  }, [isSlackEnabled, slackChannels]);
 
   const labelSubmitButton = t('Update');
   const labelOverwriteScopes = t('page_edit.overwrite_scopes', { operation: labelSubmitButton });
@@ -197,11 +199,11 @@ export const SavePageControls = (): JSX.Element | null => {
               )
             }
 
-            <SavePageButton slackChannels={slackChannels} isDeviceLargerThanMd />
+            <SavePageButton isSlackEnabled={isSlackEnabled} slackChannels={slackChannels} isDeviceLargerThanMd />
           </>
         ) : (
           <>
-            <SavePageButton slackChannels={slackChannels} />
+            <SavePageButton isSlackEnabled={isSlackEnabled} slackChannels={slackChannels} />
             <button
               type="button"
               className="btn btn-outline-neutral-secondary border-0 fs-5 p-0 ms-1 text-muted"

--- a/apps/app/src/server/routes/apiv3/page/update-page.ts
+++ b/apps/app/src/server/routes/apiv3/page/update-page.ts
@@ -65,9 +65,7 @@ export const updatePageHandlersFactory: UpdatePageHandlersFactory = (crowi) => {
   const validator: ValidationChain[] = [
     body('pageId').exists().not().isEmpty({ ignore_whitespace: true })
       .withMessage("'pageId' must be specified"),
-    body('revisionId').optional().exists().not()
-      .isEmpty({ ignore_whitespace: true })
-      .withMessage("'revisionId' must be specified"),
+    body('revisionId').optional().isMongoId().withMessage("'revisionId' must be mongoId"),
     body('body').exists().isString()
       .withMessage("The empty value is not allowd for the 'body'"),
     body('grant').optional().isInt({ min: 0, max: 5 }).withMessage('grant must be integer from 1 to 5'),

--- a/apps/app/src/server/routes/apiv3/page/update-page.ts
+++ b/apps/app/src/server/routes/apiv3/page/update-page.ts
@@ -65,7 +65,9 @@ export const updatePageHandlersFactory: UpdatePageHandlersFactory = (crowi) => {
   const validator: ValidationChain[] = [
     body('pageId').exists().not().isEmpty({ ignore_whitespace: true })
       .withMessage("'pageId' must be specified"),
-    body('revisionId').optional().isMongoId().withMessage("'revisionId' must be mongoId"),
+    body('revisionId').optional().exists().not()
+      .isEmpty({ ignore_whitespace: true })
+      .withMessage("'revisionId' must be specified"),
     body('body').exists().isString()
       .withMessage("The empty value is not allowd for the 'body'"),
     body('grant').optional().isInt({ min: 0, max: 5 }).withMessage('grant must be integer from 1 to 5'),

--- a/apps/app/src/server/routes/apiv3/page/update-page.ts
+++ b/apps/app/src/server/routes/apiv3/page/update-page.ts
@@ -169,7 +169,7 @@ export const updatePageHandlersFactory: UpdatePageHandlersFactory = (crowi) => {
           options.grant = grant;
           options.userRelatedGrantUserGroupIds = userRelatedGrantUserGroupIds;
         }
-        previousRevision = await Revision.findById<IRevisionHasId>(revisionId);
+        previousRevision = await Revision.findById(revisionId);
         updatedPage = await crowi.pageService.updatePage(currentPage, body, previousRevision?.body ?? null, req.user, options);
       }
       catch (err) {

--- a/apps/app/src/server/service/user-notification/index.ts
+++ b/apps/app/src/server/service/user-notification/index.ts
@@ -1,3 +1,5 @@
+import type { IRevisionHasId } from '@growi/core';
+
 import { toArrayFromCsv } from '~/utils/to-array-from-csv';
 
 
@@ -27,11 +29,11 @@ export class UserNotificationService {
    * @param {User} user
    * @param {string} slackChannelsStr comma separated string. e.g. 'general,channel1,channel2'
    * @param {string} mode 'create' or 'update' or 'comment'
-   * @param {string} previousRevision
+   * @param {IRevisionHasId} previousRevision
    * @param {Comment} comment
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  async fire(page, user, slackChannelsStr, mode, option?: { previousRevision: string }, comment = {}): Promise<PromiseSettledResult<any>[]> {
+  async fire(page, user, slackChannelsStr, mode, option?: { previousRevision: IRevisionHasId }, comment = {}): Promise<PromiseSettledResult<any>[]> {
     const {
       appService, slackIntegrationService,
     } = this.crowi;

--- a/apps/app/src/server/util/slack.js
+++ b/apps/app/src/server/util/slack.js
@@ -24,6 +24,12 @@ const prepareAttachmentTextForCreate = function(page, siteUrl) {
   return convertMarkdownToMarkdown(body, siteUrl);
 };
 
+/**
+ * Return diff with latest revisionBody
+ * @param {IPageHasId} page
+ * @param {string} siteUrl
+ * @param {IRevisionHasId} previousRevision
+ */
 const prepareAttachmentTextForUpdate = function(page, siteUrl, previousRevision) {
   if (previousRevision == null) {
     return;

--- a/apps/app/src/server/util/slack.js
+++ b/apps/app/src/server/util/slack.js
@@ -25,6 +25,10 @@ const prepareAttachmentTextForCreate = function(page, siteUrl) {
 };
 
 const prepareAttachmentTextForUpdate = function(page, siteUrl, previousRevision) {
+  if (previousRevision == null) {
+    return;
+  }
+
   const diff = require('diff');
   let diffText = '';
 


### PR DESCRIPTION
## Tasks
[#146960](https://redmine.weseek.co.jp/issues/146960) [v7] slack 連携した slack に対して wiki からの通知が飛ばない件の修正
┗ [#146980](https://redmine.weseek.co.jp/issues/146980) 修正
