### PR TITLE
add like button on comments

### DIFF
--- a/apps/app/src/client/components/PageComment/LikeButtons.module.scss
+++ b/apps/app/src/client/components/PageComment/LikeButtons.module.scss
@@ -1,0 +1,24 @@
+@use '@growi/core-styles/scss/bootstrap/init' as bs;
+@use '@growi/ui/scss/atoms/btn-muted';
+@use './button-styles';
+
+.btn-group-like-for-comment :global {
+  .btn-like-for-comment {
+    @extend %btn-basis;
+  }
+  .btn-like-for-comment.toggle-btn-like {
+    padding-right: 3px;
+  }
+  .total-counts {
+    @extend %btn-total-counts-basis;
+
+    padding-left: 5px;
+  }
+}
+
+// == Colors
+.btn-group-like-for-comment :global {
+  .btn-like-for-comment {
+    @include btn-muted.colorize(bs.$blue);
+  }
+}

--- a/apps/app/src/client/components/PageComment/LikeButtons.tsx
+++ b/apps/app/src/client/components/PageComment/LikeButtons.tsx
@@ -1,0 +1,82 @@
+import type { FC } from 'react';
+import React, { useState, useCallback } from 'react';
+
+import type { IUser } from '@growi/core';
+import { useTranslation } from 'next-i18next';
+import { UncontrolledTooltip, Popover, PopoverBody } from 'reactstrap';
+
+
+import UserPictureList from '../Common/UserPictureList';
+
+import styles from './LikeButtons.module.scss';
+import popoverStyles from './user-list-popover.module.scss';
+
+type LikeButtonsProps = {
+
+  sumOfLikers: number,
+  likers: IUser[],
+  commentId: string,
+
+  isGuestUser?: boolean,
+  isLiked?: boolean,
+  onLikeClicked?: ()=>void,
+}
+
+const LikeButtons: FC<LikeButtonsProps> = (props: LikeButtonsProps) => {
+  const { t } = useTranslation();
+
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+
+  const togglePopover = () => {
+    setIsPopoverOpen(!isPopoverOpen);
+  };
+
+  const {
+    isGuestUser, isLiked, sumOfLikers, onLikeClicked, commentId,
+  } = props;
+
+  const getTooltipMessage = useCallback(() => {
+
+    if (isLiked) {
+      return 'tooltip.cancel_like';
+    }
+    return 'tooltip.like';
+  }, [isLiked]);
+
+  return (
+    <div className={`btn-group btn-group-like-for-comment ${styles['btn-group-like-for-comment']}`} role="group" aria-label="Like buttons for comment">
+      <button
+        type="button"
+        id={`like-button-${commentId}`}
+        onClick={onLikeClicked}
+        className={`btn btn-like-for-comment toggle-btn-like
+            ${isLiked ? 'active' : ''} ${isGuestUser ? 'disabled' : ''}`}
+      >
+        <span className={`material-symbols-outlined ${isLiked ? 'fill' : ''}`}>favorite</span>
+      </button>
+
+      <UncontrolledTooltip data-testid={`like-button-tooltip-${commentId}`} target={`like-button-${commentId}`} autohide={false} fade={false}>
+        {t(getTooltipMessage())}
+      </UncontrolledTooltip>
+
+      <button
+        type="button"
+        id={`co-total-likes-${commentId}`}
+        className={`btn btn-like-for-comment
+          total-counts ${isLiked ? 'active' : ''}`}
+      >
+        {sumOfLikers}
+      </button>
+      <Popover placement="bottom" isOpen={isPopoverOpen} target={`co-total-likes-${commentId}`} toggle={togglePopover} trigger="legacy">
+        <PopoverBody className={`user-list-popover ${popoverStyles['user-list-popover']}`}>
+          <div className="px-2 text-end user-list-content text-truncate text-muted">
+            {props.likers?.length ? <UserPictureList users={props.likers} /> : t('No users have liked this yet.')}
+          </div>
+        </PopoverBody>
+      </Popover>
+    </div>
+  );
+
+};
+
+export default LikeButtons;

