### PR TITLE
fix: Input text becomes empty when opening the ReadOnlyEditor

### DIFF
--- a/packages/editor/src/client/components/CodeMirrorEditorReadOnly.tsx
+++ b/packages/editor/src/client/components/CodeMirrorEditorReadOnly.tsx
@@ -13,6 +13,7 @@ const additionalExtensions: Extension[] = [
   [
     setDataLine,
     EditorState.readOnly.of(true),
+    EditorView.editable.of(false),
   ],
 ];
 

--- a/packages/editor/src/client/components/CodeMirrorEditorReadOnly.tsx
+++ b/packages/editor/src/client/components/CodeMirrorEditorReadOnly.tsx
@@ -68,7 +68,6 @@ export const CodeMirrorEditorReadOnly = ({ markdown, onScroll }: Props): JSX.Ele
       hideToolbar
       editorKey={GlobalCodeMirrorEditorKey.READONLY}
       onScroll={onScroll}
-      cmProps={{}} // Do not pass undefined when initializing useCodeMirrorEditorIsolated
     />
   );
 };

--- a/packages/editor/src/client/components/CodeMirrorEditorReadOnly.tsx
+++ b/packages/editor/src/client/components/CodeMirrorEditorReadOnly.tsx
@@ -67,6 +67,7 @@ export const CodeMirrorEditorReadOnly = ({ markdown, onScroll }: Props): JSX.Ele
       hideToolbar
       editorKey={GlobalCodeMirrorEditorKey.READONLY}
       onScroll={onScroll}
+      cmProps={{}}
     />
   );
 };

--- a/packages/editor/src/client/components/CodeMirrorEditorReadOnly.tsx
+++ b/packages/editor/src/client/components/CodeMirrorEditorReadOnly.tsx
@@ -68,7 +68,7 @@ export const CodeMirrorEditorReadOnly = ({ markdown, onScroll }: Props): JSX.Ele
       hideToolbar
       editorKey={GlobalCodeMirrorEditorKey.READONLY}
       onScroll={onScroll}
-      cmProps={{}}
+      cmProps={{}} // Do not pass undefined when initializing useCodeMirrorEditorIsolated
     />
   );
 };

--- a/packages/editor/src/client/stores/codemirror-editor.ts
+++ b/packages/editor/src/client/stores/codemirror-editor.ts
@@ -33,7 +33,7 @@ export const useCodeMirrorEditorIsolated = (
 
   const newData = useCodeMirrorEditor(mergedProps);
 
-  const shouldUpdate = swrKey != null && container != null && props != null && (
+  const shouldUpdate = swrKey != null && container != null && (
     currentData == null
     || (isValid(newData) && !isDeepEquals(currentData, newData))
   );


### PR DESCRIPTION
## Task
- [#153286](https://redmine.weseek.co.jp/issues/153286) 過去の revision を Editor mode で開いた時に Editor が空白になってしまう
  - [#153287](https://redmine.weseek.co.jp/issues/153287) 修正