### PR TITLE
fix: remark-lsx pagination

### DIFF
--- a/packages/remark-lsx/src/server/index.ts
+++ b/packages/remark-lsx/src/server/index.ts
@@ -14,8 +14,8 @@ const filterXSS = new FilterXSS();
 
 const lsxValidator = [
   query('pagePath').notEmpty().isString(),
-  query('offset').optional().isInt(),
-  query('limit').optional().isInt(),
+  query('offset').optional().isInt().toInt(),
+  query('limit').optional().isInt().toInt(),
   query('options')
     .optional()
     .customSanitizer((options) => {


### PR DESCRIPTION
# Task
- [#159497](https://redmine.weseek.co.jp/issues/159497) Lsx の "Road more" をクリックした時に正しくページングされない
  - [#159499](https://redmine.weseek.co.jp/issues/159499) 修正