### PR TITLE
fix: Supress warning of checkbox 2

### DIFF
--- a/apps/app/src/components/PageControls/PageControls.tsx
+++ b/apps/app/src/components/PageControls/PageControls.tsx
@@ -78,24 +78,16 @@ const WideViewMenuItem = (props: WideViewMenuItemProps): JSX.Element => {
     onClick, expandContentWidth,
   } = props;
 
-  const clickHandler = useCallback<MouseEventHandler>((e) => {
-    if (onClick == null) return;
-
-    e.preventDefault();
-    onClick?.();
-  }, [onClick]);
-
   return (
-    <DropdownItem className="grw-page-control-dropdown-item dropdown-item" onClick={clickHandler} toggle={false}>
-      <div className="form-check form-switch ms-1 flex-fill d-flex">
+    <DropdownItem className="grw-page-control-dropdown-item dropdown-item" onClick={onClick} toggle={false}>
+      <div className="form-check form-switch ms-1">
         <input
-          id="wide-view-checkbox"
-          className="form-check-input"
+          className="form-check-input pe-none"
           type="checkbox"
           checked={expandContentWidth}
           onChange={() => {}}
         />
-        <label className="form-check-label flex-grow-1 ms-2">
+        <label className="form-check-label pe-none">
           { t('wide_view') }
         </label>
       </div>

--- a/apps/app/src/components/PageControls/PageControls.tsx
+++ b/apps/app/src/components/PageControls/PageControls.tsx
@@ -1,3 +1,4 @@
+import type { MouseEventHandler } from 'react';
 import React, {
   memo, useCallback, useEffect, useMemo, useRef,
 } from 'react';
@@ -10,6 +11,7 @@ import {
 } from '@growi/core';
 import { useRect } from '@growi/ui/dist/utils';
 import { useTranslation } from 'next-i18next';
+import { DropdownItem } from 'reactstrap';
 
 import {
   toggleLike, toggleSubscribe,
@@ -65,7 +67,7 @@ const Tags = (props: TagsProps): JSX.Element => {
 };
 
 type WideViewMenuItemProps = AdditionalMenuItemsRendererProps & {
-  onChange: () => void,
+  onClick: () => void,
   expandContentWidth?: boolean,
 }
 
@@ -73,24 +75,31 @@ const WideViewMenuItem = (props: WideViewMenuItemProps): JSX.Element => {
   const { t } = useTranslation();
 
   const {
-    onChange, expandContentWidth,
+    onClick, expandContentWidth,
   } = props;
 
+  const clickHandler = useCallback<MouseEventHandler>((e) => {
+    if (onClick == null) return;
+
+    e.preventDefault();
+    onClick?.();
+  }, [onClick]);
+
   return (
-    <div className="grw-page-control-dropdown-item dropdown-item">
+    <DropdownItem className="grw-page-control-dropdown-item dropdown-item" onClick={clickHandler} toggle={false}>
       <div className="form-check form-switch ms-1 flex-fill d-flex">
         <input
           id="wide-view-checkbox"
           className="form-check-input"
           type="checkbox"
-          defaultChecked={expandContentWidth}
-          onChange={onChange}
+          checked={expandContentWidth}
+          onChange={() => {}}
         />
-        <label className="form-check-label flex-grow-1 ms-2" htmlFor="wide-view-checkbox">
+        <label className="form-check-label flex-grow-1 ms-2">
           { t('wide_view') }
         </label>
       </div>
-    </div>
+    </DropdownItem>
   );
 };
 
@@ -249,7 +258,7 @@ const PageControlsSubstance = (props: PageControlsSubstanceProps): JSX.Element =
     }
     const wideviewMenuItemRenderer = (props: WideViewMenuItemProps) => {
 
-      return <WideViewMenuItem {...props} onChange={switchContentWidthClickHandler} expandContentWidth={expandContentWidth} />;
+      return <WideViewMenuItem {...props} onClick={switchContentWidthClickHandler} expandContentWidth={expandContentWidth} />;
     };
     return wideviewMenuItemRenderer;
   }, [pageInfo, switchContentWidthClickHandler, expandContentWidth]);

--- a/apps/app/src/components/Sidebar/PageTree/PageTreeSubstance.tsx
+++ b/apps/app/src/components/Sidebar/PageTree/PageTreeSubstance.tsx
@@ -55,14 +55,14 @@ export const PageTreeHeader = memo(({ isWipPageShown, onWipPageShownChange }: He
 
         <ul className="dropdown-menu">
           <li className="dropdown-item" onClick={onWipPageShownChange}>
-            <div className="form-check form-switch flex-fill d-flex">
+            <div className="form-check form-switch">
               <input
-                className="form-check-input"
+                className="form-check-input pe-none"
                 type="checkbox"
                 checked={isWipPageShown}
                 onChange={() => {}}
               />
-              <label className="form-check-label flex-grow-1 ms-2">
+              <label className="form-check-label pe-none">
                 {t('sidebar_header.show_wip_page')}
               </label>
             </div>

--- a/apps/app/src/components/Sidebar/PageTree/PageTreeSubstance.tsx
+++ b/apps/app/src/components/Sidebar/PageTree/PageTreeSubstance.tsx
@@ -54,16 +54,15 @@ export const PageTreeHeader = memo(({ isWipPageShown, onWipPageShownChange }: He
         </button>
 
         <ul className="dropdown-menu">
-          <li className="dropdown-item">
+          <li className="dropdown-item" onClick={onWipPageShownChange}>
             <div className="form-check form-switch flex-fill d-flex">
               <input
-                id="show-wip-page-checkbox"
                 className="form-check-input"
                 type="checkbox"
-                defaultChecked={isWipPageShown}
-                onChange={onWipPageShownChange}
+                checked={isWipPageShown}
+                onChange={() => {}}
               />
-              <label className="form-check-label flex-grow-1 ms-2" htmlFor="show-wip-page-checkbox">
+              <label className="form-check-label flex-grow-1 ms-2">
                 {t('sidebar_header.show_wip_page')}
               </label>
             </div>


### PR DESCRIPTION
# Purpose

- warning の抑制 (#8865 の主目的)
- clickable 領域の調整
    - input の onChange ではなく dropdown-item の onClick 利用に変更
    - それに伴って label 幅の拡張が不要になったため flex 関連クラスを削除
- pointer カーソルにするため dropdown-item 内の input/label には `pe-none` をセット
