### PR TITLE
fix: add descendants page list modal spec

### DIFF
--- a/apps/app/src/client/components/CustomNavigation/CustomNav.tsx
+++ b/apps/app/src/client/components/CustomNavigation/CustomNav.tsx
@@ -71,6 +71,7 @@ export const CustomNavDropdown = (props: CustomNavDropdownProps): JSX.Element =>
         aria-haspopup="true"
         aria-expanded={isDropdownOpen}
         onClick={toggleDropdown}
+        data-testid="custom-nav-dropdown"
       >
         <span className="float-start">
           { Icon != null && <Icon /> } {i18n}
@@ -182,7 +183,7 @@ export const CustomNavTab = (props: CustomNavTabProps): JSX.Element => {
   }
 
   return (
-    <div className={`grw-custom-nav-tab ${styles['grw-custom-nav-tab']}`}>
+    <div data-testid="custom-nav-tab" className={`grw-custom-nav-tab ${styles['grw-custom-nav-tab']}`}>
       <div ref={navContainerRef} className="d-flex justify-content-between">
         <Nav className="nav-title">
           {Object.entries(navTabMapping).map(([key, value]) => {

--- a/apps/app/src/client/components/DescendantsPageListModal.spec.tsx
+++ b/apps/app/src/client/components/DescendantsPageListModal.spec.tsx
@@ -1,0 +1,72 @@
+/* eslint-disable no-console */
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import { DescendantsPageListModal } from './DescendantsPageListModal';
+
+
+const mockClose = vi.hoisted(() => vi.fn());
+const useIsDeviceLargerThanLg = vi.hoisted(() => vi.fn().mockReturnValue({ data: true }));
+
+vi.mock('next/router', () => ({
+  useRouter: () => ({
+    events: {
+      on: vi.fn(),
+      off: vi.fn(),
+    },
+  }),
+}));
+
+vi.mock('~/stores/modal', () => ({
+  useDescendantsPageListModal: vi.fn().mockReturnValue({
+    data: { isOpened: true },
+    close: mockClose,
+  }),
+}));
+
+vi.mock('~/stores/ui', () => ({
+  useIsDeviceLargerThanLg,
+}));
+
+describe('DescendantsPageListModal.tsx', () => {
+
+  it('should render the modal when isOpened is true', () => {
+    render(<DescendantsPageListModal />);
+    expect(screen.getByTestId('descendants-page-list-modal')).not.toBeNull();
+  });
+
+  it('should call close function when close button is clicked', () => {
+    render(<DescendantsPageListModal />);
+    const closeButton = screen.getByLabelText('Close');
+    fireEvent.click(closeButton);
+    expect(mockClose).toHaveBeenCalled();
+  });
+
+  describe('when device is larger than lg', () => {
+
+    it('should render CustomNavTab', () => {
+      render(<DescendantsPageListModal />);
+      expect(screen.getByTestId('custom-nav-tab')).not.toBeNull();
+    });
+
+    it('should not render CustomNavDropdown', () => {
+      render(<DescendantsPageListModal />);
+      expect(screen.queryByTestId('custom-nav-dropdown')).toBeNull();
+    });
+  });
+
+  describe('when device is smaller than lg', () => {
+    beforeEach(() => {
+      useIsDeviceLargerThanLg.mockReturnValue({ data: false });
+    });
+
+    it('should render CustomNavDropdown on devices smaller than lg', () => {
+      render(<DescendantsPageListModal />);
+      expect(screen.queryByTestId('custom-nav-dropdown')).not.toBeNull();
+    });
+
+    it('should not render CustomNavTab', () => {
+      render(<DescendantsPageListModal />);
+      expect(screen.queryByTestId('custom-nav-tab')).toBeNull();
+    });
+  });
+});

--- a/apps/app/src/client/components/DescendantsPageListModal.spec.tsx
+++ b/apps/app/src/client/components/DescendantsPageListModal.spec.tsx
@@ -2,7 +2,6 @@ import { render, screen, fireEvent } from '@testing-library/react';
 
 import { DescendantsPageListModal } from './DescendantsPageListModal';
 
-
 const mockClose = vi.hoisted(() => vi.fn());
 const useIsDeviceLargerThanLg = vi.hoisted(() => vi.fn().mockReturnValue({ data: true }));
 

--- a/apps/app/src/client/components/DescendantsPageListModal.spec.tsx
+++ b/apps/app/src/client/components/DescendantsPageListModal.spec.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import { render, screen, fireEvent } from '@testing-library/react';
 
 import { DescendantsPageListModal } from './DescendantsPageListModal';


### PR DESCRIPTION
## Task
- [#114434](https://redmine.weseek.co.jp/issues/114434)DescendantsPageListModal.tsx を開いた状態で window サイズを縮小させるとタイムラインのタブが非表示になる
  -  [#153970](https://redmine.weseek.co.jp/issues/153970) コンポーネントテストを追加