### PR TITLE
imprv: Corrected wording on admin page (/admin/data-transfer)

### DIFF
--- a/apps/app/public/static/locales/en_US/commons.json
+++ b/apps/app/public/static/locales/en_US/commons.json
@@ -157,6 +157,6 @@
     "publish_transfer_key": "Publish transfer key",
     "transfer_key_limit": "Transfer keys are valid for 1 hour after issuance.",
     "once_transfer_key_used": "Once the transfer key is used for transfer, it cannot be used for any other transfer.",
-    "transfer_to_growi_cloud": "If you wish to transfer to GROWI.cloud, please click here."
+    "transfer_to_growi_cloud": "For more details, please click <a href='https://{{growiHelpDomain}}/ja/admin-guide/management-cookbook/g2g-transfer.html'>here.</a>"
   }
 }

--- a/apps/app/public/static/locales/en_US/commons.json
+++ b/apps/app/public/static/locales/en_US/commons.json
@@ -157,6 +157,6 @@
     "publish_transfer_key": "Publish transfer key",
     "transfer_key_limit": "Transfer keys are valid for 1 hour after issuance.",
     "once_transfer_key_used": "Once the transfer key is used for transfer, it cannot be used for any other transfer.",
-    "transfer_to_growi_cloud": "For more details, please click <a href='https://{{growiHelpDomain}}/ja/admin-guide/management-cookbook/g2g-transfer.html'>here.</a>"
+    "transfer_to_growi_cloud": "For more details, please click <a href='https://{{documentationUrl}}/ja/admin-guide/management-cookbook/g2g-transfer.html'>here.</a>"
   }
 }

--- a/apps/app/public/static/locales/fr_FR/commons.json
+++ b/apps/app/public/static/locales/fr_FR/commons.json
@@ -157,6 +157,6 @@
     "publish_transfer_key": "Publier la clé de transfert",
     "transfer_key_limit": "Les clés de transfert sont valides durant une heure.",
     "once_transfer_key_used": "Les clés de transfert sont à usage unique.",
-    "transfer_to_growi_cloud": "Si vous souhaitez transférer depuis GROWI.cloud, cliquez ici."
+    "transfer_to_growi_cloud": "Pour plus de détails, veuillez cliquer <a href='https://{{growiHelpDomain}}/ja/admin-guide/management-cookbook/g2g-transfer.html'>ici.</a>"
   }
 }

--- a/apps/app/public/static/locales/fr_FR/commons.json
+++ b/apps/app/public/static/locales/fr_FR/commons.json
@@ -157,6 +157,6 @@
     "publish_transfer_key": "Publier la clé de transfert",
     "transfer_key_limit": "Les clés de transfert sont valides durant une heure.",
     "once_transfer_key_used": "Les clés de transfert sont à usage unique.",
-    "transfer_to_growi_cloud": "Pour plus de détails, veuillez cliquer <a href='https://{{growiHelpDomain}}/ja/admin-guide/management-cookbook/g2g-transfer.html'>ici.</a>"
+    "transfer_to_growi_cloud": "Pour plus de détails, veuillez cliquer <a href='https://{{documentationUrl}}/ja/admin-guide/management-cookbook/g2g-transfer.html'>ici.</a>"
   }
 }

--- a/apps/app/public/static/locales/ja_JP/commons.json
+++ b/apps/app/public/static/locales/ja_JP/commons.json
@@ -159,6 +159,6 @@
     "publish_transfer_key": "移行キーを発行する",
     "transfer_key_limit": "※ 移行キーの有効期限は発行から1時間となります。",
     "once_transfer_key_used": "※ 移行キーは一度移行に利用するとそれ以降はご利用いただけなくなります。",
-    "transfer_to_growi_cloud": "※ GROWI.cloud への移行を実施する場合はこちらをご確認ください。"
+    "transfer_to_growi_cloud": "※ 詳しくは <a href='https://{{growiHelpDomain}}/ja/admin-guide/management-cookbook/g2g-transfer.html'>こちら</a>"
   }
 }

--- a/apps/app/public/static/locales/ja_JP/commons.json
+++ b/apps/app/public/static/locales/ja_JP/commons.json
@@ -159,6 +159,6 @@
     "publish_transfer_key": "移行キーを発行する",
     "transfer_key_limit": "※ 移行キーの有効期限は発行から1時間となります。",
     "once_transfer_key_used": "※ 移行キーは一度移行に利用するとそれ以降はご利用いただけなくなります。",
