### PR TITLE
fix: Forgot password API - reject requests with invalid email format

### DIFF
--- a/apps/app/src/server/middlewares/apiv3-form-validator.ts
+++ b/apps/app/src/server/middlewares/apiv3-form-validator.ts
@@ -1,5 +1,5 @@
 import { ErrorV3 } from '@growi/core/dist/models';
-import { NextFunction, Request, Response } from 'express';
+import type { NextFunction, Request, Response } from 'express';
 
 import loggerFactory from '~/utils/logger';
 

--- a/apps/app/src/server/routes/apiv3/forgot-password.js
+++ b/apps/app/src/server/routes/apiv3/forgot-password.js
@@ -19,8 +19,6 @@ const logger = loggerFactory('growi:routes:apiv3:forgotPassword'); // eslint-dis
 const express = require('express');
 const { body } = require('express-validator');
 
-const filterXss = new FilterXSS();
-
 const router = express.Router();
 
 module.exports = (crowi) => {
@@ -45,6 +43,13 @@ module.exports = (crowi) => {
           return (value === req.body.newPassword);
         }),
     ],
+    email: [
+      body('email')
+        .isEmail()
+        .withMessage('message.Email format is invalid')
+        .exists()
+        .withMessage('message.Email field is required'),
+    ],
   };
 
   const checkPassportStrategyMiddleware = checkForgotPasswordEnabledMiddlewareFactory(crowi, true);
@@ -63,8 +68,8 @@ module.exports = (crowi) => {
     });
   }
 
