### PR TITLE
imprv(plugin): Support github tag in githuburl.ts

### DIFF
--- a/apps/app/src/features/growi-plugin/server/models/vo/github-url.ts
+++ b/apps/app/src/features/growi-plugin/server/models/vo/github-url.ts
@@ -1,7 +1,7 @@
 
 import sanitize from 'sanitize-filename';
 
-// https://regex101.com/r/OJB2UJ/1
+// https://regex101.com/r/fK2rV3/1
 const githubReposIdPattern = new RegExp(/^\/([^/]+)\/([^/]+)$/);
 
 // https://regex101.com/r/CQjSuz/1

--- a/apps/app/src/features/growi-plugin/server/models/vo/github-url.ts
+++ b/apps/app/src/features/growi-plugin/server/models/vo/github-url.ts
@@ -39,8 +39,8 @@ export class GitHubUrl {
   get archiveUrl(): string {
     const encodedBranchName = encodeURIComponent(this.branchName);
     const encodedTagName = encodeURIComponent(this.tagName);
-    const zipUrl = encodedTagName !== '' ? `tags/${encodedTagName}.zip` : `heads/${encodedBranchName}.zip`;
-    const ghUrl = new URL(`/${this.organizationName}/${this.reposName}/archive/refs/${zipUrl}`, 'https://github.com');
+    const zipUrl = encodedTagName !== '' ? `tags/${encodedTagName}` : `heads/${encodedBranchName}`;
+    const ghUrl = new URL(`/${this.organizationName}/${this.reposName}/archive/refs/${zipUrl}.zip`, 'https://github.com');
     return ghUrl.toString();
   }
 


### PR DESCRIPTION
# Summary
- github-url.ts の改善

# Task
- https://redmine.weseek.co.jp/issues/147138
  - https://redmine.weseek.co.jp/issues/147214

# Note
- sanitize ルールの確認 >> tag と branch は確認した限り同じだったのでそのように修正
   - 特にタグ名の方は必要なら改修する
- regex101 の option を改善した URL に直す >> URL を変更