### PR TITLE
fix: Evaluating inline porps

### DIFF
--- a/apps/app/src/components/ReactMarkdownComponents/CodeBlock.tsx
+++ b/apps/app/src/components/ReactMarkdownComponents/CodeBlock.tsx
@@ -13,6 +13,17 @@ Object.entries<object>(oneDark).forEach(([key, value]) => {
 });
 
 
+type InlineCodeBlockProps = {
+  children: ReactNode,
+  className?: string,
+}
+
+const InlineCodeBlockSubstance = (props: InlineCodeBlockProps): JSX.Element => {
+  const { children, className, ...rest } = props;
+  return <code className={`code-inline ${className ?? ''}`} {...rest}>{children}</code>;
+};
+
+
 function extractChildrenToIgnoreReactNode(children: ReactNode): ReactNode {
 
   if (children == null) {
@@ -70,15 +81,15 @@ function CodeBlockSubstance({ lang, children }: { lang: string, children: ReactN
 type CodeBlockProps = {
   children: ReactNode,
   className?: string,
-  inline?: string, // "" or undefined
+  inline?: true,
 }
 
 export const CodeBlock = (props: CodeBlockProps): JSX.Element => {
 
   // TODO: set border according to the value of 'customize:highlightJsStyleBorder'
   const { className, children, inline } = props;
-  if (inline != null) {
-    return <code className={`code-inline ${className ?? ''}`}>{children}</code>;
+  if (inline) {
+    return <InlineCodeBlockSubstance className={`code-inline ${className ?? ''}`}>{children}</InlineCodeBlockSubstance>;
   }
 
   const match = /language-(\w+)(:?.+)?/.exec(className || '');

--- a/apps/app/src/services/renderer/remark-plugins/codeblock.ts
+++ b/apps/app/src/services/renderer/remark-plugins/codeblock.ts
@@ -10,7 +10,7 @@ export const remarkPlugin: Plugin = () => {
   return (tree) => {
     visit(tree, 'inlineCode', (node: InlineCode) => {
       const data = node.data || (node.data = {});
-      data.hProperties = { inline: true };
+      data.hProperties = { inline: 'true' }; // set 'true' explicitly because the empty string is evaluated as false for `if (inline) { ... }`
     });
   };
 };


### PR DESCRIPTION
## Before

- [growilabs/growi-plugin-copy-code-to-clipboard](https://github.com/growilabs/growi-plugin-copy-code-to-clipboard) didn't work well
    - [src/CodeWithCopyButton.tsx](https://github.com/growilabs/growi-plugin-copy-code-to-clipboard/blob/bca6761dfb48e1869557130e04c0da6ada2bbf3d/src/CodeWithCopyButton.tsx#L23) evaluated as `false` when the `inline` is an empty string
- 

## After

Set 'true' explicitly and handle it as a boolean in `codeblock.ts`