### PR TITLE
fix: PageControls unexpectedly move in response to opening and closing the sidebar

### DIFF
--- a/apps/app/src/client/components/Navbar/GrowiContextualSubNavigation.tsx
+++ b/apps/app/src/client/components/Navbar/GrowiContextualSubNavigation.tsx
@@ -351,7 +351,7 @@ const GrowiContextualSubNavigation = (props: GrowiContextualSubNavigationProps):
       <Sticky
         className="z-1"
         onStateChange={status => setStickyActive(status.status === Sticky.STATUS_FIXED)}
-        innerActiveClass="w-100 position-abolute end-0"
+        innerActiveClass="w-100 end-0"
       >
         <GroundGlassBar>
 

--- a/apps/app/src/client/components/Navbar/GrowiContextualSubNavigation.tsx
+++ b/apps/app/src/client/components/Navbar/GrowiContextualSubNavigation.tsx
@@ -348,7 +348,11 @@ const GrowiContextualSubNavigation = (props: GrowiContextualSubNavigationProps):
     <>
       <GroundGlassBar className="py-4 d-block d-md-none d-print-none border-bottom" />
 
-      <Sticky className="z-1" onStateChange={status => setStickyActive(status.status === Sticky.STATUS_FIXED)}>
+      <Sticky
+        className="z-1"
+        onStateChange={status => setStickyActive(status.status === Sticky.STATUS_FIXED)}
+        innerActiveClass="w-100 position-abolute end-0"
+      >
         <GroundGlassBar>
 
           <nav


### PR DESCRIPTION
## タスク
- [#144917](https://redmine.weseek.co.jp/issues/144917) サイドバーの開閉に合わせてPageControlsが想定外の場所に移動する
  -  [#145444](https://redmine.weseek.co.jp/issues/145444) 修正
## 概要
- サイドバーの開閉に合わせて PageControls も正しい位置に動くようにしました。

## 変更点
- Stickyコンポーネントの innerActiveClass props に class を新しく指定しました。

## セルフチェック
- [x] コンフリクト解消したか
- [x] 余計なコードは残っていないか
- [x] 適切にメモ化したか
- [x] 責務の問題はクリアしているか
- [x] CIは通っているか
- [x] PRの内容は適切にかけているか