### PR TITLE
feat: Implement API to sync latest revision body to Yjs draft

### DIFF
--- a/apps/app/src/server/routes/apiv3/page/index.ts
+++ b/apps/app/src/server/routes/apiv3/page/index.ts
@@ -29,6 +29,7 @@ import { checkPageExistenceHandlersFactory } from './check-page-existence';
 import { createPageHandlersFactory } from './create-page';
 import { getYjsDataHandlerFactory } from './get-yjs-data';
 import { publishPageHandlersFactory } from './publish-page';
+import { syncLatestRevisionBodyToYjsDraftHandlerFactory } from './sync-latest-revision-body-to-yjs-draft';
 import { unpublishPageHandlersFactory } from './unpublish-page';
 import { updatePageHandlersFactory } from './update-page';
 
@@ -950,6 +951,8 @@ module.exports = (crowi) => {
   router.put('/:pageId/unpublish', unpublishPageHandlersFactory(crowi));
 
   router.get('/:pageId/yjs-data', getYjsDataHandlerFactory(crowi));
+
+  router.put('/:pageId/sync-latest-revision-body-to-yjs-draft', syncLatestRevisionBodyToYjsDraftHandlerFactory(crowi));
 
   return router;
 };

--- a/apps/app/src/server/routes/apiv3/page/sync-latest-revision-body-to-yjs-draft.ts
+++ b/apps/app/src/server/routes/apiv3/page/sync-latest-revision-body-to-yjs-draft.ts
@@ -1,0 +1,57 @@
+import type { IPage, IUserHasId } from '@growi/core';
+import { ErrorV3 } from '@growi/core/dist/models';
+import type { Request, RequestHandler } from 'express';
+import type { ValidationChain } from 'express-validator';
+import { param } from 'express-validator';
+import mongoose from 'mongoose';
+
+import type Crowi from '~/server/crowi';
+import type { PageModel } from '~/server/models/page';
+import loggerFactory from '~/utils/logger';
+
+import { apiV3FormValidator } from '../../../middlewares/apiv3-form-validator';
+import type { ApiV3Response } from '../interfaces/apiv3-response';
+
+
+const logger = loggerFactory('growi:routes:apiv3:page:get-yjs-data');
+
+type SyncLatestRevisionBodyToYjsDraftHandlerFactory = (crowi: Crowi) => RequestHandler[];
+
+type ReqParams = {
+  pageId: string,
+}
+interface Req extends Request<ReqParams, ApiV3Response> {
+  user: IUserHasId,
+}
+export const syncLatestRevisionBodyToYjsDraftHandlerFactory: SyncLatestRevisionBodyToYjsDraftHandlerFactory = (crowi) => {
+  const Page = mongoose.model<IPage, PageModel>('Page');
+  const accessTokenParser = require('../../../middlewares/access-token-parser')(crowi);
+  const loginRequiredStrictly = require('../../../middlewares/login-required')(crowi);
+
+  // define validators for req.params
+  const validator: ValidationChain[] = [
+    param('pageId').isMongoId().withMessage('The param "pageId" must be specified'),
+  ];
+
+  return [
+    accessTokenParser, loginRequiredStrictly,
+    validator, apiV3FormValidator,
+    async(req: Req, res: ApiV3Response) => {
+      const { pageId } = req.params;
+
+      // check whether accessible
+      if (!(await Page.isAccessiblePageByViewer(pageId, req.user))) {
+        return res.apiv3Err(new ErrorV3('Current user is not accessible to this page.', 'forbidden-page'), 403);
+      }
+
+      try {
+        await crowi.pageService.syncLatestRevisionBodyToYjsDraft(pageId);
+        return res.apiv3({ });
+      }
+      catch (err) {
+        logger.error(err);
+        return res.apiv3Err(err);
+      }
+    },
+  ];
+};

--- a/apps/app/src/server/routes/apiv3/page/sync-latest-revision-body-to-yjs-draft.ts
+++ b/apps/app/src/server/routes/apiv3/page/sync-latest-revision-body-to-yjs-draft.ts
@@ -13,7 +13,7 @@ import { apiV3FormValidator } from '../../../middlewares/apiv3-form-validator';
 import type { ApiV3Response } from '../interfaces/apiv3-response';
 
 
-const logger = loggerFactory('growi:routes:apiv3:page:get-yjs-data');
+const logger = loggerFactory('growi:routes:apiv3:page:sync-latest-revision-body-to-yjs-draft');
 
 type SyncLatestRevisionBodyToYjsDraftHandlerFactory = (crowi: Crowi) => RequestHandler[];
 

--- a/apps/app/src/server/service/page/index.ts
+++ b/apps/app/src/server/service/page/index.ts
@@ -4458,6 +4458,15 @@ class PageService implements IPageService {
     };
   }
 
