### PR TITLE
imprv: Support tag in github-url.ts

### DIFF
--- a/apps/app/src/features/growi-plugin/server/models/vo/github-url.ts
+++ b/apps/app/src/features/growi-plugin/server/models/vo/github-url.ts
@@ -2,8 +2,12 @@ import sanitize from 'sanitize-filename';
 
 // https://regex101.com/r/fK2rV3/1
 const githubReposIdPattern = new RegExp(/^\/([^/]+)\/([^/]+)$/);
-// https://regex101.com/r/YhZVsj/1
-const sanitizeChars = new RegExp(/[^a-zA-Z_.]+/g);
+// https://regex101.com/r/CQjSuz/1
+const sanitizeBranchChars = new RegExp(/[^a-zA-Z0-9_.]+/g);
+
+// https://regex101.com/r/f4wj8q/1
+// GitHub will return a zip file with the v removed if the tag or branch name is "v + number"
+const checkVersionName = new RegExp(/^v[\d]/g);
 
 export class GitHubUrl {
 
@@ -12,6 +16,8 @@ export class GitHubUrl {
   private _reposName: string;
 
   private _branchName: string;
+
+  private _tagName: string;
 
   get organizationName(): string {
     return this._organizationName;
@@ -25,17 +31,33 @@ export class GitHubUrl {
     return this._branchName;
   }
 
+  get tagName(): string {
+    return this._tagName;
+  }
+
   get archiveUrl(): string {
     const encodedBranchName = encodeURIComponent(this.branchName);
+    const encodedTagName = encodeURIComponent(this.tagName);
+    if (encodedTagName !== '') {
+      const ghUrl = new URL(`/${this.organizationName}/${this.reposName}/archive/refs/tags/${encodedTagName}.zip`, 'https://github.com');
+      return ghUrl.toString();
+    }
+
     const ghUrl = new URL(`/${this.organizationName}/${this.reposName}/archive/refs/heads/${encodedBranchName}.zip`, 'https://github.com');
     return ghUrl.toString();
+
   }
 
   get extractedArchiveDirName(): string {
-    return this._branchName.replaceAll(sanitizeChars, '-');
+    if (this._tagName !== '') {
+      const tagName = this._tagName?.match(checkVersionName) ? this._tagName.replace('v', '') : this._tagName;
+      return tagName.replaceAll(sanitizeBranchChars, '-');
+    }
+    const branchName = this._branchName?.match(checkVersionName) ? this._branchName.replace('v', '') : this._branchName;
+    return branchName.replaceAll(sanitizeBranchChars, '-');
   }
 
-  constructor(url: string, branchName = 'main') {
+  constructor(url: string, branchName = 'main', tagName = '') {
 
     let matched;
     try {
@@ -52,6 +74,7 @@ export class GitHubUrl {
     }
 
     this._branchName = branchName;
+    this._tagName = tagName;
 
     this._organizationName = sanitize(matched[1]);
     this._reposName = sanitize(matched[2]);


### PR DESCRIPTION
# Summary
- v7 における github-url.ts の tag 名対応
- v6 での修正タスク: https://github.com/weseek/growi/pull/8827

# Task
- https://redmine.weseek.co.jp/issues/147138
  - https://redmine.weseek.co.jp/issues/147139

# Note
GitHub から ZIP ファイルをダウンロードする際、そのブランチ名、タグ名をファイル名に埋め込む。  
- 例：weseek/growi の master ブランチ -> growi-master.zip

この際、v6.3.x などの "v + 数字" から始まるもののみ、v が消える。  そのため `checkVersionName` でそれを確認している。
- 例：weseek/growi-plugin-theme-vivid-internet の v6 タグ-> growi-plugin-theme-vivid-internet-6.zip
- https://github.com/weseek/growi-plugin-theme-vivid-internet/tree/v6