### PR TITLE
support: Dark mode support for CountBadge

### DIFF
--- a/apps/app/src/client/components/Common/CountBadge.tsx
+++ b/apps/app/src/client/components/Common/CountBadge.tsx
@@ -11,7 +11,7 @@ const CountBadge: FC<CountProps> = (props:CountProps) => {
 
 
   return (
-    <span className="grw-count-badge px-2 badge bg-body-tertiary text-body-tertiary rounded-pill">
+    <span className="grw-count-badge px-2 badge bg-body-tertiary text-body-tertiary">
       { count == null && <span className="text-muted">―</span> }
       { count != null && count + offset }
     </span>

--- a/apps/app/src/client/components/Common/CountBadge.tsx
+++ b/apps/app/src/client/components/Common/CountBadge.tsx
@@ -11,7 +11,7 @@ const CountBadge: FC<CountProps> = (props:CountProps) => {
 
 
   return (
-    <span className="grw-count-badge px-2 badge rounded-pill bg-light text-dark">
+    <span className="grw-count-badge px-2 badge bg-body-tertiary text-body-tertiary rounded-pill">
       { count == null && <span className="text-muted">―</span> }
       { count != null && count + offset }
     </span>


### PR DESCRIPTION
# Task
https://redmine.weseek.co.jp/issues/152601

# Summary
‐ PageTree 左側の`Page List` `Comments` ボタンのカウントバッジをダークモードに対応させた

<img width="1020" alt="image" src="https://github.com/user-attachments/assets/5e2110dd-0baa-44e2-a76c-88250ba1009a">
<img width="1015" alt="image" src="https://github.com/user-attachments/assets/497a7e8e-84c6-4841-8fa7-8ff53e531782">

