### PR TITLE
feat: non-yjs mode badge

### DIFF
--- a/apps/app/src/client/components/PageEditor/EditorNavbar/EditorNavbar.tsx
+++ b/apps/app/src/client/components/PageEditor/EditorNavbar/EditorNavbar.tsx
@@ -11,7 +11,7 @@ const moduleClass = styles['editor-navbar'] ?? '';
 export const EditorNavbar = (): JSX.Element => {
   const { data: editingUsers } = useEditingUsers();
 
-  const isEnableYjs = true;
+  const isEnableYjs = false;
 
   return (
     <div className={`${moduleClass} d-flex flex-column flex-sm-row justify-content-between ps-3 ps-md-5 ps-xl-4 pe-4 py-1 align-items-sm-end`}>
@@ -19,25 +19,20 @@ export const EditorNavbar = (): JSX.Element => {
         <PageHeader />
       </div>
 
-      {isEnableYjs
-        ? (
-          <div className="order-1 order-sm-2">
+      <div className="order-1 order-sm-2">
+        {isEnableYjs
+          ? (
+            <EditingUserList userList={editingUsers?.userList ?? []} />
+          )
+          : (
             <div className="text-warning bg-warning-subtle rounded-1 px-1">
               <div className="d-flex align-items-center justify-content-center">
-                <span className="material-symbols-outlined fs-6 me-1">error</span>
-                <span>SINGLE</span>
+                <span className="material-symbols-outlined fs-6 me-1">error</span>SINGLE
               </div>
             </div>
-          </div>
-        )
-        : (
-          <div className="order-1 order-sm-2">
-            <EditingUserList
-              userList={editingUsers?.userList ?? []}
-            />
-          </div>
-        )
-      }
+          )
+        }
+      </div>
     </div>
   );
 };

--- a/apps/app/src/client/components/PageEditor/EditorNavbar/EditorNavbar.tsx
+++ b/apps/app/src/client/components/PageEditor/EditorNavbar/EditorNavbar.tsx
@@ -11,13 +11,33 @@ const moduleClass = styles['editor-navbar'] ?? '';
 export const EditorNavbar = (): JSX.Element => {
   const { data: editingUsers } = useEditingUsers();
 
+  const isEnableYjs = true;
+
   return (
     <div className={`${moduleClass} d-flex flex-column flex-sm-row justify-content-between ps-3 ps-md-5 ps-xl-4 pe-4 py-1 align-items-sm-end`}>
-      <div className="order-2 order-sm-1"><PageHeader /></div>
-      <div className="order-1 order-sm-2"><EditingUserList
-        userList={editingUsers?.userList ?? []}
-      />
+      <div className="order-2 order-sm-1">
+        <PageHeader />
       </div>
+
+      {isEnableYjs
+        ? (
+          <div className="order-1 order-sm-2">
+            <div className="text-warning bg-warning-subtle rounded-1 px-1">
+              <div className="d-flex align-items-center justify-content-center">
+                <span className="material-symbols-outlined fs-6 me-1">error</span>
+                <span>SINGLE</span>
+              </div>
+            </div>
+          </div>
+        )
+        : (
+          <div className="order-1 order-sm-2">
+            <EditingUserList
+              userList={editingUsers?.userList ?? []}
+            />
+          </div>
+        )
+      }
     </div>
   );
 };


### PR DESCRIPTION
## Task
[#142089](https://redmine.weseek.co.jp/issues/142089) [v7] 文字数の多いページ（Draw.ioなど）の Edit 画面開くと Markdown の内容が表示されない件の修正
┗ [#148850](https://redmine.weseek.co.jp/issues/148850) エディターがアクティブになった時にエディターに入力されている文字数が閾値以上だった場合、同時多人数編集できないことをユーザーが認識できるようにする

## Screenshot
<img width="474" alt="スクリーンショット 2024-07-26 15 21 47" src="https://github.com/user-attachments/assets/c9fbe592-c340-4e13-aac5-39a2391f2a89">


