### PR TITLE
feat: Add config for non-yjs mode

### DIFF
--- a/apps/app/src/server/service/config-loader.ts
+++ b/apps/app/src/server/service/config-loader.ts
@@ -723,6 +723,12 @@ const ENV_VAR_NAME_TO_CONFIG_INFO = {
     type: ValueType.NUMBER,
     default: 172800, // 2 days
   },
+  YJS_MAX_BODY_LENGTH: {
+    na: 'crowi',
+    keyof: 'app:yjsMazBodyLength',
+    type: ValueType.NUMBER,
+    default: 500000,
+  },
 };
 
 


### PR DESCRIPTION
## Task
[#142089](https://redmine.weseek.co.jp/issues/142089) [v7] 文字数の多いページ（Draw.ioなど）の Edit 画面開くと Markdown の内容が表示されない件の修正
┗ [#142251](https://redmine.weseek.co.jp/issues/142251) yjs を利用しないモードに変更する文字数の閾値を config-loader に定義する