### PR TITLE
Imprv/156179 156431 enable terminus in pdf converter

### DIFF
--- a/apps/pdf-converter/docker/Dockerfile
+++ b/apps/pdf-converter/docker/Dockerfile
@@ -1,83 +1,81 @@
-########################################################################
-# deps-resolver
-########################################################################
-FROM node:20-slim AS deps-resolver
+# syntax = docker/dockerfile:1
 
-WORKDIR /app
+##
+## base
+##
+FROM node:20-slim AS base
 
-COPY package.json yarn.lock ./
+ENV optDir="/opt"
 
-RUN yarn --frozen-lockfile
+WORKDIR ${optDir}
 
-RUN tar -cf node_modules.tar \
-  node_modules \
-  && rm -rf node_modules
+# install pnpm
+RUN apt-get update && apt-get install -y ca-certificates wget --no-install-recommends \
+  && wget -qO- https://get.pnpm.io/install.sh | ENV="$HOME/.shrc" SHELL="$(which sh)" sh -
+ENV PNPM_HOME="/root/.local/share/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
 
-
-########################################################################
-# deps-resolver-prod
-########################################################################
-FROM deps-resolver AS deps-resolver-prod
-
-WORKDIR /app
-
-RUN yarn --production
-
-RUN tar -cf node_modules.tar \
-  node_modules \
-  && rm -rf node_modules
+# install turbo
+RUN pnpm add turbo --global
 
 
-########################################################################
-# builder
-########################################################################
-FROM node:20-slim AS builder
 
-WORKDIR /app
+##
+## builder
+##
+FROM base AS builder
 
-COPY package.json yarn.lock tsconfig.json tsconfig.build.json .eslintrc.js ./
-COPY src ./src
-COPY --from=deps-resolver /app/node_modules.tar ./
+ENV optDir="/opt"
 
-RUN tar -xf node_modules.tar \
-  && rm node_modules.tar \
-  && yarn build \
-  && tar -cf packages.tar \
-    package.json \
-    yarn.lock \
-    dist \
-  && rm -rf node_modules
+WORKDIR ${optDir}
+
+COPY . .
+
+RUN pnpm install ---frozen-lockfile
+
+# build
+RUN turbo run build --filter @growi/pdf-converter
+
+# make artifacts
+RUN pnpm deploy out --prod --filter @growi/pdf-converter
+RUN rm -rf apps/pdf-converter/node_modules && mv out/node_modules apps/pdf-converter/node_modules
+RUN tar -zcf packages.tar.gz \
+  package.json \
+  apps/pdf-converter/package.json \
+  apps/pdf-converter/dist \
+  apps/pdf-converter/.env \
+  apps/pdf-converter/node_modules
 
 
-########################################################################
-# production
-########################################################################
+
+##
+## release
+##
 FROM node:20-slim
+LABEL maintainer="Yuki Takei <yuki@weseek.co.jp>"
 
-ENV NODE_ENV=production
-ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
-ENV LANG=ja_JP.UTF-8
+ENV NODE_ENV="production"
+ENV PUPPETEER_EXECUTABLE_PATH="/usr/bin/chromium"
+ENV LANG="ja_JP.UTF-8"
 
-RUN apt-get update && apt-get install -y tini chromium locales fonts-ipafont fonts-ipaexfont fonts-ipafont-gothic fonts-ipafont-mincho && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* \
-    && echo "ja_JP UTF-8" > /etc/locale.gen && locale-gen
+ENV optDir="/opt"
+ENV appDir="${optDir}/pdf-converter"
+
+RUN apt-get update && apt-get install -y chromium locales fonts-ipafont fonts-ipaexfont fonts-ipafont-gothic fonts-ipafont-mincho \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*; \
+    echo "ja_JP UTF-8" > /etc/locale.gen && locale-gen;
+
+# copy artifacts
+COPY --from=builder --chown=node:node \
+  ${optDir}/packages.tar.gz ${appDir}/
 
 USER node
-WORKDIR /app
+WORKDIR ${appDir}
+RUN tar -xf packages.tar.gz && rm packages.tar.gz
 
-COPY --from=deps-resolver-prod --chown=node:node \
-  /app/node_modules.tar ./
-COPY --from=builder --chown=node:node \
-  /app/packages.tar ./
-
-RUN tar -xf node_modules.tar \
-  && tar -xf packages.tar \
-  && rm node_modules.tar packages.tar
-
-# change permission for shared volume
-RUN mkdir -p /tmp/page-bulk-export && chmod -R 777 /tmp/page-bulk-export
+WORKDIR ${appDir}/apps/pdf-converter
 
 EXPOSE 3010
 
-ENTRYPOINT ["/usr/bin/tini", "-e", "143", "--"]
 CMD ["node", "dist/index.js"]

--- a/apps/pdf-converter/package.json
+++ b/apps/pdf-converter/package.json
@@ -12,7 +12,9 @@
     "build": "yarn gen:client-code && tsc -p tsconfig.build.json"
   },
   "dependencies": {
+    "@godaddy/terminus": "^4.12.1",
     "@tsed/cli": "^5.4.3",
+    "@tsed/cli-core": "^5.4.3",
     "@tsed/cli-generate-swagger": "^5.4.3",
     "@tsed/common": "7.83.4",
     "@tsed/components-scan": "7.83.4",
@@ -23,9 +25,12 @@
     "@tsed/platform-express": "7.83.4",
     "@tsed/schema": "7.83.4",
     "@tsed/swagger": "7.83.4",
+    "@tsed/terminus": "7.83.4",
+    "axios": "^0.24.0",
     "express": "^4.19.2",
     "puppeteer": "^23.1.1",
-    "puppeteer-cluster": "^0.24.0"
+    "puppeteer-cluster": "^0.24.0",
+    "tslib": "^2.8.0"
   },
   "devDependencies": {
     "@types/connect": "^3.4.38",

--- a/apps/pdf-converter/package.json
+++ b/apps/pdf-converter/package.json
@@ -7,9 +7,9 @@
   "private": true,
   "scripts": {
     "dev:pdf-converter": "nodemon --watch \"src/**/*.ts\" --ignore \"node_modules/**/*\" --exec ts-node -r \"dotenv-flow/config\" src/index.ts",
-    "lint": "yarn eslint **/*.{js,ts}",
+    "lint": "pnpm eslint **/*.{js,ts}",
     "gen:client-code": "tsed run generate-swagger --output ./specs && orval",
-    "build": "yarn gen:client-code && tsc -p tsconfig.build.json"
+    "build": "pnpm gen:client-code && tsc -p tsconfig.build.json"
   },
   "dependencies": {
     "@godaddy/terminus": "^4.12.1",

--- a/apps/pdf-converter/src/controllers/index.ts
+++ b/apps/pdf-converter/src/controllers/index.ts
@@ -1,1 +1,2 @@
-export { default } from './pdf';
+export { default as PdfCtrl } from './pdf';
+export { default as TerminusCtrl } from './terminus';

--- a/apps/pdf-converter/src/controllers/terminus.ts
+++ b/apps/pdf-converter/src/controllers/terminus.ts
@@ -1,0 +1,25 @@
+import { Logger } from '@tsed/common';
+import { Inject, Injectable } from '@tsed/di';
+
+import PdfConvertService from '../service/pdf-convert';
+
+@Injectable()
+class TerminusCtrl {
+
+  @Inject()
+    logger: Logger;
+
+  constructor(private readonly pdfConvertService: PdfConvertService) {}
+
+  async $onSignal(): Promise<void> {
+    this.logger.info('Server is starting cleanup');
+    await this.pdfConvertService.closePuppeteerCluster();
+  }
+
+  $onShutdown(): void {
+    this.logger.info('Cleanup finished, server is shutting down');
+  }
+
+}
+
+export default TerminusCtrl;

--- a/apps/pdf-converter/src/server.ts
+++ b/apps/pdf-converter/src/server.ts
@@ -2,6 +2,7 @@ import { PlatformApplication } from '@tsed/common';
 import { Configuration, Inject } from '@tsed/di';
 import express from 'express';
 import '@tsed/swagger';
+import '@tsed/terminus';
 
 import * as Controllers from './controllers';
 
@@ -26,6 +27,9 @@ const PORT = Number(process.env.PORT || 3010);
       specVersion: '3.0.1',
     },
   ],