--- a/apps/app/src/client/components/PageComment/_button-styles.scss
+++ b/apps/app/src/client/components/PageComment/_button-styles.scss
@@ -1,0 +1,17 @@
+@use '@growi/core-styles/scss/bootstrap/init' as bs;
+
+%btn-basis {
+  --bs-btn-padding-x: 6px;
+  --bs-btn-padding-y: 6px;
+  --bs-btn-line-height: 1em;
+  --bs-btn-border-width: 0;
+  --bs-btn-box-shadow: none;
+}
+
+%btn-total-counts-basis {
+  --bs-btn-font-size: 13px;
+}
+
+%text-total-counts-basis {
+  font-size: 13px;
+}

--- a/apps/app/src/client/components/PageComment/user-list-popover.module.scss
+++ b/apps/app/src/client/components/PageComment/user-list-popover.module.scss
@@ -1,0 +1,5 @@
+@use '@growi/ui/scss/molecules/user-list-popover';
+
+.user-list-popover :global {
+  @extend %user-list-popover
+}

--- a/apps/app/src/features/comment/server/models/comment.ts
+++ b/apps/app/src/features/comment/server/models/comment.ts
@@ -23,6 +23,7 @@ type Add = (
   comment: string,
   commentPosition: number,
   replyTo?: Types.ObjectId | null,
+  liker?: Array<Types.ObjectId>,
 ) => Promise<CommentDocument>;
 type FindCommentsByPageId = (pageId: Types.ObjectId) => Query<CommentDocument[], CommentDocument>;
 type FindCommentsByRevisionId = (revisionId: Types.ObjectId) => Query<CommentDocument[], CommentDocument>;
@@ -44,6 +45,7 @@ const commentSchema = new Schema<CommentDocument, CommentModel>({
   comment: { type: String, required: true },
   commentPosition: { type: Number, default: -1 },
   replyTo: { type: Schema.Types.ObjectId },
+  liker: { type: Array<Schema.Types.ObjectId> },
 }, {
   timestamps: true,
 });
@@ -65,6 +67,7 @@ const add: Add = async function(
       comment,
       commentPosition,
       replyTo,
+      liker: [],
     });
     logger.debug('Comment saved.', data);
 

--- a/apps/app/src/interfaces/comment.ts
+++ b/apps/app/src/interfaces/comment.ts
@@ -10,6 +10,7 @@ export type IComment = {
   comment: string;
   commentPosition: number,
   replyTo?: string,
+  liker?: Array<Ref<IUser>>,
   createdAt: Date,
   updatedAt: Date,
 };

--- a/apps/app/src/server/routes/index.js
+++ b/apps/app/src/server/routes/index.js
@@ -134,6 +134,7 @@ module.exports = function(crowi, app) {
   apiV1Router.post('/comments.add'       , comment.api.validators.add(), accessTokenParser , loginRequiredStrictly , excludeReadOnlyUser, addActivity, comment.api.add);
   apiV1Router.post('/comments.update'    , comment.api.validators.add(), accessTokenParser , loginRequiredStrictly , excludeReadOnlyUser, addActivity, comment.api.update);
   apiV1Router.post('/comments.remove'    , accessTokenParser , loginRequiredStrictly , excludeReadOnlyUser, addActivity, comment.api.remove);
+  apiV1Router.post('/comments.like'      , accessTokenParser , loginRequiredStrictly , excludeReadOnlyUser, addActivity, comment.api.like);
 
   apiV1Router.post('/attachments.uploadProfileImage'   , uploads.single('file'), autoReap, accessTokenParser, loginRequiredStrictly , excludeReadOnlyUser, attachmentApi.uploadProfileImage);
   apiV1Router.post('/attachments.remove'               , accessTokenParser , loginRequiredStrictly , excludeReadOnlyUser, addActivity ,attachmentApi.remove);


### PR DESCRIPTION
社内でGROWIを利用しています。コメントに対するいいね！機能が欲しくなり、実装案としてPull requestします。

## 機能

- 各commentに liker 属性を持たせ、ユーザーのリストを保持するようにしました
- フロントエンドからいいね！するユーザーのIDを引数にAPIを呼び出し、バックエンドでいいね！の付与・剥奪の処理を行います
- コメント更新、削除の実装を参考にしました。また、ページに対するいいね！の実装も参考にしています。

## できていないこと

- テストは実装できていません(ビルドして目視での動作は確認)
- イベントログへの出力は対応できていません
- SCCSがページに対するいいね！ボタンと重複するかもしれません
