### PR TITLE
imprv: Corrected wording on admin page (/admin/data-transfer)

### DIFF
--- a/apps/app/public/static/locales/en_US/commons.json
+++ b/apps/app/public/static/locales/en_US/commons.json
@@ -157,6 +157,6 @@
     "publish_transfer_key": "Publish transfer key",
     "transfer_key_limit": "Transfer keys are valid for 1 hour after issuance.",
     "once_transfer_key_used": "Once the transfer key is used for transfer, it cannot be used for any other transfer.",
-    "transfer_to_growi_cloud": "For more details, please click <a href='https://{{growiDataTransferHelpPage}}/ja/admin-guide/management-cookbook/g2g-transfer.html'>here.</a>"
+    "transfer_to_growi_cloud": "For more details, please click <a href='https://{{growiHelpUrl}}/ja/admin-guide/management-cookbook/g2g-transfer.html'>here.</a>"
   }
 }

--- a/apps/app/public/static/locales/en_US/commons.json
+++ b/apps/app/public/static/locales/en_US/commons.json
@@ -157,6 +157,6 @@
     "publish_transfer_key": "Publish transfer key",
     "transfer_key_limit": "Transfer keys are valid for 1 hour after issuance.",
     "once_transfer_key_used": "Once the transfer key is used for transfer, it cannot be used for any other transfer.",
-    "transfer_to_growi_cloud": "If you wish to transfer to GROWI.cloud, please click here."
+    "transfer_to_growi_cloud": "For more details, please click <a href='https://{{growiDataTransferHelpPage}}/ja/admin-guide/management-cookbook/g2g-transfer.html'>here.</a>"
   }
 }

--- a/apps/app/public/static/locales/en_US/commons.json
+++ b/apps/app/public/static/locales/en_US/commons.json
@@ -157,6 +157,6 @@
     "publish_transfer_key": "Publish transfer key",
     "transfer_key_limit": "Transfer keys are valid for 1 hour after issuance.",
     "once_transfer_key_used": "Once the transfer key is used for transfer, it cannot be used for any other transfer.",
-    "transfer_to_growi_cloud": "For more details, please click <a href='https://{{growiHelpUrl}}/ja/admin-guide/management-cookbook/g2g-transfer.html'>here.</a>"
+    "transfer_to_growi_cloud": "For more details, please click <a href='https://{{growiHelpDomain}}/ja/admin-guide/management-cookbook/g2g-transfer.html'>here.</a>"
   }
 }

--- a/apps/app/public/static/locales/fr_FR/commons.json
+++ b/apps/app/public/static/locales/fr_FR/commons.json
@@ -157,6 +157,6 @@
     "publish_transfer_key": "Publier la clé de transfert",
     "transfer_key_limit": "Les clés de transfert sont valides durant une heure.",
     "once_transfer_key_used": "Les clés de transfert sont à usage unique.",
-    "transfer_to_growi_cloud": "Pour plus de détails, veuillez cliquer <a href='https://{{growiDataTransferHelpPage}}/ja/admin-guide/management-cookbook/g2g-transfer.html'>ici.</a>"
+    "transfer_to_growi_cloud": "Pour plus de détails, veuillez cliquer <a href='https://{{growiHelpUrl}}/ja/admin-guide/management-cookbook/g2g-transfer.html'>ici.</a>"
   }
 }

--- a/apps/app/public/static/locales/fr_FR/commons.json
+++ b/apps/app/public/static/locales/fr_FR/commons.json
@@ -157,6 +157,6 @@
     "publish_transfer_key": "Publier la clé de transfert",
     "transfer_key_limit": "Les clés de transfert sont valides durant une heure.",
     "once_transfer_key_used": "Les clés de transfert sont à usage unique.",
-    "transfer_to_growi_cloud": "Pour plus de détails, veuillez cliquer <a href='https://{{growiHelpUrl}}/ja/admin-guide/management-cookbook/g2g-transfer.html'>ici.</a>"
+    "transfer_to_growi_cloud": "Pour plus de détails, veuillez cliquer <a href='https://{{growiHelpDomain}}/ja/admin-guide/management-cookbook/g2g-transfer.html'>ici.</a>"
   }
 }

--- a/apps/app/public/static/locales/fr_FR/commons.json
+++ b/apps/app/public/static/locales/fr_FR/commons.json
@@ -157,6 +157,6 @@
     "publish_transfer_key": "Publier la clé de transfert",
     "transfer_key_limit": "Les clés de transfert sont valides durant une heure.",
     "once_transfer_key_used": "Les clés de transfert sont à usage unique.",