+  terminus: {
+    signals: ['SIGINT', 'SIGTERM'],
+  },
 })
 class Server {
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,7 +59,7 @@ importers:
         version: 4.3.1(vite@5.4.6(@types/node@20.14.0)(sass@1.77.6)(terser@5.36.0))
       '@vitest/coverage-v8':
         specifier: ^2.1.1
-        version: 2.1.1(vitest@2.1.1)
+        version: 2.1.1(vitest@2.1.1(@types/node@20.14.0)(@vitest/ui@2.1.1)(happy-dom@15.7.4)(sass@1.77.6)(terser@5.36.0))
       '@vitest/ui':
         specifier: ^2.1.1
         version: 2.1.1(vitest@2.1.1)
@@ -77,7 +77,7 @@ importers:
         version: 12.1.6(eslint@8.41.0)(next@14.2.13(@babel/core@7.24.6)(@playwright/test@1.46.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.77.6))(typescript@5.0.4)
       eslint-config-weseek:
         specifier: ^2.1.1
-        version: 2.1.1(@babel/core@7.24.6)(@babel/eslint-parser@7.24.7(@babel/core@7.24.6)(eslint@8.41.0))(@typescript-eslint/eslint-plugin@5.59.7(@typescript-eslint/parser@5.59.7(eslint@8.41.0)(typescript@5.0.4))(eslint@8.41.0)(typescript@5.0.4))(@typescript-eslint/parser@5.59.7(eslint@8.41.0)(typescript@5.0.4))(eslint-import-resolver-typescript@3.2.5)(eslint-plugin-import@2.26.0)(eslint-plugin-jsx-a11y@6.5.1(eslint@8.41.0))(eslint-plugin-react-hooks@4.6.0(eslint@8.41.0))(eslint-plugin-react@7.30.1(eslint@8.41.0))(eslint-plugin-vue@7.20.0(eslint@8.41.0))(eslint@8.41.0)
+        version: 2.1.1(@babel/core@7.24.6)(@babel/eslint-parser@7.24.7(@babel/core@7.24.6)(eslint@8.41.0))(@typescript-eslint/eslint-plugin@5.59.7(@typescript-eslint/parser@5.59.7(eslint@8.41.0)(typescript@5.0.4))(eslint@8.41.0)(typescript@5.0.4))(@typescript-eslint/parser@5.59.7(eslint@8.41.0)(typescript@5.0.4))(eslint-import-resolver-typescript@3.2.5(eslint-plugin-import@2.26.0)(eslint@8.41.0))(eslint-plugin-import@2.26.0(@typescript-eslint/parser@5.59.7(eslint@8.41.0)(typescript@5.0.4))(eslint-import-resolver-typescript@3.2.5)(eslint@8.41.0))(eslint-plugin-jsx-a11y@6.5.1(eslint@8.41.0))(eslint-plugin-react-hooks@4.6.0(eslint@8.41.0))(eslint-plugin-react@7.30.1(eslint@8.41.0))(eslint-plugin-vue@7.20.0(eslint@8.41.0))(eslint@8.41.0)
       eslint-import-resolver-typescript:
         specifier: ^3.2.5
         version: 3.2.5(eslint-plugin-import@2.26.0)(eslint@8.41.0)
@@ -179,7 +179,7 @@ importers:
         version: 2.1.1(@types/node@20.14.0)(@vitest/ui@2.1.1)(happy-dom@15.7.4)(sass@1.77.6)(terser@5.36.0)
       vitest-mock-extended:
         specifier: ^2.0.2
-        version: 2.0.2(typescript@5.0.4)(vitest@2.1.1)
+        version: 2.0.2(typescript@5.0.4)(vitest@2.1.1(@types/node@20.14.0)(@vitest/ui@2.1.1)(happy-dom@15.7.4)(sass@1.77.6)(terser@5.36.0))
 
   apps/app:
     dependencies:
@@ -819,7 +819,7 @@ importers:
         version: 3.1.0
       eslint-plugin-jest:
         specifier: ^26.5.3
-        version: 26.9.0(@typescript-eslint/eslint-plugin@5.59.7(@typescript-eslint/parser@5.59.7(eslint@8.41.0)(typescript@5.4.2))(eslint@8.41.0)(typescript@5.4.2))(eslint@8.41.0)(jest@29.7.0(@types/node@20.14.0)(ts-node@10.9.2(@swc/core@1.5.25(@swc/helpers@0.5.11))(@types/node@20.14.0)(typescript@5.4.2)))(typescript@5.4.2)
+        version: 26.9.0(@typescript-eslint/eslint-plugin@5.59.7(@typescript-eslint/parser@5.59.7(eslint@8.41.0)(typescript@5.4.2))(eslint@8.41.0)(typescript@5.4.2))(eslint@8.41.0)(jest@29.7.0(@types/node@22.8.7)(ts-node@10.9.2(@swc/core@1.5.25(@swc/helpers@0.5.11))(@types/node@22.8.7)(typescript@5.4.2)))(typescript@5.4.2)
       fslightbox-react:
         specifier: ^1.7.6
         version: 1.7.6(prop-types@15.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -843,7 +843,7 @@ importers:
         version: 4.2.0
       jest:
         specifier: ^29.5.0
-        version: 29.7.0(@types/node@20.14.0)(ts-node@10.9.2(@swc/core@1.5.25(@swc/helpers@0.5.11))(@types/node@20.14.0)(typescript@5.4.2))
+        version: 29.7.0(@types/node@22.8.7)(ts-node@10.9.2(@swc/core@1.5.25(@swc/helpers@0.5.11))(@types/node@22.8.7)(typescript@5.4.2))
       jest-date-mock:
         specifier: ^1.0.8
         version: 1.0.10
@@ -879,7 +879,7 @@ importers:
         version: 5.1.0(react@18.2.0)
       react-dnd:
         specifier: ^14.0.5
-        version: 14.0.5(@types/hoist-non-react-statics@3.3.5)(@types/node@20.14.0)(@types/react@18.3.3)(react@18.2.0)
+        version: 14.0.5(@types/hoist-non-react-statics@3.3.5)(@types/node@22.8.7)(@types/react@18.3.3)(react@18.2.0)
       react-dnd-html5-backend:
         specifier: ^14.1.0
         version: 14.1.0
@@ -922,15 +922,21 @@ importers:
 
   apps/pdf-converter:
     dependencies:
+      '@godaddy/terminus':
+        specifier: ^4.12.1
+        version: 4.12.1
       '@tsed/cli':
         specifier: ^5.4.3
-        version: 5.4.3(@tsed/cli-core@5.4.3(@babel/core@7.24.6)(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@5.17.0)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(ejs@3.1.10)(hogan.js@3.0.2)(lodash@4.17.21)(mustache@4.2.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@5.17.0)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/logger@5.17.0)(@tsed/openspec@7.83.4)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))
+        version: 5.4.3(@tsed/cli-core@5.4.3(@babel/core@7.24.6)(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@6.7.8)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(ejs@3.1.10)(hogan.js@3.0.2)(lodash@4.17.21)(mustache@4.2.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@6.7.8)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/logger@6.7.8)(@tsed/openspec@7.83.4)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))
+      '@tsed/cli-core':
+        specifier: ^5.4.3
+        version: 5.4.3(@babel/core@7.24.6)(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@6.7.8)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(ejs@3.1.10)(hogan.js@3.0.2)(lodash@4.17.21)(mustache@4.2.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@tsed/cli-generate-swagger':
         specifier: ^5.4.3
-        version: 5.4.3(@tsed/common@7.83.4(@tsed/engines@7.83.4)(@tsed/logger-file@6.7.8(@tsed/logger@5.17.0))(@tsed/logger@5.17.0)(@tsed/openspec@7.83.4))(@tsed/swagger@7.83.4(@tsed/common@7.83.4(@tsed/engines@7.83.4)(@tsed/logger-file@6.7.8(@tsed/logger@5.17.0))(@tsed/logger@5.17.0)(@tsed/openspec@7.83.4)))
+        version: 5.4.3(@tsed/common@7.83.4(@tsed/engines@7.83.4)(@tsed/logger-file@6.7.8(@tsed/logger@6.7.8))(@tsed/logger@6.7.8)(@tsed/openspec@7.83.4))(@tsed/swagger@7.83.4(@tsed/common@7.83.4(@tsed/engines@7.83.4)(@tsed/logger-file@6.7.8(@tsed/logger@6.7.8))(@tsed/logger@6.7.8)(@tsed/openspec@7.83.4)))
       '@tsed/common':
         specifier: 7.83.4
-        version: 7.83.4(@tsed/engines@7.83.4)(@tsed/logger-file@6.7.8(@tsed/logger@5.17.0))(@tsed/logger@5.17.0)(@tsed/openspec@7.83.4)
+        version: 7.83.4(@tsed/engines@7.83.4)(@tsed/logger-file@6.7.8(@tsed/logger@6.7.8))(@tsed/logger@6.7.8)(@tsed/openspec@7.83.4)
       '@tsed/components-scan':
         specifier: 7.83.4
         version: 7.83.4(@tsed/core@7.83.4)
@@ -939,7 +945,7 @@ importers:
         version: 7.83.4
       '@tsed/di':
         specifier: 7.83.4
-        version: 7.83.4(@tsed/core@7.83.4)(@tsed/logger@5.17.0)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))
+        version: 7.83.4(@tsed/core@7.83.4)(@tsed/logger@6.7.8)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))
       '@tsed/exceptions':
         specifier: 7.83.4
         version: 7.83.4(@tsed/core@7.83.4)
