### PR TITLE
fix: Readonly editor prevents ctrl+v and paste.

### DIFF
--- a/packages/editor/src/client/components/CodeMirrorEditorReadOnly.tsx
+++ b/packages/editor/src/client/components/CodeMirrorEditorReadOnly.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 
-import { type Extension, EditorState } from '@codemirror/state';
+import { type Extension, EditorState, Prec } from '@codemirror/state';
+import { EditorView, keymap } from '@codemirror/view';
 
 import { GlobalCodeMirrorEditorKey } from '../../consts';
 import { setDataLine } from '../services-internal';
@@ -28,6 +29,38 @@ export const CodeMirrorEditorReadOnly = ({ markdown, onScroll }: Props): JSX.Ele
   useEffect(() => {
     return codeMirrorEditor?.appendExtensions?.(additionalExtensions);
   }, [codeMirrorEditor]);
+
+
+  // prevent Ctrl+V and paste
+  useEffect(() => {
+    const extension = keymap.of([
+      {
+        key: 'Mod-v',
+        preventDefault: true,
+        run: () => {
+          return true;
+        },
+      },
+    ]);
+    const cleanupFunction = codeMirrorEditor?.appendExtensions?.(extension);
+
+    return cleanupFunction;
+  }, [codeMirrorEditor]);
+
+  useEffect(() => {
+    const handlePaste = (event: ClipboardEvent) => {
+      event.preventDefault();
+      return;
+    };
+    const extension = EditorView.domEventHandlers({
+      paste: handlePaste,
+    });
+
+    const cleanupFunction = codeMirrorEditor?.appendExtensions?.(Prec.high(extension));
+
+    return cleanupFunction;
+  }, [codeMirrorEditor]);
+
 
   return (
     <CodeMirrorEditor


### PR DESCRIPTION
# Summary
- Readonly なエディタでの Ctrl+V や右クリックからのペーストの抑制

# Task
- https://redmine.weseek.co.jp/issues/143347
  - https://redmine.weseek.co.jp/issues/148459

