### PR TITLE
fix: Error when creating pages with deep hierarchy

### DIFF
--- a/apps/app/public/static/locales/en_US/translation.json
+++ b/apps/app/public/static/locales/en_US/translation.json
@@ -157,7 +157,7 @@
   "duplicated_path": "Duplicated path",
   "Link sharing is disabled": "Link sharing is disabled",
   "successfully_saved_the_page": "Successfully saved the page",
-  "you_can_not_create_page_with_this_name": "You can not create page with this name",
+  "you_can_not_create_page_with_this_name_or_hierarchy": "You can not create page with this name or page hierarchy",
   "not_allowed_to_see_this_page": "You cannot see this page",
   "Confirm": "Confirm",
   "Successfully requested": "Successfully requested.",

--- a/apps/app/public/static/locales/fr_FR/translation.json
+++ b/apps/app/public/static/locales/fr_FR/translation.json
@@ -157,7 +157,7 @@
   "duplicated_path": "Chemin dupliqué",
   "Link sharing is disabled": "Le partage est désactivé",
   "successfully_saved_the_page": "Page sauvegardée",
-  "you_can_not_create_page_with_this_name": "Vous ne pouvez pas créer cette page",
+  "you_can_not_create_page_with_this_name_or_hierarchy": "Vous ne pouvez pas créer de page avec ce nom ou cette hiérarchie de pages",
   "not_allowed_to_see_this_page": "Vous ne pouvez pas voir cette page",
   "Confirm": "Confirmer",
   "Successfully requested": "Demande envoyée.",

--- a/apps/app/public/static/locales/ja_JP/translation.json
+++ b/apps/app/public/static/locales/ja_JP/translation.json
@@ -158,7 +158,7 @@
   "duplicated_path": "重複したパス",
   "Link sharing is disabled": "リンクのシェアは無効化されています",
   "successfully_saved_the_page": "ページが正常に保存されました",
-  "you_can_not_create_page_with_this_name": "この名前でページを作成することはできません",
+  "you_can_not_create_page_with_this_name_or_hierarchy": "この名前、または階層でページを作成することはできません",
   "not_allowed_to_see_this_page": "このページは閲覧できません",
   "Confirm": "確認",
   "Successfully requested": "正常に処理を受け付けました",

--- a/apps/app/public/static/locales/zh_CN/translation.json
+++ b/apps/app/public/static/locales/zh_CN/translation.json
@@ -163,7 +163,7 @@
   "duplicated_path": "Duplicated path",
   "Link sharing is disabled": "你不允许分享该链接",
   "successfully_saved_the_page": "成功地保存了该页面",
-  "you_can_not_create_page_with_this_name": "您无法使用此名称创建页面",
+  "you_can_not_create_page_with_this_name_or_hierarchy": "您無法使用此名稱或頁面層級建立頁面",
   "not_allowed_to_see_this_page": "你不能看到这个页面",
   "Confirm": "确定",
   "Successfully requested": "进程成功接受",

