### PR TITLE
fix: put / before the page name

### DIFF
--- a/apps/app/src/client/components/Common/CopyDropdown/CopyDropdown.jsx
+++ b/apps/app/src/client/components/Common/CopyDropdown/CopyDropdown.jsx
@@ -195,7 +195,7 @@ export const CopyDropdown = (props) => {
                 <DropdownItemContents
                   title={t('copy_to_clipboard.Page path and permanent link')}
                   contents={<>{pagePathWithParams}<br />{permalink}</>}
-                  className="text-truncate"
+                  className="text-truncate d-block"
                 />
               </DropdownItem>
             </CopyToClipboard>

--- a/apps/app/src/client/components/Common/CopyDropdown/CopyDropdown.jsx
+++ b/apps/app/src/client/components/Common/CopyDropdown/CopyDropdown.jsx
@@ -196,7 +196,6 @@ export const CopyDropdown = (props) => {
                   title={t('copy_to_clipboard.Page path and permanent link')}
                   contents={<>{pagePathWithParams}<br />{permalink}</>}
                   className="text-truncate"
-                  style={{ direction: 'rtl' }}
                 />
               </DropdownItem>
             </CopyToClipboard>

--- a/apps/app/src/components/Common/PagePathNavTitle/PagePathNavTitle.module.scss
+++ b/apps/app/src/components/Common/PagePathNavTitle/PagePathNavTitle.module.scss
@@ -1,6 +1,5 @@
 @use '@growi/core-styles/scss/bootstrap/init' as bs;
 
 .grw-page-path-nav-title :global {
-  min-width: 300px;
   min-height: 75px;
 }

--- a/apps/app/src/components/Common/PagePathNavTitle/PagePathNavTitle.module.scss
+++ b/apps/app/src/components/Common/PagePathNavTitle/PagePathNavTitle.module.scss
@@ -1,5 +1,6 @@
 @use '@growi/core-styles/scss/bootstrap/init' as bs;
 
 .grw-page-path-nav-title :global {
+  min-width: 300px;
   min-height: 75px;
 }


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/157767
通常ページのページタイトルをホバーし、クリップボードをクリックすると、ページ名の前の”/”がなくなっていた。

修正点
「ページ名」、「ページURL」と同じように後ろをtruncateし、ページ名の長さにかかわらずページ名の前に/を入れた。