-    "transfer_to_growi_cloud": "Si vous souhaitez transférer depuis GROWI.cloud, cliquez ici."
+    "transfer_to_growi_cloud": "Pour plus de détails, veuillez cliquer <a href='https://{{growiDataTransferHelpPage}}/ja/admin-guide/management-cookbook/g2g-transfer.html'>ici.</a>"
   }
 }

--- a/apps/app/public/static/locales/ja_JP/commons.json
+++ b/apps/app/public/static/locales/ja_JP/commons.json
@@ -159,6 +159,6 @@
     "publish_transfer_key": "移行キーを発行する",
     "transfer_key_limit": "※ 移行キーの有効期限は発行から1時間となります。",
     "once_transfer_key_used": "※ 移行キーは一度移行に利用するとそれ以降はご利用いただけなくなります。",
-    "transfer_to_growi_cloud": "※ 詳しくは <a href='https://{{growiDataTransferHelpPage}}/ja/admin-guide/management-cookbook/g2g-transfer.html'>こちら</a>"
+    "transfer_to_growi_cloud": "※ 詳しくは <a href='https://{{growiHelpUrl}}/ja/admin-guide/management-cookbook/g2g-transfer.html'>こちら</a>"
   }
 }

--- a/apps/app/public/static/locales/ja_JP/commons.json
+++ b/apps/app/public/static/locales/ja_JP/commons.json
@@ -159,6 +159,6 @@
     "publish_transfer_key": "移行キーを発行する",
     "transfer_key_limit": "※ 移行キーの有効期限は発行から1時間となります。",
     "once_transfer_key_used": "※ 移行キーは一度移行に利用するとそれ以降はご利用いただけなくなります。",
-    "transfer_to_growi_cloud": "※ GROWI.cloud への移行を実施する場合はこちらをご確認ください。"
+    "transfer_to_growi_cloud": "※ 詳しくは <a href='{{growiDataTransferHelpPage}}'>こちら</a>"
   }
 }

--- a/apps/app/public/static/locales/ja_JP/commons.json
+++ b/apps/app/public/static/locales/ja_JP/commons.json
@@ -159,6 +159,6 @@
     "publish_transfer_key": "移行キーを発行する",
     "transfer_key_limit": "※ 移行キーの有効期限は発行から1時間となります。",
     "once_transfer_key_used": "※ 移行キーは一度移行に利用するとそれ以降はご利用いただけなくなります。",
-    "transfer_to_growi_cloud": "※ 詳しくは <a href='https://{{growiHelpUrl}}/ja/admin-guide/management-cookbook/g2g-transfer.html'>こちら</a>"
+    "transfer_to_growi_cloud": "※ 詳しくは <a href='https://{{growiHelpDomain}}/ja/admin-guide/management-cookbook/g2g-transfer.html'>こちら</a>"
   }
 }

--- a/apps/app/public/static/locales/ja_JP/commons.json
+++ b/apps/app/public/static/locales/ja_JP/commons.json
@@ -159,6 +159,6 @@
     "publish_transfer_key": "移行キーを発行する",
     "transfer_key_limit": "※ 移行キーの有効期限は発行から1時間となります。",
     "once_transfer_key_used": "※ 移行キーは一度移行に利用するとそれ以降はご利用いただけなくなります。",
-    "transfer_to_growi_cloud": "※ 詳しくは <a href='{{growiDataTransferHelpPage}}'>こちら</a>"
+    "transfer_to_growi_cloud": "※ 詳しくは <a href='https://{{growiDataTransferHelpPage}}/ja/admin-guide/management-cookbook/g2g-transfer.html'>こちら</a>"
   }
 }

--- a/apps/app/public/static/locales/zh_CN/commons.json
+++ b/apps/app/public/static/locales/zh_CN/commons.json
@@ -160,6 +160,6 @@
     "publish_transfer_key": "发布迁移密钥",
     "transfer_key_limit": "迁移密钥在签发后一小时内有效。",
     "once_transfer_key_used": "一旦迁移密钥被用于迁移，它将不再可用于进一步的迁移。",
-    "transfer_to_growi_cloud": "有关更多详情，请点击<a href='https://{{growiDataTransferHelpPage}}/ja/admin-guide/management-cookbook/g2g-transfer.html'>此处</a>。"
+    "transfer_to_growi_cloud": "有关更多详情，请点击<a href='https://{{growiHelpUrl}}/ja/admin-guide/management-cookbook/g2g-transfer.html'>此处</a>。"
   }
 }

--- a/apps/app/public/static/locales/zh_CN/commons.json
+++ b/apps/app/public/static/locales/zh_CN/commons.json
@@ -160,6 +160,6 @@
     "publish_transfer_key": "发布迁移密钥",
     "transfer_key_limit": "迁移密钥在签发后一小时内有效。",
     "once_transfer_key_used": "一旦迁移密钥被用于迁移，它将不再可用于进一步的迁移。",
