### PR TITLE
add fonts (lato and noto-cjk)

### DIFF
--- a/.devcontainer/pdf-converter/postCreateCommand.sh
+++ b/.devcontainer/pdf-converter/postCreateCommand.sh
@@ -1,7 +1,7 @@
 # Instal additional packages
 sudo apt update
 sudo apt-get install -y --no-install-recommends \
-  chromium locales fonts-ipafont fonts-ipaexfont fonts-ipafont-gothic fonts-ipafont-mincho
+  chromium fonts-lato fonts-ipafont-gothic fonts-noto-cjk
 sudo apt-get clean -y
 
 # Setup pnpm

--- a/apps/pdf-converter/docker/Dockerfile
+++ b/apps/pdf-converter/docker/Dockerfile
@@ -61,7 +61,7 @@ ENV LANG="ja_JP.UTF-8"
 ENV optDir="/opt"
 ENV appDir="${optDir}/pdf-converter"
 
-RUN apt-get update && apt-get install -y chromium locales fonts-ipafont fonts-ipaexfont fonts-ipafont-gothic fonts-ipafont-mincho \
+RUN apt-get update && apt-get install -y chromium fonts-lato fonts-ipafont-gothic fonts-noto-cjk \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*; \
     echo "ja_JP UTF-8" > /etc/locale.gen && locale-gen;

--- a/apps/pdf-converter/src/service/pdf-convert.ts
+++ b/apps/pdf-converter/src/service/pdf-convert.ts
@@ -261,6 +261,13 @@ class PdfConvertService implements OnInit {
 
     await this.puppeteerCluster.task(async({ page, data: htmlString }) => {
       await page.setContent(htmlString, { waitUntil: 'domcontentloaded' });
+      await page.addStyleTag({
+        content: `
+          body {
+            font-family: 'Lato', 'IPAGothic', 'Noto Sans CJK';
+          }
+        `,
+      });
       await page.emulateMediaType('screen');
       const pdfResult = await page.pdf({
         margin: {


### PR DESCRIPTION
## 実装内容
- 中国語と韓国語が PDF に表示されるように fonts-noto-cjk を追加
- なるべく font-family-base に設定されている font-family-sans-serif (以下参照) に従うように fonts-lato を追加
    - https://github.com/weseek/growi/blob/675b6f12b2de542197ff31eab63c52e90ed0c9cc/packages/core-styles/scss/bootstrap/_variables.scss#L58
    - https://github.com/weseek/growi/blob/675b6f12b2de542197ff31eab63c52e90ed0c9cc/apps/app/src/styles/_fonts.scss#L2

## 動作確認
chat gpt に適当に1000文字の中国語と韓国語の文章を考えてもらい、それを GROWI のページに入力 -> pdf エクスポートした時に文字化けしていないことを確認

## task
https://redmine.weseek.co.jp/issues/159175