-  router.post('/', checkPassportStrategyMiddleware, addActivity, async(req, res) => {
-    const email = filterXss.process(req.body.email);
+  router.post('/', checkPassportStrategyMiddleware, validator.email, addActivity, async(req, res) => {
+    const { email } = req.body;
     const locale = configManager.getConfig('crowi', 'app:globalLang');
     const appUrl = appService.getSiteUrl();
 
@@ -100,7 +105,7 @@ module.exports = (crowi) => {
   // eslint-disable-next-line max-len
   router.put('/', checkPassportStrategyMiddleware, injectResetOrderByTokenMiddleware, validator.password, apiV3FormValidator, addActivity, async(req, res) => {
     const { passwordResetOrder } = req;
-    const email = filterXss.process(passwordResetOrder.email);
+    const { email } = passwordResetOrder;
     const grobalLang = configManager.getConfig('crowi', 'app:globalLang');
     const i18n = grobalLang || req.language;
     const { newPassword } = req.body;

--- a/apps/app/src/server/routes/apiv3/forgot-password.js
+++ b/apps/app/src/server/routes/apiv3/forgot-password.js
@@ -68,17 +68,12 @@ module.exports = (crowi) => {
     });
   }
 
-  router.post('/', checkPassportStrategyMiddleware, validator.email, addActivity, async(req, res) => {
+  router.post('/', checkPassportStrategyMiddleware, validator.email, apiV3FormValidator, addActivity, async(req, res) => {
+    const { email } = req.query;
     const locale = configManager.getConfig('crowi', 'app:globalLang');
     const appUrl = appService.getSiteUrl();
 
     try {
-
-      const error = validationResult(req);
-      if (!error.isEmpty()) {
-        throw Error('invalid email format');
-      }
-      const email = req.query.email;
       const user = await User.findOne({ email });
 
       // when the user is not found or active
@@ -113,6 +108,7 @@ module.exports = (crowi) => {
     const grobalLang = configManager.getConfig('crowi', 'app:globalLang');
     const i18n = grobalLang || req.language;
 
+    const { newPassword } = req.body;
 
     const user = await User.findOne({ email });
 
@@ -122,11 +118,6 @@ module.exports = (crowi) => {
     }
 
     try {
-      const error = validationResult(req);
-      if (!error.isEmpty) {
-        throw Error('invalid password format');
-      }
-      const { newPassword } = req.body;
       const userData = await user.updatePassword(newPassword);
       const serializedUserData = serializeUserSecurely(userData);
       passwordResetOrder.revokeOneTimeToken();

--- a/apps/app/src/server/routes/apiv3/forgot-password.js
+++ b/apps/app/src/server/routes/apiv3/forgot-password.js
@@ -62,11 +62,16 @@ module.exports = (crowi) => {
   }
 
   router.post('/', checkPassportStrategyMiddleware, addActivity, async(req, res) => {
+    const validEmailRegexp = new RegExp(/^[\w+\-.]+@[a-z\d\-.]+\.[a-z]+$/, 'i');
     const { email } = req.body;
     const locale = configManager.getConfig('crowi', 'app:globalLang');
     const appUrl = appService.getSiteUrl();
 
     try {
+      if (!validEmailRegexp.test(email.toString())) {
+        throw new Error('invalid email format.');
+      }
+
       const user = await User.findOne({ email });
 
       // when the user is not found or active

--- a/apps/app/src/server/routes/apiv3/forgot-password.js
+++ b/apps/app/src/server/routes/apiv3/forgot-password.js
@@ -112,7 +112,7 @@ module.exports = (crowi) => {
     const { email } = passwordResetOrder;
     const grobalLang = configManager.getConfig('crowi', 'app:globalLang');
     const i18n = grobalLang || req.language;
-    const { newPassword } = req.body;
+
 
     const user = await User.findOne({ email });
 
@@ -122,6 +122,11 @@ module.exports = (crowi) => {
     }
 
     try {
+      const error = validationResult(req);
+      if (!error.isEmpty) {
+        throw Error('invalid password format');
+      }
+      const { newPassword } = req.body;
       const userData = await user.updatePassword(newPassword);
       const serializedUserData = serializeUserSecurely(userData);
       passwordResetOrder.revokeOneTimeToken();

--- a/apps/app/src/server/routes/apiv3/forgot-password.js
+++ b/apps/app/src/server/routes/apiv3/forgot-password.js
@@ -16,7 +16,8 @@ import { checkForgotPasswordEnabledMiddlewareFactory } from '../forgot-password'
 const logger = loggerFactory('growi:routes:apiv3:forgotPassword'); // eslint-disable-line no-unused-vars
 
 const express = require('express');
-const { body, validationResult } = require('express-validator');
+const { body } = require('express-validator');
+
 
 const router = express.Router();
 
@@ -69,7 +70,7 @@ module.exports = (crowi) => {
   }
 
   router.post('/', checkPassportStrategyMiddleware, validator.email, apiV3FormValidator, addActivity, async(req, res) => {
-    const { email } = req.query;
+    const { email } = req.body;
     const locale = configManager.getConfig('crowi', 'app:globalLang');
     const appUrl = appService.getSiteUrl();
 
@@ -107,7 +108,6 @@ module.exports = (crowi) => {
     const { email } = passwordResetOrder;
     const grobalLang = configManager.getConfig('crowi', 'app:globalLang');
     const i18n = grobalLang || req.language;
-
     const { newPassword } = req.body;
 
     const user = await User.findOne({ email });

--- a/apps/app/src/server/routes/forgot-password.ts
+++ b/apps/app/src/server/routes/forgot-password.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   NextFunction, Request, Response,
 } from 'express';
 import createError from 'http-errors';
@@ -6,7 +6,7 @@ import createError from 'http-errors';
 import { forgotPasswordErrorCode } from '~/interfaces/errors/forgot-password';
 import loggerFactory from '~/utils/logger';
 
-import { IPasswordResetOrder } from '../models/password-reset-order';
+import type { IPasswordResetOrder } from '../models/password-reset-order';
 
 const logger = loggerFactory('growi:routes:forgot-password');
 


### PR DESCRIPTION
# タスク
[forgot-password api へのメールヘッダインジェクション対応](https://redmine.weseek.co.jp/issues/154291)
pr and merge: https://redmine.weseek.co.jp/issues/154297

# 修正後の挙動
## 正しい挙動
**この例のエラーは、メールが正しいと判断された後のエラー**
今回のタスク要件は満たしています。

![image](https://github.com/user-attachments/assets/6f891fd6-5dcf-4743-adf0-73e233c76a9c)

## エラー時の挙動
不適切なメールアドレスに対しエラーを出します
![image](https://github.com/user-attachments/assets/a7a2936a-6755-4ec7-9fb4-9fd1281abf04)

