### PR TITLE
fix: Only return empty page when restricted page is requested by path

### DIFF
--- a/apps/app/src/client/components/Bookmarks/BookmarkItem.tsx
+++ b/apps/app/src/client/components/Bookmarks/BookmarkItem.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useState } from 'react';
 import nodePath from 'path';
 
 import type { IPageHasId, IPageInfoAll, IPageToDeleteWithMeta } from '@growi/core';
-import { DevidedPagePath } from '@growi/core/dist/models';
+import { DividedPagePath } from '@growi/core/dist/models';
 import { pathUtils } from '@growi/core/dist/utils';
 import { useRouter } from 'next/router';
 import { useTranslation } from 'react-i18next';
@@ -159,7 +159,7 @@ export const BookmarkItem = (props: Props): JSX.Element => {
     return <></>;
   }
 
-  const dPagePath = new DevidedPagePath(bookmarkedPage.path, false, true);
+  const dPagePath = new DividedPagePath(bookmarkedPage.path, false, true);
   const { latter: pageTitle, former: formerPagePath } = dPagePath;
 
   const bookmarkItemId = `bookmark-item-${bookmarkedPage._id}`;

--- a/apps/app/src/client/components/IdenticalPathPage.tsx
+++ b/apps/app/src/client/components/IdenticalPathPage.tsx
@@ -1,7 +1,7 @@
 import type { FC } from 'react';
 import React from 'react';
 
-import { DevidedPagePath } from '@growi/core/dist/models';
+import { DividedPagePath } from '@growi/core/dist/models';
 import { useTranslation } from 'next-i18next';
 
 import { useCurrentPathname } from '~/stores-universal/context';