-    "transfer_to_growi_cloud": "有关更多详情，请点击<a href='https://{{growiHelpUrl}}/ja/admin-guide/management-cookbook/g2g-transfer.html'>此处</a>。"
+    "transfer_to_growi_cloud": "有关更多详情，请点击<a href='https://{{growiHelpDomain}}/ja/admin-guide/management-cookbook/g2g-transfer.html'>此处</a>。"
   }
 }

--- a/apps/app/public/static/locales/zh_CN/commons.json
+++ b/apps/app/public/static/locales/zh_CN/commons.json
@@ -160,6 +160,6 @@
     "publish_transfer_key": "发布迁移密钥",
     "transfer_key_limit": "迁移密钥在签发后一小时内有效。",
     "once_transfer_key_used": "一旦迁移密钥被用于迁移，它将不再可用于进一步的迁移。",
-    "transfer_to_growi_cloud": "如果您希望迁移到GROWI.cloud，请点击这里。"
+    "transfer_to_growi_cloud": "有关更多详情，请点击<a href='https://{{growiDataTransferHelpPage}}/ja/admin-guide/management-cookbook/g2g-transfer.html'>此处</a>。"
   }
 }

--- a/apps/app/src/client/components/Admin/G2GDataTransfer.tsx
+++ b/apps/app/src/client/components/Admin/G2GDataTransfer.tsx
@@ -8,7 +8,7 @@ import { useGenerateTransferKey } from '~/client/services/g2g-transfer';
 import { apiv3Get, apiv3Post } from '~/client/util/apiv3-client';
 import { toastError, toastSuccess } from '~/client/util/toastr';
 import { G2G_PROGRESS_STATUS, type G2GProgress } from '~/interfaces/g2g-transfer';
-import { useIsGrowiHelpUrl } from '~/stores-universal/context';
+import { useGrowiHelpUrl } from '~/stores-universal/context';
 import { useAdminSocket } from '~/stores/socket-io';
 
 import CustomCopyToClipBoard from '../Common/CustomCopyToClipBoard';
@@ -124,7 +124,7 @@ const G2GDataTransfer = (): JSX.Element => {
     }
   }, [setTransferring, startTransferKey, selectedCollections, optionsMap]);
 
-  const { data: growiHelpUrl } = useIsGrowiHelpUrl();
+  const { data: growiHelpUrl } = useGrowiHelpUrl();
 
   // File upload
   // const onChangeFileUploadTypeHandler = useCallback((e: ChangeEvent, type: string) => {

--- a/apps/app/src/client/components/Admin/G2GDataTransfer.tsx
+++ b/apps/app/src/client/components/Admin/G2GDataTransfer.tsx
@@ -126,9 +126,7 @@ const G2GDataTransfer = (): JSX.Element => {
     }
   }, [setTransferring, startTransferKey, selectedCollections, optionsMap]);
 
-  const growiDataTransferHelpPage = growiCloudUri != null && growiAppIdForGrowiCloud != null
-    ? 'https://growi.cloud/help/ja/admin-guide/management-cookbook/g2g-transfer.html'
-    : 'https://docs.growi.org/ja/admin-guide/management-cookbook/g2g-transfer.html';
+  const growiDataTransferHelpPage = growiCloudUri != null && growiAppIdForGrowiCloud != null ? 'growi.cloud' : 'docs.growi.org';
 
   // File upload
   // const onChangeFileUploadTypeHandler = useCallback((e: ChangeEvent, type: string) => {

--- a/apps/app/src/client/components/Admin/G2GDataTransfer.tsx
+++ b/apps/app/src/client/components/Admin/G2GDataTransfer.tsx
@@ -124,7 +124,7 @@ const G2GDataTransfer = (): JSX.Element => {
     }
   }, [setTransferring, startTransferKey, selectedCollections, optionsMap]);
 
-  const { data: growiHelpUrl } = useGrowiHelpUrl();
+  const { data: growiHelpDomain } = useGrowiHelpUrl();
 
   // File upload
   // const onChangeFileUploadTypeHandler = useCallback((e: ChangeEvent, type: string) => {
