### PR TITLE
fix: Lint Error

### DIFF
--- a/apps/app/src/@types/emoji-mart.d.ts
+++ b/apps/app/src/@types/emoji-mart.d.ts
@@ -1,0 +1,3 @@
+declare module 'emoji-mart';
+declare module '@emoji-mart/data';
+declare module '@emoji-mart/react';

--- a/apps/app/src/@types/emoji-mart.d.ts
+++ b/apps/app/src/@types/emoji-mart.d.ts
@@ -1,3 +1,0 @@
-declare module 'emoji-mart';
-declare module '@emoji-mart/data';
-declare module '@emoji-mart/react';

--- a/apps/app/src/client/components/PageEditor/PageEditorMainSwitcher.tsx
+++ b/apps/app/src/client/components/PageEditor/PageEditorMainSwitcher.tsx
@@ -3,9 +3,9 @@ import React, { useMemo } from 'react';
 import { type IUserHasId } from '@growi/core';
 import { GlobalCodeMirrorEditorKey } from '@growi/editor';
 import { CodeMirrorEditorMain } from '@growi/editor/dist/client/components/CodeMirrorEditorMain';
+import { type CodeMirrorEditorProps } from '@growi/editor/dist/client/interfaces/CodeMirrorEditor';
 import { useCodeMirrorEditorIsolated } from '@growi/editor/dist/client/stores/codemirror-editor';
-import { type CodeMirrorEditorProps } from '@growi/editor/src/client/components-internal/CodeMirrorEditor';
-import { useCollaborativeEditorMode } from '@growi/editor/src/client/stores/use-collaborative-editor-mode';
+import { useCollaborativeEditorMode } from '@growi/editor/dist/client/stores/use-collaborative-editor-mode';
 import type { ReactCodeMirrorProps } from '@uiw/react-codemirror';
 import deepmerge from 'ts-deepmerge';
 

--- a/packages/editor/src/client/components-internal/CodeMirrorEditor/CodeMirrorEditor.tsx
+++ b/packages/editor/src/client/components-internal/CodeMirrorEditor/CodeMirrorEditor.tsx
@@ -8,9 +8,9 @@ import {
   EditorView,
 } from '@codemirror/view';
 import { AcceptedUploadFileType } from '@growi/core';
-import type { ReactCodeMirrorProps } from '@uiw/react-codemirror';
 
-import type { EditorSettings, GlobalCodeMirrorEditorKey } from '../../../consts';
+import type { GlobalCodeMirrorEditorKey } from '../../../consts';
+import type { CodeMirrorEditorProps } from '../../interfaces/CodeMirrorEditor';
 import {
   useFileDropzone, FileDropzoneOverlay,
   adjustPasteData, getStrFromBol, useShowTableIcon,
@@ -33,18 +33,6 @@ const CodeMirrorEditorContainer = forwardRef<HTMLDivElement, DetailedHTMLProps<R
   },
 );
 
-export type CodeMirrorEditorProps = {
-  /**
-   * Specity the props for the react-codemirror component. **This must be a memolized object.**
-   */
-  cmProps?: ReactCodeMirrorProps,
-  acceptedUploadFileType?: AcceptedUploadFileType,
-  indentSize?: number,
-  editorSettings?: EditorSettings,
-  onSave?: () => void,
-  onUpload?: (files: File[]) => void,
-  onScroll?: () => void,
-}
 
 type Props = CodeMirrorEditorProps & {
   editorKey: string | GlobalCodeMirrorEditorKey,

--- a/packages/editor/src/client/components/CodeMirrorEditorComment.tsx
+++ b/packages/editor/src/client/components/CodeMirrorEditorComment.tsx
@@ -4,7 +4,8 @@ import type { Extension } from '@codemirror/state';
 import { keymap } from '@codemirror/view';
 
 import type { GlobalCodeMirrorEditorKey } from '../../consts';
-import { CodeMirrorEditor, type CodeMirrorEditorProps } from '../components-internal/CodeMirrorEditor';
+import { CodeMirrorEditor } from '../components-internal/CodeMirrorEditor';
+import type { CodeMirrorEditorProps } from '../interfaces/CodeMirrorEditor';
 import { useCodeMirrorEditorIsolated } from '../stores/codemirror-editor';
 
 

--- a/packages/editor/src/client/components/CodeMirrorEditorMain.tsx
+++ b/packages/editor/src/client/components/CodeMirrorEditorMain.tsx
@@ -4,7 +4,8 @@ import { type Extension } from '@codemirror/state';
 import { keymap, scrollPastEnd } from '@codemirror/view';
 
 import { GlobalCodeMirrorEditorKey } from '../../consts';
-import { CodeMirrorEditor, type CodeMirrorEditorProps } from '../components-internal/CodeMirrorEditor';
+import { CodeMirrorEditor } from '../components-internal/CodeMirrorEditor';
+import type { CodeMirrorEditorProps } from '../interfaces/CodeMirrorEditor';
 import { setDataLine } from '../services-internal';
 import { useCodeMirrorEditorIsolated } from '../stores/codemirror-editor';
 

--- a/packages/editor/src/client/interfaces/CodeMirrorEditor.ts
+++ b/packages/editor/src/client/interfaces/CodeMirrorEditor.ts
@@ -1,0 +1,17 @@
+import type { AcceptedUploadFileType } from '@growi/core';
+import type { ReactCodeMirrorProps } from '@uiw/react-codemirror';
+
+import type { EditorSettings } from 'src/consts';
+
+export type CodeMirrorEditorProps = {
+  /**
+   * Specity the props for the react-codemirror component. **This must be a memolized object.**
+   */
+  cmProps?: ReactCodeMirrorProps,
+  acceptedUploadFileType?: AcceptedUploadFileType,
+  indentSize?: number,
+  editorSettings?: EditorSettings,
+  onSave?: () => void,
+  onUpload?: (files: File[]) => void,
+  onScroll?: () => void,
+}

--- a/packages/editor/src/client/interfaces/CodeMirrorEditor.ts
+++ b/packages/editor/src/client/interfaces/CodeMirrorEditor.ts
@@ -1,7 +1,7 @@
 import type { AcceptedUploadFileType } from '@growi/core';
 import type { ReactCodeMirrorProps } from '@uiw/react-codemirror';
 
-import type { EditorSettings } from 'src/consts';
+import type { EditorSettings } from '../../consts';
 
 export type CodeMirrorEditorProps = {
   /**


### PR DESCRIPTION
## Task
- [#142089](https://redmine.weseek.co.jp/issues/142089) [v7] 文字数の多いページ（Draw.ioなど）の Edit 画面開くと Markdown の内容が表示されない件の修正
  - [#152245](https://redmine.weseek.co.jp/issues/152245) 151113, 148852 で出た lint error の修正

## 発生源の PR
- https://github.com/weseek/growi/pull/8990
