### PR TITLE
fix: PageTree auto-scrolling sometimges not woking

### DIFF
--- a/apps/app/public/static/locales/en_US/translation.json
+++ b/apps/app/public/static/locales/en_US/translation.json
@@ -743,7 +743,8 @@
   "pagetree": {
     "cannot_rename_a_title_that_contains_slash": "Cannot rename a title that contains '/'",
     "you_cannot_move_this_page_now": "You cannot move this page now",
-    "something_went_wrong_with_moving_page": "Something went wrong with moving page"
+    "something_went_wrong_with_moving_page": "Something went wrong with moving page",
+    "error_retrieving_the_pagetree": "Error occurred while retrieving the PageTree"
   },
   "duplicated_page_alert": {
     "same_page_name_exists": "Same page name exits as「{{pageName}}」",

--- a/apps/app/public/static/locales/fr_FR/translation.json
+++ b/apps/app/public/static/locales/fr_FR/translation.json
@@ -736,7 +736,8 @@
   "pagetree": {
     "cannot_rename_a_title_that_contains_slash": "Renommage impossible lorsque le titre contient '/'",
     "you_cannot_move_this_page_now": "Déplacement de la page impossible",
-    "something_went_wrong_with_moving_page": "Échec de déplacement de la page"
+    "something_went_wrong_with_moving_page": "Échec de déplacement de la page",
+    "error_retrieving_the_pagetree": "Une erreur s'est produite lors de la récupération de l'arbre des pages"
   },
   "duplicated_page_alert": {
     "same_page_name_exists": "Une page avec ce nom 「{{pageName}}」 existe déjà",

--- a/apps/app/public/static/locales/ja_JP/translation.json
+++ b/apps/app/public/static/locales/ja_JP/translation.json
@@ -775,7 +775,8 @@
   "pagetree": {
     "cannot_rename_a_title_that_contains_slash": "`/` が含まれているタイトルにリネームできません",
     "you_cannot_move_this_page_now": "現在、このページを移動することはできません",
-    "something_went_wrong_with_moving_page": "ページの移動に問題が発生しました"
+    "something_went_wrong_with_moving_page": "ページの移動に問題が発生しました",
+    "error_retrieving_the_pagetree": "ページツリーの取得中にエラーが発生しました"
   },
   "duplicated_page_alert": {
     "same_page_name_exists": "ページ名 「{{pageName}}」が重複しています",

--- a/apps/app/public/static/locales/zh_CN/translation.json
+++ b/apps/app/public/static/locales/zh_CN/translation.json
@@ -745,7 +745,8 @@
   "pagetree": {
     "cannot_rename_a_title_that_contains_slash": "不能重命名包含 ’/' 的标题",
     "you_cannot_move_this_page_now": "你现在不能移动这个页面",
-    "something_went_wrong_with_moving_page": "移动页面时出了问题"
+    "something_went_wrong_with_moving_page": "移动页面时出了问题",
+    "error_retrieving_the_pagetree": "检索页面树时发生错误"
   },
   "duplicated_page_alert": {
     "same_page_name_exists": "页面名称「{{pageName}}」是重复的",

--- a/apps/app/src/client/components/ItemsTree/ItemsTree.tsx
+++ b/apps/app/src/client/components/ItemsTree/ItemsTree.tsx
@@ -4,7 +4,7 @@ import React, {
 
 import path from 'path';
 
-import type { Nullable, IPageHasId, IPageToDeleteWithMeta } from '@growi/core';
+import type { IPageHasId, IPageToDeleteWithMeta } from '@growi/core';
 import { useGlobalSocket } from '@growi/core/dist/swr';
 import { useTranslation } from 'next-i18next';
 import { useRouter } from 'next/router';
@@ -93,7 +93,7 @@ type ItemsTreeProps = {
   isReadOnlyUser: boolean
   isWipPageShown?: boolean
   targetPath: string
-  targetPathOrId?: Nullable<string>
+  targetPathOrId?: string,
   targetAndAncestorsData?: TargetAndAncestors
   CustomTreeItem: React.FunctionComponent<TreeItemProps>
   onClickTreeItem?: (page: IPageForItem) => void;
@@ -225,6 +225,7 @@ export const ItemsTree = (props: ItemsTreeProps): JSX.Element => {
       <ul className={`${moduleClass} list-group`}>
         <CustomTreeItem
           key={initialItemNode.page.path}
+          targetPath={targetPath}
           targetPathOrId={targetPathOrId}
           itemNode={initialItemNode}
           isOpen

--- a/apps/app/src/client/components/ItemsTree/ItemsTree.tsx
+++ b/apps/app/src/client/components/ItemsTree/ItemsTree.tsx
@@ -134,8 +134,7 @@ export const ItemsTree = (props: ItemsTreeProps): JSX.Element => {
 
 
   if (error != null) {
-    // TODO: improve message
-    toastError('Error occurred while fetching pages to render PageTree');
+    toastError(t('pagetree.error_retrieving_the_pagetree'));
     return <></>;
   }
 

--- a/apps/app/src/client/components/PageSelectModal/PageSelectModal.tsx
+++ b/apps/app/src/client/components/PageSelectModal/PageSelectModal.tsx
@@ -13,7 +13,7 @@ import {
 import SimpleBar from 'simplebar-react';
 
 import type { IPageForItem } from '~/interfaces/page';
-import { useTargetAndAncestors, useIsGuestUser, useIsReadOnlyUser } from '~/stores-universal/context';
+import { useIsGuestUser, useIsReadOnlyUser } from '~/stores-universal/context';
 import { usePageSelectModal } from '~/stores/modal';
 import { useSWRxCurrentPage } from '~/stores/page';
 
@@ -38,7 +38,6 @@ export const PageSelectModal: FC = () => {
 
   const { data: isGuestUser } = useIsGuestUser();
   const { data: isReadOnlyUser } = useIsReadOnlyUser();
-  const { data: targetAndAncestorsData } = useTargetAndAncestors();
   const { data: currentPage } = useSWRxCurrentPage();
 
   const pagePathRenameHandler = usePagePathRenameHandler(currentPage);
@@ -96,7 +95,6 @@ export const PageSelectModal: FC = () => {
                 isReadOnlyUser={!!isReadOnlyUser}
                 targetPath={targetPath}
                 targetPathOrId={targetPathOrId}
-                targetAndAncestorsData={targetAndAncestorsData}
                 onClickTreeItem={onClickTreeItem}
               />
             </div>

--- a/apps/app/src/client/components/Sidebar/PageTree/PageTreeSubstance.tsx
+++ b/apps/app/src/client/components/Sidebar/PageTree/PageTreeSubstance.tsx
@@ -5,10 +5,10 @@ import React, {
 import { useTranslation } from 'next-i18next';
 import { debounce } from 'throttle-debounce';
 
-import { useTargetAndAncestors, useIsGuestUser, useIsReadOnlyUser } from '~/stores-universal/context';
+import { useIsGuestUser, useIsReadOnlyUser } from '~/stores-universal/context';
 import { useCurrentPagePath, useCurrentPageId } from '~/stores/page';
 import {
-  mutatePageTree, mutateRecentlyUpdated, useSWRxPageAncestorsChildren, useSWRxRootPage, useSWRxV5MigrationStatus,
+  mutatePageTree, mutateRecentlyUpdated, useSWRxRootPage, useSWRxV5MigrationStatus,
 } from '~/stores/page-listing';
 import { useSidebarScrollerRef } from '~/stores/ui';
 import loggerFactory from '~/utils/logger';
@@ -99,14 +99,12 @@ export const PageTreeContent = memo(({ isWipPageShown }: PageTreeContentProps) =
   const { data: isReadOnlyUser } = useIsReadOnlyUser();
   const { data: currentPath } = useCurrentPagePath();
   const { data: targetId } = useCurrentPageId();
-  const { data: targetAndAncestorsData } = useTargetAndAncestors();
 
   const { data: migrationStatus } = useSWRxV5MigrationStatus({ suspense: true });
 
   const targetPathOrId = targetId || currentPath;
   const path = currentPath || '/';
 
-  const { data: ancestorsChildrenResult } = useSWRxPageAncestorsChildren(path, { suspense: true });
   const { data: rootPageResult } = useSWRxRootPage({ suspense: true });
   const { data: sidebarScrollerRef } = useSidebarScrollerRef();
   const [isInitialScrollCompleted, setIsInitialScrollCompleted] = useState(false);
@@ -144,7 +142,7 @@ export const PageTreeContent = memo(({ isWipPageShown }: PageTreeContentProps) =
   const scrollOnInitDebounced = useMemo(() => debounce(500, scrollOnInit), [scrollOnInit]);
 
   useEffect(() => {
-    if (isInitialScrollCompleted || ancestorsChildrenResult == null || rootPageResult == null) {
+    if (isInitialScrollCompleted || rootPageResult == null) {
       return;
     }
 
@@ -166,7 +164,7 @@ export const PageTreeContent = memo(({ isWipPageShown }: PageTreeContentProps) =
     return () => {
       observer.disconnect();
     };
-  }, [isInitialScrollCompleted, scrollOnInitDebounced, ancestorsChildrenResult, rootPageResult]);
+  }, [isInitialScrollCompleted, scrollOnInitDebounced, rootPageResult]);
   // *******************************  end  *******************************
 
 
@@ -189,7 +187,6 @@ export const PageTreeContent = memo(({ isWipPageShown }: PageTreeContentProps) =
         isWipPageShown={isWipPageShown}
         targetPath={path}
         targetPathOrId={targetPathOrId}
-        targetAndAncestorsData={targetAndAncestorsData}
         CustomTreeItem={PageTreeItem}
       />
 

--- a/apps/app/src/client/components/Sidebar/PageTreeItem/PageTreeItem.tsx
+++ b/apps/app/src/client/components/Sidebar/PageTreeItem/PageTreeItem.tsx
@@ -34,7 +34,7 @@ const moduleClass = styles['page-tree-item'] ?? '';
 
 const logger = loggerFactory('growi:cli:Item');
 
-export const PageTreeItem: FC<TreeItemProps> = (props) => {
+export const PageTreeItem = (props:TreeItemProps): JSX.Element => {
   const router = useRouter();
 
   const getNewPathAfterMoved = (droppedPagePath: string, newParentPagePath: string): string => {
@@ -186,6 +186,7 @@ export const PageTreeItem: FC<TreeItemProps> = (props) => {
   return (
     <TreeItemLayout
       className={moduleClass}
+      targetPath={props.targetPath}
       targetPathOrId={props.targetPathOrId}
       itemLevel={props.itemLevel}
       itemNode={props.itemNode}

--- a/apps/app/src/client/components/TreeItem/TreeItemLayout.tsx
+++ b/apps/app/src/client/components/TreeItem/TreeItemLayout.tsx
@@ -34,9 +34,9 @@ export const TreeItemLayout = (props: TreeItemLayoutProps): JSX.Element => {
     showAlternativeContent,
   } = props;
 
-  const { page, children } = itemNode;
+  const { page } = itemNode;
 
-  const [currentChildren, setCurrentChildren] = useState<ItemNode[]>(children);
+  const [currentChildren, setCurrentChildren] = useState<ItemNode[]>([]);
   const [isOpen, setIsOpen] = useState(_isOpen);
 
   const { data } = useSWRxPageChildren(isOpen ? page._id : null);
@@ -75,8 +75,8 @@ export const TreeItemLayout = (props: TreeItemLayoutProps): JSX.Element => {
   const hasDescendants = descendantCount > 0 || isChildrenLoaded;
 
   const hasChildren = useCallback((): boolean => {
-    return page.path != null && targetPath.startsWith(page.path);
-  }, [page, targetPath]);
+    return currentChildren != null && currentChildren.length > 0;
+  }, [currentChildren]);
 
   const onClickLoadChildren = useCallback(() => {
     setIsOpen(!isOpen);
@@ -84,8 +84,9 @@ export const TreeItemLayout = (props: TreeItemLayoutProps): JSX.Element => {
 
   // didMount
   useEffect(() => {
-    if (hasChildren()) setIsOpen(true);
-  }, [hasChildren]);
+    const isPathToTarget = page.path != null && targetPath.startsWith(page.path) && targetPath !== page.path; // Target Page does not need to be opened
+    if (hasChildren() || isPathToTarget) setIsOpen(true);
+  }, [hasChildren, targetPath, page.path]);
 
   /*
    * When swr fetch succeeded

--- a/apps/app/src/client/components/TreeItem/TreeItemLayout.tsx
+++ b/apps/app/src/client/components/TreeItem/TreeItemLayout.tsx
@@ -22,7 +22,7 @@ type TreeItemLayoutProps = TreeItemProps & {
   indentSize?: number,
 }
 
-export const TreeItemLayout: FC<TreeItemLayoutProps> = (props) => {
+export const TreeItemLayout = (props: TreeItemLayoutProps): JSX.Element => {
   const {
     className, itemClassName,
     indentSize = 10,

--- a/apps/app/src/client/components/TreeItem/TreeItemLayout.tsx
+++ b/apps/app/src/client/components/TreeItem/TreeItemLayout.tsx
@@ -27,7 +27,7 @@ export const TreeItemLayout = (props: TreeItemLayoutProps): JSX.Element => {
     className, itemClassName,
     indentSize = 10,
     itemLevel: baseItemLevel = 1,
-    itemNode, targetPathOrId, isOpen: _isOpen = false,
+    itemNode, targetPath, targetPathOrId, isOpen: _isOpen = false,
     onRenamed, onClick, onClickDuplicateMenuItem, onClickDeleteMenuItem, onWheelClick,
     isEnableActions, isReadOnlyUser, isWipPageShown = true,
     itemRef, itemClass,
@@ -75,8 +75,8 @@ export const TreeItemLayout = (props: TreeItemLayoutProps): JSX.Element => {
   const hasDescendants = descendantCount > 0 || isChildrenLoaded;
 
   const hasChildren = useCallback((): boolean => {
-    return currentChildren != null && currentChildren.length > 0;
-  }, [currentChildren]);
+    return page.path != null && targetPath.startsWith(page.path);
+  }, [page, targetPath]);
 
   const onClickLoadChildren = useCallback(() => {
     setIsOpen(!isOpen);
@@ -108,6 +108,7 @@ export const TreeItemLayout = (props: TreeItemLayoutProps): JSX.Element => {
     isReadOnlyUser,
     isOpen: false,
     isWipPageShown,
+    targetPath,
     targetPathOrId,
     onRenamed,
     onClickDuplicateMenuItem,

--- a/apps/app/src/client/components/TreeItem/TreeItemLayout.tsx
+++ b/apps/app/src/client/components/TreeItem/TreeItemLayout.tsx
@@ -85,8 +85,8 @@ export const TreeItemLayout = (props: TreeItemLayoutProps): JSX.Element => {
   // didMount
   useEffect(() => {
     const isPathToTarget = page.path != null && targetPath.startsWith(page.path) && targetPath !== page.path; // Target Page does not need to be opened
-    if (hasChildren() || isPathToTarget) setIsOpen(true);
-  }, [hasChildren, targetPath, page.path]);
+    if (isPathToTarget) setIsOpen(true);
+  }, [targetPath, page.path]);
 
   /*
    * When swr fetch succeeded

--- a/apps/app/src/client/components/TreeItem/interfaces/index.ts
+++ b/apps/app/src/client/components/TreeItem/interfaces/index.ts
@@ -1,5 +1,4 @@
 import type { IPageToDeleteWithMeta } from '@growi/core';
-import type { Nullable } from 'vitest';
 
 import type { IPageForItem } from '~/interfaces/page';
 import type { IPageForPageDuplicateModal } from '~/stores/modal';
@@ -23,7 +22,8 @@ export type TreeItemToolProps = TreeItemBaseProps & {
 };
 
 export type TreeItemProps = TreeItemBaseProps & {
-  targetPathOrId?: Nullable<string>,
+  targetPath: string,
+  targetPathOrId?:string,
   isOpen?: boolean,
   isWipPageShown?: boolean,
   itemClass?: React.FunctionComponent<TreeItemProps>,

--- a/apps/app/src/interfaces/page-listing-results.ts
+++ b/apps/app/src/interfaces/page-listing-results.ts
@@ -18,13 +18,6 @@ export interface ChildrenResult {
   children: Partial<IPageForItem>[]
 }
 
-
-export interface TargetAndAncestors {
-  targetAndAncestors: Partial<IPageForItem>[]
-  rootPage: Partial<IPageForItem>,
-}
-
-
 export interface V5MigrationStatus {
   isV5Compatible : boolean,
   migratablePagesCount: number

--- a/apps/app/src/stores-universal/context.tsx
+++ b/apps/app/src/stores-universal/context.tsx
@@ -10,8 +10,6 @@ import useSWRImmutable from 'swr/immutable';
 import type { SupportedActionType } from '~/interfaces/activity';
 import type { RendererConfig } from '~/interfaces/services/renderer';
 
-import type { TargetAndAncestors } from '../interfaces/page-listing-results';
-
 import { useContextSWR } from './use-context-swr';
 
 declare global {

--- a/apps/app/src/stores-universal/context.tsx
+++ b/apps/app/src/stores-universal/context.tsx
@@ -78,10 +78,6 @@ export const useIsSearchPage = (initialData?: Nullable<boolean>) : SWRResponse<N
   return useContextSWR<Nullable<any>, Error>('isSearchPage', initialData);
 };
 
-export const useTargetAndAncestors = (initialData?: TargetAndAncestors): SWRResponse<TargetAndAncestors, Error> => {
-  return useContextSWR<TargetAndAncestors, Error>('targetAndAncestors', initialData);
-};
-
 export const useIsAclEnabled = (initialData?: boolean) : SWRResponse<boolean, Error> => {
   return useContextSWR<boolean, Error>('isAclEnabled', initialData);
 };

--- a/apps/app/src/stores/page-listing.tsx
+++ b/apps/app/src/stores/page-listing.tsx
@@ -185,32 +185,6 @@ export const mutatePageTree = async(): Promise<undefined[]> => {
   return mutate(keyMatcherForPageTree);
 };
 
-export const useSWRxPageAncestorsChildren = (
-    path: string | null,
-    config?: SWRConfiguration,
-): SWRResponse<AncestorsChildrenResult, Error> => {
-  const key = path ? [MUTATION_ID_FOR_PAGETREE, '/page-listing/ancestors-children', path] : null;
-
-  // take care of the degration
-  // see: https://github.com/weseek/growi/pull/7038
-
-  if (key != null) {
-    assert(keyMatcherForPageTree(key));
-  }
-
-  return useSWRImmutable(
-    key,
-    ([, endpoint, path]) => apiv3Get(endpoint, { path }).then((response) => {
-      return {
-        ancestorsChildren: response.data.ancestorsChildren,
-      };
-    }),
-    {
-      ...config,
-      keepPreviousData: true,
-    },
-  );
-};
 
 export const useSWRxPageChildren = (
     id?: string | null,


### PR DESCRIPTION
# Summary
- 任意のページを開いた際、時々ページツリーの自動スクロールが効かなくなっている問題を修正
- Ancestors 周りを削除し、初回ロード時に TargetPath からページツリーを開くかどうかを決める。

# Task
- https://redmine.weseek.co.jp/issues/111603
  - https://redmine.weseek.co.jp/issues/158197

# Note
- もともと initialItemNode には、開きたいページまでの ItemNode が再帰的に入っていた。
```
initialItemNode のイメージ。例えば"/parent2/child1" を開くとき、こうなる。
{
  pagePath: "/",
  children: [
    {
      pagePath: "/parent1",
      children: [],
      ...
    },
    {
      pagePath: "/parent2",
      children: [
        {
          pagePath: "/parent2/child1",
          children: [],
          ...
        },        
        {
          pagePath: "/parent2/child2",
          children: [],
          ...
        }
      ],
      ...
    },
    {
      pagePath: "/parent3",
      children: [],
      ...
    },
  ],
  ...
}
```
- だがその情報はページの削除をすぐには反映できず、/trash へ遷移すると削除前のページツリーが表示される問題があった
- TreeItemLayout.tsx ではそのページの子ページを useSWRxPageChildren で取ってくる。
- initialItemNode でいくら開きたいページまでの ItemNode を再帰的に持っていたところで、途中でuseSWRxPageChildrenで上書きされると開きたいページまでのパスが消え、結果ページツリー上で開けず、自動スクロールも起こらない
```
 "/" での useSWRxPageChildren は次のように返す。"/parent2/child1" までの情報が消えるため、開けない。
{
  pagePath: "/",
  children: [
    {
      pagePath: "/parent1",
      children: [],
      ...
    },
    {
      pagePath: "/parent2",
      children: [],
      ...
    },
    {
      pagePath: "/parent3",
      children: [],
      ...
    },
  ],
  ...
}
```
- よって、開きたいページまでの ItemNode を再帰的に持つのではなく、TargetPath で初回遷移時に開くかどうかを判断する

# 通信回数について
- 開くページのパスの深さ分、通信の回数が必要になる。
- だが修正前もそれは変わらず。Ancestors まわりを削除した分一回だけ減っている。
  - いままで(`ancestors-children?path=...` が存在する)
    -  ![スクリーンショット 2025-01-09 121207](https://github.com/user-attachments/assets/2ed51864-d8bf-4f7e-87d1-a5fde2fca7c1)
  - 今回の修正
    -  ![スクリーンショット 2025-01-09 131616](https://github.com/user-attachments/assets/4909634b-4de3-426b-a679-13fe236a2d75)
