### PR TITLE
imprv: fix pipeline of callback version

### DIFF
--- a/apps/app/src/server/service/export.js
+++ b/apps/app/src/server/service/export.js
@@ -355,7 +355,7 @@ class ExportService {
     // finalize the archive (ie we are done appending files but streams have to finish yet)
     // 'close', 'end' or 'finish' may be fired right after calling this method so register to them beforehand
     archive.finalize();
-    await stream;
+    await finished(stream);
 
     logger.info(`zipped GROWI data into ${zipFile} (${archive.pointer()} bytes)`);
 

--- a/apps/app/src/server/service/export.js
+++ b/apps/app/src/server/service/export.js
@@ -8,7 +8,7 @@ const logger = loggerFactory('growi:services:ExportService'); // eslint-disable-
 const fs = require('fs');
 const path = require('path');
 const { Transform } = require('stream');
-const { pipeline } = require('stream/promises');
+const { pipeline, finished } = require('stream/promises');
 
 const archiver = require('archiver');
 const mongoose = require('mongoose');
@@ -107,7 +107,7 @@ class ExportService {
     writeStream.write(JSON.stringify(metaData));
     writeStream.close();
 
-    await pipeline([writeStream]);
+    await finished(writeStream);
 
     return metaJson;
   }

--- a/apps/app/src/server/service/growi-bridge/index.ts
+++ b/apps/app/src/server/service/growi-bridge/index.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { pipeline } from 'stream';
-import { pipeline as pipelinePromise } from 'stream/promises';
+import { finished } from 'stream/promises';
 
 import unzipStream, { type Entry } from 'unzip-stream';
 
@@ -80,7 +80,7 @@ class GrowiBridgeService {
 
     const readStream = fs.createReadStream(zipFile);
     const parseStream = unzipStream.Parse();
-    const unzipEntryStream = pipeline(readStream, parseStream);
+    const unzipEntryStream = pipeline(readStream, parseStream, () => {});
 
     let tapPromise;
 
@@ -103,7 +103,7 @@ class GrowiBridgeService {
     });
 
     try {
-      await pipelinePromise([unzipEntryStream]);
+      await finished(unzipEntryStream);
       await tapPromise;
     }
     // if zip is broken


### PR DESCRIPTION
# Summary
- promise 版ではない pipeline の使い方を修正
- すべての pipeline を promise にしたり、eslint で import { pipeline } from 'stream' を禁止することは**していない**

# Task
https://redmine.weseek.co.jp/issues/158095
- https://redmine.weseek.co.jp/issues/158175
 
# Note
- promise 版と callback 版の違いは、Promise を返す Stream を受け取れるかどうか
- 基本的には promise 版で問題ない
- だが、pipeline 後の Stream を使用したい場合は、callback 版を用いる必要がある
  - その際、finished を使うことで Stream の完了待ちができる
- callback 版では、最後の引数に関数が必要なので、今回は適当な関数を入れている。
- 修正箇所の export 機能 import 機能等は試し、使えることを確認済み