-    "transfer_to_growi_cloud": "※ 詳しくは <a href='https://{{growiHelpDomain}}/ja/admin-guide/management-cookbook/g2g-transfer.html'>こちら</a>"
+    "transfer_to_growi_cloud": "※ 詳しくは <a href='https://{{documentationUrl}}/ja/admin-guide/management-cookbook/g2g-transfer.html'>こちら</a>"
   }
 }

--- a/apps/app/public/static/locales/ja_JP/commons.json
+++ b/apps/app/public/static/locales/ja_JP/commons.json
@@ -159,6 +159,6 @@
     "publish_transfer_key": "移行キーを発行する",
     "transfer_key_limit": "※ 移行キーの有効期限は発行から1時間となります。",
     "once_transfer_key_used": "※ 移行キーは一度移行に利用するとそれ以降はご利用いただけなくなります。",
-    "transfer_to_growi_cloud": "※ 詳しくは <a href='https://{{documentationUrl}}/ja/admin-guide/management-cookbook/g2g-transfer.html'>こちら</a>"
+    "transfer_to_growi_cloud": "※ 詳しくは <a href='https://{{documentationUrl}}/ja/admin-guide/management-cookbook/g2g-transfer.html'> GROWI お引越し機能</a>をご確認ください。"
   }
 }

--- a/apps/app/public/static/locales/zh_CN/commons.json
+++ b/apps/app/public/static/locales/zh_CN/commons.json
@@ -160,6 +160,6 @@
     "publish_transfer_key": "发布迁移密钥",
     "transfer_key_limit": "迁移密钥在签发后一小时内有效。",
     "once_transfer_key_used": "一旦迁移密钥被用于迁移，它将不再可用于进一步的迁移。",
-    "transfer_to_growi_cloud": "如果您希望迁移到GROWI.cloud，请点击这里。"
+    "transfer_to_growi_cloud": "有关更多详情，请点击<a href='https://{{growiHelpDomain}}/ja/admin-guide/management-cookbook/g2g-transfer.html'>此处</a>。"
   }
 }

--- a/apps/app/public/static/locales/zh_CN/commons.json
+++ b/apps/app/public/static/locales/zh_CN/commons.json
@@ -160,6 +160,6 @@
     "publish_transfer_key": "发布迁移密钥",
     "transfer_key_limit": "迁移密钥在签发后一小时内有效。",
     "once_transfer_key_used": "一旦迁移密钥被用于迁移，它将不再可用于进一步的迁移。",
-    "transfer_to_growi_cloud": "有关更多详情，请点击<a href='https://{{growiHelpDomain}}/ja/admin-guide/management-cookbook/g2g-transfer.html'>此处</a>。"
+    "transfer_to_growi_cloud": "有关更多详情，请点击<a href='https://{{documentationUrl}}/ja/admin-guide/management-cookbook/g2g-transfer.html'>此处</a>。"
   }
 }

--- a/apps/app/src/client/components/Admin/G2GDataTransfer.tsx
+++ b/apps/app/src/client/components/Admin/G2GDataTransfer.tsx
@@ -8,7 +8,7 @@ import { useGenerateTransferKey } from '~/client/services/g2g-transfer';
 import { apiv3Get, apiv3Post } from '~/client/util/apiv3-client';
 import { toastError, toastSuccess } from '~/client/util/toastr';
 import { G2G_PROGRESS_STATUS, type G2GProgress } from '~/interfaces/g2g-transfer';
-import { useGrowiHelpDomain } from '~/stores-universal/context';
+import { useGrowiDocumentationUrl } from '~/stores-universal/context';
 import { useAdminSocket } from '~/stores/socket-io';
 
 import CustomCopyToClipBoard from '../Common/CustomCopyToClipBoard';
@@ -124,7 +124,7 @@ const G2GDataTransfer = (): JSX.Element => {
     }
   }, [setTransferring, startTransferKey, selectedCollections, optionsMap]);
 
-  const { data: growiHelpDomain } = useGrowiHelpDomain();
+  const { data: documentationUrl } = useGrowiDocumentationUrl();
 
   // File upload
   // const onChangeFileUploadTypeHandler = useCallback((e: ChangeEvent, type: string) => {
