### PR TITLE
support: Bootstrap color on GitHub Alert

### DIFF
--- a/apps/app/src/features/callout/components/CalloutViewer.module.scss
+++ b/apps/app/src/features/callout/components/CalloutViewer.module.scss
@@ -1,24 +1,12 @@
 @use '@growi/core-styles/scss/bootstrap/init' as bs;
 
 // == Colors
-@include bs.color-mode(light) {
-  .callout-viewer {
-    --callout-accent-note: var(--bs-info);
-    --callout-accent-tip: var(--bs-success);
-    --callout-accent-important: var(--bs-primary);
-    --callout-accent-warning: var(--bs-warning);
-    --callout-accent-caution: var(--bs-danger);
-  }
-}
-
-@include bs.color-mode(dark) {
-  .callout-viewer {
-    --callout-accent-note: hsl(215, 93%, 58%);
-    --callout-accent-tip: hsl(128, 49%, 49%);
-    --callout-accent-important: hsl(262, 89%, 71%);
-    --callout-accent-warning: hsl(41, 72%, 48%);
-    --callout-accent-caution: hsl(3, 93%, 63%);
-  }
+.callout-viewer {
+  --callout-accent-note: var(--bs-info);
+  --callout-accent-tip: var(--bs-success);
+  --callout-accent-important: var(--bs-primary);
+  --callout-accent-warning: var(--bs-warning);
+  --callout-accent-caution: var(--bs-danger);
 }
 
 .callout-viewer :global{

--- a/apps/app/src/features/callout/components/CalloutViewer.module.scss
+++ b/apps/app/src/features/callout/components/CalloutViewer.module.scss
@@ -3,11 +3,11 @@
 // == Colors
 @include bs.color-mode(light) {
   .callout-viewer {
-    --callout-accent-note: hsl(212, 92%, 45%);
-    --callout-accent-tip: hsl(137, 66%, 30%);
-    --callout-accent-important: hsl(261, 69%, 59%);
-    --callout-accent-warning: hsl(40, 100%, 30%);
-    --callout-accent-caution: hsl(356, 71%, 48%);
+    --callout-accent-note: var(--bs-info);
+    --callout-accent-tip: var(--bs-success);
+    --callout-accent-important: var(--bs-primary);
+    --callout-accent-warning: var(--bs-warning);
+    --callout-accent-caution: var(--bs-danger);
   }
 }
 


### PR DESCRIPTION
# Task
https://redmine.weseek.co.jp/issues/154673

# Summary
- GitHubAlert の色設定に Bootstrap のカラーと共通化
- ライト/ダーク対応は Bootstrapの各カラー側で対応

<img width="1113" alt="image" src="https://github.com/user-attachments/assets/498dcde8-65e3-4501-b755-9413d13bbf85">
<img width="1112" alt="image" src="https://github.com/user-attachments/assets/0ffbcf2b-5d9e-49f2-83fd-da1c2ffa98b7">
