### PR TITLE
fix: Modify DescendantsPageListModal spec

### DIFF
--- a/apps/app/src/client/components/DescendantsPageListModal.spec.tsx
+++ b/apps/app/src/client/components/DescendantsPageListModal.spec.tsx
@@ -54,6 +54,7 @@ vi.mock('~/stores/modal', () => ({
   }),
 }));
 
+// Mocking getComputedStyle to simulate the values of Bootstrap's CSS
 Object.defineProperty(window, 'getComputedStyle', {
   value: () => ({
     getPropertyValue: (prop: string) => (prop === '--bs-breakpoint-lg' ? '992px' : ''),

--- a/apps/app/src/client/components/DescendantsPageListModal.spec.tsx
+++ b/apps/app/src/client/components/DescendantsPageListModal.spec.tsx
@@ -3,13 +3,16 @@ import { SWRConfig } from 'swr';
 
 import { DescendantsPageListModal } from './DescendantsPageListModal';
 
+let breakpointPixel; // Variable to hold the current breakpoint pixel
 let mockMatchMedia;
 
+const defaultBreakpointPixel = '992px';
 const mockClose = vi.hoisted(() => vi.fn());
 
-const setMatchMedia = (matches) => {
+const setMatchMedia = (breakpointPixel) => {
+  const expectedQuery = `(min-width: ${breakpointPixel})`;
   mockMatchMedia.mockImplementationOnce(query => ({
-    matches,
+    matches: query === expectedQuery,
     media: query,
     onchange: null,
     addListener: vi.fn(),
@@ -18,6 +21,21 @@ const setMatchMedia = (matches) => {
     removeEventListener: vi.fn(),
     dispatchEvent: vi.fn(),
   }));
+};
+
+// Determine the breakpoint pixel based on window width
+const getBreakpointPixel = (windowWidth) => {
+  if (windowWidth >= 992) return '992px'; // lg
+  if (windowWidth >= 768) return '768px'; // md
+  if (windowWidth >= 576) return '576px'; // sm
+  return '0'; // xs
+};
+
+// Set the window width and update the breakpoint pixel
+const setWindowWidth = (windowWidth) => {
+  Object.defineProperty(window, 'innerWidth', { value: windowWidth });
+  breakpointPixel = getBreakpointPixel(windowWidth);
+  setMatchMedia(breakpointPixel);
 };
 
 vi.mock('next/router', () => ({
@@ -36,6 +54,12 @@ vi.mock('~/stores/modal', () => ({
   }),
 }));
 
+Object.defineProperty(window, 'getComputedStyle', {
+  value: () => ({
+    getPropertyValue: (prop: string) => (prop === '--bs-breakpoint-lg' ? '992px' : ''),
+  }),
+});
+
 describe('DescendantsPageListModal.tsx', () => {
   beforeEach(() => {
     mockMatchMedia = vi.fn();
@@ -45,9 +69,9 @@ describe('DescendantsPageListModal.tsx', () => {
       value: mockMatchMedia,
     });
 
-    // default settings
-    mockMatchMedia.mockImplementation(query => ({
-      matches: true, // set true
+    // Default settings for matchMedia
+    mockMatchMedia.mockImplementation((query: string) => ({
+      matches: query === `(min-width: ${defaultBreakpointPixel})`,
       media: query,
       onchange: null,
       addListener: vi.fn(),
@@ -59,12 +83,20 @@ describe('DescendantsPageListModal.tsx', () => {
   });
 
   it('should render the modal when isOpened is true', () => {
-    render(<DescendantsPageListModal />);
+    render(
+      <SWRConfig value={{ provider: () => new Map() }}>
+        <DescendantsPageListModal />
+      </SWRConfig>,
+    );
     expect(screen.getByTestId('descendants-page-list-modal')).not.toBeNull();
   });
 
   it('should call close function when close button is clicked', () => {
-    render(<DescendantsPageListModal />);
+    render(
+      <SWRConfig value={{ provider: () => new Map() }}>
+        <DescendantsPageListModal />
+      </SWRConfig>,
+    );
     const closeButton = screen.getByLabelText('Close');
     fireEvent.click(closeButton);
     expect(mockClose).toHaveBeenCalled();
@@ -76,21 +108,16 @@ describe('DescendantsPageListModal.tsx', () => {
         <DescendantsPageListModal />
       </SWRConfig>,
     );
-
     expect(screen.getByTestId('custom-nav-tab')).not.toBeNull();
 
-    // The rendered component to be unmounted
-    unmount();
-
-    // Set isDeviceLargerThanLg to false by simulating a smaller screen size
-    setMatchMedia(false);
+    unmount(); // Unmount the component to remove the result of the first render
+    setWindowWidth(500); // Simulate a smaller screen size
 
     render(
       <SWRConfig value={{ provider: () => new Map() }}>
         <DescendantsPageListModal />
       </SWRConfig>,
     );
-
     expect(screen.queryByTestId('custom-nav-tab')).toBeNull();
   });
 
@@ -100,21 +127,16 @@ describe('DescendantsPageListModal.tsx', () => {
         <DescendantsPageListModal />
       </SWRConfig>,
     );
-
     expect(screen.queryByTestId('custom-nav-dropdown')).toBeNull();
 
-    // The rendered component to be unmounted
-    unmount();
-
-    // Set isDeviceLargerThanLg to false by simulating a smaller screen size
-    setMatchMedia(false);
+    unmount(); // Unmount the component to remove the result of the first render
+    setWindowWidth(500); // Simulate a smaller screen size
 
     render(
       <SWRConfig value={{ provider: () => new Map() }}>
         <DescendantsPageListModal />
       </SWRConfig>,
     );
-
     expect(screen.getByTestId('custom-nav-dropdown')).not.toBeNull();
   });
 });


### PR DESCRIPTION
# Task
- https://redmine.weseek.co.jp/issues/154341

# 備考
- テスト内で render される window のサイズを更新するだけでは、その結果が反映されなかった (window.matchMedia を使っているためと思われる)
- window.matchMedia を使っている場合は、これを mock 化する必要があるらしいので、そのようにした
- 動的に mock 化した matchMedia の true/false の決定には、設定した windowWidth から、対応する breakpoint を設定し、受け取る media query と一致するかどうかで判定するようにした。
- <SWRConfig> でコンポーネントを wrap  しないと、window.matchMedia による状態の更新が反映されないらしいので、そのようにした