@@ -279,7 +279,7 @@ const G2GDataTransfer = (): JSX.Element => {
         <p className="mb-1">{t('commons:g2g_data_transfer.transfer_key_limit')}</p>
         <p className="mb-1">{t('commons:g2g_data_transfer.once_transfer_key_used')}</p>
         {/* eslint-disable-next-line react/no-danger */}
-        <p className="mb-0" dangerouslySetInnerHTML={{ __html: t('commons:g2g_data_transfer.transfer_to_growi_cloud', { growiHelpDomain }) }} />
+        <p className="mb-0" dangerouslySetInnerHTML={{ __html: t('commons:g2g_data_transfer.transfer_to_growi_cloud', { documentationUrl }) }} />
       </div>
     </div>
   );

--- a/apps/app/src/client/components/Admin/G2GDataTransfer.tsx
+++ b/apps/app/src/client/components/Admin/G2GDataTransfer.tsx
@@ -278,8 +278,13 @@ const G2GDataTransfer = (): JSX.Element => {
       <div className="alert alert-warning mt-4">
         <p className="mb-1">{t('commons:g2g_data_transfer.transfer_key_limit')}</p>
         <p className="mb-1">{t('commons:g2g_data_transfer.once_transfer_key_used')}</p>
-        {/* eslint-disable-next-line react/no-danger */}
-        <p className="mb-0" dangerouslySetInnerHTML={{ __html: t('commons:g2g_data_transfer.transfer_to_growi_cloud', { documentationUrl }) }} />
+        <p
+          className="mb-0"
+          // eslint-disable-next-line react/no-danger
+          dangerouslySetInnerHTML={{
+            __html: t('commons:g2g_data_transfer.transfer_to_growi_cloud', { documentationUrl: documentationUrl || 'docs.growi.org' }),
+          }}
+        />
       </div>
     </div>
   );

--- a/apps/app/src/client/components/Admin/G2GDataTransfer.tsx
+++ b/apps/app/src/client/components/Admin/G2GDataTransfer.tsx
@@ -8,6 +8,7 @@ import { useGenerateTransferKey } from '~/client/services/g2g-transfer';
 import { apiv3Get, apiv3Post } from '~/client/util/apiv3-client';
 import { toastError, toastSuccess } from '~/client/util/toastr';
 import { G2G_PROGRESS_STATUS, type G2GProgress } from '~/interfaces/g2g-transfer';
+import { useGrowiHelpDomain } from '~/stores-universal/context';
 import { useAdminSocket } from '~/stores/socket-io';
 
 import CustomCopyToClipBoard from '../Common/CustomCopyToClipBoard';
@@ -122,6 +123,8 @@ const G2GDataTransfer = (): JSX.Element => {
       toastError(errs);
     }
   }, [setTransferring, startTransferKey, selectedCollections, optionsMap]);
+
+  const { data: growiHelpDomain } = useGrowiHelpDomain();
 
   // File upload
   // const onChangeFileUploadTypeHandler = useCallback((e: ChangeEvent, type: string) => {
@@ -275,7 +278,8 @@ const G2GDataTransfer = (): JSX.Element => {
       <div className="alert alert-warning mt-4">
         <p className="mb-1">{t('commons:g2g_data_transfer.transfer_key_limit')}</p>
         <p className="mb-1">{t('commons:g2g_data_transfer.once_transfer_key_used')}</p>
-        <p className="mb-0">{t('commons:g2g_data_transfer.transfer_to_growi_cloud')}</p>
+        {/* eslint-disable-next-line react/no-danger */}
+        <p className="mb-0" dangerouslySetInnerHTML={{ __html: t('commons:g2g_data_transfer.transfer_to_growi_cloud', { growiHelpDomain }) }} />
       </div>
     </div>
   );

--- a/apps/app/src/client/components/DataTransferForm.tsx
+++ b/apps/app/src/client/components/DataTransferForm.tsx
@@ -3,14 +3,14 @@ import React from 'react';
 import { useTranslation } from 'next-i18next';
 
 import { useGenerateTransferKey } from '~/client/services/g2g-transfer';
