### PR TITLE
fix: issue that material symbols icons are not displayed in ReplyComments component

### DIFF
--- a/apps/app/src/client/components/PageComment/ReplyComments.tsx
+++ b/apps/app/src/client/components/PageComment/ReplyComments.tsx
@@ -69,7 +69,7 @@ export const ReplyComments = (props: ReplycommentsProps): JSX.Element => {
 
   const areThereHiddenReplies = (replyList.length > 2);
   const toggleButtonIconName = isOlderRepliesShown ? 'expand_less' : 'more_vert';
-  const toggleButtonIcon = <span className="material-icons-outlined me-1">{toggleButtonIconName}</span>;
+  const toggleButtonIcon = <span className="material-symbols-outlined me-1">{toggleButtonIconName}</span>;
   const toggleButtonLabel = isOlderRepliesShown ? '' : 'more';
   const shownReplies = replyList.slice(replyList.length - 2, replyList.length);
   const hiddenReplies = replyList.slice(0, replyList.length - 2);


### PR DESCRIPTION
## タスク
https://redmine.weseek.co.jp/issues/153697
## 概要
- 任意の記事のコメントに返信 (reply) を3つ以上つけた際に、material symbols iconが正しく表示されない問題を解決しました。
## 変更点
- ReplyComments コンポーネントの該当箇所の className の修正 

## セルフチェック
- [x] コンフリクト解消したか
- [x] 余計なコードは残っていないか
- [x] 適切にメモ化したか
- [x] 責務の問題はクリアしているか
- [x] CIは通っているか
- [x] PRの内容は適切にかけているか