### PR TITLE
fix: Cannot comment when comments from rom user are allowed

### DIFF
--- a/apps/app/src/pages/[[...path]].page.tsx
+++ b/apps/app/src/pages/[[...path]].page.tsx
@@ -247,6 +247,7 @@ const Page: NextPageWithLayout<Props> = (props: Props) => {
   useIsUploadEnabled(props.isUploadEnabled);
 
   useIsLocalAccountRegistrationEnabled(props.isLocalAccountRegistrationEnabled);
+  useIsRomUserAllowedToComment(props.isRomUserAllowedToComment);
 
   useIsAiEnabled(props.aiEnabled);
 


### PR DESCRIPTION
# Task
- [#158877](https://redmine.weseek.co.jp/issues/158877) 「閲覧のみユーザもコメント操作可能」が設定されている時に閲覧のみユーザーがコメントできない
  - [#158878](https://redmine.weseek.co.jp/issues/158878) 修正