@@ -948,13 +954,19 @@ importers:
         version: 7.83.4(@tsed/core@7.83.4)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))
       '@tsed/platform-express':
         specifier: 7.83.4
-        version: 7.83.4(@tsed/common@7.83.4(@tsed/engines@7.83.4)(@tsed/logger-file@6.7.8(@tsed/logger@5.17.0))(@tsed/logger@5.17.0)(@tsed/openspec@7.83.4))(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@5.17.0)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/json-mapper@7.83.4(@tsed/core@7.83.4)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/logger@5.17.0)(@tsed/openspec@7.83.4)(@tsed/platform-views@7.83.4(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@5.17.0)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/engines@7.83.4)(@tsed/exceptions@7.83.4(@tsed/core@7.83.4))(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))(@types/multer@1.4.12)(body-parser@1.20.3)(cross-env@7.0.0)(multer@1.4.4)
+        version: 7.83.4(@tsed/common@7.83.4(@tsed/engines@7.83.4)(@tsed/logger-file@6.7.8(@tsed/logger@6.7.8))(@tsed/logger@6.7.8)(@tsed/openspec@7.83.4))(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@6.7.8)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/json-mapper@7.83.4(@tsed/core@7.83.4)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/logger@6.7.8)(@tsed/openspec@7.83.4)(@tsed/platform-views@7.83.4(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@6.7.8)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/engines@7.83.4)(@tsed/exceptions@7.83.4(@tsed/core@7.83.4))(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))(@types/multer@1.4.12)(body-parser@1.20.3)(cross-env@7.0.0)(multer@1.4.4)
       '@tsed/schema':
         specifier: 7.83.4
         version: 7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)
       '@tsed/swagger':
         specifier: 7.83.4
-        version: 7.83.4(@tsed/common@7.83.4(@tsed/engines@7.83.4)(@tsed/logger-file@6.7.8(@tsed/logger@5.17.0))(@tsed/logger@5.17.0)(@tsed/openspec@7.83.4))
+        version: 7.83.4(@tsed/common@7.83.4(@tsed/engines@7.83.4)(@tsed/logger-file@6.7.8(@tsed/logger@6.7.8))(@tsed/logger@6.7.8)(@tsed/openspec@7.83.4))
+      '@tsed/terminus':
+        specifier: 7.83.4
+        version: 7.83.4(@godaddy/terminus@4.12.1)(@tsed/common@7.83.4(@tsed/engines@7.83.4)(@tsed/logger-file@6.7.8(@tsed/logger@6.7.8))(@tsed/logger@6.7.8)(@tsed/openspec@7.83.4))(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@6.7.8)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))
+      axios:
+        specifier: ^0.24.0
+        version: 0.24.0
       express:
         specifier: ^4.19.2
         version: 4.21.0
@@ -964,6 +976,9 @@ importers:
       puppeteer-cluster:
         specifier: ^0.24.0
         version: 0.24.0(puppeteer@23.6.1(typescript@5.4.2))
+      tslib:
+        specifier: ^2.8.0
+        version: 2.8.0
     devDependencies:
       '@types/connect':
         specifier: ^3.4.38
@@ -4465,6 +4480,15 @@ packages:
     resolution: {integrity: sha512-mEcBk5mxMVoCpJ7HJ5KXiFB3m2kKIfQR59hl7ZIREa7HDByEDksbBZQC5ChsCrpahB+ZqXo0VVFbsCcCL+I1jA==}
     peerDependencies:
       '@tsed/common': 7.83.4
+
+  '@tsed/terminus@7.83.4':
+    resolution: {integrity: sha512-1K/aKp/ALGEoNhursVnjC2x8piybLHOxcyRUDaJ40RsuIV5ohYDVXghywBWTNFhRghfBjc3SggYLMjIojM4n2Q==}
+    peerDependencies:
+      '@godaddy/terminus': ^4.7.1
+      '@tsed/common': 7.83.4
+      '@tsed/core': 7.83.4
+      '@tsed/di': 7.83.4
+      '@tsed/schema': 7.83.4
 
   '@tsed/typeorm@6.43.0':
     resolution: {integrity: sha512-B2xU8fsKQYaAW+DNDoAOvawmqaqmKLia17p9AdTcc1aaxsJ51KTdpOxn9CkwcvWExMqyJNrJldELiaH5LuBqOw==}
@@ -15731,27 +15755,27 @@ snapshots:
   '@jest/console@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.14.0
+      '@types/node': 22.8.7
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0(ts-node@10.9.2(@swc/core@1.5.25(@swc/helpers@0.5.11))(@types/node@20.14.0)(typescript@5.4.2))':
+  '@jest/core@29.7.0(ts-node@10.9.2(@swc/core@1.5.25(@swc/helpers@0.5.11))(@types/node@22.8.7)(typescript@5.4.2))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.14.0
+      '@types/node': 22.8.7
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.14.0)(ts-node@10.9.2(@swc/core@1.5.25(@swc/helpers@0.5.11))(@types/node@20.14.0)(typescript@5.4.2))
+      jest-config: 29.7.0(@types/node@22.8.7)(ts-node@10.9.2(@swc/core@1.5.25(@swc/helpers@0.5.11))(@types/node@22.8.7)(typescript@5.4.2))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -15780,7 +15804,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.14.0
+      '@types/node': 22.8.7
       jest-mock: 29.7.0
 
   '@jest/expect-utils@29.7.0':
@@ -15798,7 +15822,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 20.14.0
+      '@types/node': 22.8.7
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -15820,7 +15844,7 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.25
-      '@types/node': 20.14.0
+      '@types/node': 22.8.7
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit: 0.1.2
@@ -15890,7 +15914,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 20.14.0
+      '@types/node': 22.8.7
       '@types/yargs': 17.0.32
       chalk: 4.1.2
 
@@ -17621,11 +17645,11 @@ snapshots:
 
   '@tsconfig/node16@1.0.3': {}
 
-  '@tsed/cli-core@5.4.3(@babel/core@7.24.6)(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@5.17.0)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(ejs@3.1.10)(hogan.js@3.0.2)(lodash@4.17.21)(mustache@4.2.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@tsed/cli-core@5.4.3(@babel/core@7.24.6)(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@6.7.8)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(ejs@3.1.10)(hogan.js@3.0.2)(lodash@4.17.21)(mustache@4.2.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@npmcli/run-script': 3.0.1
       '@tsed/core': 7.83.4
-      '@tsed/di': 7.83.4(@tsed/core@7.83.4)(@tsed/logger@5.17.0)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))
+      '@tsed/di': 7.83.4(@tsed/core@7.83.4)(@tsed/logger@6.7.8)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))
       '@tsed/logger': 6.7.8
       '@tsed/normalize-path': 7.84.0
       '@types/fs-extra': 9.0.13
@@ -17712,19 +17736,19 @@ snapshots:
       - walrus
       - whiskers
 
-  '@tsed/cli-generate-swagger@5.4.3(@tsed/common@7.83.4(@tsed/engines@7.83.4)(@tsed/logger-file@6.7.8(@tsed/logger@5.17.0))(@tsed/logger@5.17.0)(@tsed/openspec@7.83.4))(@tsed/swagger@7.83.4(@tsed/common@7.83.4(@tsed/engines@7.83.4)(@tsed/logger-file@6.7.8(@tsed/logger@5.17.0))(@tsed/logger@5.17.0)(@tsed/openspec@7.83.4)))':
+  '@tsed/cli-generate-swagger@5.4.3(@tsed/common@7.83.4(@tsed/engines@7.83.4)(@tsed/logger-file@6.7.8(@tsed/logger@6.7.8))(@tsed/logger@6.7.8)(@tsed/openspec@7.83.4))(@tsed/swagger@7.83.4(@tsed/common@7.83.4(@tsed/engines@7.83.4)(@tsed/logger-file@6.7.8(@tsed/logger@6.7.8))(@tsed/logger@6.7.8)(@tsed/openspec@7.83.4)))':
     dependencies:
-      '@tsed/common': 7.83.4(@tsed/engines@7.83.4)(@tsed/logger-file@6.7.8(@tsed/logger@5.17.0))(@tsed/logger@5.17.0)(@tsed/openspec@7.83.4)
-      '@tsed/swagger': 7.83.4(@tsed/common@7.83.4(@tsed/engines@7.83.4)(@tsed/logger-file@6.7.8(@tsed/logger@5.17.0))(@tsed/logger@5.17.0)(@tsed/openspec@7.83.4))
+      '@tsed/common': 7.83.4(@tsed/engines@7.83.4)(@tsed/logger-file@6.7.8(@tsed/logger@6.7.8))(@tsed/logger@6.7.8)(@tsed/openspec@7.83.4)
+      '@tsed/swagger': 7.83.4(@tsed/common@7.83.4(@tsed/engines@7.83.4)(@tsed/logger-file@6.7.8(@tsed/logger@6.7.8))(@tsed/logger@6.7.8)(@tsed/openspec@7.83.4))
       change-case: 4.1.2
       tslib: 2.3.1
 