@@ -25,9 +25,9 @@ const IdenticalPathAlert : FC<IdenticalPathAlertProps> = (props: IdenticalPathAl
   let _pageName = '――';
 
   if (path != null) {
-    const devidedPath = new DevidedPagePath(path);
-    _path = devidedPath.isFormerRoot ? '/' : devidedPath.former;
-    _pageName = devidedPath.latter;
+    const dividedPath = new DividedPagePath(path);
+    _path = dividedPath.isFormerRoot ? '/' : dividedPath.former;
+    _pageName = dividedPath.latter;
   }
 
 

--- a/apps/app/src/client/components/PageHeader/PagePathHeader.tsx
+++ b/apps/app/src/client/components/PageHeader/PagePathHeader.tsx
@@ -4,7 +4,7 @@ import {
 } from 'react';
 
 import type { IPagePopulatedToShowRevision } from '@growi/core';
-import { DevidedPagePath } from '@growi/core/dist/models';
+import { DividedPagePath } from '@growi/core/dist/models';
 import { normalizePath } from '@growi/core/dist/utils/path-utils';
 import { useTranslation } from 'next-i18next';
 import { debounce } from 'throttle-debounce';
@@ -37,7 +37,7 @@ export const PagePathHeader = memo((props: Props): JSX.Element => {
     currentPage, className, maxWidth, onRenameTerminated,
   } = props;
 
-  const dPagePath = new DevidedPagePath(currentPage.path, true);
+  const dPagePath = new DividedPagePath(currentPage.path, true);
   const parentPagePath = dPagePath.former;
 
   const linkedPagePath = new LinkedPagePath(parentPagePath);

--- a/apps/app/src/client/components/PageHeader/PageTitleHeader.tsx
+++ b/apps/app/src/client/components/PageHeader/PageTitleHeader.tsx
@@ -4,7 +4,7 @@ import { useState, useCallback, useEffect } from 'react';
 import nodePath from 'path';
 
 import type { IPagePopulatedToShowRevision } from '@growi/core';
-import { DevidedPagePath } from '@growi/core/dist/models';
+import { DividedPagePath } from '@growi/core/dist/models';
 import { pathUtils } from '@growi/core/dist/utils';
 import { isMovablePage } from '@growi/core/dist/utils/page-path-utils';
 import { useTranslation } from 'next-i18next';
@@ -38,7 +38,7 @@ export const PageTitleHeader = (props: Props): JSX.Element => {
 
   const isMovable = isMovablePage(currentPagePath);
 
-  const dPagePath = new DevidedPagePath(currentPage.path, true);
+  const dPagePath = new DividedPagePath(currentPage.path, true);
   const pageTitle = dPagePath.latter;
 
   const [isRenameInputShown, setRenameInputShown] = useState(false);

--- a/apps/app/src/client/components/PageList/PageListItemL.tsx
+++ b/apps/app/src/client/components/PageList/PageListItemL.tsx
@@ -7,7 +7,7 @@ import type {
   IPageInfoAll, IPageWithMeta, IPageInfoForListing,
 } from '@growi/core';
 import { isIPageInfoForListing, isIPageInfoForEntity } from '@growi/core';
-import { DevidedPagePath } from '@growi/core/dist/models';
+import { DividedPagePath } from '@growi/core/dist/models';
 import { pathUtils } from '@growi/core/dist/utils';
 import { UserPicture, PageListMeta } from '@growi/ui/dist/components';
 import { format } from 'date-fns/format';
@@ -97,10 +97,10 @@ const PageListItemLSubstance: ForwardRefRenderFunction<ISelectable, Props> = (pr
   const elasticSearchResult = isIPageSearchMeta(pageMeta) ? pageMeta.elasticSearchResult : null;
   const revisionShortBody = isIPageInfoForListing(pageMeta) ? pageMeta.revisionShortBody : null;
 
-  const dPagePath: DevidedPagePath = new DevidedPagePath(pageData.path, false);
+  const dPagePath: DividedPagePath = new DividedPagePath(pageData.path, false);
   const linkedPagePathFormer = new LinkedPagePath(dPagePath.former);
 
-  const dPagePathHighlighted: DevidedPagePath = new DevidedPagePath(elasticSearchResult?.highlightedPath || pageData.path, true);
+  const dPagePathHighlighted: DividedPagePath = new DividedPagePath(elasticSearchResult?.highlightedPath || pageData.path, true);
   const linkedPagePathHighlightedFormer = new LinkedPagePath(dPagePathHighlighted.former);
   const linkedPagePathHighlightedLatter = new LinkedPagePath(dPagePathHighlighted.latter);
 

--- a/apps/app/src/client/components/PagePathNavSticky/PagePathNavSticky.tsx
+++ b/apps/app/src/client/components/PagePathNavSticky/PagePathNavSticky.tsx
@@ -5,7 +5,7 @@ import {
   useState,
 } from 'react';
 
-import { DevidedPagePath } from '@growi/core/dist/models';
+import { DividedPagePath } from '@growi/core/dist/models';
 import { pagePathUtils } from '@growi/core/dist/utils';
 import Sticky from 'react-stickynode';
 
@@ -58,7 +58,7 @@ export const PagePathNavSticky = (props: PagePathNavLayoutProps): JSX.Element =>
   }, [pageControlsX, pagePathNavRef, sidebarMode]);
 
   const latterLink = useMemo(() => {
-    const dPagePath = new DevidedPagePath(pagePath, false, true);
+    const dPagePath = new DividedPagePath(pagePath, false, true);
 
     const isInTrash = isTrashPage(pagePath);
 

--- a/apps/app/src/client/components/Sidebar/RecentChanges/RecentChangesSubstance.tsx
+++ b/apps/app/src/client/components/Sidebar/RecentChanges/RecentChangesSubstance.tsx
@@ -5,7 +5,7 @@ import React, {
 import {
   isPopulated, type IPageHasId,
 } from '@growi/core';
-import { DevidedPagePath } from '@growi/core/dist/models';
+import { DividedPagePath } from '@growi/core/dist/models';
 import { UserPicture } from '@growi/ui/dist/components';
 import { useTranslation } from 'react-i18next';
 
@@ -88,7 +88,7 @@ const PageTags = memo((props: PageTagsProps): JSX.Element => {
 PageTags.displayName = 'PageTags';
 
 const PageItem = memo(({ page, isSmall, onClickTag }: PageItemProps): JSX.Element => {
-  const dPagePath = new DevidedPagePath(page.path, false, true);
+  const dPagePath = new DividedPagePath(page.path, false, true);
   const linkedPagePathFormer = new LinkedPagePath(dPagePath.former);
   const linkedPagePathLatter = new LinkedPagePath(dPagePath.latter);
   const FormerLink = () => (

--- a/apps/app/src/components/Common/PagePathNav/PagePathNav.tsx
+++ b/apps/app/src/components/Common/PagePathNav/PagePathNav.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 
-import { DevidedPagePath } from '@growi/core/dist/models';
+import { DividedPagePath } from '@growi/core/dist/models';
 import { pagePathUtils } from '@growi/core/dist/utils';
 
 import LinkedPagePath from '~/models/linked-page-path';
@@ -26,7 +26,7 @@ export const PagePathNav = (props: PagePathNavLayoutProps): JSX.Element => {
   const isInTrash = isTrashPage(pagePath);
 
   const formerLink = useMemo(() => {
-    const dPagePath = new DevidedPagePath(pagePath, false, true);
+    const dPagePath = new DividedPagePath(pagePath, false, true);
 
     // one line
     if (dPagePath.isRoot || dPagePath.isFormerRoot) {
@@ -44,7 +44,7 @@ export const PagePathNav = (props: PagePathNavLayoutProps): JSX.Element => {
   }, [isInTrash, pagePath]);
 
   const latterLink = useMemo(() => {
-    const dPagePath = new DevidedPagePath(pagePath, false, true);
+    const dPagePath = new DividedPagePath(pagePath, false, true);
 
     // one line
     if (dPagePath.isRoot || dPagePath.isFormerRoot) {

--- a/apps/app/src/features/search/client/components/SearchMethodMenuItem.tsx
+++ b/apps/app/src/features/search/client/components/SearchMethodMenuItem.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { DevidedPagePath } from '@growi/core/dist/models';
+import { DividedPagePath } from '@growi/core/dist/models';
 import { useTranslation } from 'next-i18next';
 
 import { useCurrentPagePath } from '~/stores/page';
@@ -24,7 +24,7 @@ export const SearchMethodMenuItem = (props: Props): JSX.Element => {
 
   const { data: currentPagePath } = useCurrentPagePath();
 
-  const dPagePath = (new DevidedPagePath(currentPagePath ?? '', true, true));
+  const dPagePath = (new DividedPagePath(currentPagePath ?? '', true, true));
   const currentPageName = `
   ${(!(dPagePath.isRoot || dPagePath.isFormerRoot) ? '...' : '')}/${(dPagePath.isRoot ? '' : `${dPagePath.latter}/`)}
   `;

--- a/apps/app/src/models/linked-page-path.js
+++ b/apps/app/src/models/linked-page-path.js
@@ -1,4 +1,4 @@
-import { DevidedPagePath } from '@growi/core/dist/models';
+import { DividedPagePath } from '@growi/core/dist/models';
 import { pagePathUtils, pathUtils } from '@growi/core/dist/utils';
 
 const { isTrashPage } = pagePathUtils;
@@ -10,7 +10,7 @@ export default class LinkedPagePath {
 
   constructor(path) {
 
-    const pagePath = new DevidedPagePath(path);
+    const pagePath = new DividedPagePath(path);
 
     this.path = path;
     this.pathName = pagePath.latter;

--- a/apps/app/src/pages/utils/commons.ts
+++ b/apps/app/src/pages/utils/commons.ts
@@ -1,6 +1,6 @@
 import type { ColorScheme, IUserHasId } from '@growi/core';
 import { Lang, AllLang, Locale } from '@growi/core';
-import { DevidedPagePath } from '@growi/core/dist/models';
+import { DividedPagePath } from '@growi/core/dist/models';
 import { isServer } from '@growi/core/dist/utils';
 import type { GetServerSideProps, GetServerSidePropsContext } from 'next';
 import type { SSRConfig, UserConfig } from 'next-i18next';
@@ -167,7 +167,7 @@ export const generateCustomTitle = (props: CommonProps, title: string): string =
  * @param pagePath
  */
 export const generateCustomTitleForPage = (props: CommonProps, pagePath: string): string => {
-  const dPagePath = new DevidedPagePath(pagePath, true, true);
+  const dPagePath = new DividedPagePath(pagePath, true, true);
 
   return props.customTitleTemplate
     .replace('{{sitename}}', props.appTitle)

--- a/apps/app/src/server/models/page.ts
+++ b/apps/app/src/server/models/page.ts
@@ -74,8 +74,12 @@ export interface PageModel extends Model<PageDocument> {
     pageIds: ObjectIdLike[], user, userGroups?, includeEmpty?: boolean, includeAnyoneWithTheLink?: boolean,
   ): Promise<HydratedDocument<PageDocument>[]>
   findByPath(path: string, includeEmpty?: boolean): Promise<HydratedDocument<PageDocument> | null>
-  findByPathAndViewer(path: string | null, user, userGroups?, useFindOne?: true, includeEmpty?: boolean): Promise<HydratedDocument<PageDocument> | null>
-  findByPathAndViewer(path: string | null, user, userGroups?, useFindOne?: false, includeEmpty?: boolean): Promise<HydratedDocument<PageDocument>[]>
+  findByPathAndViewer(
+    path: string | null, user, userGroups?, useFindOne?: true, includeEmpty?: boolean, includeAnyoneWithTheLink?: boolean
+  ): Promise<HydratedDocument<PageDocument> | null>
+  findByPathAndViewer(
+    path: string | null, user, userGroups?, useFindOne?: false, includeEmpty?: boolean, includeAnyoneWithTheLink?: boolean
+  ): Promise<HydratedDocument<PageDocument>[]>
   countByPathAndViewer(path: string | null, user, userGroups?, includeEmpty?:boolean): Promise<number>
   findParentByPath(path: string | null): Promise<HydratedDocument<PageDocument> | null>
   findTargetAndAncestorsByPathOrId(pathOrId: string): Promise<TargetAndAncestorsResult>

--- a/apps/app/src/server/models/page.ts
+++ b/apps/app/src/server/models/page.ts
@@ -635,14 +635,13 @@ schema.statics.findByIdsAndViewer = async function(
  * Find a page by path and viewer. Pass true to useFindOne to use findOne method.
  */
 schema.statics.findByPathAndViewer = async function(
-    path: string | null, user, userGroups = null, useFindOne = false, includeEmpty = false,
+    path: string | null, user, userGroups = null, useFindOne = false, includeEmpty = false, includeAnyoneWithTheLink = false,
 ): Promise<(PageDocument | PageDocument[]) & HasObjectId | null> {
   if (path == null) {
     throw new Error('path is required.');
   }
 
   const baseQuery = useFindOne ? this.findOne({ path }) : this.find({ path });
-  const includeAnyoneWithTheLink = useFindOne;
   const queryBuilder = new PageQueryBuilder(baseQuery, includeEmpty);
 
   await queryBuilder.addViewerCondition(user, userGroups, includeAnyoneWithTheLink);

--- a/apps/app/src/server/routes/apiv3/page-listing.ts
+++ b/apps/app/src/server/routes/apiv3/page-listing.ts
@@ -70,7 +70,7 @@ const routerFactory = (crowi: Crowi): Router => {
 
     let rootPage;
     try {
-      rootPage = await Page.findByPathAndViewer('/', req.user, null, true);
+      rootPage = await Page.findByPathAndViewer('/', req.user, null, true, false, true);
     }
     catch (err) {
       return res.apiv3Err(new ErrorV3('rootPage not found'));

--- a/apps/app/src/server/routes/apiv3/page/index.ts
+++ b/apps/app/src/server/routes/apiv3/page/index.ts
@@ -300,7 +300,7 @@ module.exports = (crowi) => {
         page = await Page.findByIdAndViewer(pageId, user);
       }
       else if (!findAll) {
-        page = await Page.findByPathAndViewer(path, user, null, true);
+        page = await Page.findByPathAndViewer(path, user, null, true, false, true);
       }
       else {
         pages = await Page.findByPathAndViewer(path, user, null, false);

--- a/apps/app/src/server/routes/ogp.ts
+++ b/apps/app/src/server/routes/ogp.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import path from 'path';
 
-import { DevidedPagePath } from '@growi/core/dist/models';
+import { DividedPagePath } from '@growi/core/dist/models';
 // eslint-disable-next-line no-restricted-imports
 import axios from 'axios';
 import {
@@ -69,7 +69,7 @@ module.exports = function(crowi) {
 
       bufferedUserImage = user.imageUrlCached === DEFAULT_USER_IMAGE_URL ? bufferedDefaultUserImageCache : (await getBufferedUserImage(user.imageUrlCached));
       // todo: consider page title
-      pageTitle = (new DevidedPagePath(page.path)).latter;
+      pageTitle = (new DividedPagePath(page.path)).latter;
     }
     catch (err) {
       logger.error(err);

--- a/packages/core/src/models/divided-page-path.ts
+++ b/packages/core/src/models/divided-page-path.ts
@@ -3,7 +3,7 @@ import * as pathUtils from '../utils/path-utils';
 // https://regex101.com/r/BahpKX/2
 const PATTERN_INCLUDE_DATE = /^(.+\/[^/]+)\/(\d{4}|\d{4}\/\d{2}|\d{4}\/\d{2}\/\d{2})$/;
 
-export class DevidedPagePath {
+export class DividedPagePath {
 
   isRoot: boolean;
 

--- a/packages/core/src/models/index.ts
+++ b/packages/core/src/models/index.ts
@@ -1,2 +1,2 @@
-export * from './devided-page-path';
+export * from './divided-page-path';
 export * from './vo/error-apiv3';

--- a/packages/remark-attachment-refs/src/server/routes/refs.ts
+++ b/packages/remark-attachment-refs/src/server/routes/refs.ts
@@ -87,7 +87,7 @@ export const routesFactory = (crowi): any => {
       return;
     }
 
-    const page = await Page.findByPathAndViewer(pagePath, user, undefined, true);
+    const page = await Page.findByPathAndViewer(pagePath, user, undefined, true, false, true);
 
     // not found
     if (page == null) {

--- a/packages/ui/src/components/PagePath/PagePathLabel.tsx
+++ b/packages/ui/src/components/PagePath/PagePathLabel.tsx
@@ -1,6 +1,6 @@
 import type { FC, ReactNode } from 'react';
 
-import { DevidedPagePath } from '@growi/core/dist/models';
+import { DividedPagePath } from '@growi/core/dist/models';
 
 
 type TextElemProps = {
@@ -32,7 +32,7 @@ export const PagePathLabel: FC<Props> = (props:Props) => {
     isLatterOnly, isFormerOnly, isPathIncludedHtml, additionalClassNames, path,
   } = props;
 
-  const dPagePath = new DevidedPagePath(path, false, true);
+  const dPagePath = new DividedPagePath(path, false, true);
 
   const classNames = additionalClassNames || [];
 


### PR DESCRIPTION
## task
https://redmine.weseek.co.jp/issues/151976

## 実装内容
- ページを ID または path で取得するメソッド (findPageAndMetaDataByViewer) において、path でリクエストされた場合に、ページの grant が restricted の場合は isEmpty なページのみを返却するように変更
- "divided" の typo を修正

## レビューしていただきたい点
今まで path (e.g /test_restricted_page) でのリンクでも restricted なページにアクセスできていたが、それができなくなり、page _id でのリンクもしくは共有リンクでのみアクセス可能となる。
この破壊的変更で問題が生じるかどうか。