### PR TITLE
fix: Page body sometimes appears doubled up when the editor is opened

### DIFF
--- a/apps/app/src/pages/[[...path]].page.tsx
+++ b/apps/app/src/pages/[[...path]].page.tsx
@@ -500,7 +500,7 @@ async function injectRoutingInformation(context: GetServerSidePropsContext, prop
     }
 
     if (!props.skipSSR) {
-      props.yjsData = await crowi.pageService.getYjsData(page._id);
+      props.yjsData = await crowi.pageService.getYjsData(page._id.toString());
     }
   }
 }

--- a/apps/app/src/server/service/page/index.ts
+++ b/apps/app/src/server/service/page/index.ts
@@ -4453,8 +4453,11 @@ class PageService implements IPageService {
 
   async getYjsData(pageId: string): Promise<CurrentPageYjsData> {
     const yjsConnectionManager = getYjsConnectionManager();
+
     const currentYdoc = yjsConnectionManager.getCurrentYdoc(pageId);
-    const yjsDraft = currentYdoc?.getText('codemirror').toString();
+    const persistedYdoc = await yjsConnectionManager.getPersistedYdoc(pageId);
+
+    const yjsDraft = (currentYdoc ?? persistedYdoc)?.getText('codemirror').toString();
     const hasRevisionBodyDiff = await this.hasRevisionBodyDiff(pageId, yjsDraft);
 
     return {

--- a/apps/app/src/server/service/yjs-connection-manager.ts
+++ b/apps/app/src/server/service/yjs-connection-manager.ts
@@ -54,13 +54,13 @@ class YjsConnectionManager {
       return;
     }
 
-    const persistedYdoc = await this.mdb.getYDoc(pageId);
+    const persistedYdoc = await this.getPersistedYdoc(pageId);
     const persistedStateVector = Y.encodeStateVector(persistedYdoc);
 
     await this.mdb.flushDocument(pageId);
 
     // If no write operation has been performed, insert initial value
-    const clientsSize = currentYdoc.store.clients.size;
+    const clientsSize = persistedYdoc.store.clients.size;
     if (clientsSize === 0) {
       currentYdoc.getText('codemirror').insert(0, initialValue);
     }
@@ -101,6 +101,11 @@ class YjsConnectionManager {
   public getCurrentYdoc(pageId: string): Ydoc | undefined {
     const currentYdoc = this.ysocketio.documents.get(`yjs/${pageId}`);
     return currentYdoc;
+  }
+
+  public async getPersistedYdoc(pageId: string): Promise<Y.Doc> {
+    const persistedYdoc = await this.mdb.getYDoc(pageId);
+    return persistedYdoc;
   }
 
 }


### PR DESCRIPTION
## Task
[#147249](https://redmine.weseek.co.jp/issues/147249) [v7][bug] エディターを開いた時にページ本文が繰り返されて表示されることがある
┗ [#147257](https://redmine.weseek.co.jp/issues/147257) 修正