@@ -279,7 +279,7 @@ const G2GDataTransfer = (): JSX.Element => {
         <p className="mb-1">{t('commons:g2g_data_transfer.transfer_key_limit')}</p>
         <p className="mb-1">{t('commons:g2g_data_transfer.once_transfer_key_used')}</p>
         {/* eslint-disable-next-line react/no-danger */}
-        <p className="mb-0" dangerouslySetInnerHTML={{ __html: t('commons:g2g_data_transfer.transfer_to_growi_cloud', { growiHelpUrl }) }} />
+        <p className="mb-0" dangerouslySetInnerHTML={{ __html: t('commons:g2g_data_transfer.transfer_to_growi_cloud', { growiHelpDomain }) }} />
       </div>
     </div>
   );

--- a/apps/app/src/client/components/Admin/G2GDataTransfer.tsx
+++ b/apps/app/src/client/components/Admin/G2GDataTransfer.tsx
@@ -8,6 +8,7 @@ import { useGenerateTransferKey } from '~/client/services/g2g-transfer';
 import { apiv3Get, apiv3Post } from '~/client/util/apiv3-client';
 import { toastError, toastSuccess } from '~/client/util/toastr';
 import { G2G_PROGRESS_STATUS, type G2GProgress } from '~/interfaces/g2g-transfer';
+import { useGrowiCloudUri, useGrowiAppIdForGrowiCloud } from '~/stores-universal/context';
 import { useAdminSocket } from '~/stores/socket-io';
 
 import CustomCopyToClipBoard from '../Common/CustomCopyToClipBoard';
@@ -34,6 +35,8 @@ const G2GDataTransfer = (): JSX.Element => {
     mongo: G2G_PROGRESS_STATUS.PENDING,
     attachments: G2G_PROGRESS_STATUS.PENDING,
   });
+  const { data: growiCloudUri } = useGrowiCloudUri();
+  const { data: growiAppIdForGrowiCloud } = useGrowiAppIdForGrowiCloud();
 
   // File upload settings
   // const [fileUploadType, setFileUploadType] = useState('aws');
@@ -122,6 +125,10 @@ const G2GDataTransfer = (): JSX.Element => {
       toastError(errs);
     }
   }, [setTransferring, startTransferKey, selectedCollections, optionsMap]);
+
+  const growiDataTransferHelpPage = growiCloudUri != null && growiAppIdForGrowiCloud != null
+    ? 'https://growi.cloud/help/ja/admin-guide/management-cookbook/g2g-transfer.html'
+    : 'https://docs.growi.org/ja/admin-guide/management-cookbook/g2g-transfer.html';
 
   // File upload
   // const onChangeFileUploadTypeHandler = useCallback((e: ChangeEvent, type: string) => {
@@ -275,7 +282,8 @@ const G2GDataTransfer = (): JSX.Element => {
       <div className="alert alert-warning mt-4">
         <p className="mb-1">{t('commons:g2g_data_transfer.transfer_key_limit')}</p>
         <p className="mb-1">{t('commons:g2g_data_transfer.once_transfer_key_used')}</p>
-        <p className="mb-0">{t('commons:g2g_data_transfer.transfer_to_growi_cloud')}</p>
+        {/* eslint-disable-next-line react/no-danger */}
+        <p className="mb-0" dangerouslySetInnerHTML={{ __html: t('commons:g2g_data_transfer.transfer_to_growi_cloud', { growiDataTransferHelpPage }) }} />
       </div>
     </div>
   );

--- a/apps/app/src/client/components/Admin/G2GDataTransfer.tsx
+++ b/apps/app/src/client/components/Admin/G2GDataTransfer.tsx
@@ -8,7 +8,7 @@ import { useGenerateTransferKey } from '~/client/services/g2g-transfer';
 import { apiv3Get, apiv3Post } from '~/client/util/apiv3-client';
 import { toastError, toastSuccess } from '~/client/util/toastr';
 import { G2G_PROGRESS_STATUS, type G2GProgress } from '~/interfaces/g2g-transfer';
-import { useGrowiHelpUrl } from '~/stores-universal/context';
+import { useGrowiHelpDomain } from '~/stores-universal/context';
 import { useAdminSocket } from '~/stores/socket-io';
 
 import CustomCopyToClipBoard from '../Common/CustomCopyToClipBoard';
@@ -124,7 +124,7 @@ const G2GDataTransfer = (): JSX.Element => {
     }
   }, [setTransferring, startTransferKey, selectedCollections, optionsMap]);
 
-  const { data: growiHelpDomain } = useGrowiHelpUrl();
+  const { data: growiHelpDomain } = useGrowiHelpDomain();
 
   // File upload
   // const onChangeFileUploadTypeHandler = useCallback((e: ChangeEvent, type: string) => {

--- a/apps/app/src/client/components/Admin/G2GDataTransfer.tsx
+++ b/apps/app/src/client/components/Admin/G2GDataTransfer.tsx
@@ -126,7 +126,7 @@ const G2GDataTransfer = (): JSX.Element => {
     }
   }, [setTransferring, startTransferKey, selectedCollections, optionsMap]);
 