-import { useGrowiHelpDomain } from '~/stores-universal/context';
+import { useGrowiDocumentationUrl } from '~/stores-universal/context';
 
 import CustomCopyToClipBoard from './Common/CustomCopyToClipBoard';
 
 const DataTransferForm = (): JSX.Element => {
   const { t } = useTranslation('commons');
   const { transferKey, generateTransferKey } = useGenerateTransferKey();
-  const { data: growiHelpDomain } = useGrowiHelpDomain();
+  const { data: documentationUrl } = useGrowiDocumentationUrl();
 
   return (
     <div data-testid="installerForm" className="py-3 px-4">
@@ -36,7 +36,7 @@ const DataTransferForm = (): JSX.Element => {
         <p className="mb-1">{t('g2g_data_transfer.transfer_key_limit')}</p>
         <p className="mb-1">{t('g2g_data_transfer.once_transfer_key_used')}</p>
         {/* eslint-disable-next-line react/no-danger */}
-        <p className="mb-0" dangerouslySetInnerHTML={{ __html: t('g2g_data_transfer.transfer_to_growi_cloud', { growiHelpDomain }) }} />
+        <p className="mb-0" dangerouslySetInnerHTML={{ __html: t('g2g_data_transfer.transfer_to_growi_cloud', { documentationUrl }) }} />
       </div>
     </div>
   );

--- a/apps/app/src/client/components/DataTransferForm.tsx
+++ b/apps/app/src/client/components/DataTransferForm.tsx
@@ -3,12 +3,14 @@ import React from 'react';
 import { useTranslation } from 'next-i18next';
 
 import { useGenerateTransferKey } from '~/client/services/g2g-transfer';
+import { useGrowiHelpDomain } from '~/stores-universal/context';
 
 import CustomCopyToClipBoard from './Common/CustomCopyToClipBoard';
 
 const DataTransferForm = (): JSX.Element => {
   const { t } = useTranslation('commons');
   const { transferKey, generateTransferKey } = useGenerateTransferKey();
+  const { data: growiHelpDomain } = useGrowiHelpDomain();
 
   return (
     <div data-testid="installerForm" className="py-3 px-4">
@@ -33,7 +35,8 @@ const DataTransferForm = (): JSX.Element => {
       <div className="alert alert-warning mt-4">
         <p className="mb-1">{t('g2g_data_transfer.transfer_key_limit')}</p>
         <p className="mb-1">{t('g2g_data_transfer.once_transfer_key_used')}</p>
-        <p className="mb-0">{t('g2g_data_transfer.transfer_to_growi_cloud')}</p>
+        {/* eslint-disable-next-line react/no-danger */}
+        <p className="mb-0" dangerouslySetInnerHTML={{ __html: t('g2g_data_transfer.transfer_to_growi_cloud', { growiHelpDomain }) }} />
       </div>
     </div>
   );

--- a/apps/app/src/client/components/DataTransferForm.tsx
+++ b/apps/app/src/client/components/DataTransferForm.tsx
@@ -35,8 +35,13 @@ const DataTransferForm = (): JSX.Element => {
       <div className="alert alert-warning mt-4">
         <p className="mb-1">{t('g2g_data_transfer.transfer_key_limit')}</p>
         <p className="mb-1">{t('g2g_data_transfer.once_transfer_key_used')}</p>
-        {/* eslint-disable-next-line react/no-danger */}
-        <p className="mb-0" dangerouslySetInnerHTML={{ __html: t('g2g_data_transfer.transfer_to_growi_cloud', { documentationUrl }) }} />
+        <p
+          className="mb-0"
+          // eslint-disable-next-line react/no-danger
+          dangerouslySetInnerHTML={{
+            __html: t('g2g_data_transfer.transfer_to_growi_cloud', { documentationUrl: documentationUrl || 'docs.growi.org' }),
+          }}
+        />
       </div>
     </div>
   );

--- a/apps/app/src/stores-universal/context.tsx
+++ b/apps/app/src/stores-universal/context.tsx
@@ -285,3 +285,18 @@ export const useAcceptedUploadFileType = (): SWRResponse<AcceptedUploadFileType,
     },
   );
 };
+
+export const useGrowiHelpDomain = (): SWRResponse<'growi.cloud/help' | 'docs.growi.org', Error> => {
+  const { data: growiCloudUri } = useGrowiCloudUri();
+  const { data: growiAppIdForGrowiCloud } = useGrowiAppIdForGrowiCloud();
+
+  return useSWRImmutable(
+    [growiCloudUri, growiAppIdForGrowiCloud],
+    ([growiCloudUri, growiAppIdForGrowiCloud]) => {
+      if (growiCloudUri != null && growiAppIdForGrowiCloud != null) {
+        return 'growi.cloud/help';
+      }
+      return 'docs.growi.org';
+    },
+  );
+};

--- a/apps/app/src/stores-universal/context.tsx
+++ b/apps/app/src/stores-universal/context.tsx
@@ -286,7 +286,7 @@ export const useAcceptedUploadFileType = (): SWRResponse<AcceptedUploadFileType,
   );
 };
 
