### PR TITLE
fix: splitMarkdownIntoChunks to prevent # in code blocks from being recognized as header

### DIFF
--- a/packages/markdown-splitter/src/services/markdown-splitter.ts
+++ b/packages/markdown-splitter/src/services/markdown-splitter.ts
@@ -63,11 +63,21 @@ export function splitMarkdownIntoChunks(markdown: string): Chunk[] {
   const contentLines: string[] = [];
   let currentLabel = '';
   let previousLineEmpty = false;
-
+  let inCodeBlock = false;
   for (const line of lines) {
     const trimmedLine = line.trim();
 
-    if (trimmedLine.startsWith('#')) {
+    if (trimmedLine.startsWith('```')) {
+      inCodeBlock = !inCodeBlock;
+      contentLines.push(line);
+      previousLineEmpty = false;
+    }
+    else if (inCodeBlock) {
+      // Inside code block, add line to content
+      contentLines.push(line);
+      previousLineEmpty = false;
+    }
+    else if (trimmedLine.startsWith('#')) {
       // Process any pending content before starting a new section
       if (contentLines.length > 0) {
         const contentLabel = currentLabel !== '' ? `${currentLabel}-content` : '0-content';
@@ -81,6 +91,7 @@ export function splitMarkdownIntoChunks(markdown: string): Chunk[] {
         currentLabel = updateSectionNumbers(sectionNumbers, headingDepth);
         chunks.push({ label: `${currentLabel}-heading`, text: line });
       }
+      previousLineEmpty = false;
     }
     else if (trimmedLine === '') {
       // Handle empty lines to avoid multiple consecutive empty lines

--- a/packages/markdown-splitter/test/index.spec.ts
+++ b/packages/markdown-splitter/test/index.spec.ts
@@ -248,5 +248,30 @@ Content under header 2.
     const result = splitMarkdownIntoChunks(markdown);
     expect(result).toEqual(expected);
   });
+  test('code blocks containing # are not treated as headings', () => {
+    const markdown = `
+# Header 1
+Some introductory content.
 
+\`\`\`
+# This is a comment with a # symbol
+Some code line
+\`\`\`
+
+Additional content.
+
+# Header 2
+Content under header 2.
+    `;
+
+    const expected: Chunk[] = [
+      { label: '1-heading', text: '# Header 1' },
+      { label: '1-content', text: 'Some introductory content.\n\n```\n# This is a comment with a # symbol\nSome code line\n```\n\nAdditional content.' },
+      { label: '2-heading', text: '# Header 2' },
+      { label: '2-content', text: 'Content under header 2.' },
+    ];
+
+    const result = splitMarkdownIntoChunks(markdown);
+    expect(result).toEqual(expected);
+  });
 });


### PR DESCRIPTION
[#153983 ](https://redmine.weseek.co.jp/issues/153983) markdown をヘッダーセクションごと(更に指定文字数以下になるように子セクションごと)に再起的に分割できる
┗ [ #155178](https://redmine.weseek.co.jp/issues/155178) code block 内の '#' がヘッダーとして認識されないようにする