--- a/apps/app/src/client/components/TreeItem/NewPageInput/use-new-page-input.tsx
+++ b/apps/app/src/client/components/TreeItem/NewPageInput/use-new-page-input.tsx
@@ -99,7 +99,7 @@ export const useNewPageInput = (): UseNewPageInput => {
       const isCreatable = pagePathUtils.isCreatablePage(newPagePath);
 
       if (!isCreatable) {
-        toastWarning(t('you_can_not_create_page_with_this_name'));
+        toastWarning(t('you_can_not_create_page_with_this_name_or_hierarchy'));
         return;
       }
 

--- a/apps/app/src/server/models/page.ts
+++ b/apps/app/src/server/models/page.ts
@@ -9,7 +9,7 @@ import {
 } from '@growi/core';
 import type { IPagePopulatedToShowRevision } from '@growi/core/dist/interfaces';
 import { getIdForRef, isPopulated } from '@growi/core/dist/interfaces';
-import { isTopPage, hasSlash } from '@growi/core/dist/utils/page-path-utils';
+import { isTopPage, hasSlash, isCreatablePage } from '@growi/core/dist/utils/page-path-utils';
 import { addTrailingSlash, normalizePath } from '@growi/core/dist/utils/path-utils';
 import escapeStringRegexp from 'escape-string-regexp';
 import type {

--- a/apps/app/src/server/models/page.ts
+++ b/apps/app/src/server/models/page.ts
@@ -9,7 +9,7 @@ import {
 } from '@growi/core';
 import type { IPagePopulatedToShowRevision } from '@growi/core/dist/interfaces';
 import { getIdForRef, isPopulated } from '@growi/core/dist/interfaces';
-import { isTopPage, hasSlash, isCreatablePage } from '@growi/core/dist/utils/page-path-utils';
+import { isTopPage, hasSlash } from '@growi/core/dist/utils/page-path-utils';
 import { addTrailingSlash, normalizePath } from '@growi/core/dist/utils/path-utils';
 import escapeStringRegexp from 'escape-string-regexp';
 import type {

--- a/packages/core/src/utils/page-path-utils/index.ts
+++ b/packages/core/src/utils/page-path-utils/index.ts
@@ -117,9 +117,10 @@ const restrictedPatternsToCreate: Array<RegExp> = [
   /^\/(_search|_private-legacy-pages)(\/.*|$)/,
   /^\/(installer|register|login|logout|admin|me|files|trash|paste|comments|tags|share|attachment)(\/.*|$)/,
   /^\/user(?:\/[^/]+)?$/, // https://regex101.com/r/9Eh2S1/1
+  /^(\/.+){500,}$/, // avoid deep layer path. see: https://regex101.com/r/s9cCdf/1
 ];
 export const isCreatablePage = (path: string): boolean => {
-  return !restrictedPatternsToCreate.some(pattern => path.match(pattern)) && path.length <= 2_000_000;
+  return !restrictedPatternsToCreate.some(pattern => path.match(pattern));
 };
 
 /**

--- a/packages/core/src/utils/page-path-utils/index.ts
+++ b/packages/core/src/utils/page-path-utils/index.ts
@@ -117,7 +117,7 @@ const restrictedPatternsToCreate: Array<RegExp> = [
   /^\/(_search|_private-legacy-pages)(\/.*|$)/,
   /^\/(installer|register|login|logout|admin|me|files|trash|paste|comments|tags|share|attachment)(\/.*|$)/,
   /^\/user(?:\/[^/]+)?$/, // https://regex101.com/r/9Eh2S1/1
-  /^(\/.+){500,}$/, // avoid deep layer path. see: https://regex101.com/r/s9cCdf/1
+  /^(\/.+){500,}$/, // avoid deep layer path. see: https://regex101.com/r/L0kzOD/1
 ];
 export const isCreatablePage = (path: string): boolean => {
   return !restrictedPatternsToCreate.some(pattern => path.match(pattern));

--- a/packages/core/src/utils/page-path-utils/index.ts
+++ b/packages/core/src/utils/page-path-utils/index.ts
@@ -1,6 +1,6 @@
 import escapeStringRegexp from 'escape-string-regexp';
 
-import { IUser } from '~/interfaces';
+import type { IUser } from '~/interfaces';
 
 import { isValidObjectId } from '../objectid-utils';
 import { addTrailingSlash } from '../path-utils';
@@ -117,6 +117,7 @@ const restrictedPatternsToCreate: Array<RegExp> = [
   /^\/(_search|_private-legacy-pages)(\/.*|$)/,
   /^\/(installer|register|login|logout|admin|me|files|trash|paste|comments|tags|share|attachment)(\/.*|$)/,
   /^\/user(?:\/[^/]+)?$/, // https://regex101.com/r/9Eh2S1/1
+  /^.{2000000,}$/, // avoid very long path. see: https://regex101.com/r/s9cCdf/1
 ];
 export const isCreatablePage = (path: string): boolean => {
   return !restrictedPatternsToCreate.some(pattern => path.match(pattern));

--- a/packages/core/src/utils/page-path-utils/index.ts
+++ b/packages/core/src/utils/page-path-utils/index.ts
@@ -117,7 +117,7 @@ const restrictedPatternsToCreate: Array<RegExp> = [
   /^\/(_search|_private-legacy-pages)(\/.*|$)/,
   /^\/(installer|register|login|logout|admin|me|files|trash|paste|comments|tags|share|attachment)(\/.*|$)/,
   /^\/user(?:\/[^/]+)?$/, // https://regex101.com/r/9Eh2S1/1
-  /^(\/.+){500,}$/, // avoid deep layer path. see: https://regex101.com/r/L0kzOD/1
+  /^(\/.+){130,}$/, // avoid deep layer path. see: https://regex101.com/r/L0kzOD/1
 ];
 export const isCreatablePage = (path: string): boolean => {
   return !restrictedPatternsToCreate.some(pattern => path.match(pattern));

--- a/packages/core/src/utils/page-path-utils/index.ts
+++ b/packages/core/src/utils/page-path-utils/index.ts
@@ -117,10 +117,9 @@ const restrictedPatternsToCreate: Array<RegExp> = [
   /^\/(_search|_private-legacy-pages)(\/.*|$)/,
   /^\/(installer|register|login|logout|admin|me|files|trash|paste|comments|tags|share|attachment)(\/.*|$)/,
   /^\/user(?:\/[^/]+)?$/, // https://regex101.com/r/9Eh2S1/1
-  /^.{2000000,}$/, // avoid very long path. see: https://regex101.com/r/s9cCdf/1
 ];
 export const isCreatablePage = (path: string): boolean => {
-  return !restrictedPatternsToCreate.some(pattern => path.match(pattern));
+  return !restrictedPatternsToCreate.some(pattern => path.match(pattern)) && path.length <= 2_000_000;
 };
 
 /**


### PR DESCRIPTION
# Summary
- 深い階層のページを作成する際にエラーが出ないように

# Task
- https://redmine.weseek.co.jp/issues/156799
  - https://redmine.weseek.co.jp/issues/156857

# Noes
- 動作確認をしている中で、510 程度のスラッシュの数を持つパスでエラーが発生したので、500 以上は作れないようにしている。
  - だがそもそも 500 も階層があるページを作成する際は動作が重くなり現実的に作成できないことが多い。

- 深い階層のページを作成する方法は次の２つを想定しており、どちらでも作成できない旨を伝えられることを確認済み
  - ページツリーから作成する
  - permalink で作成 

## スラッシュ 5 個以上は作れないようにして実験
![スクリーンショット 2024-12-13 165630](https://github.com/user-attachments/assets/59a0b6bc-c52e-45e3-a534-713c791762cb)
![スクリーンショット 2024-12-13 165705](https://github.com/user-attachments/assets/68c14629-ad0c-4cec-8b3e-f1d4e246420c)
