### PR TITLE
fix: Failed to export the page markdown

### DIFF
--- a/apps/app/src/server/routes/apiv3/page/index.ts
+++ b/apps/app/src/server/routes/apiv3/page/index.ts
@@ -761,7 +761,14 @@ module.exports = (crowi) => {
     };
     await crowi.activityService.createActivity(parameters);
 
-    return pipeline(stream, res);
+    // The last stream in the pipeline must be a function
+    // https://stackoverflow.com/questions/75118262/gulp-generates-typeerror-the-streams-property-must-be-of-type-function
+    return pipeline(stream, res, (err) => {
+      if (err) {
+        logger.error('Failed to export page', err);
+        return res.apiv3Err(err, 500);
+      }
+    });
   });
 
   /**

--- a/apps/app/src/server/routes/apiv3/page/index.ts
+++ b/apps/app/src/server/routes/apiv3/page/index.ts
@@ -1,5 +1,6 @@
 import path from 'path';
-import { pipeline, type Readable } from 'stream';
+import { type Readable } from 'stream';
+import { pipeline } from 'stream/promises';
 
 import type { IPage } from '@growi/core';
 import {
@@ -761,14 +762,7 @@ module.exports = (crowi) => {
     };
     await crowi.activityService.createActivity(parameters);
 
-    // The last stream in the pipeline must be a function
-    // https://stackoverflow.com/questions/75118262/gulp-generates-typeerror-the-streams-property-must-be-of-type-function
-    return pipeline(stream, res, (err) => {
-      if (err) {
-        logger.error('Failed to export page', err);
-        return res.apiv3Err(err, 500);
-      }
-    });
+    await pipeline(stream, res);
   });
 
   /**


### PR DESCRIPTION
# Task
- [#158072](https://redmine.weseek.co.jp/issues/158072) 「マークダウン形式でページをエクスポート」が機能しない
  - [#158086](https://redmine.weseek.co.jp/issues/158086) 修正 