-  '@tsed/cli@5.4.3(@tsed/cli-core@5.4.3(@babel/core@7.24.6)(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@5.17.0)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(ejs@3.1.10)(hogan.js@3.0.2)(lodash@4.17.21)(mustache@4.2.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@5.17.0)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/logger@5.17.0)(@tsed/openspec@7.83.4)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))':
+  '@tsed/cli@5.4.3(@tsed/cli-core@5.4.3(@babel/core@7.24.6)(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@6.7.8)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(ejs@3.1.10)(hogan.js@3.0.2)(lodash@4.17.21)(mustache@4.2.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@6.7.8)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/logger@6.7.8)(@tsed/openspec@7.83.4)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))':
     dependencies:
-      '@tsed/cli-core': 5.4.3(@babel/core@7.24.6)(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@5.17.0)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(ejs@3.1.10)(hogan.js@3.0.2)(lodash@4.17.21)(mustache@4.2.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tsed/cli-core': 5.4.3(@babel/core@7.24.6)(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@6.7.8)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(ejs@3.1.10)(hogan.js@3.0.2)(lodash@4.17.21)(mustache@4.2.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@tsed/core': 7.83.4
-      '@tsed/di': 7.83.4(@tsed/core@7.83.4)(@tsed/logger@5.17.0)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))
-      '@tsed/logger': 5.17.0
+      '@tsed/di': 7.83.4(@tsed/core@7.83.4)(@tsed/logger@6.7.8)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))
+      '@tsed/logger': 6.7.8
       '@tsed/openspec': 7.83.4
       '@tsed/schema': 7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)
       chalk: 4.1.2
@@ -17808,21 +17832,21 @@ snapshots:
       - walrus
       - whiskers
 
-  '@tsed/common@7.83.4(@tsed/engines@7.83.4)(@tsed/logger-file@6.7.8(@tsed/logger@5.17.0))(@tsed/logger@5.17.0)(@tsed/openspec@7.83.4)':
+  '@tsed/common@7.83.4(@tsed/engines@7.83.4)(@tsed/logger-file@6.7.8(@tsed/logger@6.7.8))(@tsed/logger@6.7.8)(@tsed/openspec@7.83.4)':
     dependencies:
       '@tsed/core': 7.83.4
-      '@tsed/di': 7.83.4(@tsed/core@7.83.4)(@tsed/logger@5.17.0)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))
+      '@tsed/di': 7.83.4(@tsed/core@7.83.4)(@tsed/logger@6.7.8)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))
       '@tsed/exceptions': 7.83.4(@tsed/core@7.83.4)
       '@tsed/json-mapper': 7.83.4(@tsed/core@7.83.4)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))
-      '@tsed/logger': 5.17.0
-      '@tsed/logger-file': 6.7.8(@tsed/logger@5.17.0)
-      '@tsed/platform-exceptions': 7.83.4(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@5.17.0)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/exceptions@7.83.4(@tsed/core@7.83.4))(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))
-      '@tsed/platform-log-middleware': 7.83.4(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@5.17.0)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/platform-middlewares@7.83.4(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@5.17.0)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/platform-params@7.83.4(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@5.17.0)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/exceptions@7.83.4(@tsed/core@7.83.4))(@tsed/json-mapper@7.83.4(@tsed/core@7.83.4)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))
-      '@tsed/platform-middlewares': 7.83.4(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@5.17.0)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))
-      '@tsed/platform-params': 7.83.4(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@5.17.0)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/exceptions@7.83.4(@tsed/core@7.83.4))(@tsed/json-mapper@7.83.4(@tsed/core@7.83.4)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))
-      '@tsed/platform-response-filter': 7.83.4(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@5.17.0)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/exceptions@7.83.4(@tsed/core@7.83.4))(@tsed/json-mapper@7.83.4(@tsed/core@7.83.4)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))
-      '@tsed/platform-router': 7.83.4(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@5.17.0)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/exceptions@7.83.4(@tsed/core@7.83.4))(@tsed/json-mapper@7.83.4(@tsed/core@7.83.4)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/platform-params@7.83.4(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@5.17.0)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/exceptions@7.83.4(@tsed/core@7.83.4))(@tsed/json-mapper@7.83.4(@tsed/core@7.83.4)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))
-      '@tsed/platform-views': 7.83.4(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@5.17.0)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/engines@7.83.4)(@tsed/exceptions@7.83.4(@tsed/core@7.83.4))(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))
+      '@tsed/logger': 6.7.8
+      '@tsed/logger-file': 6.7.8(@tsed/logger@6.7.8)
+      '@tsed/platform-exceptions': 7.83.4(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@6.7.8)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/exceptions@7.83.4(@tsed/core@7.83.4))(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))
+      '@tsed/platform-log-middleware': 7.83.4(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@6.7.8)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/platform-middlewares@7.83.4(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@6.7.8)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/platform-params@7.83.4(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@6.7.8)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/exceptions@7.83.4(@tsed/core@7.83.4))(@tsed/json-mapper@7.83.4(@tsed/core@7.83.4)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))
+      '@tsed/platform-middlewares': 7.83.4(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@6.7.8)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))
+      '@tsed/platform-params': 7.83.4(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@6.7.8)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/exceptions@7.83.4(@tsed/core@7.83.4))(@tsed/json-mapper@7.83.4(@tsed/core@7.83.4)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))
+      '@tsed/platform-response-filter': 7.83.4(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@6.7.8)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/exceptions@7.83.4(@tsed/core@7.83.4))(@tsed/json-mapper@7.83.4(@tsed/core@7.83.4)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))
+      '@tsed/platform-router': 7.83.4(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@6.7.8)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/exceptions@7.83.4(@tsed/core@7.83.4))(@tsed/json-mapper@7.83.4(@tsed/core@7.83.4)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/platform-params@7.83.4(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@6.7.8)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/exceptions@7.83.4(@tsed/core@7.83.4))(@tsed/json-mapper@7.83.4(@tsed/core@7.83.4)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))
+      '@tsed/platform-views': 7.83.4(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@6.7.8)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/engines@7.83.4)(@tsed/exceptions@7.83.4(@tsed/core@7.83.4))(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))
       '@tsed/schema': 7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)
       '@types/json-schema': 7.0.15
       accepts: 1.3.8
@@ -17858,10 +17882,10 @@ snapshots:
       globby: 11.0.1
       tslib: 2.1.0
 
-  '@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@5.17.0)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))':
+  '@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@6.7.8)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))':
     dependencies:
       '@tsed/core': 7.83.4
-      '@tsed/logger': 5.17.0
+      '@tsed/logger': 6.7.8
       '@tsed/schema': 7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)
       tslib: 2.6.2
 
@@ -17892,9 +17916,9 @@ snapshots:
       '@tsed/schema': 7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)
       tslib: 2.6.1
 
-  '@tsed/logger-file@6.7.8(@tsed/logger@5.17.0)':
+  '@tsed/logger-file@6.7.8(@tsed/logger@6.7.8)':
     dependencies:
-      '@tsed/logger': 5.17.0
+      '@tsed/logger': 6.7.8
       streamroller: 3.1.5
       tslib: 2.6.2
     transitivePeerDependencies:
@@ -17932,10 +17956,10 @@ snapshots:
 
   '@tsed/openspec@7.83.4': {}
 
-  '@tsed/platform-exceptions@7.83.4(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@5.17.0)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/exceptions@7.83.4(@tsed/core@7.83.4))(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))':
+  '@tsed/platform-exceptions@7.83.4(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@6.7.8)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/exceptions@7.83.4(@tsed/core@7.83.4))(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))':
     dependencies:
       '@tsed/core': 7.83.4
-      '@tsed/di': 7.83.4(@tsed/core@7.83.4)(@tsed/logger@5.17.0)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))
+      '@tsed/di': 7.83.4(@tsed/core@7.83.4)(@tsed/logger@6.7.8)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))
       '@tsed/exceptions': 7.83.4(@tsed/core@7.83.4)
       '@tsed/schema': 7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)
       tslib: 2.6.1
@@ -17949,13 +17973,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tsed/platform-express@7.83.4(@tsed/common@7.83.4(@tsed/engines@7.83.4)(@tsed/logger-file@6.7.8(@tsed/logger@5.17.0))(@tsed/logger@5.17.0)(@tsed/openspec@7.83.4))(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@5.17.0)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/json-mapper@7.83.4(@tsed/core@7.83.4)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/logger@5.17.0)(@tsed/openspec@7.83.4)(@tsed/platform-views@7.83.4(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@5.17.0)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/engines@7.83.4)(@tsed/exceptions@7.83.4(@tsed/core@7.83.4))(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))(@types/multer@1.4.12)(body-parser@1.20.3)(cross-env@7.0.0)(multer@1.4.4)':
+  '@tsed/platform-express@7.83.4(@tsed/common@7.83.4(@tsed/engines@7.83.4)(@tsed/logger-file@6.7.8(@tsed/logger@6.7.8))(@tsed/logger@6.7.8)(@tsed/openspec@7.83.4))(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@6.7.8)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/json-mapper@7.83.4(@tsed/core@7.83.4)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/logger@6.7.8)(@tsed/openspec@7.83.4)(@tsed/platform-views@7.83.4(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@6.7.8)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/engines@7.83.4)(@tsed/exceptions@7.83.4(@tsed/core@7.83.4))(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))(@types/multer@1.4.12)(body-parser@1.20.3)(cross-env@7.0.0)(multer@1.4.4)':
     dependencies:
