### PR TITLE
fix: Make CustomNavTab responsive

### DIFF
--- a/apps/app/src/client/components/Admin/Notification/NotificationSetting.jsx
+++ b/apps/app/src/client/components/Admin/Notification/NotificationSetting.jsx
@@ -14,7 +14,7 @@ import { toastError } from '~/client/util/toastr';
 import { toArrayIfNot } from '~/utils/array-utils';
 import loggerFactory from '~/utils/logger';
 
-import { CustomNavTab } from '../../CustomNavigation/CustomNav';
+import CustomNav from '../../CustomNavigation/CustomNav';
 import { withUnstatedContainers } from '../../UnstatedUtils';
 
 
@@ -155,7 +155,13 @@ function NotificationSetting(props) {
 
       <h2 className="admin-setting-header mt-5">{t('notification_settings.notification_settings')}</h2>
 
-      <CustomNavTab activeTab={activeTab} navTabMapping={navTabMapping} onNavSelected={switchActiveTab} hideBorderBottom />
+      <CustomNav
+        activeTab={activeTab}
+        navTabMapping={navTabMapping}
+        onNavSelected={switchActiveTab}
+        hideBorderBottom
+        breakpointToSwitchDropdownDown="md"
+      />
 
       <TabContent activeTab={activeTab} className="p-5">
         <TabPane tabId="user_trigger_notification">

--- a/apps/app/src/client/components/CustomNavigation/CustomNav.module.scss
+++ b/apps/app/src/client/components/CustomNavigation/CustomNav.module.scss
@@ -15,7 +15,3 @@
     transition: 0.3s ease-in-out;
   }
 }
-
-.dropdown-menu :global {
-  width: 100%;
-}

--- a/apps/app/src/client/components/CustomNavigation/CustomNav.module.scss
+++ b/apps/app/src/client/components/CustomNavigation/CustomNav.module.scss
@@ -14,5 +14,8 @@
     border-bottom: 3px solid;
     transition: 0.3s ease-in-out;
   }
+}
 
+.dropdown-menu :global {
+  width: 100%;
 }

--- a/apps/app/src/client/components/CustomNavigation/CustomNav.tsx
+++ b/apps/app/src/client/components/CustomNavigation/CustomNav.tsx
@@ -61,7 +61,7 @@ export const CustomNavDropdown = (props: CustomNavDropdownProps): JSX.Element =>
           { Icon != null && <Icon /> } {i18n}
         </span>
       </button>