-export const useGrowiHelpDomain = (): SWRResponse<'growi.cloud/help' | 'docs.growi.org', Error> => {
+export const useGrowiDocumentationUrl = (): SWRResponse<'growi.cloud/help' | 'docs.growi.org', Error> => {
   const { data: growiCloudUri } = useGrowiCloudUri();
   const { data: growiAppIdForGrowiCloud } = useGrowiAppIdForGrowiCloud();
 

--- a/apps/app/src/stores-universal/context.tsx
+++ b/apps/app/src/stores-universal/context.tsx
@@ -291,7 +291,7 @@ export const useGrowiDocumentationUrl = (): SWRResponse<'growi.cloud/help' | 'do
   const { data: growiAppIdForGrowiCloud } = useGrowiAppIdForGrowiCloud();
 
   return useSWRImmutable(
-    ['growiDocumentationUrl', growiCloudUri, growiAppIdForGrowiCloud],
+    ['documentationUrl', growiCloudUri, growiAppIdForGrowiCloud],
     ([growiCloudUri, growiAppIdForGrowiCloud]) => {
       if (growiCloudUri != null && growiAppIdForGrowiCloud != null) {
         return 'growi.cloud/help';

--- a/apps/app/src/stores-universal/context.tsx
+++ b/apps/app/src/stores-universal/context.tsx
@@ -291,7 +291,7 @@ export const useGrowiDocumentationUrl = (): SWRResponse<'growi.cloud/help' | 'do
   const { data: growiAppIdForGrowiCloud } = useGrowiAppIdForGrowiCloud();
 
   return useSWRImmutable(
-    [growiCloudUri, growiAppIdForGrowiCloud],
+    ['growiDocumentationUrl', growiCloudUri, growiAppIdForGrowiCloud],
     ([growiCloudUri, growiAppIdForGrowiCloud]) => {
       if (growiCloudUri != null && growiAppIdForGrowiCloud != null) {
         return 'growi.cloud/help';


### PR DESCRIPTION
## Task
[改善 #144244 [v7] 管理画面 (/admin/data-transfer) の文言修正](https://redmine.weseek.co.jp/issues/144244)
┗ [#153642 文言修正](https://redmine.weseek.co.jp/issues/153642)

revert 前 PR: https://github.com/weseek/growi/pull/9098

## 各言語
- 英語: For more details, please click here.
- フランス語: Pour plus de détails, veuillez cliquer ici.
- 中国語: 有关更多详情，请点击此处。

## 画面スクリーンショット
### org
(左下の path 差分)
![スクリーンショット 2024-09-19 192256](https://github.com/user-attachments/assets/29ee8587-812c-46f2-8e43-7ee29bad79ca)

### cloud
(左下の path 差分)
![スクリーンショット 2024-09-19 192654](https://github.com/user-attachments/assets/ab804670-bb07-4d98-9192-1aa68deebc2c)

### 英語
![スクリーンショット 2024-09-12 143146](https://github.com/user-attachments/assets/c3082a35-7dc1-4bdb-8be9-2257eaa8e140)

### フランス
![スクリーンショット 2024-09-12 143211](https://github.com/user-attachments/assets/1cce5599-a1a1-4f47-96fe-e9001e6bef21)

### 中国語
![スクリーンショット 2024-09-12 143159](https://github.com/user-attachments/assets/33090fca-402a-431a-90a5-4dd14326869b)

## 備考
現状、遷移先の「GROWI お引越し機能」 のページについては、日本語以外、未実装のためすべての遷移先を、日本語としている、
英語版「GROWI お引越し機能」ページ作成、link の変更については、後続ストーリーを作成
- [機能 #153898 [docs] GROWI お引越し機能 の 英語対応ページを作成する](https://redmine.weseek.co.jp/issues/153898)
- [改善 #153904 [v7] 管理画面 (/admin/data-transfer) の link 修正](https://redmine.weseek.co.jp/issues/153904)
