### PR TITLE
fix: Unable to update the page when the latest revision origin is "editor-single" in collaborative editor mode

### DIFF
--- a/apps/app/src/client/components/PageEditor/PageEditor.tsx
+++ b/apps/app/src/client/components/PageEditor/PageEditor.tsx
@@ -130,7 +130,8 @@ export const PageEditor = React.memo((props: Props): JSX.Element => {
   mutateResolvedTheme({ themeData: resolvedTheme });
 
   const currentRevisionId = currentPage?.revision?._id;
-  const isRevisionIdRequiredForPageUpdate = currentPage?.revision?.origin === undefined || isYjsEnabled === false;
+  const currentRevisionOrigin = currentPage?.revision?.origin;
+  const isRevisionIdRequiredForPageUpdate = currentRevisionOrigin === undefined || currentRevisionOrigin === Origin.EditorSingle || isYjsEnabled === false;
 
   const initialValueRef = useRef('');
   const initialValue = useMemo(() => {


### PR DESCRIPTION
## Task
- [#142089](https://redmine.weseek.co.jp/issues/142089) [v7] 文字数の多いページ（Draw.ioなど）の Edit 画面開くと Markdown の内容が表示されない件の修正
  - [#152875](https://redmine.weseek.co.jp/issues/152875) 同時多人数編集時に最新の revision.origin が "editor-single" だった場合にページを更新できない
