### PR TITLE
fix: 134084 158634 add return values for successful creation

### DIFF
--- a/apps/app/src/features/announcement/routes/apiv3/announcement.ts
+++ b/apps/app/src/features/announcement/routes/apiv3/announcement.ts
@@ -93,6 +93,8 @@ module.exports = (crowi: Crowi): Router => {
       const activity = await crowi.activityService.createActivity(parametersForActivity);
 
       announcementService?.doAnnounce(activity, page, params);
+
+      return res.apiv3();
     }
     catch (err) {
       logger.error(err);


### PR DESCRIPTION
## タスク
https://redmine.weseek.co.jp/issues/158634
## 概要
- announcement 作成時の戻り値が抜けていたので、追加しました。
## 変更点
- announcement 作成時に res.apiv3() を返すようにしました。

## セルフチェック
- [x] コンフリクト解消したか
- [x] 余計なコードは残っていないか
- [x] 適切にメモ化したか
- [x] 責務の問題はクリアしているか
- [x] CIは通っているか
- [x] PRの内容は適切にかけているか