### PR TITLE
only skip puppeteer init on swagger generation

### DIFF
--- a/apps/pdf-converter/src/service/pdf-convert.ts
+++ b/apps/pdf-converter/src/service/pdf-convert.ts
@@ -53,8 +53,6 @@ class PdfConvertService implements OnInit {
     logger: Logger;
 
   async $onInit(): Promise<void> {
-    if (process.env.SWAGGER_GENERATION === 'true') return;
-
     await this.initPuppeteerCluster();
   }
 
@@ -253,6 +251,9 @@ class PdfConvertService implements OnInit {
    * Initialize puppeteer cluster
    */
   private async initPuppeteerCluster(): Promise<void> {
+    // puppeteer is unnecessary for swagger schema generation
+    if (process.env.SWAGGER_GENERATION === 'true') return;
+
     this.puppeteerCluster = await Cluster.launch({
       concurrency: Cluster.CONCURRENCY_PAGE,
       maxConcurrency: this.maxConcurrency,


### PR DESCRIPTION
## 背景
https://github.com/weseek/growi/pull/9283#discussion_r1886712062 の FB 対応のための[調査](https://redmine.weseek.co.jp/issues/159609)の結果、generate-swagger のコマンドではアプリの起動 ($onInit の実行) が避けられないことがわかったため、
> generate-swagger するためだけのエントリーポイント

は作成するのが難しそう。

詳細)
https://github.com/weseek/growi/blob/edea8bed2e9933a9a13ca1ac785018fa9abc025b/apps/pdf-converter/src/bin/index.ts#L7
で渡した Server が
https://github.com/tsedio/tsed-cli/blob/a18462ea5200690dfb6a3dc42f24a97d6cd5843b/packages/cli-generate-swagger/src/commands/GenerateSwaggerCmd.ts#L62-L68
で起動されている。

## 実装内容
とりあえず generate-swagger 実行時にエラーの原因となっているのは puppeteer だけなので、スキップする処理を puppeteer に限定

## task
https://redmine.weseek.co.jp/issues/159690