### PR TITLE
fix: Regaining lost backward compatibility for MongoDB 4.4

### DIFF
--- a/apps/app/src/server/service/search-delegator/aggregate-to-index.ts
+++ b/apps/app/src/server/service/search-delegator/aggregate-to-index.ts
@@ -51,11 +51,32 @@ export const aggregatePipelineToIndex = (maxBodyLengthToIndex: number, query?: Q
 
     // join Comment
     {
+      // MongoDB 5.0 or later can use concise syntax
+      // https://www.mongodb.com/docs/v6.0/reference/operator/aggregation/lookup/#correlated-subqueries-using-concise-syntax
+      // $lookup: {
+      //   from: 'comments',
+      //   localField: '_id',
+      //   foreignField: 'page',
+      //   pipeline: [
+      //     {
+      //       $addFields: {
+      //         commentLength: { $strLenCP: '$comment' },
+      //       },
+      //     },
+      //   ],
+      //   as: 'comments',
+      // },
       $lookup: {
         from: 'comments',
-        localField: '_id',
-        foreignField: 'page',
+        let: { pageId: '$_id' },
         pipeline: [
+          {
+            $match: {
+              $expr: {
+                $eq: ['$page', '$$pageId'],
+              },
+            },
+          },
           {
             $addFields: {
               commentLength: { $strLenCP: '$comment' },


### PR DESCRIPTION
Reproduced by #8937


## Error message

> MongoServerError: $lookup with 'pipeline' may not specify 'localField' or 'foreignField'