-  const growiDataTransferHelpPage = growiCloudUri != null && growiAppIdForGrowiCloud != null ? 'growi.cloud/help' : 'docs.growi.org';
+  const growiHelpUrl = growiCloudUri != null && growiAppIdForGrowiCloud != null ? 'growi.cloud/help' : 'docs.growi.org';
 
   // File upload
   // const onChangeFileUploadTypeHandler = useCallback((e: ChangeEvent, type: string) => {
@@ -281,7 +281,7 @@ const G2GDataTransfer = (): JSX.Element => {
         <p className="mb-1">{t('commons:g2g_data_transfer.transfer_key_limit')}</p>
         <p className="mb-1">{t('commons:g2g_data_transfer.once_transfer_key_used')}</p>
         {/* eslint-disable-next-line react/no-danger */}
-        <p className="mb-0" dangerouslySetInnerHTML={{ __html: t('commons:g2g_data_transfer.transfer_to_growi_cloud', { growiDataTransferHelpPage }) }} />
+        <p className="mb-0" dangerouslySetInnerHTML={{ __html: t('commons:g2g_data_transfer.transfer_to_growi_cloud', { growiHelpUrl }) }} />
       </div>
     </div>
   );

--- a/apps/app/src/client/components/Admin/G2GDataTransfer.tsx
+++ b/apps/app/src/client/components/Admin/G2GDataTransfer.tsx
@@ -126,7 +126,7 @@ const G2GDataTransfer = (): JSX.Element => {
     }
   }, [setTransferring, startTransferKey, selectedCollections, optionsMap]);
 
-  const growiDataTransferHelpPage = growiCloudUri != null && growiAppIdForGrowiCloud != null ? 'growi.cloud' : 'docs.growi.org';
+  const growiDataTransferHelpPage = growiCloudUri != null && growiAppIdForGrowiCloud != null ? 'growi.cloud/help' : 'docs.growi.org';
 
   // File upload
   // const onChangeFileUploadTypeHandler = useCallback((e: ChangeEvent, type: string) => {

--- a/apps/app/src/client/components/Admin/G2GDataTransfer.tsx
+++ b/apps/app/src/client/components/Admin/G2GDataTransfer.tsx
@@ -8,7 +8,7 @@ import { useGenerateTransferKey } from '~/client/services/g2g-transfer';
 import { apiv3Get, apiv3Post } from '~/client/util/apiv3-client';
 import { toastError, toastSuccess } from '~/client/util/toastr';
 import { G2G_PROGRESS_STATUS, type G2GProgress } from '~/interfaces/g2g-transfer';
-import { useGrowiCloudUri, useGrowiAppIdForGrowiCloud } from '~/stores-universal/context';
+import { useIsGrowiHelpUrl } from '~/stores-universal/context';
 import { useAdminSocket } from '~/stores/socket-io';
 
 import CustomCopyToClipBoard from '../Common/CustomCopyToClipBoard';
@@ -35,8 +35,6 @@ const G2GDataTransfer = (): JSX.Element => {
     mongo: G2G_PROGRESS_STATUS.PENDING,
     attachments: G2G_PROGRESS_STATUS.PENDING,
   });
-  const { data: growiCloudUri } = useGrowiCloudUri();
-  const { data: growiAppIdForGrowiCloud } = useGrowiAppIdForGrowiCloud();
 
   // File upload settings
   // const [fileUploadType, setFileUploadType] = useState('aws');
@@ -126,7 +124,7 @@ const G2GDataTransfer = (): JSX.Element => {
     }
   }, [setTransferring, startTransferKey, selectedCollections, optionsMap]);
 
-  const growiHelpUrl = growiCloudUri != null && growiAppIdForGrowiCloud != null ? 'growi.cloud/help' : 'docs.growi.org';
+  const { data: growiHelpUrl } = useIsGrowiHelpUrl();
 
   // File upload
   // const onChangeFileUploadTypeHandler = useCallback((e: ChangeEvent, type: string) => {

--- a/apps/app/src/client/components/DataTransferForm.tsx
+++ b/apps/app/src/client/components/DataTransferForm.tsx
@@ -3,16 +3,15 @@ import React from 'react';
 import { useTranslation } from 'next-i18next';
 
 import { useGenerateTransferKey } from '~/client/services/g2g-transfer';
