### PR TITLE
support: Replace possition usericon

### DIFF
--- a/apps/app/src/client/components/Sidebar/SidebarNav/SecondaryItems.tsx
+++ b/apps/app/src/client/components/Sidebar/SidebarNav/SecondaryItems.tsx
@@ -47,10 +47,10 @@ export const SecondaryItems: FC = memo(() => {
 
   return (
     <div className={styles['grw-secondary-items']}>
-      {!isGuestUser && <PersonalDropdown />}
       <SecondaryItem label="Help" iconName="help" href={growiCloudUri != null ? 'https://growi.cloud/help/' : 'https://docs.growi.org'} isBlank />
       {isAdmin && <SecondaryItem label="Admin" iconName="settings" href="/admin" />}
       <SecondaryItem label="Trash" href="/trash" iconName="delete" />
+      {!isGuestUser && <PersonalDropdown />}
     </div>
   );
 });


### PR DESCRIPTION
# Task
- https://redmine.weseek.co.jp/issues/150153

# Summary
- ユーザーアイコンの位置を変更

<img width="222" alt="image" src="https://github.com/user-attachments/assets/a73406da-8a79-464a-9372-9f2a50cba068">