-      '@tsed/common': 7.83.4(@tsed/engines@7.83.4)(@tsed/logger-file@6.7.8(@tsed/logger@5.17.0))(@tsed/logger@5.17.0)(@tsed/openspec@7.83.4)
+      '@tsed/common': 7.83.4(@tsed/engines@7.83.4)(@tsed/logger-file@6.7.8(@tsed/logger@6.7.8))(@tsed/logger@6.7.8)(@tsed/openspec@7.83.4)
       '@tsed/core': 7.83.4
-      '@tsed/di': 7.83.4(@tsed/core@7.83.4)(@tsed/logger@5.17.0)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))
+      '@tsed/di': 7.83.4(@tsed/core@7.83.4)(@tsed/logger@6.7.8)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))
       '@tsed/json-mapper': 7.83.4(@tsed/core@7.83.4)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))
-      '@tsed/logger': 5.17.0
+      '@tsed/logger': 6.7.8
       '@tsed/openspec': 7.83.4
       '@tsed/schema': 7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)
       '@types/multer': 1.4.12
@@ -17965,57 +17989,57 @@ snapshots:
       multer: 1.4.4
       tslib: 2.6.1
     optionalDependencies:
-      '@tsed/platform-views': 7.83.4(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@5.17.0)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/engines@7.83.4)(@tsed/exceptions@7.83.4(@tsed/core@7.83.4))(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))
+      '@tsed/platform-views': 7.83.4(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@6.7.8)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/engines@7.83.4)(@tsed/exceptions@7.83.4(@tsed/core@7.83.4))(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))
     transitivePeerDependencies:
       - supports-color
 
-  '@tsed/platform-log-middleware@7.83.4(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@5.17.0)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/platform-middlewares@7.83.4(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@5.17.0)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/platform-params@7.83.4(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@5.17.0)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/exceptions@7.83.4(@tsed/core@7.83.4))(@tsed/json-mapper@7.83.4(@tsed/core@7.83.4)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))':
+  '@tsed/platform-log-middleware@7.83.4(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@6.7.8)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/platform-middlewares@7.83.4(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@6.7.8)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/platform-params@7.83.4(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@6.7.8)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/exceptions@7.83.4(@tsed/core@7.83.4))(@tsed/json-mapper@7.83.4(@tsed/core@7.83.4)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))':
     dependencies:
-      '@tsed/di': 7.83.4(@tsed/core@7.83.4)(@tsed/logger@5.17.0)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))
-      '@tsed/platform-middlewares': 7.83.4(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@5.17.0)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))
-      '@tsed/platform-params': 7.83.4(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@5.17.0)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/exceptions@7.83.4(@tsed/core@7.83.4))(@tsed/json-mapper@7.83.4(@tsed/core@7.83.4)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))
+      '@tsed/di': 7.83.4(@tsed/core@7.83.4)(@tsed/logger@6.7.8)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))
+      '@tsed/platform-middlewares': 7.83.4(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@6.7.8)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))
+      '@tsed/platform-params': 7.83.4(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@6.7.8)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/exceptions@7.83.4(@tsed/core@7.83.4))(@tsed/json-mapper@7.83.4(@tsed/core@7.83.4)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))
       tslib: 2.6.1
 
-  '@tsed/platform-middlewares@7.83.4(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@5.17.0)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))':
+  '@tsed/platform-middlewares@7.83.4(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@6.7.8)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))':
     dependencies:
       tslib: 2.6.1
     optionalDependencies:
       '@tsed/core': 7.83.4
-      '@tsed/di': 7.83.4(@tsed/core@7.83.4)(@tsed/logger@5.17.0)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))
+      '@tsed/di': 7.83.4(@tsed/core@7.83.4)(@tsed/logger@6.7.8)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))
       '@tsed/schema': 7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)
 
-  '@tsed/platform-params@7.83.4(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@5.17.0)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/exceptions@7.83.4(@tsed/core@7.83.4))(@tsed/json-mapper@7.83.4(@tsed/core@7.83.4)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))':
+  '@tsed/platform-params@7.83.4(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@6.7.8)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/exceptions@7.83.4(@tsed/core@7.83.4))(@tsed/json-mapper@7.83.4(@tsed/core@7.83.4)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))':
     dependencies:
       '@tsed/core': 7.83.4
-      '@tsed/di': 7.83.4(@tsed/core@7.83.4)(@tsed/logger@5.17.0)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))
+      '@tsed/di': 7.83.4(@tsed/core@7.83.4)(@tsed/logger@6.7.8)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))
       '@tsed/exceptions': 7.83.4(@tsed/core@7.83.4)
       '@tsed/json-mapper': 7.83.4(@tsed/core@7.83.4)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))
       '@tsed/schema': 7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)
       tslib: 2.6.1
 
-  '@tsed/platform-response-filter@7.83.4(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@5.17.0)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/exceptions@7.83.4(@tsed/core@7.83.4))(@tsed/json-mapper@7.83.4(@tsed/core@7.83.4)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))':
+  '@tsed/platform-response-filter@7.83.4(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@6.7.8)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/exceptions@7.83.4(@tsed/core@7.83.4))(@tsed/json-mapper@7.83.4(@tsed/core@7.83.4)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))':
     dependencies:
       '@tsed/core': 7.83.4
-      '@tsed/di': 7.83.4(@tsed/core@7.83.4)(@tsed/logger@5.17.0)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))
+      '@tsed/di': 7.83.4(@tsed/core@7.83.4)(@tsed/logger@6.7.8)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))
       '@tsed/exceptions': 7.83.4(@tsed/core@7.83.4)
       '@tsed/json-mapper': 7.83.4(@tsed/core@7.83.4)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))
       '@tsed/schema': 7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)
       tslib: 2.6.1
 
-  '@tsed/platform-router@7.83.4(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@5.17.0)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/exceptions@7.83.4(@tsed/core@7.83.4))(@tsed/json-mapper@7.83.4(@tsed/core@7.83.4)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/platform-params@7.83.4(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@5.17.0)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/exceptions@7.83.4(@tsed/core@7.83.4))(@tsed/json-mapper@7.83.4(@tsed/core@7.83.4)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))':
+  '@tsed/platform-router@7.83.4(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@6.7.8)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/exceptions@7.83.4(@tsed/core@7.83.4))(@tsed/json-mapper@7.83.4(@tsed/core@7.83.4)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/platform-params@7.83.4(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@6.7.8)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/exceptions@7.83.4(@tsed/core@7.83.4))(@tsed/json-mapper@7.83.4(@tsed/core@7.83.4)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))':
     dependencies:
       '@tsed/core': 7.83.4
-      '@tsed/di': 7.83.4(@tsed/core@7.83.4)(@tsed/logger@5.17.0)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))
+      '@tsed/di': 7.83.4(@tsed/core@7.83.4)(@tsed/logger@6.7.8)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))
       '@tsed/exceptions': 7.83.4(@tsed/core@7.83.4)
       '@tsed/json-mapper': 7.83.4(@tsed/core@7.83.4)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))
-      '@tsed/platform-params': 7.83.4(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@5.17.0)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/exceptions@7.83.4(@tsed/core@7.83.4))(@tsed/json-mapper@7.83.4(@tsed/core@7.83.4)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))
+      '@tsed/platform-params': 7.83.4(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@6.7.8)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/exceptions@7.83.4(@tsed/core@7.83.4))(@tsed/json-mapper@7.83.4(@tsed/core@7.83.4)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))
       '@tsed/schema': 7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)
       tslib: 2.6.1
 
-  '@tsed/platform-views@7.83.4(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@5.17.0)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/engines@7.83.4)(@tsed/exceptions@7.83.4(@tsed/core@7.83.4))(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))':
+  '@tsed/platform-views@7.83.4(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@6.7.8)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/engines@7.83.4)(@tsed/exceptions@7.83.4(@tsed/core@7.83.4))(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))':
     dependencies:
       '@tsed/core': 7.83.4
-      '@tsed/di': 7.83.4(@tsed/core@7.83.4)(@tsed/logger@5.17.0)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))
+      '@tsed/di': 7.83.4(@tsed/core@7.83.4)(@tsed/logger@6.7.8)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))
       '@tsed/engines': 7.83.4
       '@tsed/exceptions': 7.83.4(@tsed/core@7.83.4)
       '@tsed/schema': 7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)
@@ -18046,14 +18070,23 @@ snapshots:
       swagger-ui-dist: 3.52.5
       tslib: 2.1.0
 