-import { useGrowiCloudUri, useGrowiAppIdForGrowiCloud } from '~/stores-universal/context';
+import { useIsGrowiHelpUrl } from '~/stores-universal/context';
 
 import CustomCopyToClipBoard from './Common/CustomCopyToClipBoard';
 
 const DataTransferForm = (): JSX.Element => {
   const { t } = useTranslation('commons');
   const { transferKey, generateTransferKey } = useGenerateTransferKey();
-  const { data: growiCloudUri } = useGrowiCloudUri();
-  const { data: growiAppIdForGrowiCloud } = useGrowiAppIdForGrowiCloud();
-  const growiHelpUrl = growiCloudUri != null && growiAppIdForGrowiCloud != null ? 'growi.cloud/help' : 'docs.growi.org';
+  const { data: growiHelpUrl } = useIsGrowiHelpUrl();
+
   return (
     <div data-testid="installerForm" className="py-3 px-4">
       <p className="text-white fs-5 mt-2">

--- a/apps/app/src/client/components/DataTransferForm.tsx
+++ b/apps/app/src/client/components/DataTransferForm.tsx
@@ -10,7 +10,7 @@ import CustomCopyToClipBoard from './Common/CustomCopyToClipBoard';
 const DataTransferForm = (): JSX.Element => {
   const { t } = useTranslation('commons');
   const { transferKey, generateTransferKey } = useGenerateTransferKey();
-  const { data: growiHelpUrl } = useGrowiHelpUrl();
+  const { data: growiHelpDomain } = useGrowiHelpUrl();
 
   return (
     <div data-testid="installerForm" className="py-3 px-4">
@@ -36,7 +36,7 @@ const DataTransferForm = (): JSX.Element => {
         <p className="mb-1">{t('g2g_data_transfer.transfer_key_limit')}</p>
         <p className="mb-1">{t('g2g_data_transfer.once_transfer_key_used')}</p>
         {/* eslint-disable-next-line react/no-danger */}
-        <p className="mb-0" dangerouslySetInnerHTML={{ __html: t('g2g_data_transfer.transfer_to_growi_cloud', { growiHelpUrl }) }} />
+        <p className="mb-0" dangerouslySetInnerHTML={{ __html: t('g2g_data_transfer.transfer_to_growi_cloud', { growiHelpDomain }) }} />
       </div>
     </div>
   );

--- a/apps/app/src/client/components/DataTransferForm.tsx
+++ b/apps/app/src/client/components/DataTransferForm.tsx
@@ -12,10 +12,7 @@ const DataTransferForm = (): JSX.Element => {
   const { transferKey, generateTransferKey } = useGenerateTransferKey();
   const { data: growiCloudUri } = useGrowiCloudUri();
   const { data: growiAppIdForGrowiCloud } = useGrowiAppIdForGrowiCloud();
-  const growiDataTransferHelpPage = growiCloudUri != null && growiAppIdForGrowiCloud != null
-    ? 'https://growi.cloud/help/ja/admin-guide/management-cookbook/g2g-transfer.html'
-    : 'https://docs.growi.org/ja/admin-guide/management-cookbook/g2g-transfer.html';
-
+  const growiDataTransferHelpPage = growiCloudUri != null && growiAppIdForGrowiCloud != null ? 'growi.cloud' : 'docs.growi.org';
   return (
     <div data-testid="installerForm" className="py-3 px-4">
       <p className="text-white fs-5 mt-2">

--- a/apps/app/src/client/components/DataTransferForm.tsx
+++ b/apps/app/src/client/components/DataTransferForm.tsx
@@ -3,12 +3,18 @@ import React from 'react';
 import { useTranslation } from 'next-i18next';
 
 import { useGenerateTransferKey } from '~/client/services/g2g-transfer';
+import { useGrowiCloudUri, useGrowiAppIdForGrowiCloud } from '~/stores-universal/context';
 
 import CustomCopyToClipBoard from './Common/CustomCopyToClipBoard';
 
 const DataTransferForm = (): JSX.Element => {
   const { t } = useTranslation('commons');
   const { transferKey, generateTransferKey } = useGenerateTransferKey();
+  const { data: growiCloudUri } = useGrowiCloudUri();
+  const { data: growiAppIdForGrowiCloud } = useGrowiAppIdForGrowiCloud();
+  const growiDataTransferHelpPage = growiCloudUri != null && growiAppIdForGrowiCloud != null
+    ? 'https://growi.cloud/help/ja/admin-guide/management-cookbook/g2g-transfer.html'
+    : 'https://docs.growi.org/ja/admin-guide/management-cookbook/g2g-transfer.html';
 
   return (
     <div data-testid="installerForm" className="py-3 px-4">
@@ -33,7 +39,8 @@ const DataTransferForm = (): JSX.Element => {
       <div className="alert alert-warning mt-4">
         <p className="mb-1">{t('g2g_data_transfer.transfer_key_limit')}</p>
         <p className="mb-1">{t('g2g_data_transfer.once_transfer_key_used')}</p>
-        <p className="mb-0">{t('g2g_data_transfer.transfer_to_growi_cloud')}</p>
+        {/* eslint-disable-next-line react/no-danger */}
+        <p className="mb-0" dangerouslySetInnerHTML={{ __html: t('g2g_data_transfer.transfer_to_growi_cloud', { growiDataTransferHelpPage }) }} />
       </div>
     </div>
   );

--- a/apps/app/src/client/components/DataTransferForm.tsx
+++ b/apps/app/src/client/components/DataTransferForm.tsx
@@ -12,7 +12,7 @@ const DataTransferForm = (): JSX.Element => {
   const { transferKey, generateTransferKey } = useGenerateTransferKey();
   const { data: growiCloudUri } = useGrowiCloudUri();
   const { data: growiAppIdForGrowiCloud } = useGrowiAppIdForGrowiCloud();
-  const growiDataTransferHelpPage = growiCloudUri != null && growiAppIdForGrowiCloud != null ? 'growi.cloud' : 'docs.growi.org';
+  const growiDataTransferHelpPage = growiCloudUri != null && growiAppIdForGrowiCloud != null ? 'growi.cloud/help' : 'docs.growi.org';
   return (
     <div data-testid="installerForm" className="py-3 px-4">
       <p className="text-white fs-5 mt-2">

--- a/apps/app/src/client/components/DataTransferForm.tsx
+++ b/apps/app/src/client/components/DataTransferForm.tsx
@@ -12,7 +12,7 @@ const DataTransferForm = (): JSX.Element => {
   const { transferKey, generateTransferKey } = useGenerateTransferKey();
   const { data: growiCloudUri } = useGrowiCloudUri();
   const { data: growiAppIdForGrowiCloud } = useGrowiAppIdForGrowiCloud();
-  const growiDataTransferHelpPage = growiCloudUri != null && growiAppIdForGrowiCloud != null ? 'growi.cloud/help' : 'docs.growi.org';
+  const growiHelpUrl = growiCloudUri != null && growiAppIdForGrowiCloud != null ? 'growi.cloud/help' : 'docs.growi.org';
   return (
     <div data-testid="installerForm" className="py-3 px-4">
       <p className="text-white fs-5 mt-2">
@@ -37,7 +37,7 @@ const DataTransferForm = (): JSX.Element => {
         <p className="mb-1">{t('g2g_data_transfer.transfer_key_limit')}</p>
         <p className="mb-1">{t('g2g_data_transfer.once_transfer_key_used')}</p>
         {/* eslint-disable-next-line react/no-danger */}
-        <p className="mb-0" dangerouslySetInnerHTML={{ __html: t('g2g_data_transfer.transfer_to_growi_cloud', { growiDataTransferHelpPage }) }} />
+        <p className="mb-0" dangerouslySetInnerHTML={{ __html: t('g2g_data_transfer.transfer_to_growi_cloud', { growiHelpUrl }) }} />
       </div>
     </div>
   );

--- a/apps/app/src/client/components/DataTransferForm.tsx
+++ b/apps/app/src/client/components/DataTransferForm.tsx
@@ -3,14 +3,14 @@ import React from 'react';
 import { useTranslation } from 'next-i18next';
 
 import { useGenerateTransferKey } from '~/client/services/g2g-transfer';
-import { useIsGrowiHelpUrl } from '~/stores-universal/context';
+import { useGrowiHelpUrl } from '~/stores-universal/context';
 
 import CustomCopyToClipBoard from './Common/CustomCopyToClipBoard';
 
 const DataTransferForm = (): JSX.Element => {
   const { t } = useTranslation('commons');
   const { transferKey, generateTransferKey } = useGenerateTransferKey();
-  const { data: growiHelpUrl } = useIsGrowiHelpUrl();
+  const { data: growiHelpUrl } = useGrowiHelpUrl();
 
   return (
     <div data-testid="installerForm" className="py-3 px-4">

--- a/apps/app/src/client/components/DataTransferForm.tsx
+++ b/apps/app/src/client/components/DataTransferForm.tsx
@@ -3,14 +3,14 @@ import React from 'react';
 import { useTranslation } from 'next-i18next';
 
 import { useGenerateTransferKey } from '~/client/services/g2g-transfer';
-import { useGrowiHelpUrl } from '~/stores-universal/context';
+import { useGrowiHelpDomain } from '~/stores-universal/context';
 
 import CustomCopyToClipBoard from './Common/CustomCopyToClipBoard';
 
 const DataTransferForm = (): JSX.Element => {
   const { t } = useTranslation('commons');
   const { transferKey, generateTransferKey } = useGenerateTransferKey();
-  const { data: growiHelpDomain } = useGrowiHelpUrl();
+  const { data: growiHelpDomain } = useGrowiHelpDomain();
 
   return (
     <div data-testid="installerForm" className="py-3 px-4">

--- a/apps/app/src/stores-universal/context.tsx
+++ b/apps/app/src/stores-universal/context.tsx
@@ -286,7 +286,7 @@ export const useAcceptedUploadFileType = (): SWRResponse<AcceptedUploadFileType,
   );
 };
 
-export const useGrowiHelpUrl = (): SWRResponse<'growi.cloud/help' | 'docs.growi.org', Error> => {
+export const useGrowiHelpDomain = (): SWRResponse<'growi.cloud/help' | 'docs.growi.org', Error> => {
   const { data: growiCloudUri } = useGrowiCloudUri();
   const { data: growiAppIdForGrowiCloud } = useGrowiAppIdForGrowiCloud();
 

--- a/apps/app/src/stores-universal/context.tsx
+++ b/apps/app/src/stores-universal/context.tsx
@@ -286,7 +286,7 @@ export const useAcceptedUploadFileType = (): SWRResponse<AcceptedUploadFileType,
   );
 };
 
-export const useIsGrowiHelpUrl = (): SWRResponse<'growi.cloud/help' | 'docs.growi.org', Error> => {
+export const useGrowiHelpUrl = (): SWRResponse<'growi.cloud/help' | 'docs.growi.org', Error> => {
   const { data: growiCloudUri } = useGrowiCloudUri();
   const { data: growiAppIdForGrowiCloud } = useGrowiAppIdForGrowiCloud();
 

--- a/apps/app/src/stores-universal/context.tsx
+++ b/apps/app/src/stores-universal/context.tsx
@@ -285,3 +285,18 @@ export const useAcceptedUploadFileType = (): SWRResponse<AcceptedUploadFileType,
     },
   );
 };
+
+export const useIsGrowiHelpUrl = (): SWRResponse<'growi.cloud/help' | 'docs.growi.org', Error> => {
+  const { data: growiCloudUri } = useGrowiCloudUri();
+  const { data: growiAppIdForGrowiCloud } = useGrowiAppIdForGrowiCloud();
+
+  return useSWRImmutable(
+    [growiCloudUri, growiAppIdForGrowiCloud],
+    ([growiCloudUri, growiAppIdForGrowiCloud]) => {
+      if (growiCloudUri != null && growiAppIdForGrowiCloud != null) {
+        return 'growi.cloud/help';
+      }
+      return 'docs.growi.org';
+    },
+  );
+};


### PR DESCRIPTION
## Task
[改善 #144244 [v7] 管理画面 (/admin/data-transfer) の文言修正](https://redmine.weseek.co.jp/issues/144244)
┗ [#153642 文言修正](https://redmine.weseek.co.jp/issues/153642)

## 各言語
- 英語: For more details, please click here.
- フランス語: Pour plus de détails, veuillez cliquer ici.
- 中国語: 有关更多详情，请点击此处。

## 画面スクリーンショット
### org
(左下の path 差分)
![スクリーンショット 2024-09-11 163940](https://github.com/user-attachments/assets/fb537fe1-178d-4259-9187-7076e464a5f0)

### cloud
(左下の path 差分)
![スクリーンショット 2024-09-11 164057](https://github.com/user-attachments/assets/c053c51c-216e-4436-b7e5-7f0b1bf74573)

### 英語
![スクリーンショット 2024-09-12 143146](https://github.com/user-attachments/assets/c3082a35-7dc1-4bdb-8be9-2257eaa8e140)

### フランス
![スクリーンショット 2024-09-12 143211](https://github.com/user-attachments/assets/1cce5599-a1a1-4f47-96fe-e9001e6bef21)

### 中国語
![スクリーンショット 2024-09-12 143159](https://github.com/user-attachments/assets/33090fca-402a-431a-90a5-4dd14326869b)

## 備考
現状、遷移先の「GROWI お引越し機能」 のページについては、日本語以外、未実装のためすべての遷移先を、日本語としている、
英語版「GROWI お引越し機能」ページ作成、link の変更については、後続ストーリーを作成
- [機能 #153898 [docs] GROWI お引越し機能 の 英語対応ページを作成する](https://redmine.weseek.co.jp/issues/153898)
- [改善 #153904 [v7] 管理画面 (/admin/data-transfer) の link 修正](https://redmine.weseek.co.jp/issues/153904)
