### PR TITLE
fix: The grant of pages can be changed via api even if restricted

### DIFF
--- a/apps/app/src/interfaces/apiv3/page.ts
+++ b/apps/app/src/interfaces/apiv3/page.ts
@@ -42,4 +42,5 @@ export type IApiv3PageUpdateResponse = {
 
 export const PageUpdateErrorCode = {
   CONFLICT: 'conflict',
+  FORBIDDEN: 'forbidden',
 } as const;

--- a/apps/app/src/server/routes/apiv3/page/update-page.ts
+++ b/apps/app/src/server/routes/apiv3/page/update-page.ts
@@ -175,10 +175,7 @@ export const updatePageHandlersFactory: UpdatePageHandlersFactory = (crowi) => {
           if (isGrantImmutable) {
             return res.apiv3Err(new ErrorV3('The grant settings for the specified page cannot be modified.', PageUpdateErrorCode.FORBIDDEN), 403);
           }
-          else {
-            options.grant = grant;
-            options.userRelatedGrantUserGroupIds = userRelatedGrantUserGroupIds;
-          }
+          options.userRelatedGrantUserGroupIds = userRelatedGrantUserGroupIds;
         }
         previousRevision = await Revision.findById(sanitizeRevisionId);
         updatedPage = await crowi.pageService.updatePage(currentPage, body, previousRevision?.body ?? null, req.user, options);

--- a/apps/app/src/server/routes/apiv3/page/update-page.ts
+++ b/apps/app/src/server/routes/apiv3/page/update-page.ts
@@ -143,7 +143,7 @@ export const updatePageHandlersFactory: UpdatePageHandlersFactory = (crowi) => {
 
       const isGrantImmutable = isTopPage(currentPage.path) || isUsersProtectedPages(currentPage.path);
 
-      if (grant && grant !== currentPage.grant && isGrantImmutable) {
+      if (grant != null && grant !== currentPage.grant && isGrantImmutable) {
         return res.apiv3Err(new ErrorV3('The grant settings for the specified page cannot be modified.', PageUpdateErrorCode.FORBIDDEN), 403);
       }
 

--- a/apps/app/src/server/routes/apiv3/page/update-page.ts
+++ b/apps/app/src/server/routes/apiv3/page/update-page.ts
@@ -4,6 +4,7 @@ import type {
 } from '@growi/core';
 import { ErrorV3 } from '@growi/core/dist/models';
 import { serializeUserSecurely } from '@growi/core/dist/models/serializers';
+import { isTopPage, isUsersProtectedPages } from '@growi/core/dist/utils/page-path-utils';
 import type { Request, RequestHandler } from 'express';
 import type { ValidationChain } from 'express-validator';
 import { body } from 'express-validator';
@@ -27,7 +28,6 @@ import { apiV3FormValidator } from '../../../middlewares/apiv3-form-validator';
 import { excludeReadOnlyUser } from '../../../middlewares/exclude-read-only-user';
 import type { ApiV3Response } from '../interfaces/apiv3-response';
 
-import { isTopPage, isUsersProtectedPages } from '@growi/core/dist/utils/page-path-utils';
 
 const logger = loggerFactory('growi:routes:apiv3:page:update-page');
 
@@ -121,7 +121,7 @@ export const updatePageHandlersFactory: UpdatePageHandlersFactory = (crowi) => {
   return [
     accessTokenParser, loginRequiredStrictly, excludeReadOnlyUser, addActivity,
     validator, apiV3FormValidator,
-    async (req: UpdatePageRequest, res: ApiV3Response) => {
+    async(req: UpdatePageRequest, res: ApiV3Response) => {
       const {
         pageId, revisionId, body, origin,
       } = req.body;

--- a/apps/app/src/server/routes/apiv3/page/update-page.ts
+++ b/apps/app/src/server/routes/apiv3/page/update-page.ts
@@ -143,7 +143,7 @@ export const updatePageHandlersFactory: UpdatePageHandlersFactory = (crowi) => {
 
       const isGrantImmutable = isTopPage(currentPage.path) || isUsersProtectedPages(currentPage.path);
 
-      if (grant && isGrantImmutable) {
+      if (grant && grant !== currentPage.grant && isGrantImmutable) {
         return res.apiv3Err(new ErrorV3('The grant settings for the specified page cannot be modified.', PageUpdateErrorCode.FORBIDDEN), 403);
       }
 


### PR DESCRIPTION
## タスク
- [#147836](https://redmine.weseek.co.jp/issues/147836) UI から公開設定を変更できないページ (/, /user, /user 直下ページ) を API 経由で変更できてしまう
  -  [#153724](https://redmine.weseek.co.jp/issues/153724) 修正
## 概要
- UI から公開設定を変更できないページ (/, /user, /user 直下ページ) のgrantを API 経由で変更できないようにしました。
- 変更を試みた場合には403エラーが返ってくるようにしました。

## 変更点
- PageUpdateErrorCode に新しくforbiddenを追加しました。
- isTopPage, isUsersProtectedPagesを用いて、公開設定を変更できないページのgrantを変更できないように条件を追加しました。

## セルフチェック
- [x] コンフリクト解消したか
- [x] 余計なコードは残っていないか
- [x] 適切にメモ化したか
- [x] 責務の問題はクリアしているか
- [x] CIは通っているか
- [x] PRの内容は適切にかけているか