### PR TITLE
imprv: Fix CI errors due to package upgrades

### DIFF
--- a/apps/app/playwright/20-basic-features/access-to-page.spec.ts
+++ b/apps/app/playwright/20-basic-features/access-to-page.spec.ts
@@ -23,7 +23,7 @@ test('/Sandbox/Math is successfully loaded', async({ page }) => {
   await page.goto('/Sandbox/Math');
 
   // Expect the Math-specific elements to be present
-  await expect(page.locator('.math').first()).toBeVisible();
+  await expect(page.locator('.katex').first()).toBeVisible();
 });
 
 test('Sandbox with edit is successfully loaded', async({ page }) => {

--- a/apps/app/playwright/21-basic-features-for-guest/access-to-page.spec.ts
+++ b/apps/app/playwright/21-basic-features-for-guest/access-to-page.spec.ts
@@ -15,7 +15,7 @@ test('/Sandbox/math is successfully loaded', async({ page }) => {
   await page.goto('/Sandbox/Math');
 
   // Check if the math elements are visible
-  await expect(page.locator('.math').first()).toBeVisible();
+  await expect(page.locator('.katex').first()).toBeVisible();
 });
 
 test('Access to /me page', async({ page }) => {


### PR DESCRIPTION
# Summary 
- remak-math と rehype-katex の変更による CI のエラーを修正
- `.math` ではなく `.katex` を見るように変更する
- Production Build で通ることは確認済み
- cypress は通っていない
# Task
- https://redmine.weseek.co.jp/issues/148445 
  - https://redmine.weseek.co.jp/issues/153459

# Note
remark-math と rehype-katex の生成する HTML が変更された。
```
// 変更前
<span class="math math-inline">
  <span class="katex">
    hoge
  </span>
</span>
```
```
// 変更後
<span class="katex">
    hoge
</span>
```

参考：https://wsgrowi.slack.com/archives/C05LB9T4KR9/p1725428367422379?thread_ts=1725337316.688899&cid=C05LB9T4KR9
