### PR TITLE
fix: Brackets appearance when Nord editor theme

### DIFF
--- a/packages/editor/src/services-internal/editor-theme/nord.ts
+++ b/packages/editor/src/services-internal/editor-theme/nord.ts
@@ -87,7 +87,7 @@ export const nordTheme = EditorView.theme(
     '&.cm-focused .cm-matchingBracket': {
       // Customize
       backgroundColor: base02,
-      color: base02,
+      color: base04,
     },
 
     '.cm-gutters': {


### PR DESCRIPTION
# Task
https://redmine.weseek.co.jp/issues/146998

# Summary
- エディタテーマのNordを選択した時において括弧 `(` `{` `[` を入力した時に入力が見えなくなってしまう問題の修正

# Screenshot
<img width="172" alt="スクリーンショット 2024-05-28 20 28 40" src="https://github.com/weseek/growi/assets/113958844/9ececc2c-53be-4c04-88bc-63a352053694">
<img width="208" alt="スクリーンショット 2024-05-28 20 29 11" src="https://github.com/weseek/growi/assets/113958844/1c0bbf2d-d6cb-44dc-9bcd-40f28d04fe0e">
