### PR TITLE
fix: TypeError occurs during export

### DIFF
--- a/apps/app/src/server/service/export.js
+++ b/apps/app/src/server/service/export.js
@@ -349,13 +349,12 @@ class ExportService {
 
     const output = fs.createWriteStream(zipFile);
 
-    // pipe archive data to the file
-    const stream = await pipeline(archive, output);
-
     // finalize the archive (ie we are done appending files but streams have to finish yet)
     // 'close', 'end' or 'finish' may be fired right after calling this method so register to them beforehand
     archive.finalize();
-    await finished(stream);
+
+    // pipe archive data to the file
+    await pipeline(archive, output);
 
     logger.info(`zipped GROWI data into ${zipFile} (${archive.pointer()} bytes)`);
 

--- a/apps/app/src/server/service/export.js
+++ b/apps/app/src/server/service/export.js
@@ -350,7 +350,7 @@ class ExportService {
     const output = fs.createWriteStream(zipFile);
 
     // pipe archive data to the file
-    const stream = pipeline(archive, output);
+    const stream = await pipeline(archive, output);
 
     // finalize the archive (ie we are done appending files but streams have to finish yet)
     // 'close', 'end' or 'finish' may be fired right after calling this method so register to them beforehand


### PR DESCRIPTION
## Task
- [#158989](https://redmine.weseek.co.jp/issues/158989) POST /_api/v3/export 時にサーバー側でエラーが出る
  -  [#159007](https://redmine.weseek.co.jp/issues/159007) 修正
- [#159015](https://redmine.weseek.co.jp/issues/159015) export 後に次の export ができない
  -  [#159018](https://redmine.weseek.co.jp/issues/159018) 修正


## 経緯

1. https://github.com/weseek/growi/pull/9361/files#diff-24c321cd621aaa24219022f980552d9f29902d40749092511a496e46ceeff06d
    - `stream/promises` package の pipeline を利用
1.  https://github.com/weseek/growi/pull/9455/files#diff-24c321cd621aaa24219022f980552d9f29902d40749092511a496e46ceeff06d
    - finished を用いて完了待ちを実装
1. 本PR