-  '@tsed/swagger@7.83.4(@tsed/common@7.83.4(@tsed/engines@7.83.4)(@tsed/logger-file@6.7.8(@tsed/logger@5.17.0))(@tsed/logger@5.17.0)(@tsed/openspec@7.83.4))':
+  '@tsed/swagger@7.83.4(@tsed/common@7.83.4(@tsed/engines@7.83.4)(@tsed/logger-file@6.7.8(@tsed/logger@6.7.8))(@tsed/logger@6.7.8)(@tsed/openspec@7.83.4))':
     dependencies:
-      '@tsed/common': 7.83.4(@tsed/engines@7.83.4)(@tsed/logger-file@6.7.8(@tsed/logger@5.17.0))(@tsed/logger@5.17.0)(@tsed/openspec@7.83.4)
+      '@tsed/common': 7.83.4(@tsed/engines@7.83.4)(@tsed/logger-file@6.7.8(@tsed/logger@6.7.8))(@tsed/logger@6.7.8)(@tsed/openspec@7.83.4)
       '@tsed/normalize-path': 7.83.4
       '@tsed/openspec': 7.83.4
       fs-extra: 11.2.0
       micromatch: 4.0.8
       swagger-ui-dist: 5.17.14
+      tslib: 2.6.1
+
+  '@tsed/terminus@7.83.4(@godaddy/terminus@4.12.1)(@tsed/common@7.83.4(@tsed/engines@7.83.4)(@tsed/logger-file@6.7.8(@tsed/logger@6.7.8))(@tsed/logger@6.7.8)(@tsed/openspec@7.83.4))(@tsed/core@7.83.4)(@tsed/di@7.83.4(@tsed/core@7.83.4)(@tsed/logger@6.7.8)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)))(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))':
+    dependencies:
+      '@godaddy/terminus': 4.12.1
+      '@tsed/common': 7.83.4(@tsed/engines@7.83.4)(@tsed/logger-file@6.7.8(@tsed/logger@6.7.8))(@tsed/logger@6.7.8)(@tsed/openspec@7.83.4)
+      '@tsed/core': 7.83.4
+      '@tsed/di': 7.83.4(@tsed/core@7.83.4)(@tsed/logger@6.7.8)(@tsed/schema@7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4))
+      '@tsed/schema': 7.83.4(@tsed/core@7.83.4)(@tsed/openspec@7.83.4)
       tslib: 2.6.1
 
   '@tsed/typeorm@6.43.0(typeorm@0.2.45(mysql2@2.3.3)(redis@3.1.2))':
@@ -18126,7 +18159,7 @@ snapshots:
 
   '@types/cors@2.8.17':
     dependencies:
-      '@types/node': 20.14.0
+      '@types/node': 22.8.7
 
   '@types/css-modules@1.0.2': {}
 
@@ -18170,7 +18203,7 @@ snapshots:
 
   '@types/fs-extra@9.0.13':
     dependencies:
-      '@types/node': 20.14.0
+      '@types/node': 22.8.7
 
   '@types/glob@7.2.0':
     dependencies:
@@ -18179,7 +18212,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 20.14.0
+      '@types/node': 22.8.7
 
   '@types/hast@2.3.4':
     dependencies:
@@ -18203,7 +18236,7 @@ snapshots:
 
   '@types/is-stream@1.1.0':
     dependencies:
-      '@types/node': 20.14.0
+      '@types/node': 22.8.7
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -18354,7 +18387,7 @@ snapshots:
 
   '@types/through@0.0.33':
     dependencies:
-      '@types/node': 20.14.0
+      '@types/node': 22.8.7
 
   '@types/ungap__structured-clone@1.2.0': {}
 
@@ -18380,7 +18413,7 @@ snapshots:
 
   '@types/whatwg-url@8.2.1':
     dependencies:
-      '@types/node': 20.14.0
+      '@types/node': 22.8.7
       '@types/webidl-conversions': 6.1.1
 
   '@types/yargs-parser@21.0.3': {}
@@ -18619,7 +18652,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@2.1.1(vitest@2.1.1)':
+  '@vitest/coverage-v8@2.1.1(vitest@2.1.1(@types/node@20.14.0)(@vitest/ui@2.1.1)(happy-dom@15.7.4)(sass@1.77.6)(terser@5.36.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -19478,7 +19511,7 @@ snapshots:
       fs-extra: 3.0.1
       http-proxy: 1.18.1
       immutable: 3.8.2
-      micromatch: 4.0.5
+      micromatch: 4.0.8
       opn: 5.3.0
       portscanner: 2.2.0
       raw-body: 2.5.2
@@ -20202,13 +20235,13 @@ snapshots:
       isobject: 3.0.1
       lazy-cache: 2.0.2
 
-  create-jest@29.7.0(@types/node@20.14.0)(ts-node@10.9.2(@swc/core@1.5.25(@swc/helpers@0.5.11))(@types/node@20.14.0)(typescript@5.4.2)):
+  create-jest@29.7.0(@types/node@22.8.7)(ts-node@10.9.2(@swc/core@1.5.25(@swc/helpers@0.5.11))(@types/node@22.8.7)(typescript@5.4.2)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@20.14.0)(ts-node@10.9.2(@swc/core@1.5.25(@swc/helpers@0.5.11))(@types/node@20.14.0)(typescript@5.4.2))
+      jest-config: 29.7.0(@types/node@22.8.7)(ts-node@10.9.2(@swc/core@1.5.25(@swc/helpers@0.5.11))(@types/node@22.8.7)(typescript@5.4.2))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -20905,7 +20938,7 @@ snapshots:
     dependencies:
       '@types/cookie': 0.4.1
       '@types/cors': 2.8.17
-      '@types/node': 20.14.0
+      '@types/node': 22.8.7
       accepts: 1.3.8
       base64id: 2.0.0
       cookie: 0.4.1
@@ -21125,7 +21158,7 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
-  eslint-config-airbnb-base@13.1.0(eslint-plugin-import@2.26.0)(eslint@8.41.0):
+  eslint-config-airbnb-base@13.1.0(eslint-plugin-import@2.26.0(@typescript-eslint/parser@5.59.7(eslint@8.41.0)(typescript@5.0.4))(eslint-import-resolver-typescript@3.2.5)(eslint@8.41.0))(eslint@8.41.0):
     dependencies:
       eslint: 8.41.0
       eslint-plugin-import: 2.26.0(@typescript-eslint/parser@5.59.7(eslint@8.41.0)(typescript@5.0.4))(eslint-import-resolver-typescript@3.2.5)(eslint@8.41.0)
@@ -21133,10 +21166,10 @@ snapshots:
       object.assign: 4.1.5
       object.entries: 1.1.5
 
-  eslint-config-airbnb@17.1.0(eslint-plugin-import@2.26.0)(eslint-plugin-jsx-a11y@6.5.1(eslint@8.41.0))(eslint-plugin-react@7.30.1(eslint@8.41.0))(eslint@8.41.0):
+  eslint-config-airbnb@17.1.0(eslint-plugin-import@2.26.0(@typescript-eslint/parser@5.59.7(eslint@8.41.0)(typescript@5.0.4))(eslint-import-resolver-typescript@3.2.5)(eslint@8.41.0))(eslint-plugin-jsx-a11y@6.5.1(eslint@8.41.0))(eslint-plugin-react@7.30.1(eslint@8.41.0))(eslint@8.41.0):
     dependencies:
       eslint: 8.41.0
-      eslint-config-airbnb-base: 13.1.0(eslint-plugin-import@2.26.0)(eslint@8.41.0)
+      eslint-config-airbnb-base: 13.1.0(eslint-plugin-import@2.26.0(@typescript-eslint/parser@5.59.7(eslint@8.41.0)(typescript@5.0.4))(eslint-import-resolver-typescript@3.2.5)(eslint@8.41.0))(eslint@8.41.0)
       eslint-plugin-import: 2.26.0(@typescript-eslint/parser@5.59.7(eslint@8.41.0)(typescript@5.0.4))(eslint-import-resolver-typescript@3.2.5)(eslint@8.41.0)
       eslint-plugin-jsx-a11y: 6.5.1(eslint@8.41.0)
       eslint-plugin-react: 7.30.1(eslint@8.41.0)
@@ -21150,8 +21183,8 @@ snapshots:
       '@typescript-eslint/parser': 5.59.7(eslint@8.41.0)(typescript@5.0.4)
       eslint: 8.41.0
       eslint-import-resolver-node: 0.3.6