-      <div className="dropdown-menu dropdown-menu-right">
+      <div className={`dropdown-menu dropdown-menu-right ${styles['dropdown-menu']}`}>
         {Object.entries(navTabMapping).map(([key, value]) => {
 
           const isActive = activeTab === key;
@@ -162,8 +162,8 @@ export const CustomNavTab = (props: CustomNavTabProps): JSX.Element => {
   const inactiveClassnames: string[] = [];
   if (breakpointToHideInactiveTabsDown != null) {
     const breakpointOneLevelLarger = getBreakpointOneLevelLarger(breakpointToHideInactiveTabsDown);
-    inactiveClassnames.push('d-none');
-    inactiveClassnames.push(`d-${breakpointOneLevelLarger}-block`);
+    // inactiveClassnames.push('d-none');
+    // inactiveClassnames.push(`d-${breakpointOneLevelLarger}-block`);
   }
 
   return (

--- a/apps/app/src/client/components/CustomNavigation/CustomNav.tsx
+++ b/apps/app/src/client/components/CustomNavigation/CustomNav.tsx
@@ -77,7 +77,7 @@ export const CustomNavDropdown = (props: CustomNavDropdownProps): JSX.Element =>
           { Icon != null && <Icon /> } {i18n}
         </span>
       </button>
-      <div className={`dropdown-menu dropdown-menu-right ${isDropdownOpen ? 'show' : ''} ${styles['dropdown-menu']}`}>
+      <div className={`dropdown-menu dropdown-menu-right w-100 ${isDropdownOpen ? 'show' : ''} ${styles['dropdown-menu']}`}>
         {Object.entries(navTabMapping).map(([key, value]) => {
 
           const isActive = activeTab === key;

--- a/apps/app/src/client/components/CustomNavigation/CustomNav.tsx
+++ b/apps/app/src/client/components/CustomNavigation/CustomNav.tsx
@@ -33,11 +33,13 @@ type CustomNavDropdownProps = {
   navTabMapping: ICustomNavTabMappings,
   activeTab: string,
   onNavSelected?: (selectedTabKey: string) => void,
+  breakpointToHideDropDown?: Breakpoint,
 };
 
 export const CustomNavDropdown = (props: CustomNavDropdownProps): JSX.Element => {
   const {
     activeTab, navTabMapping, onNavSelected,
+    breakpointToHideDropDown,
   } = props;
 
   const { Icon, i18n } = navTabMapping[activeTab];
@@ -48,10 +50,17 @@ export const CustomNavDropdown = (props: CustomNavDropdownProps): JSX.Element =>
     }
   }, [onNavSelected]);
 
+  // Set classes to hide dropdown
+  const dropdownVisibilityClassnames: string[] = [];
+  if (breakpointToHideDropDown != null) {
+    const breakpointOneLevelLarger = getBreakpointOneLevelLarger(breakpointToHideDropDown);
+    dropdownVisibilityClassnames.push(`d-${breakpointOneLevelLarger}-none`);
+  }
+
   return (
     <div className="btn-group">
       <button
-        className="btn btn-outline-primary btn-lg dropdown-toggle text-end"
+        className={`btn btn-outline-primary btn-lg dropdown-toggle text-end ${dropdownVisibilityClassnames.join(' ')}`}
         type="button"
         data-bs-toggle="dropdown"
         aria-haspopup="true"
@@ -160,10 +169,13 @@ export const CustomNavTab = (props: CustomNavTabProps): JSX.Element => {
 
   // determine inactive classes to hide NavItem
   const inactiveClassnames: string[] = [];
+  const slideHrVisibilityClassnames: string[] = [];
   if (breakpointToHideInactiveTabsDown != null) {
     const breakpointOneLevelLarger = getBreakpointOneLevelLarger(breakpointToHideInactiveTabsDown);
-    // inactiveClassnames.push('d-none');
-    // inactiveClassnames.push(`d-${breakpointOneLevelLarger}-block`);
+    inactiveClassnames.push('d-none');
+    inactiveClassnames.push(`d-${breakpointOneLevelLarger}-block`);
+    // slideHrVisibilityClassnames.push('d-none');
+    // slideHrVisibilityClassnames.push(`d-${breakpointOneLevelLarger}-block`);
   }
 
   return (
@@ -191,7 +203,10 @@ export const CustomNavTab = (props: CustomNavTabProps): JSX.Element => {
         </Nav>
         {navRightElement}
       </div>
-      <hr className="my-0 grw-nav-slide-hr border-none" style={{ width: `${sliderWidth}%`, marginLeft: `${sliderMarginLeft}%` }} />
+      <hr
+        className={`my-0 grw-nav-slide-hr border-none ${slideHrVisibilityClassnames.join(' ')}`}
+        style={{ width: `${sliderWidth}%`, marginLeft: `${sliderMarginLeft}%`, display: 'inline-block' }}
+      />
       { !hideBorderBottom && <hr className="my-0 border-top-0 border-bottom" /> }
     </div>
   );

--- a/apps/app/src/client/components/CustomNavigation/CustomNav.tsx
+++ b/apps/app/src/client/components/CustomNavigation/CustomNav.tsx
@@ -50,17 +50,11 @@ export const CustomNavDropdown = (props: CustomNavDropdownProps): JSX.Element =>
     }
   }, [onNavSelected]);
 
-  // Set classes to hide dropdown
-  const dropdownVisibilityClassnames: string[] = [];
-  if (breakpointToHideDropDown != null) {
-    const breakpointOneLevelLarger = getBreakpointOneLevelLarger(breakpointToHideDropDown);
-    dropdownVisibilityClassnames.push(`d-${breakpointOneLevelLarger}-none`);
-  }
 
   return (
     <div className="btn-group">
       <button
-        className={`btn btn-outline-primary btn-lg dropdown-toggle text-end ${dropdownVisibilityClassnames.join(' ')}`}
+        className="btn btn-outline-primary btn-lg dropdown-toggle text-end"
         type="button"
         data-bs-toggle="dropdown"
         aria-haspopup="true"
@@ -169,13 +163,10 @@ export const CustomNavTab = (props: CustomNavTabProps): JSX.Element => {
 
   // determine inactive classes to hide NavItem
   const inactiveClassnames: string[] = [];
-  const slideHrVisibilityClassnames: string[] = [];
   if (breakpointToHideInactiveTabsDown != null) {
     const breakpointOneLevelLarger = getBreakpointOneLevelLarger(breakpointToHideInactiveTabsDown);
     inactiveClassnames.push('d-none');
     inactiveClassnames.push(`d-${breakpointOneLevelLarger}-block`);
-    // slideHrVisibilityClassnames.push('d-none');
-    // slideHrVisibilityClassnames.push(`d-${breakpointOneLevelLarger}-block`);
   }
 
   return (
@@ -203,10 +194,7 @@ export const CustomNavTab = (props: CustomNavTabProps): JSX.Element => {
         </Nav>
         {navRightElement}
       </div>
-      <hr
-        className={`my-0 grw-nav-slide-hr border-none ${slideHrVisibilityClassnames.join(' ')}`}
-        style={{ width: `${sliderWidth}%`, marginLeft: `${sliderMarginLeft}%`, display: 'inline-block' }}
-      />
+      <hr className="my-0 grw-nav-slide-hr border-none" style={{ width: `${sliderWidth}%`, marginLeft: `${sliderMarginLeft}%` }} />
       { !hideBorderBottom && <hr className="my-0 border-top-0 border-bottom" /> }
     </div>
   );

--- a/apps/app/src/client/components/CustomNavigation/CustomNav.tsx
+++ b/apps/app/src/client/components/CustomNavigation/CustomNav.tsx
@@ -44,6 +44,8 @@ export const CustomNavDropdown = (props: CustomNavDropdownProps): JSX.Element =>
 
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
+  const dropdownButtonRef = useRef<HTMLButtonElement>(null);
+
   const handleDropdownToggle = () => {
     setIsDropdownOpen(prev => !prev);
   };
@@ -52,12 +54,17 @@ export const CustomNavDropdown = (props: CustomNavDropdownProps): JSX.Element =>
     if (onNavSelected != null) {
       onNavSelected(key);
     }
+    // Manually close the dropdown
     setIsDropdownOpen(false);
+    if (dropdownButtonRef.current) {
+      dropdownButtonRef.current.classList.remove('show');
+    }
   }, [onNavSelected]);
 
   return (
     <div className="btn-group">
       <button
+        ref={dropdownButtonRef}
         className="btn btn-outline-primary btn-lg dropdown-toggle text-end"
         type="button"
         data-bs-toggle="dropdown"

--- a/apps/app/src/client/components/CustomNavigation/CustomNav.tsx
+++ b/apps/app/src/client/components/CustomNavigation/CustomNav.tsx
@@ -42,10 +42,17 @@ export const CustomNavDropdown = (props: CustomNavDropdownProps): JSX.Element =>
 
   const { Icon, i18n } = navTabMapping[activeTab];
 
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+
+  const handleDropdownToggle = () => {
+    setIsDropdownOpen(prev => !prev);
+  };
+
   const menuItemClickHandler = useCallback((key) => {
     if (onNavSelected != null) {
       onNavSelected(key);
     }
+    setIsDropdownOpen(false);
   }, [onNavSelected]);
 
   return (
@@ -55,13 +62,14 @@ export const CustomNavDropdown = (props: CustomNavDropdownProps): JSX.Element =>
         type="button"
         data-bs-toggle="dropdown"
         aria-haspopup="true"
-        aria-expanded="false"
+        aria-expanded={isDropdownOpen}
+        onClick={handleDropdownToggle}
       >
         <span className="float-start">
           { Icon != null && <Icon /> } {i18n}
         </span>
       </button>
-      <div className={`dropdown-menu dropdown-menu-right ${styles['dropdown-menu']}`}>
+      <div className={`dropdown-menu dropdown-menu-right ${isDropdownOpen ? 'show' : ''} ${styles['dropdown-menu']}`}>
         {Object.entries(navTabMapping).map(([key, value]) => {
 
           const isActive = activeTab === key;

--- a/apps/app/src/client/components/CustomNavigation/CustomNav.tsx
+++ b/apps/app/src/client/components/CustomNavigation/CustomNav.tsx
@@ -33,13 +33,11 @@ type CustomNavDropdownProps = {
   navTabMapping: ICustomNavTabMappings,
   activeTab: string,
   onNavSelected?: (selectedTabKey: string) => void,
-  breakpointToHideDropDown?: Breakpoint,
 };
 
 export const CustomNavDropdown = (props: CustomNavDropdownProps): JSX.Element => {
   const {
     activeTab, navTabMapping, onNavSelected,
-    breakpointToHideDropDown,
   } = props;
 
   const { Icon, i18n } = navTabMapping[activeTab];
@@ -49,7 +47,6 @@ export const CustomNavDropdown = (props: CustomNavDropdownProps): JSX.Element =>
       onNavSelected(key);
     }
   }, [onNavSelected]);
-
 
   return (
     <div className="btn-group">

--- a/apps/app/src/client/components/CustomNavigation/CustomNav.tsx
+++ b/apps/app/src/client/components/CustomNavigation/CustomNav.tsx
@@ -46,7 +46,7 @@ export const CustomNavDropdown = (props: CustomNavDropdownProps): JSX.Element =>
 
   const dropdownButtonRef = useRef<HTMLButtonElement>(null);
 
-  const handleDropdownToggle = () => {
+  const toggleDropdown = () => {
     setIsDropdownOpen(prev => !prev);
   };
 
@@ -70,7 +70,7 @@ export const CustomNavDropdown = (props: CustomNavDropdownProps): JSX.Element =>
         data-bs-toggle="dropdown"
         aria-haspopup="true"
         aria-expanded={isDropdownOpen}
-        onClick={handleDropdownToggle}
+        onClick={toggleDropdown}
       >
         <span className="float-start">
           { Icon != null && <Icon /> } {i18n}

--- a/apps/app/src/client/components/DescendantsPageListModal.module.scss
+++ b/apps/app/src/client/components/DescendantsPageListModal.module.scss
@@ -9,6 +9,10 @@
     padding: 25px 30px;
   }
 
+  .grw-tab-content-style-md-down {
+    padding-top: 25px;
+  }
+
   .grw-modal-body-style {
     max-height: calc(100vh - 100px);
   }

--- a/apps/app/src/client/components/DescendantsPageListModal.spec.tsx
+++ b/apps/app/src/client/components/DescendantsPageListModal.spec.tsx
@@ -59,7 +59,7 @@ describe('DescendantsPageListModal.tsx', () => {
 
     it('should render CustomNavDropdown on devices smaller than lg', () => {
       render(<DescendantsPageListModal />);
-      expect(screen.queryByTestId('custom-nav-dropdown')).not.toBeNull();
+      expect(screen.getByTestId('custom-nav-dropdown')).not.toBeNull();
     });
 
     it('should not render CustomNavTab', () => {

--- a/apps/app/src/client/components/DescendantsPageListModal.tsx
+++ b/apps/app/src/client/components/DescendantsPageListModal.tsx
@@ -11,7 +11,7 @@ import {
 import { useIsSharedUser } from '~/stores-universal/context';
 import { useDescendantsPageListModal } from '~/stores/modal';
 
-import { CustomNavTab } from './CustomNavigation/CustomNav';
+import CustomNav, { CustomNavTab } from './CustomNavigation/CustomNav';
 import CustomTabContent from './CustomNavigation/CustomTabContent';
 import type { DescendantsPageListProps } from './DescendantsPageList';
 import ExpandOrContractButton from './ExpandOrContractButton';
@@ -94,10 +94,11 @@ export const DescendantsPageListModal = (): JSX.Element => {
       className={`grw-descendants-page-list-modal ${styles['grw-descendants-page-list-modal']} ${isWindowExpanded ? 'grw-modal-expanded' : ''} `}
     >
       <ModalHeader className="p-0" toggle={close} close={buttons}>
-        <CustomNavTab
+        <CustomNav
           activeTab={activeTab}
           navTabMapping={navTabMapping}
           breakpointToHideInactiveTabsDown="md"
+          breakpointToSwitchDropdownDown="md"
           onNavSelected={v => setActiveTab(v)}
           hideBorderBottom
         />

--- a/apps/app/src/client/components/DescendantsPageListModal.tsx
+++ b/apps/app/src/client/components/DescendantsPageListModal.tsx
@@ -10,6 +10,7 @@ import {
 
 import { useIsSharedUser } from '~/stores-universal/context';
 import { useDescendantsPageListModal } from '~/stores/modal';
+import { useIsDeviceLargerThanLg } from '~/stores/ui';
 
 import { CustomNavDropdown, CustomNavTab } from './CustomNavigation/CustomNav';
 import CustomTabContent from './CustomNavigation/CustomTabContent';
@@ -33,6 +34,8 @@ export const DescendantsPageListModal = (): JSX.Element => {
   const { data: status, close } = useDescendantsPageListModal();
 
   const { events } = useRouter();
+
+  const { data: isDeviceLargerThanLg } = useIsDeviceLargerThanLg();
 
   useEffect(() => {
     events.on('routeChangeStart', close);
@@ -94,21 +97,25 @@ export const DescendantsPageListModal = (): JSX.Element => {
       className={`grw-descendants-page-list-modal ${styles['grw-descendants-page-list-modal']} ${isWindowExpanded ? 'grw-modal-expanded' : ''} `}
     >
       <ModalHeader className="p-0" toggle={close} close={buttons}>
-        <CustomNavTab
-          activeTab={activeTab}
-          navTabMapping={navTabMapping}
-          breakpointToHideInactiveTabsDown="md"
-          onNavSelected={v => setActiveTab(v)}
-          hideBorderBottom
-        />
+        {isDeviceLargerThanLg && (
+          <CustomNavTab
+            activeTab={activeTab}
+            navTabMapping={navTabMapping}
+            breakpointToHideInactiveTabsDown="md"
+            onNavSelected={v => setActiveTab(v)}
+            hideBorderBottom
+          />
+        )}
       </ModalHeader>
       <ModalBody>
-        <CustomNavDropdown
-          activeTab={activeTab}
-          navTabMapping={navTabMapping}
-          breakpointToHideDropDown="md"
-          onNavSelected={v => setActiveTab(v)}
-        />
+        {!isDeviceLargerThanLg && (
+          <CustomNavDropdown
+            activeTab={activeTab}
+            navTabMapping={navTabMapping}
+            breakpointToHideDropDown="md"
+            onNavSelected={v => setActiveTab(v)}
+          />
+        )}
         <CustomTabContent activeTab={activeTab} navTabMapping={navTabMapping} />
       </ModalBody>
     </Modal>

--- a/apps/app/src/client/components/DescendantsPageListModal.tsx
+++ b/apps/app/src/client/components/DescendantsPageListModal.tsx
@@ -112,7 +112,6 @@ export const DescendantsPageListModal = (): JSX.Element => {
           <CustomNavDropdown
             activeTab={activeTab}
             navTabMapping={navTabMapping}
-            breakpointToHideDropDown="md"
             onNavSelected={v => setActiveTab(v)}
           />
         )}

--- a/apps/app/src/client/components/DescendantsPageListModal.tsx
+++ b/apps/app/src/client/components/DescendantsPageListModal.tsx
@@ -11,7 +11,7 @@ import {
 import { useIsSharedUser } from '~/stores-universal/context';
 import { useDescendantsPageListModal } from '~/stores/modal';
 
-import CustomNav, { CustomNavTab } from './CustomNavigation/CustomNav';
+import { CustomNavDropdown, CustomNavTab } from './CustomNavigation/CustomNav';
 import CustomTabContent from './CustomNavigation/CustomTabContent';
 import type { DescendantsPageListProps } from './DescendantsPageList';
 import ExpandOrContractButton from './ExpandOrContractButton';
@@ -94,16 +94,21 @@ export const DescendantsPageListModal = (): JSX.Element => {
       className={`grw-descendants-page-list-modal ${styles['grw-descendants-page-list-modal']} ${isWindowExpanded ? 'grw-modal-expanded' : ''} `}
     >
       <ModalHeader className="p-0" toggle={close} close={buttons}>
-        <CustomNav
+        <CustomNavTab
           activeTab={activeTab}
           navTabMapping={navTabMapping}
           breakpointToHideInactiveTabsDown="md"
-          breakpointToSwitchDropdownDown="md"
           onNavSelected={v => setActiveTab(v)}
           hideBorderBottom
         />
       </ModalHeader>
       <ModalBody>
+        <CustomNavDropdown
+          activeTab={activeTab}
+          navTabMapping={navTabMapping}
+          breakpointToHideDropDown="md"
+          onNavSelected={v => setActiveTab(v)}
+        />
         <CustomTabContent activeTab={activeTab} navTabMapping={navTabMapping} />
       </ModalBody>
     </Modal>

--- a/apps/app/src/client/components/DescendantsPageListModal.tsx
+++ b/apps/app/src/client/components/DescendantsPageListModal.tsx
@@ -96,7 +96,7 @@ export const DescendantsPageListModal = (): JSX.Element => {
       data-testid="descendants-page-list-modal"
       className={`grw-descendants-page-list-modal ${styles['grw-descendants-page-list-modal']} ${isWindowExpanded ? 'grw-modal-expanded' : ''} `}
     >
-      <ModalHeader className="p-0" toggle={close} close={buttons}>
+      <ModalHeader className={isDeviceLargerThanLg ? 'p-0' : ''} toggle={close} close={buttons}>
         {isDeviceLargerThanLg && (
           <CustomNavTab
             activeTab={activeTab}
@@ -115,7 +115,11 @@ export const DescendantsPageListModal = (): JSX.Element => {
             onNavSelected={v => setActiveTab(v)}
           />
         )}
-        <CustomTabContent activeTab={activeTab} navTabMapping={navTabMapping} />
+        <CustomTabContent
+          activeTab={activeTab}
+          navTabMapping={navTabMapping}
+          additionalClassNames={!isDeviceLargerThanLg ? ['grw-tab-content-style-md-down'] : undefined}
+        />
       </ModalBody>
     </Modal>
   );


### PR DESCRIPTION
## タスク
- [#114434](https://redmine.weseek.co.jp/issues/114434)DescendantsPageListModal.tsx を開いた状態で window サイズを縮小させるとタイムラインのタブが非表示になる
  -  [#153937](https://redmine.weseek.co.jp/issues/153937) 実装
 
# やったこと
## DescendantsPageListModal
- 画面サイズが md 以下のとき、body にドロップダウンを表示
  - このとき、タブは非表示
- モーダル内の dropdown において、メニューをクリック時にメニューが閉じるなどの bootstrap のデフォルトの機能が動作しなかったので、モーダル側で dropdown を閉じるようなコードを書いた
  - メニュー外をクリックしたときも同様にメニューが消えない問題については、相談の上無視した(https://wsgrowi.slack.com/archives/CL5SMPHB2/p1726555790035049?thread_ts=1726216093.039779&cid=CL5SMPHB2)

- padding などの見た目は、fumiya さんに確認してもらった
 
## 管理画面の通知設定(/admin/notification)
- ここは `/admin/security` 同様に、ドロップダウンにした(ブラウザ幅を小さくしたときに、スタイルがくずれていたので)

 # 備考
- 最終的に PageAccessoriesModal は DescendantsPageListModal と同様の変更が加わる予定

# キャプチャ
- ページリストモーダル
<img width="547" alt="image" src="https://github.com/user-attachments/assets/2c0d10a7-15c7-4965-b26f-7294b65ffceb">
<img width="690" alt="image" src="https://github.com/user-attachments/assets/38b9f8f8-c831-4a26-acef-838512da14fe">


- /admin/notification
<img width="575" alt="image" src="https://github.com/user-attachments/assets/3a433c1e-b33b-4433-b860-d28607942d6b">
