### PR TITLE
imprv: Highlighted search results

### DIFF
--- a/apps/app/src/components/SearchPage/SearchPageBase.module.scss
+++ b/apps/app/src/components/SearchPage/SearchPageBase.module.scss
@@ -1,4 +1,6 @@
 @use '@growi/ui/scss/molecules/page_list';
+@use '~/styles/variables' as var;
+@use '@growi/core-styles/scss/bootstrap/init' as bs;
 
 .page-list :global {
   .highlighted-keyword {
@@ -7,8 +9,19 @@
   }
 }
 
-.search-result-content :global  {
-  .highlighted-keyword {
-    background:linear-gradient(transparent 40%, #FCF0C0 40%);
+// == Colors
+@include bs.color-mode(light) {
+  .search-result-content :global {
+    .highlighted-keyword {
+      background:linear-gradient(transparent 40%, var.$grw-marker-yellow 40%);
+    }
+  }
+}
+
+@include bs.color-mode(dark) {
+  .search-result-content :global {
+    .highlighted-keyword {
+      background:linear-gradient(transparent 40%, var.$grw-marker-yellow 40%);
+    }
   }
 }


### PR DESCRIPTION
##  Task
[#141571](https://redmine.weseek.co.jp/issues/141571) [v7][design] ダークモード_検索結果一覧で該当のキーワードに黄色ハイライトが表示される際のテキストの視認性が低い件の修正
┗ [#146825](https://redmine.weseek.co.jp/issues/146825) 改善