### PR TITLE
fix: Display revisions only if they are not corrupted

### DIFF
--- a/apps/app/src/client/components/PageHistory/PageRevisionTable.tsx
+++ b/apps/app/src/client/components/PageHistory/PageRevisionTable.tsx
@@ -21,8 +21,6 @@ type PageRevisionTableProps = {
   currentPagePath: string
 }
 
-const REVISION_BROKEN_BEFORE = new Date('2023-06-07T23:45:20.348+0000');
-
 export const PageRevisionTable = (props: PageRevisionTableProps): JSX.Element => {
   const { t } = useTranslation();
 

--- a/apps/app/src/client/components/PageHistory/PageRevisionTable.tsx
+++ b/apps/app/src/client/components/PageHistory/PageRevisionTable.tsx
@@ -21,6 +21,8 @@ type PageRevisionTableProps = {
   currentPagePath: string
 }
 
+const REVISION_BROKEN_BEFORE = new Date('2023-06-07T23:45:20.348+0000');
+
 export const PageRevisionTable = (props: PageRevisionTableProps): JSX.Element => {
   const { t } = useTranslation();
 
@@ -201,9 +203,17 @@ export const PageRevisionTable = (props: PageRevisionTableProps): JSX.Element =>
               const isOldestRevision = revision === oldestRevision;
               const latestRevision = revisions[0];
 
+              const formattedRevisionCreatedAt = new Date(revision.createdAt);
+
+              const isBrokenRevision = formattedRevisionCreatedAt < REVISION_BROKEN_BEFORE;
+
               // set 'true' if undefined for backward compatibility
               const hasDiff = revision.hasDiffToPrev !== false;
-              return renderRow(revision, previousRevision, latestRevision, isOldestRevision, hasDiff);
+
+              if (!isBrokenRevision) {
+                return renderRow(revision, previousRevision, latestRevision, isOldestRevision, hasDiff);
+              }
+              return;
             })
           }
         </tbody>

--- a/apps/app/src/client/components/PageHistory/PageRevisionTable.tsx
+++ b/apps/app/src/client/components/PageHistory/PageRevisionTable.tsx
@@ -203,17 +203,9 @@ export const PageRevisionTable = (props: PageRevisionTableProps): JSX.Element =>
               const isOldestRevision = revision === oldestRevision;
               const latestRevision = revisions[0];
 
-              const formattedRevisionCreatedAt = new Date(revision.createdAt);
-
-              const isBrokenRevision = formattedRevisionCreatedAt < REVISION_BROKEN_BEFORE;
-
               // set 'true' if undefined for backward compatibility
               const hasDiff = revision.hasDiffToPrev !== false;
-
-              if (!isBrokenRevision) {
-                return renderRow(revision, previousRevision, latestRevision, isOldestRevision, hasDiff);
-              }
-              return;
+              return renderRow(revision, previousRevision, latestRevision, isOldestRevision, hasDiff);
             })
           }
         </tbody>

--- a/apps/app/src/server/routes/apiv3/revisions.js
+++ b/apps/app/src/server/routes/apiv3/revisions.js
@@ -156,6 +156,7 @@ module.exports = (crowi) => {
         createdAt: { $gt: appliedAt },
       };
 
+      // https://redmine.weseek.co.jp/issues/151652
       const paginateResult = await Revision.paginate(
         queryCondition,
         queryOpts,

--- a/apps/app/src/server/routes/apiv3/revisions.js
+++ b/apps/app/src/server/routes/apiv3/revisions.js
@@ -151,8 +151,13 @@ module.exports = (crowi) => {
         queryOpts.pagination = true;
       }
 
+      const queryCondition = {
+        pageId: page._id,
+        createdAt: { $gt: appliedAt },
+      };
+
       const paginateResult = await Revision.paginate(
-        { pageId: page._id },
+        queryCondition,
         queryOpts,
       );
 
@@ -162,17 +167,8 @@ module.exports = (crowi) => {
         }
       });
 
-      const isNotBrokenRevision = (doc) => {
-        const formattedRevisionCreatedAt = new Date(doc.createdAt);
-        const revisionBrokenBefore = new Date(appliedAt);
-
-        return formattedRevisionCreatedAt > revisionBrokenBefore;
-      };
-
-      const revisions = paginateResult.docs.filter(isNotBrokenRevision);
-
       const result = {
-        revisions,
+        revisions: paginateResult.docs,
         totalCount: paginateResult.totalDocs,
         offset: paginateResult.offset,
       };

