### PR TITLE
Feat/150418 153064 show duplicate export job info in modal

### DIFF
--- a/apps/app/public/static/locales/en_US/translation.json
+++ b/apps/app/public/static/locales/en_US/translation.json
@@ -644,8 +644,10 @@
     "bulk_export_job_expired": "Export process was canceled because it took too long",
     "export_in_progress": "Export in progress",
     "export_in_progress_explanation": "Export with the same format is already in progress. Would you like to restart to export the latest page contents?",
-    "export_cancel_warning": "The export in progress will be canceled",
-    "restart": "Restart"
+    "export_cancel_warning": "The following export in progress will be canceled",
+    "restart": "Restart",
+    "format": "Format",
+    "started_on": "Started on"
   },
   "message": {
     "successfully_connected": "Successfully Connected!",

--- a/apps/app/public/static/locales/fr_FR/translation.json
+++ b/apps/app/public/static/locales/fr_FR/translation.json
@@ -638,8 +638,10 @@
     "bulk_export_job_expired": "Le traitement a été interrompu car le temps d'exportation était trop long",
     "export_in_progress": "Exportation en cours",
     "export_in_progress_explanation": "L'exportation avec le même format est déjà en cours. Souhaitez-vous redémarrer pour exporter le dernier contenu de la page ?",
-    "export_cancel_warning": "L'export en cours sera annulé",
-    "restart": "Redémarrage"
+    "export_cancel_warning": "Les exportations suivantes en cours seront annulées",
+    "restart": "Redémarrage",
+    "format": "Format",
+    "started_on": "Commencé le"
   },
   "message": {
     "successfully_connected": "Connecté!",

--- a/apps/app/public/static/locales/ja_JP/translation.json
+++ b/apps/app/public/static/locales/ja_JP/translation.json
@@ -677,8 +677,10 @@
     "bulk_export_job_expired": "エクスポート時間が長すぎるため、処理が中断されました",
     "export_in_progress": "エクスポート進行中",
     "export_in_progress_explanation": "既に同じ形式でのエクスポートが進行中です。最新のページ内容でエクスポートを最初からやり直しますか？",
-    "export_cancel_warning": "進行中のエクスポートはキャンセルされます",
-    "restart": "やり直す"
+    "export_cancel_warning": "進行中の以下のエクスポートはキャンセルされます",
+    "restart": "やり直す",
+    "format": "形式",
+    "started_on": "開始日時"
   },
   "message": {
     "successfully_connected": "接続に成功しました!",

--- a/apps/app/public/static/locales/zh_CN/translation.json
+++ b/apps/app/public/static/locales/zh_CN/translation.json
@@ -647,8 +647,10 @@
     "bulk_export_job_expired": "由于导出时间太长，处理被中断",
     "export_in_progress": "导出正在进行中",
     "export_in_progress_explanation": "已在进行相同格式的导出。您要重新启动以导出最新的页面内容吗？",
-    "export_cancel_warning": "正在进行的导出将被取消",
-    "restart": "重新开始"
+    "export_cancel_warning": "以下正在进行的导出将被取消",
+    "restart": "重新开始",
+    "format": "格式",
+    "started_on": "开始于"
   },
   "message": {
     "successfully_connected": "连接成功！",

--- a/apps/app/src/features/page-bulk-export/client/components/PageBulkExportSelectModal.tsx
+++ b/apps/app/src/features/page-bulk-export/client/components/PageBulkExportSelectModal.tsx
@@ -23,9 +23,6 @@ const PageBulkExportSelectModal = (): JSX.Element => {
       setFormatMemoForRestart(format);
       await apiv3Post('/page-bulk-export', { path: currentPagePath, format });
       toastSuccess(t('page_export.bulk_export_started'));
-
-      // setDuplicateJob({ createdAt: new Date(), format } as any);
-      // setIsRestartModalOpened(true);
     }
     catch (e) {
       const errorCode = e?.[0].code ?? 'page_export.failed_to_export';

--- a/apps/app/src/features/page-bulk-export/client/components/PageBulkExportSelectModal.tsx
+++ b/apps/app/src/features/page-bulk-export/client/components/PageBulkExportSelectModal.tsx
@@ -6,7 +6,6 @@ import { Modal, ModalHeader, ModalBody } from 'reactstrap';
 import { apiv3Post } from '~/client/util/apiv3-client';
 import { toastError, toastSuccess } from '~/client/util/toastr';
 import { usePageBulkExportSelectModal } from '~/features/page-bulk-export/client/stores/modal';
-import type { IPageBulkExportJob } from '~/features/page-bulk-export/interfaces/page-bulk-export';
 import { PageBulkExportFormat } from '~/features/page-bulk-export/interfaces/page-bulk-export';
 import { useCurrentPagePath } from '~/stores/page';
 
@@ -17,18 +16,21 @@ const PageBulkExportSelectModal = (): JSX.Element => {
 
   const [isRestartModalOpened, setIsRestartModalOpened] = useState(false);
   const [formatMemoForRestart, setFormatMemoForRestart] = useState<PageBulkExportFormat | undefined>(undefined);
-  const [duplicateJob, setDuplicateJob] = useState<IPageBulkExportJob | undefined>(undefined);
+  const [duplicateJobInfo, setDuplicateJobInfo] = useState<{createdAt: string} | undefined>(undefined);
 
   const startBulkExport = async(format: PageBulkExportFormat) => {
     try {
       setFormatMemoForRestart(format);
       await apiv3Post('/page-bulk-export', { path: currentPagePath, format });
       toastSuccess(t('page_export.bulk_export_started'));
+
+      // setDuplicateJob({ createdAt: new Date(), format } as any);
+      // setIsRestartModalOpened(true);
     }
     catch (e) {
       const errorCode = e?.[0].code ?? 'page_export.failed_to_export';
       if (errorCode === 'page_export.duplicate_bulk_export_job_error') {
-        setDuplicateJob(e[0].args.duplicateJob);
+        setDuplicateJobInfo(e[0].args.duplicateJob);
         setIsRestartModalOpened(true);
       }
       else {
@@ -49,6 +51,16 @@ const PageBulkExportSelectModal = (): JSX.Element => {
       }
       setIsRestartModalOpened(false);
     }
+  };
+
+  const formatStartDate = (createdAt: string) => {
+    const date = new Date(createdAt);
+    const mm = String(date.getMonth() + 1).padStart(2, '0');
+    const dd = String(date.getDate()).padStart(2, '0');
+    const hh = String(date.getHours()).padStart(2, '0');
+    const min = String(date.getMinutes()).padStart(2, '0');
+
+    return `${mm}/${dd} ${hh}:${min}`;
   };
 
   return (
@@ -82,11 +94,21 @@ const PageBulkExportSelectModal = (): JSX.Element => {
         </ModalHeader>
         <ModalBody>
           {t('page_export.export_in_progress_explanation')}
-          <div className="my-1 text-danger">
-            <small className="text-danger">
-              {t('page_export.export_cancel_warning')}
-            </small>
+          <div className="text-danger">
+            {t('page_export.export_cancel_warning')}:
           </div>
+          { duplicateJobInfo && (
+            <div className="my-1">
+              <ul>
+                { formatMemoForRestart && (
+                  <li>
+                    {t('page_export.format')}: {formatMemoForRestart === PageBulkExportFormat.md ? t('page_export.markdown') : 'PDF'}
+                  </li>
+                )}
+                <li>{t('page_export.started_on')}: {formatStartDate(duplicateJobInfo.createdAt)}</li>
+              </ul>
+            </div>
+          )}
           <div className="d-flex justify-content-center mt-3">
             <button className="btn btn-primary" type="button" onClick={() => restartBulkExport()}>
               {t('page_export.restart')}

--- a/apps/app/src/features/page-bulk-export/client/components/PageBulkExportSelectModal.tsx
+++ b/apps/app/src/features/page-bulk-export/client/components/PageBulkExportSelectModal.tsx
@@ -6,6 +6,7 @@ import { Modal, ModalHeader, ModalBody } from 'reactstrap';
 import { apiv3Post } from '~/client/util/apiv3-client';
 import { toastError, toastSuccess } from '~/client/util/toastr';
 import { usePageBulkExportSelectModal } from '~/features/page-bulk-export/client/stores/modal';
+import type { IPageBulkExportJob } from '~/features/page-bulk-export/interfaces/page-bulk-export';
 import { PageBulkExportFormat } from '~/features/page-bulk-export/interfaces/page-bulk-export';
 import { useCurrentPagePath } from '~/stores/page';
 
@@ -15,7 +16,8 @@ const PageBulkExportSelectModal = (): JSX.Element => {
   const { data: currentPagePath } = useCurrentPagePath();
 
   const [isRestartModalOpened, setIsRestartModalOpened] = useState(false);
-  const [formatMemoForRestart, setFormatMemoForRestart] = useState<PageBulkExportFormat | null>(null);
+  const [formatMemoForRestart, setFormatMemoForRestart] = useState<PageBulkExportFormat | undefined>(undefined);
+  const [duplicateJob, setDuplicateJob] = useState<IPageBulkExportJob | undefined>(undefined);
 
   const startBulkExport = async(format: PageBulkExportFormat) => {
     try {
@@ -26,6 +28,7 @@ const PageBulkExportSelectModal = (): JSX.Element => {
     catch (e) {
       const errorCode = e?.[0].code ?? 'page_export.failed_to_export';
       if (errorCode === 'page_export.duplicate_bulk_export_job_error') {
+        setDuplicateJob(e[0].args.duplicateJob);
         setIsRestartModalOpened(true);
       }
       else {

--- a/apps/app/src/features/page-bulk-export/client/components/PageBulkExportSelectModal.tsx
+++ b/apps/app/src/features/page-bulk-export/client/components/PageBulkExportSelectModal.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 
+import { format } from 'date-fns/format';
 import { useTranslation } from 'next-i18next';
 import { Modal, ModalHeader, ModalBody } from 'reactstrap';
 
@@ -50,16 +51,6 @@ const PageBulkExportSelectModal = (): JSX.Element => {
     }
   };
 
-  const formatStartDate = (createdAt: string) => {
-    const date = new Date(createdAt);
-    const mm = String(date.getMonth() + 1).padStart(2, '0');
-    const dd = String(date.getDate()).padStart(2, '0');
-    const hh = String(date.getHours()).padStart(2, '0');
-    const min = String(date.getMinutes()).padStart(2, '0');
-
-    return `${mm}/${dd} ${hh}:${min}`;
-  };
-
   return (
     <>
       {status != null && (
@@ -102,7 +93,7 @@ const PageBulkExportSelectModal = (): JSX.Element => {
                     {t('page_export.format')}: {formatMemoForRestart === PageBulkExportFormat.md ? t('page_export.markdown') : 'PDF'}
                   </li>
                 )}
-                <li>{t('page_export.started_on')}: {formatStartDate(duplicateJobInfo.createdAt)}</li>
+                <li>{t('page_export.started_on')}: {format(new Date(duplicateJobInfo.createdAt), 'MM/dd HH:mm')}</li>
               </ul>
             </div>
           )}

--- a/apps/app/src/features/page-bulk-export/interfaces/page-bulk-export.ts
+++ b/apps/app/src/features/page-bulk-export/interfaces/page-bulk-export.ts
@@ -35,6 +35,8 @@ export interface IPageBulkExportJob {
   attachment?: Ref<IAttachment>,
   status: PageBulkExportJobStatus,
   revisionListHash?: string, // Hash created from the list of revision IDs. Used to detect existing duplicate uploads.
+  createdAt?: Date,
+  updatedAt?: Date
 }
 
 export interface IPageBulkExportJobHasId extends IPageBulkExportJob, HasObjectId {}

--- a/apps/app/src/features/page-bulk-export/server/routes/apiv3/page-bulk-export.ts
+++ b/apps/app/src/features/page-bulk-export/server/routes/apiv3/page-bulk-export.ts
@@ -48,7 +48,9 @@ module.exports = (crowi: Crowi): Router => {
     catch (err) {
       logger.error(err);
       if (err instanceof DuplicateBulkExportJobError) {
-        return res.apiv3Err(new ErrorV3('Duplicate bulk export job is in progress', 'page_export.duplicate_bulk_export_job_error'), 409);
+        return res.apiv3Err(new ErrorV3(
+          'Duplicate bulk export job is in progress', 'page_export.duplicate_bulk_export_job_error', undefined, { duplicateJob: err.duplicateJob },
+        ), 409);
       }
       return res.apiv3Err(new ErrorV3('Failed to start bulk export', 'page_export.failed_to_export'));
     }

--- a/apps/app/src/features/page-bulk-export/server/routes/apiv3/page-bulk-export.ts
+++ b/apps/app/src/features/page-bulk-export/server/routes/apiv3/page-bulk-export.ts
@@ -49,7 +49,9 @@ module.exports = (crowi: Crowi): Router => {
       logger.error(err);
       if (err instanceof DuplicateBulkExportJobError) {
         return res.apiv3Err(new ErrorV3(
-          'Duplicate bulk export job is in progress', 'page_export.duplicate_bulk_export_job_error', undefined, { duplicateJob: err.duplicateJob },
+          'Duplicate bulk export job is in progress',
+          'page_export.duplicate_bulk_export_job_error', undefined,
+          { duplicateJob: { createdAt: err.duplicateJob.createdAt } },
         ), 409);
       }
       return res.apiv3Err(new ErrorV3('Failed to start bulk export', 'page_export.failed_to_export'));

--- a/apps/app/src/features/page-bulk-export/server/service/page-bulk-export/errors.ts
+++ b/apps/app/src/features/page-bulk-export/server/service/page-bulk-export/errors.ts
@@ -1,7 +1,14 @@
+import type { HydratedDocument } from 'mongoose';
+
+import type { PageBulkExportJobDocument } from '../../models/page-bulk-export-job';
+
 export class DuplicateBulkExportJobError extends Error {
 
-  constructor() {
+  duplicateJob: HydratedDocument<PageBulkExportJobDocument>;
+
+  constructor(duplicateJob: HydratedDocument<PageBulkExportJobDocument>) {
     super('Duplicate bulk export job is in progress');
+    this.duplicateJob = duplicateJob;
   }
 
 }

--- a/apps/app/src/features/page-bulk-export/server/service/page-bulk-export/index.ts
+++ b/apps/app/src/features/page-bulk-export/server/service/page-bulk-export/index.ts
@@ -94,7 +94,7 @@ class PageBulkExportService {
         this.restartBulkExportJob(duplicatePageBulkExportJobInProgress);
         return;
       }
-      throw new DuplicateBulkExportJobError();
+      throw new DuplicateBulkExportJobError(duplicatePageBulkExportJobInProgress);
     }
     const pageBulkExportJob: HydratedDocument<PageBulkExportJobDocument> = await PageBulkExportJob.create({
       user: currentUser, page: basePage, format, status: PageBulkExportJobStatus.initializing,


### PR DESCRIPTION
## イメージ
![image](https://github.com/user-attachments/assets/1553964b-661b-4d75-a791-d3fc3cde9e9b)

## task
https://redmine.weseek.co.jp/issues/153064

## 備考
ユーザによってアクセスできるページが異なり、それぞれでエクスポート内容が異なるため、ユーザが被っていなければ PageBulkExportJob は duplicate と見なしていません。
そのため、ユーザ名をモーダルに表示する必要はありません。