### PR TITLE
feat: Create one VectorStoreFile per page

### DIFF
--- a/apps/app/src/features/openai/server/services/openai.ts
+++ b/apps/app/src/features/openai/server/services/openai.ts
@@ -21,7 +21,7 @@ import loggerFactory from '~/utils/logger';
 import { OpenaiServiceTypes } from '../../interfaces/ai';
 
 import { getClient } from './client-delegator';
-import { splitMarkdownIntoChunks } from './markdown-splitter/markdown-token-splitter';
+// import { splitMarkdownIntoChunks } from './markdown-splitter/markdown-token-splitter';
 import { oepnaiApiErrorHandler } from './openai-api-error-handler';
 
 const BATCH_SIZE = 100;
@@ -137,6 +137,7 @@ class OpenaiService implements IOpenaiService {
     return newVectorStoreDocument;
   }
 
+  // TODO: 156643
   // private async uploadFileByChunks(pageId: Types.ObjectId, body: string, vectorStoreFileRelationsMap: VectorStoreFileRelationsMap) {
   //   const chunks = await splitMarkdownIntoChunks(body, 'gpt-4o');
   //   for await (const [index, chunk] of chunks.entries()) {

--- a/apps/app/src/features/openai/server/services/openai.ts
+++ b/apps/app/src/features/openai/server/services/openai.ts
@@ -137,7 +137,7 @@ class OpenaiService implements IOpenaiService {
     return newVectorStoreDocument;
   }
 
-  // TODO: 156643
+  // TODO: https://redmine.weseek.co.jp/issues/156643
   // private async uploadFileByChunks(pageId: Types.ObjectId, body: string, vectorStoreFileRelationsMap: VectorStoreFileRelationsMap) {
   //   const chunks = await splitMarkdownIntoChunks(body, 'gpt-4o');
   //   for await (const [index, chunk] of chunks.entries()) {


### PR DESCRIPTION
# Task
https://redmine.weseek.co.jp/issues/156684

# やったこと
- markdown-splitter を使わない実装 (1 file 1 VectorStoreFile) という実装に戻した。
- https://github.com/weseek/growi/pull/9297 の revert 相当のコード