+  async syncLatestRevisionBodyToYjsDraft(pageId: string): Promise<void> {
+    const yjsConnectionManager = getYjsConnectionManager();
+    await yjsConnectionManager.mdbInstance.clearDocument(pageId);
+
+    // const Revision = mongoose.model<IRevisionHasId>('Revision');
+    // const revision = await Revision.findOne({ pageId }).sort({ createdAt: -1 });
+    // await yjsConnectionManager.handleYDocUpdate(pageId, 'hoge');
+  }
+
   async hasRevisionBodyDiff(pageId: string, comparisonTarget?: string): Promise<boolean> {
     if (comparisonTarget == null) {
       return false;

--- a/apps/app/src/server/service/page/index.ts
+++ b/apps/app/src/server/service/page/index.ts
@@ -4462,9 +4462,12 @@ class PageService implements IPageService {
     const yjsConnectionManager = getYjsConnectionManager();
     await yjsConnectionManager.mdbInstance.clearDocument(pageId);
 
-    // const Revision = mongoose.model<IRevisionHasId>('Revision');
-    // const revision = await Revision.findOne({ pageId }).sort({ createdAt: -1 });
-    // await yjsConnectionManager.handleYDocUpdate(pageId, 'hoge');
+    const Revision = mongoose.model<IRevisionHasId>('Revision');
+    const revision = await Revision.findOne({ pageId }).sort({ createdAt: -1 });
+
+    if (revision != null) {
+      await yjsConnectionManager.handleYDocUpdate(pageId, revision.body);
+    }
   }
 
   async hasRevisionBodyDiff(pageId: string, comparisonTarget?: string): Promise<boolean> {

--- a/apps/app/src/server/service/page/index.ts
+++ b/apps/app/src/server/service/page/index.ts
@@ -4460,11 +4460,8 @@ class PageService implements IPageService {
 
   async syncLatestRevisionBodyToYjsDraft(pageId: string): Promise<void> {
     const yjsConnectionManager = getYjsConnectionManager();
-    await yjsConnectionManager.mdbInstance.clearDocument(pageId);
-
     const Revision = mongoose.model<IRevisionHasId>('Revision');
     const revision = await Revision.findOne({ pageId }).sort({ createdAt: -1 });
-
     if (revision != null) {
       await yjsConnectionManager.handleYDocUpdate(pageId, revision.body);
     }

--- a/apps/app/src/server/service/page/index.ts
+++ b/apps/app/src/server/service/page/index.ts
@@ -67,6 +67,7 @@ import { preNotifyService } from '../pre-notify';
 import { BULK_REINDEX_SIZE, LIMIT_FOR_MULTIPLE_PAGE_OP } from './consts';
 import type { IPageService } from './page-service';
 import { shouldUseV4Process } from './should-use-v4-process';
+import { syncLatestRevisionBodyToYjsDraft } from './sync-latest-revision-body-to-yjs-draft';
 
 export * from './page-service';
 
@@ -4459,12 +4460,7 @@ class PageService implements IPageService {
   }
 
   async syncLatestRevisionBodyToYjsDraft(pageId: string): Promise<void> {
-    const yjsConnectionManager = getYjsConnectionManager();
-    const Revision = mongoose.model<IRevisionHasId>('Revision');
-    const revision = await Revision.findOne({ pageId }).sort({ createdAt: -1 });
-    if (revision != null) {
-      await yjsConnectionManager.handleYDocUpdate(pageId, revision.body);
-    }
+    await syncLatestRevisionBodyToYjsDraft(pageId);
   }
 
   async hasRevisionBodyDiff(pageId: string, comparisonTarget?: string): Promise<boolean> {

--- a/apps/app/src/server/service/page/page-service.ts
+++ b/apps/app/src/server/service/page/page-service.ts
@@ -32,4 +32,5 @@ export interface IPageService {
     page: PageDocument, creatorId: ObjectIdLike | null, operator: any | null, userRelatedGroups: PopulatedGrantedGroup[]
   ): boolean,
   getYjsData(pageId: string, revisionBody?: string): Promise<CurrentPageYjsData>,
+  syncLatestRevisionBodyToYjsDraft(pageId: string): Promise<void>,
 }

--- a/apps/app/src/server/service/page/sync-latest-revision-body-to-yjs-draft.ts
+++ b/apps/app/src/server/service/page/sync-latest-revision-body-to-yjs-draft.ts
@@ -1,0 +1,13 @@
+import type { IRevisionHasId } from '@growi/core';
+import mongoose from 'mongoose';
+
+import { getYjsConnectionManager } from '~/server/service/yjs-connection-manager';
+
+export const syncLatestRevisionBodyToYjsDraft = async(pageId: string): Promise<void> => {
+  const yjsConnectionManager = getYjsConnectionManager();
+  const Revision = mongoose.model<IRevisionHasId>('Revision');
+  const revision = await Revision.findOne({ pageId }).sort({ createdAt: -1 });
+  if (revision != null) {
+    await yjsConnectionManager.handleYDocUpdate(pageId, revision.body);
+  }
+};

--- a/apps/app/src/server/service/yjs-connection-manager.ts
+++ b/apps/app/src/server/service/yjs-connection-manager.ts
@@ -103,6 +103,7 @@ class YjsConnectionManager {
     if (diff.reduce((prev, curr) => prev + curr, 0) > 0) {
       await this.mdb.storeUpdate(pageId, diff);
     }
+    Y.applyUpdate(currentYdoc, Y.encodeStateAsUpdate(persistedYdoc));
   }
 
   public getCurrentYdoc(pageId: string): Ydoc | undefined {

--- a/apps/app/src/server/service/yjs-connection-manager.ts
+++ b/apps/app/src/server/service/yjs-connection-manager.ts
@@ -25,6 +25,10 @@ class YjsConnectionManager {
     return this.ysocketio;
   }
 
+  get mdbInstance(): MongodbPersistence {
+    return this.mdb;
+  }
+
   private constructor(io: Server) {
     this.ysocketio = new YSocketIO(io);
     this.ysocketio.initialize();


### PR DESCRIPTION
## Task
[#149414](https://redmine.weseek.co.jp/issues/149414) ページごとにドラフトを削除できる
┗ [#149417](https://redmine.weseek.co.jp/issues/149417) ドラフト削除用のAPI 実装

## Demo
https://github.com/weseek/growi/assets/34241526/f17505fc-5303-4da9-b03a-233c35b5fe23