-      eslint-import-resolver-typescript: 2.7.1(eslint-plugin-import@2.26.0)(eslint@8.41.0)
-      eslint-plugin-import: 2.26.0(@typescript-eslint/parser@5.59.7(eslint@8.41.0)(typescript@5.0.4))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.26.0)(eslint@8.41.0))(eslint@8.41.0)
+      eslint-import-resolver-typescript: 2.7.1(eslint-plugin-import@2.26.0(@typescript-eslint/parser@5.59.7(eslint@8.41.0)(typescript@5.0.4))(eslint-import-resolver-typescript@3.2.5)(eslint@8.41.0))(eslint@8.41.0)
+      eslint-plugin-import: 2.26.0(@typescript-eslint/parser@5.59.7(eslint@8.41.0)(typescript@5.0.4))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.26.0(@typescript-eslint/parser@5.59.7(eslint@8.41.0)(typescript@5.0.4))(eslint-import-resolver-typescript@3.2.5)(eslint@8.41.0))(eslint@8.41.0))(eslint@8.41.0)
       eslint-plugin-jsx-a11y: 6.5.1(eslint@8.41.0)
       eslint-plugin-react: 7.30.1(eslint@8.41.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.41.0)
@@ -21162,14 +21195,14 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-config-weseek@2.1.1(@babel/core@7.24.6)(@babel/eslint-parser@7.24.7(@babel/core@7.24.6)(eslint@8.41.0))(@typescript-eslint/eslint-plugin@5.59.7(@typescript-eslint/parser@5.59.7(eslint@8.41.0)(typescript@5.0.4))(eslint@8.41.0)(typescript@5.0.4))(@typescript-eslint/parser@5.59.7(eslint@8.41.0)(typescript@5.0.4))(eslint-import-resolver-typescript@3.2.5)(eslint-plugin-import@2.26.0)(eslint-plugin-jsx-a11y@6.5.1(eslint@8.41.0))(eslint-plugin-react-hooks@4.6.0(eslint@8.41.0))(eslint-plugin-react@7.30.1(eslint@8.41.0))(eslint-plugin-vue@7.20.0(eslint@8.41.0))(eslint@8.41.0):
+  eslint-config-weseek@2.1.1(@babel/core@7.24.6)(@babel/eslint-parser@7.24.7(@babel/core@7.24.6)(eslint@8.41.0))(@typescript-eslint/eslint-plugin@5.59.7(@typescript-eslint/parser@5.59.7(eslint@8.41.0)(typescript@5.0.4))(eslint@8.41.0)(typescript@5.0.4))(@typescript-eslint/parser@5.59.7(eslint@8.41.0)(typescript@5.0.4))(eslint-import-resolver-typescript@3.2.5(eslint-plugin-import@2.26.0)(eslint@8.41.0))(eslint-plugin-import@2.26.0(@typescript-eslint/parser@5.59.7(eslint@8.41.0)(typescript@5.0.4))(eslint-import-resolver-typescript@3.2.5)(eslint@8.41.0))(eslint-plugin-jsx-a11y@6.5.1(eslint@8.41.0))(eslint-plugin-react-hooks@4.6.0(eslint@8.41.0))(eslint-plugin-react@7.30.1(eslint@8.41.0))(eslint-plugin-vue@7.20.0(eslint@8.41.0))(eslint@8.41.0):
     dependencies:
       '@babel/core': 7.24.6
       '@babel/eslint-parser': 7.24.7(@babel/core@7.24.6)(eslint@8.41.0)
       '@typescript-eslint/eslint-plugin': 5.59.7(@typescript-eslint/parser@5.59.7(eslint@8.41.0)(typescript@5.0.4))(eslint@8.41.0)(typescript@5.0.4)
       '@typescript-eslint/parser': 5.59.7(eslint@8.41.0)(typescript@5.0.4)
       eslint: 8.41.0
-      eslint-config-airbnb: 17.1.0(eslint-plugin-import@2.26.0)(eslint-plugin-jsx-a11y@6.5.1(eslint@8.41.0))(eslint-plugin-react@7.30.1(eslint@8.41.0))(eslint@8.41.0)
+      eslint-config-airbnb: 17.1.0(eslint-plugin-import@2.26.0(@typescript-eslint/parser@5.59.7(eslint@8.41.0)(typescript@5.0.4))(eslint-import-resolver-typescript@3.2.5)(eslint@8.41.0))(eslint-plugin-jsx-a11y@6.5.1(eslint@8.41.0))(eslint-plugin-react@7.30.1(eslint@8.41.0))(eslint@8.41.0)
       eslint-import-resolver-typescript: 3.2.5(eslint-plugin-import@2.26.0)(eslint@8.41.0)
       eslint-plugin-import: 2.26.0(@typescript-eslint/parser@5.59.7(eslint@8.41.0)(typescript@5.0.4))(eslint-import-resolver-typescript@3.2.5)(eslint@8.41.0)
       eslint-plugin-react: 7.30.1(eslint@8.41.0)
@@ -21185,7 +21218,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.26.0)(eslint@8.41.0):
+  eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.26.0(@typescript-eslint/parser@5.59.7(eslint@8.41.0)(typescript@5.0.4))(eslint-import-resolver-typescript@3.2.5)(eslint@8.41.0))(eslint@8.41.0):
     dependencies:
       debug: 4.3.7(supports-color@5.5.0)
       eslint: 8.41.0
@@ -21211,18 +21244,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.7.3(@typescript-eslint/parser@5.59.7(eslint@8.41.0)(typescript@5.0.4))(eslint-import-resolver-node@0.3.6)(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.26.0)(eslint@8.41.0)):
+  eslint-module-utils@2.7.3(@typescript-eslint/parser@5.59.7(eslint@8.41.0)(typescript@5.0.4))(eslint-import-resolver-node@0.3.6)(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.26.0(@typescript-eslint/parser@5.59.7(eslint@8.41.0)(typescript@5.0.4))(eslint-import-resolver-typescript@3.2.5)(eslint@8.41.0))(eslint@8.41.0)):
     dependencies:
       debug: 3.2.7
       find-up: 2.1.0
     optionalDependencies:
       '@typescript-eslint/parser': 5.59.7(eslint@8.41.0)(typescript@5.0.4)
       eslint-import-resolver-node: 0.3.6
-      eslint-import-resolver-typescript: 2.7.1(eslint-plugin-import@2.26.0)(eslint@8.41.0)
+      eslint-import-resolver-typescript: 2.7.1(eslint-plugin-import@2.26.0(@typescript-eslint/parser@5.59.7(eslint@8.41.0)(typescript@5.0.4))(eslint-import-resolver-typescript@3.2.5)(eslint@8.41.0))(eslint@8.41.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.7.3(@typescript-eslint/parser@5.59.7(eslint@8.41.0)(typescript@5.0.4))(eslint-import-resolver-node@0.3.6)(eslint-import-resolver-typescript@3.2.5):
+  eslint-module-utils@2.7.3(@typescript-eslint/parser@5.59.7(eslint@8.41.0)(typescript@5.0.4))(eslint-import-resolver-node@0.3.6)(eslint-import-resolver-typescript@3.2.5(eslint-plugin-import@2.26.0)(eslint@8.41.0)):
     dependencies:
       debug: 3.2.7
       find-up: 2.1.0
@@ -21233,7 +21266,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.26.0(@typescript-eslint/parser@5.59.7(eslint@8.41.0)(typescript@5.0.4))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.26.0)(eslint@8.41.0))(eslint@8.41.0):
+  eslint-plugin-import@2.26.0(@typescript-eslint/parser@5.59.7(eslint@8.41.0)(typescript@5.0.4))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.26.0(@typescript-eslint/parser@5.59.7(eslint@8.41.0)(typescript@5.0.4))(eslint-import-resolver-typescript@3.2.5)(eslint@8.41.0))(eslint@8.41.0))(eslint@8.41.0):
     dependencies:
       array-includes: 3.1.5
       array.prototype.flat: 1.3.2
@@ -21241,7 +21274,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.41.0
       eslint-import-resolver-node: 0.3.6
-      eslint-module-utils: 2.7.3(@typescript-eslint/parser@5.59.7(eslint@8.41.0)(typescript@5.0.4))(eslint-import-resolver-node@0.3.6)(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.26.0)(eslint@8.41.0))
+      eslint-module-utils: 2.7.3(@typescript-eslint/parser@5.59.7(eslint@8.41.0)(typescript@5.0.4))(eslint-import-resolver-node@0.3.6)(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.26.0(@typescript-eslint/parser@5.59.7(eslint@8.41.0)(typescript@5.0.4))(eslint-import-resolver-typescript@3.2.5)(eslint@8.41.0))(eslint@8.41.0))
       has: 1.0.3
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -21264,7 +21297,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.41.0
       eslint-import-resolver-node: 0.3.6
-      eslint-module-utils: 2.7.3(@typescript-eslint/parser@5.59.7(eslint@8.41.0)(typescript@5.0.4))(eslint-import-resolver-node@0.3.6)(eslint-import-resolver-typescript@3.2.5)
+      eslint-module-utils: 2.7.3(@typescript-eslint/parser@5.59.7(eslint@8.41.0)(typescript@5.0.4))(eslint-import-resolver-node@0.3.6)(eslint-import-resolver-typescript@3.2.5(eslint-plugin-import@2.26.0)(eslint@8.41.0))
       has: 1.0.3
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -21290,13 +21323,13 @@ snapshots:
       - typescript
     optional: true
 
