### PR TITLE
fix: Global search button is not clickable

### DIFF
--- a/apps/app/src/client/components/Sidebar/AppTitle/AppTitle.module.scss
+++ b/apps/app/src/client/components/Sidebar/AppTitle/AppTitle.module.scss
@@ -39,7 +39,7 @@
 // == App title truncation
 .on-subnavigation {
   // set width for truncation
-  $grw-page-controls-width: 280px;
+  $grw-page-controls-width: 324px;
   $grw-page-editor-mode-manager-width: 90px;
   $grw-contextual-subnavigation-padding-right: 12px;
   $gap: 8px;

--- a/apps/app/src/client/components/Sidebar/AppTitle/AppTitle.module.scss
+++ b/apps/app/src/client/components/Sidebar/AppTitle/AppTitle.module.scss
@@ -45,7 +45,7 @@
   $gap: 8px;
 
   @include bs.media-breakpoint-up(sm) {
-    width: calc(100vw - #{$grw-page-controls-width + $grw-page-editor-mode-manager-width + $grw-contextual-subnavigation-padding-right + $gap * 2});
+    width: calc(100% - #{$grw-page-controls-width + $grw-page-editor-mode-manager-width + $grw-contextual-subnavigation-padding-right + $gap * 2});
   }
 
   @include bs.media-breakpoint-up(md) {
@@ -53,7 +53,7 @@
     $gap: 24px;
     $grw-contextual-subnavigation-padding-right: 24px;
 
-    width: calc(100vw - #{var.$grw-sidebar-nav-width + $grw-page-controls-width + $grw-page-editor-mode-manager-width + $grw-contextual-subnavigation-padding-right + $gap * 2});
+    width: calc(100% - #{var.$grw-sidebar-nav-width + $grw-page-controls-width + $grw-page-editor-mode-manager-width + $grw-contextual-subnavigation-padding-right + $gap * 2});
   }
 }
 


### PR DESCRIPTION
# Task
https://redmine.weseek.co.jp/issues/155813

# Summary
- ナレッジアシスタントのボタンが追加された分`$grw-page-controls-width`を増やし、グローバル検索が押せない問題を解決した
<img width="1028" alt="image" src="https://github.com/user-attachments/assets/34212368-9ff4-43e8-b05e-a14041f72ec3">

- 100vw から 100% にすることでスクロールバーを width から除外し、ブラウザの表示サイズが小さい時にクリックできなくなる問題を解決した(ナレッジアシスタントボタンを入れる前からの症状)
<img width="211" alt="image" src="https://github.com/user-attachments/assets/d2ba81a8-7590-4383-b884-d32fecb9a7f6">
<img width="273" alt="image" src="https://github.com/user-attachments/assets/ffe10085-be28-4d61-8ab3-9b7b1d1de579">
