### PR TITLE
fix: The $size query when aggregation to rebuild the index

### DIFF
--- a/apps/app/src/server/service/search-delegator/aggregate-to-index.ts
+++ b/apps/app/src/server/service/search-delegator/aggregate-to-index.ts
@@ -88,7 +88,7 @@ export const aggregatePipelineToIndex = (maxBodyLengthToIndex: number, query?: Q
     },
     {
       $addFields: {
-        commentsCount: { $size: '$comments' },
+        commentsCount: { $size: { $ifNull: ['$comments', []] } },
       },
     },
 
@@ -103,19 +103,19 @@ export const aggregatePipelineToIndex = (maxBodyLengthToIndex: number, query?: Q
     },
     {
       $addFields: {
-        bookmarksCount: { $size: '$bookmarks' },
+        bookmarksCount: { $size: { $ifNull: ['$bookmarks', []] } },
       },
     },
 
     // add counts for embedded arrays
     {
       $addFields: {
-        likeCount: { $size: '$liker' },
+        likeCount: { $size: { $ifNull: ['$liker', []] } },
       },
     },
     {
       $addFields: {
-        seenUsersCount: { $size: '$seenUsers' },
+        seenUsersCount: { $size: { $ifNull: ['$seenUsers', []] } },
       },
     },
 


### PR DESCRIPTION
Reproduced by #8937

## Error message

> MongoServerError: PlanExecutor error during aggregation :: caused by :: The argument to $size must be an array, but was of type: missing