### PR TITLE
fix: Non-admin user gets 500 error when opening history modal

### DIFF
--- a/apps/app/src/server/routes/apiv3/customize-setting.js
+++ b/apps/app/src/server/routes/apiv3/customize-setting.js
@@ -272,7 +272,7 @@ module.exports = (crowi) => {
     }
   });
 
-  router.get('/theme', loginRequiredStrictly, adminRequired, async(req, res) => {
+  router.get('/theme', loginRequiredStrictly, async(req, res) => {
 
     try {
       const currentTheme = await crowi.configManager.getConfig('crowi', 'customize:theme');


### PR DESCRIPTION
## Task
[#151601](https://redmine.weseek.co.jp/issues/151601) 非 Admin user が History modal を開くと 500 エラーになる
┗ [#151602](https://redmine.weseek.co.jp/issues/151602) 修正