-  eslint-plugin-jest@26.9.0(@typescript-eslint/eslint-plugin@5.59.7(@typescript-eslint/parser@5.59.7(eslint@8.41.0)(typescript@5.4.2))(eslint@8.41.0)(typescript@5.4.2))(eslint@8.41.0)(jest@29.7.0(@types/node@20.14.0)(ts-node@10.9.2(@swc/core@1.5.25(@swc/helpers@0.5.11))(@types/node@20.14.0)(typescript@5.4.2)))(typescript@5.4.2):
+  eslint-plugin-jest@26.9.0(@typescript-eslint/eslint-plugin@5.59.7(@typescript-eslint/parser@5.59.7(eslint@8.41.0)(typescript@5.4.2))(eslint@8.41.0)(typescript@5.4.2))(eslint@8.41.0)(jest@29.7.0(@types/node@22.8.7)(ts-node@10.9.2(@swc/core@1.5.25(@swc/helpers@0.5.11))(@types/node@22.8.7)(typescript@5.4.2)))(typescript@5.4.2):
     dependencies:
       '@typescript-eslint/utils': 5.59.7(eslint@8.41.0)(typescript@5.4.2)
       eslint: 8.41.0
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 5.59.7(@typescript-eslint/parser@5.59.7(eslint@8.41.0)(typescript@5.4.2))(eslint@8.41.0)(typescript@5.4.2)
-      jest: 29.7.0(@types/node@20.14.0)(ts-node@10.9.2(@swc/core@1.5.25(@swc/helpers@0.5.11))(@types/node@20.14.0)(typescript@5.4.2))
+      jest: 29.7.0(@types/node@22.8.7)(ts-node@10.9.2(@swc/core@1.5.25(@swc/helpers@0.5.11))(@types/node@22.8.7)(typescript@5.4.2))
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -22967,7 +23000,7 @@ snapshots:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.14.0
+      '@types/node': 22.8.7
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.5.3
@@ -22987,16 +23020,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@20.14.0)(ts-node@10.9.2(@swc/core@1.5.25(@swc/helpers@0.5.11))(@types/node@20.14.0)(typescript@5.4.2)):
+  jest-cli@29.7.0(@types/node@22.8.7)(ts-node@10.9.2(@swc/core@1.5.25(@swc/helpers@0.5.11))(@types/node@22.8.7)(typescript@5.4.2)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.5.25(@swc/helpers@0.5.11))(@types/node@20.14.0)(typescript@5.4.2))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.5.25(@swc/helpers@0.5.11))(@types/node@22.8.7)(typescript@5.4.2))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.14.0)(ts-node@10.9.2(@swc/core@1.5.25(@swc/helpers@0.5.11))(@types/node@20.14.0)(typescript@5.4.2))
+      create-jest: 29.7.0(@types/node@22.8.7)(ts-node@10.9.2(@swc/core@1.5.25(@swc/helpers@0.5.11))(@types/node@22.8.7)(typescript@5.4.2))
       exit: 0.1.2
       import-local: 3.1.0
-      jest-config: 29.7.0(@types/node@20.14.0)(ts-node@10.9.2(@swc/core@1.5.25(@swc/helpers@0.5.11))(@types/node@20.14.0)(typescript@5.4.2))
+      jest-config: 29.7.0(@types/node@22.8.7)(ts-node@10.9.2(@swc/core@1.5.25(@swc/helpers@0.5.11))(@types/node@22.8.7)(typescript@5.4.2))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -23006,7 +23039,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@20.14.0)(ts-node@10.9.2(@swc/core@1.5.25(@swc/helpers@0.5.11))(@types/node@20.14.0)(typescript@5.4.2)):
+  jest-config@29.7.0(@types/node@22.8.7)(ts-node@10.9.2(@swc/core@1.5.25(@swc/helpers@0.5.11))(@types/node@22.8.7)(typescript@5.4.2)):
     dependencies:
       '@babel/core': 7.24.6
       '@jest/test-sequencer': 29.7.0
@@ -23031,8 +23064,8 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 20.14.0
-      ts-node: 10.9.2(@swc/core@1.5.25(@swc/helpers@0.5.11))(@types/node@20.14.0)(typescript@5.4.2)
+      '@types/node': 22.8.7
+      ts-node: 10.9.2(@swc/core@1.5.25(@swc/helpers@0.5.11))(@types/node@22.8.7)(typescript@5.4.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -23063,7 +23096,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.14.0
+      '@types/node': 22.8.7
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -23073,7 +23106,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 20.14.0
+      '@types/node': 22.8.7
       anymatch: 3.1.2
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -23114,7 +23147,7 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.14.0
+      '@types/node': 22.8.7
       jest-util: 29.7.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
@@ -23149,7 +23182,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.14.0
+      '@types/node': 22.8.7
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -23177,7 +23210,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.14.0
+      '@types/node': 22.8.7
       chalk: 4.1.2
       cjs-module-lexer: 1.3.1
       collect-v8-coverage: 1.0.2
@@ -23223,7 +23256,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.14.0
+      '@types/node': 22.8.7
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -23242,7 +23275,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.14.0
+      '@types/node': 22.8.7
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -23251,23 +23284,23 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 20.14.0
+      '@types/node': 22.8.7
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 20.14.0
+      '@types/node': 22.8.7
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@20.14.0)(ts-node@10.9.2(@swc/core@1.5.25(@swc/helpers@0.5.11))(@types/node@20.14.0)(typescript@5.4.2)):
+  jest@29.7.0(@types/node@22.8.7)(ts-node@10.9.2(@swc/core@1.5.25(@swc/helpers@0.5.11))(@types/node@22.8.7)(typescript@5.4.2)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.5.25(@swc/helpers@0.5.11))(@types/node@20.14.0)(typescript@5.4.2))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.5.25(@swc/helpers@0.5.11))(@types/node@22.8.7)(typescript@5.4.2))
       '@jest/types': 29.6.3
       import-local: 3.1.0
-      jest-cli: 29.7.0(@types/node@20.14.0)(ts-node@10.9.2(@swc/core@1.5.25(@swc/helpers@0.5.11))(@types/node@20.14.0)(typescript@5.4.2))
+      jest-cli: 29.7.0(@types/node@22.8.7)(ts-node@10.9.2(@swc/core@1.5.25(@swc/helpers@0.5.11))(@types/node@22.8.7)(typescript@5.4.2))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -25810,7 +25843,7 @@ snapshots:
     dependencies:
       dnd-core: 14.0.1
 
-  react-dnd@14.0.5(@types/hoist-non-react-statics@3.3.5)(@types/node@20.14.0)(@types/react@18.3.3)(react@18.2.0):
+  react-dnd@14.0.5(@types/hoist-non-react-statics@3.3.5)(@types/node@22.8.7)(@types/react@18.3.3)(react@18.2.0):
     dependencies:
       '@react-dnd/invariant': 2.0.0
       '@react-dnd/shallowequal': 2.0.0
@@ -25820,7 +25853,7 @@ snapshots:
       react: 18.2.0
     optionalDependencies:
       '@types/hoist-non-react-statics': 3.3.5
-      '@types/node': 20.14.0
+      '@types/node': 22.8.7
       '@types/react': 18.3.3
 
   react-dom@18.2.0(react@18.2.0):
@@ -27694,14 +27727,14 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.5.25(@swc/helpers@0.5.11)
 
-  ts-node@10.9.2(@swc/core@1.5.25(@swc/helpers@0.5.11))(@types/node@20.14.0)(typescript@5.4.2):
+  ts-node@10.9.2(@swc/core@1.5.25(@swc/helpers@0.5.11))(@types/node@22.8.7)(typescript@5.4.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.9
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.3
-      '@types/node': 20.14.0
+      '@types/node': 22.8.7
       acorn: 8.12.1
       acorn-walk: 8.3.2
       arg: 4.1.3
@@ -28323,7 +28356,7 @@ snapshots:
       sass: 1.77.6
       terser: 5.36.0
 
-  vitest-mock-extended@2.0.2(typescript@5.0.4)(vitest@2.1.1):
+  vitest-mock-extended@2.0.2(typescript@5.0.4)(vitest@2.1.1(@types/node@20.14.0)(@vitest/ui@2.1.1)(happy-dom@15.7.4)(sass@1.77.6)(terser@5.36.0)):
     dependencies:
       ts-essentials: 10.0.2(typescript@5.0.4)
       typescript: 5.0.4


### PR DESCRIPTION
## 実装内容
- terminus で graceful shutdown を pdf-converter に実装
- pdf-converter の Dockerfile をモノレポ + pnpm 仕様に書き直し
    - 元々別レポジトリで開発していた際の内容になっていました、すみません

## 動作確認
docker build したコンテナで graceful shutdown によって puppeteer cluster が閉じられることを確認

## task
https://redmine.weseek.co.jp/issues/156431

## 備考
base branch は [feat/135772-pdf-page-bulk-export](https://github.com/weseek/growi/tree/feat/135772-pdf-page-bulk-export) です。