--- a/apps/app/src/server/routes/apiv3/revisions.js
+++ b/apps/app/src/server/routes/apiv3/revisions.js
@@ -136,7 +136,7 @@ module.exports = (crowi) => {
       const page = await Page.findOne({ _id: pageId });
 
       const migrationCollection = connection.collection('migrations');
-      const migration = await migrationCollection.findOne({ MIGRATION_FILE_NAME });
+      const migration = await migrationCollection.findOne({ fileName: MIGRATION_FILE_NAME });
       const appliedAt = migration.appliedAt;
 
       const queryOpts = {

--- a/apps/app/src/server/routes/apiv3/revisions.js
+++ b/apps/app/src/server/routes/apiv3/revisions.js
@@ -1,7 +1,7 @@
 import { ErrorV3 } from '@growi/core/dist/models';
 import { serializeUserSecurely } from '@growi/core/dist/models/serializers';
 import express from 'express';
-import mongoose, { connection } from 'mongoose';
+import { connection } from 'mongoose';
 
 import { Revision } from '~/server/models/revision';
 import { normalizeLatestRevisionIfBroken } from '~/server/service/revision/normalize-latest-revision-if-broken';

--- a/apps/app/src/server/routes/apiv3/revisions.js
+++ b/apps/app/src/server/routes/apiv3/revisions.js
@@ -134,13 +134,9 @@ module.exports = (crowi) => {
       const page = await Page.findOne({ _id: pageId });
 
       const fileName = '20211227060705-revision-path-to-page-id-schema-migration--fixed-7549.js';
-      // const Migration = mongoose.models.Migration;
-      const Migration = connection.collection('migrations');
-      const migration = await Migration.findOne({ fileName });
+      const migrationCollection = connection.collection('migrations');
+      const migration = await migrationCollection.findOne({ fileName });
       const appliedAt = migration.appliedAt;
-
-      console.log(migration);
-      console.log(appliedAt);
 
       const queryOpts = {
         offset,
@@ -172,10 +168,10 @@ module.exports = (crowi) => {
         return formattedRevisionCreatedAt > revisionBrokenBefore;
       };
 
-      paginateResult.docs.filter(isNotBrokenRevision);
+      const revisions = paginateResult.docs.filter(isNotBrokenRevision);
 
       const result = {
-        revisions: paginateResult.docs,
+        revisions,
         totalCount: paginateResult.totalDocs,
         offset: paginateResult.offset,
       };

--- a/apps/app/src/server/routes/apiv3/revisions.js
+++ b/apps/app/src/server/routes/apiv3/revisions.js
@@ -15,6 +15,8 @@ const { query, param } = require('express-validator');
 
 const router = express.Router();
 
+const MIGRATION_FILE_NAME = '20211227060705-revision-path-to-page-id-schema-migration--fixed-7549.js';
+
 /**
  * @swagger
  *  tags:
@@ -133,9 +135,8 @@ module.exports = (crowi) => {
     try {
       const page = await Page.findOne({ _id: pageId });
 
-      const fileName = '20211227060705-revision-path-to-page-id-schema-migration--fixed-7549.js';
       const migrationCollection = connection.collection('migrations');
-      const migration = await migrationCollection.findOne({ fileName });
+      const migration = await migrationCollection.findOne({ MIGRATION_FILE_NAME });
       const appliedAt = migration.appliedAt;
 
       const queryOpts = {


### PR DESCRIPTION
## タスク
- [#151652](https://redmine.weseek.co.jp/issues/151652) 壊れた revision document が存在する場合、特定のページの History で壊れた revision の内容を閲覧することができてしまう
  -  [#153892](https://redmine.weseek.co.jp/issues/153892) 修正
## 概要
- 不完全なマイグレーションスクリプトによって置き換わってしまった revision.pageId を持つ page の　History で壊れた revision の内容を表示しないようにしました。

## 変更点
- 「20211227060705-revision-path-to-page-id-schema-migration--fixed-7549.js」を適用した日付より前に作成されたrevisionを表示しないようにしました。

## セルフチェック
- [x] コンフリクト解消したか
- [x] 余計なコードは残っていないか
- [x] 適切にメモ化したか
- [x] 責務の問題はクリアしているか
- [x] CIは通っているか
- [x] PRの内容は適切にかけているか