### PR TITLE
fix tsed logger error in pdf converter

### DIFF
--- a/apps/pdf-converter/package.json
+++ b/apps/pdf-converter/package.json
@@ -27,7 +27,6 @@
     "@tsed/exceptions": "=8.3.5",
     "@tsed/json-mapper": "=8.3.5",
     "@tsed/logger": ">=7.0.1",
-    "@tsed/logger-file": ">=7.0.1",
     "@tsed/platform-express": "=8.3.5",
     "@tsed/schema": "=8.3.5",
     "@tsed/swagger": "=8.3.5",

--- a/apps/pdf-converter/package.json
+++ b/apps/pdf-converter/package.json
@@ -26,6 +26,8 @@
     "@tsed/di": "=8.3.5",
     "@tsed/exceptions": "=8.3.5",
     "@tsed/json-mapper": "=8.3.5",
+    "@tsed/logger": ">=7.0.1",
+    "@tsed/logger-file": ">=7.0.1",
     "@tsed/platform-express": "=8.3.5",
     "@tsed/schema": "=8.3.5",
     "@tsed/swagger": "=8.3.5",

--- a/apps/pdf-converter/src/controllers/pdf.ts
+++ b/apps/pdf-converter/src/controllers/pdf.ts
@@ -1,6 +1,7 @@
-import { BodyParams, Logger } from '@tsed/common';
+import { BodyParams } from '@tsed/common';
 import { Controller, Inject } from '@tsed/di';
 import { InternalServerError } from '@tsed/exceptions';
+import { Logger } from '@tsed/logger';
 import {
   Post, Returns, Enum, Description,
 } from '@tsed/schema';

--- a/apps/pdf-converter/src/controllers/terminus.ts
+++ b/apps/pdf-converter/src/controllers/terminus.ts
@@ -1,5 +1,5 @@
-import { Logger } from '@tsed/common';
 import { Inject, Injectable } from '@tsed/di';
+import { Logger } from '@tsed/logger';
 
 import PdfConvertService from '../service/pdf-convert.js';
 

--- a/apps/pdf-converter/src/service/pdf-convert.ts
+++ b/apps/pdf-converter/src/service/pdf-convert.ts
@@ -3,8 +3,9 @@ import path from 'path';
 import { Readable, Writable } from 'stream';
 import { pipeline as pipelinePromise } from 'stream/promises';
 
-import { Logger, OnInit } from '@tsed/common';
+import { OnInit } from '@tsed/common';
 import { Inject, Service } from '@tsed/di';
+import { Logger } from '@tsed/logger';
 import { Cluster } from 'puppeteer-cluster';
 
 interface PageInfo {

--- a/apps/slackbot-proxy/package.json
+++ b/apps/slackbot-proxy/package.json
@@ -29,7 +29,7 @@
   },
   "// comments for dependencies": {
     "@tsed/*": "v6.133.1 causes 'TypeError: Cannot read properties of undefined (reading 'prototype')' with `@Middleware()`",
-    "@tsed/common,di,schema": "force package to local node_modules in tsconfig.json since pnpm reads wrong hoisted tsed version (https://github.com/pnpm/pnpm/issues/7158)",
+    "@tsed/common,di,logger,schema": "force package to local node_modules in tsconfig.json since pnpm reads wrong hoisted tsed version (https://github.com/pnpm/pnpm/issues/7158)",
     "read-pkg-up": "v8 doesn't support CommonJS anymore. https://github.com/sindresorhus/read-pkg-up/issues/17",
     "typeorm": "Upgrading to v0.3.x requires significant changes. https://github.com/tsedio/tsed/blob/production/docs/tutorials/typeorm.md"
   },

--- a/apps/slackbot-proxy/tsconfig.json
+++ b/apps/slackbot-proxy/tsconfig.json
@@ -14,6 +14,7 @@
       "@tsed/exceptions": ["./node_modules/@tsed/exceptions"],
       "@tsed/common": ["./node_modules/@tsed/common"],
       "@tsed/di": ["./node_modules/@tsed/di"],
+      "@tsed/logger": ["./node_modules/@tsed/logger"],
     },
 
     /* TODO: remove below flags for strict checking */

--- a/packages/pdf-converter-client/package.json
+++ b/packages/pdf-converter-client/package.json
@@ -12,7 +12,8 @@
     "build": "pnpm gen:client-code && tsc -p tsconfig.json"
   },
   "dependencies": {
-    "axios": "^0.24.0"
+    "axios": "^0.24.0",
+    "tslib": "^2.8.0"
   },
   "devDependencies": {
     "orval": "=7.2.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -982,9 +982,6 @@ importers:
       '@tsed/logger':
         specifier: '>=7.0.1'
         version: 7.0.1
-      '@tsed/logger-file':
-        specifier: '>=7.0.1'
-        version: 7.0.1(@tsed/logger@7.0.1)
       '@tsed/platform-express':
         specifier: '=8.3.5'
         version: 8.3.5(@tsed/core@8.3.5)(@tsed/di@8.3.5(@tsed/core@8.3.5)(@tsed/hooks@8.3.5)(@tsed/logger@7.0.1)(@tsed/schema@8.3.5(@tsed/core@8.3.5)(@tsed/hooks@8.3.5)(@tsed/openspec@8.3.5)))(@tsed/json-mapper@8.3.5(@tsed/core@8.3.5)(@tsed/schema@8.3.5(@tsed/core@8.3.5)(@tsed/hooks@8.3.5)(@tsed/openspec@8.3.5)))(@tsed/logger@7.0.1)(@tsed/openspec@8.3.5)(@tsed/platform-http@8.3.5(@tsed/engines@8.3.5)(@tsed/logger@7.0.1)(@tsed/openspec@8.3.5))(@tsed/platform-views@8.3.5(@tsed/core@8.3.5)(@tsed/di@8.3.5(@tsed/core@8.3.5)(@tsed/hooks@8.3.5)(@tsed/logger@7.0.1)(@tsed/schema@8.3.5(@tsed/core@8.3.5)(@tsed/hooks@8.3.5)(@tsed/openspec@8.3.5)))(@tsed/engines@8.3.5)(@tsed/exceptions@8.3.5(@tsed/core@8.3.5))(@tsed/schema@8.3.5(@tsed/core@8.3.5)(@tsed/hooks@8.3.5)(@tsed/openspec@8.3.5)))(@tsed/schema@8.3.5(@tsed/core@8.3.5)(@tsed/hooks@8.3.5)(@tsed/openspec@8.3.5))(@types/multer@1.4.12)(body-parser@1.20.3)(cross-env@7.0.0)(multer@1.4.4)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -960,7 +960,7 @@ importers:
         version: 6.1.4(@tsed/platform-http@8.3.5(@tsed/engines@8.3.5)(@tsed/logger@7.0.1)(@tsed/openspec@8.3.5))(@tsed/swagger@8.3.5(@tsed/platform-http@8.3.5(@tsed/engines@8.3.5)(@tsed/logger@7.0.1)(@tsed/openspec@8.3.5)))
       '@tsed/common':
         specifier: '=8.3.5'
-        version: 8.3.5(@tsed/engines@8.3.5)(@tsed/logger-file@6.7.8(@tsed/logger@7.0.1))(@tsed/logger@7.0.1)(@tsed/openspec@8.3.5)
+        version: 8.3.5(@tsed/engines@8.3.5)(@tsed/logger-file@7.0.1(@tsed/logger@7.0.1))(@tsed/logger@7.0.1)(@tsed/openspec@8.3.5)
       '@tsed/components-scan':
         specifier: '=8.3.5'
         version: 8.3.5(@tsed/core@8.3.5)
@@ -979,6 +979,12 @@ importers:
       '@tsed/json-mapper':
         specifier: '=8.3.5'
         version: 8.3.5(@tsed/core@8.3.5)(@tsed/schema@8.3.5(@tsed/core@8.3.5)(@tsed/hooks@8.3.5)(@tsed/openspec@8.3.5))
+      '@tsed/logger':
+        specifier: '>=7.0.1'
+        version: 7.0.1
+      '@tsed/logger-file':
+        specifier: '>=7.0.1'
+        version: 7.0.1(@tsed/logger@7.0.1)
       '@tsed/platform-express':
         specifier: '=8.3.5'
         version: 8.3.5(@tsed/core@8.3.5)(@tsed/di@8.3.5(@tsed/core@8.3.5)(@tsed/hooks@8.3.5)(@tsed/logger@7.0.1)(@tsed/schema@8.3.5(@tsed/core@8.3.5)(@tsed/hooks@8.3.5)(@tsed/openspec@8.3.5)))(@tsed/json-mapper@8.3.5(@tsed/core@8.3.5)(@tsed/schema@8.3.5(@tsed/core@8.3.5)(@tsed/hooks@8.3.5)(@tsed/openspec@8.3.5)))(@tsed/logger@7.0.1)(@tsed/openspec@8.3.5)(@tsed/platform-http@8.3.5(@tsed/engines@8.3.5)(@tsed/logger@7.0.1)(@tsed/openspec@8.3.5))(@tsed/platform-views@8.3.5(@tsed/core@8.3.5)(@tsed/di@8.3.5(@tsed/core@8.3.5)(@tsed/hooks@8.3.5)(@tsed/logger@7.0.1)(@tsed/schema@8.3.5(@tsed/core@8.3.5)(@tsed/hooks@8.3.5)(@tsed/openspec@8.3.5)))(@tsed/engines@8.3.5)(@tsed/exceptions@8.3.5(@tsed/core@8.3.5))(@tsed/schema@8.3.5(@tsed/core@8.3.5)(@tsed/hooks@8.3.5)(@tsed/openspec@8.3.5)))(@tsed/schema@8.3.5(@tsed/core@8.3.5)(@tsed/hooks@8.3.5)(@tsed/openspec@8.3.5))(@types/multer@1.4.12)(body-parser@1.20.3)(cross-env@7.0.0)(multer@1.4.4)
@@ -4598,10 +4604,10 @@ packages:
       '@tsed/core': 8.3.5
       '@tsed/schema': 8.3.5
 
-  '@tsed/logger-file@6.7.8':
-    resolution: {integrity: sha512-xOZtTia2ipZRSdaRcOeCSajfYHV+FvTxvtmtiu1gP9l7tvtsAS7TZ3e6XY0LsFZdv/3Eor7n1jVdaEKZYznMwA==}
+  '@tsed/logger-file@7.0.1':
+    resolution: {integrity: sha512-F2eDpqMMXi3rcUUhORrbLoLzIML7r9hb2eBqTQcmbv5C6+teAhBmgyyPj5kuQvYDyA7ZXLAVsZs1DvKogvvgxA==}
     peerDependencies:
-      '@tsed/logger': 6.7.8
+      '@tsed/logger': 7.0.1
 
   '@tsed/logger@5.17.0':
     resolution: {integrity: sha512-co8DdRgtQaisudEQFP2/7y/ji9bnB9QrJYfEr0SEqdHIBJdwuq8joo2vyfOY8ht/w5LOcqo2NVebtwULSsD9Pg==}
@@ -18546,10 +18552,10 @@ snapshots:
       - walrus
       - whiskers
 
-  '@tsed/common@8.3.5(@tsed/engines@8.3.5)(@tsed/logger-file@6.7.8(@tsed/logger@7.0.1))(@tsed/logger@7.0.1)(@tsed/openspec@8.3.5)':
+  '@tsed/common@8.3.5(@tsed/engines@8.3.5)(@tsed/logger-file@7.0.1(@tsed/logger@7.0.1))(@tsed/logger@7.0.1)(@tsed/openspec@8.3.5)':
     dependencies:
       '@tsed/logger': 7.0.1
-      '@tsed/logger-file': 6.7.8(@tsed/logger@7.0.1)
+      '@tsed/logger-file': 7.0.1(@tsed/logger@7.0.1)
       '@tsed/platform-http': 8.3.5(@tsed/engines@8.3.5)(@tsed/logger@7.0.1)(@tsed/openspec@8.3.5)
       tslib: 2.7.0
     transitivePeerDependencies:
@@ -18623,7 +18629,7 @@ snapshots:
       '@tsed/schema': 8.3.5(@tsed/core@8.3.5)(@tsed/hooks@8.3.5)(@tsed/openspec@8.3.5)
       tslib: 2.7.0
 
-  '@tsed/logger-file@6.7.8(@tsed/logger@7.0.1)':
+  '@tsed/logger-file@7.0.1(@tsed/logger@7.0.1)':
     dependencies:
       '@tsed/logger': 7.0.1
       streamroller: 3.1.5
@@ -21975,7 +21981,7 @@ snapshots:
       eslint: 8.41.0
       eslint-import-resolver-node: 0.3.6
       eslint-import-resolver-typescript: 2.7.1(eslint-plugin-import@2.26.0)(eslint@8.41.0)
-      eslint-plugin-import: 2.26.0(@typescript-eslint/parser@5.59.7(eslint@8.41.0)(typescript@5.0.4))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.26.0)(eslint@8.41.0))(eslint@8.41.0)
+      eslint-plugin-import: 2.26.0(@typescript-eslint/parser@5.59.7(eslint@8.41.0)(typescript@5.0.4))(eslint-import-resolver-typescript@2.7.1)(eslint@8.41.0)
       eslint-plugin-jsx-a11y: 6.5.1(eslint@8.41.0)
       eslint-plugin-react: 7.30.1(eslint@8.41.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.41.0)
@@ -22035,7 +22041,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.7.3(@typescript-eslint/parser@5.59.7(eslint@8.41.0)(typescript@5.0.4))(eslint-import-resolver-node@0.3.6)(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.26.0)(eslint@8.41.0)):
+  eslint-module-utils@2.7.3(@typescript-eslint/parser@5.59.7(eslint@8.41.0)(typescript@5.0.4))(eslint-import-resolver-node@0.3.6)(eslint-import-resolver-typescript@2.7.1):
     dependencies:
       debug: 3.2.7
       find-up: 2.1.0
@@ -22057,7 +22063,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.26.0(@typescript-eslint/parser@5.59.7(eslint@8.41.0)(typescript@5.0.4))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.26.0)(eslint@8.41.0))(eslint@8.41.0):
+  eslint-plugin-import@2.26.0(@typescript-eslint/parser@5.59.7(eslint@8.41.0)(typescript@5.0.4))(eslint-import-resolver-typescript@2.7.1)(eslint@8.41.0):
     dependencies:
       array-includes: 3.1.5
       array.prototype.flat: 1.3.2
@@ -22065,7 +22071,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.41.0
       eslint-import-resolver-node: 0.3.6
-      eslint-module-utils: 2.7.3(@typescript-eslint/parser@5.59.7(eslint@8.41.0)(typescript@5.0.4))(eslint-import-resolver-node@0.3.6)(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.26.0)(eslint@8.41.0))
+      eslint-module-utils: 2.7.3(@typescript-eslint/parser@5.59.7(eslint@8.41.0)(typescript@5.0.4))(eslint-import-resolver-node@0.3.6)(eslint-import-resolver-typescript@2.7.1)
       has: 1.0.3
       is-core-module: 2.15.1
       is-glob: 4.0.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1335,6 +1335,9 @@ importers:
       axios:
         specifier: ^0.24.0
         version: 0.24.0
+      tslib:
+        specifier: ^2.8.0
+        version: 2.8.0
     devDependencies:
       orval:
         specifier: '=7.2.0'
@@ -21978,7 +21981,7 @@ snapshots:
       eslint: 8.41.0
       eslint-import-resolver-node: 0.3.6
       eslint-import-resolver-typescript: 2.7.1(eslint-plugin-import@2.26.0)(eslint@8.41.0)
-      eslint-plugin-import: 2.26.0(@typescript-eslint/parser@5.59.7(eslint@8.41.0)(typescript@5.0.4))(eslint-import-resolver-typescript@2.7.1)(eslint@8.41.0)
+      eslint-plugin-import: 2.26.0(@typescript-eslint/parser@5.59.7(eslint@8.41.0)(typescript@5.0.4))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.26.0)(eslint@8.41.0))(eslint@8.41.0)
       eslint-plugin-jsx-a11y: 6.5.1(eslint@8.41.0)
       eslint-plugin-react: 7.30.1(eslint@8.41.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.41.0)
@@ -22038,7 +22041,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.7.3(@typescript-eslint/parser@5.59.7(eslint@8.41.0)(typescript@5.0.4))(eslint-import-resolver-node@0.3.6)(eslint-import-resolver-typescript@2.7.1):
+  eslint-module-utils@2.7.3(@typescript-eslint/parser@5.59.7(eslint@8.41.0)(typescript@5.0.4))(eslint-import-resolver-node@0.3.6)(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.26.0)(eslint@8.41.0)):
     dependencies:
       debug: 3.2.7
       find-up: 2.1.0
@@ -22060,7 +22063,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.26.0(@typescript-eslint/parser@5.59.7(eslint@8.41.0)(typescript@5.0.4))(eslint-import-resolver-typescript@2.7.1)(eslint@8.41.0):
+  eslint-plugin-import@2.26.0(@typescript-eslint/parser@5.59.7(eslint@8.41.0)(typescript@5.0.4))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.26.0)(eslint@8.41.0))(eslint@8.41.0):
     dependencies:
       array-includes: 3.1.5
       array.prototype.flat: 1.3.2
@@ -22068,7 +22071,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.41.0
       eslint-import-resolver-node: 0.3.6
-      eslint-module-utils: 2.7.3(@typescript-eslint/parser@5.59.7(eslint@8.41.0)(typescript@5.0.4))(eslint-import-resolver-node@0.3.6)(eslint-import-resolver-typescript@2.7.1)
+      eslint-module-utils: 2.7.3(@typescript-eslint/parser@5.59.7(eslint@8.41.0)(typescript@5.0.4))(eslint-import-resolver-node@0.3.6)(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.26.0)(eslint@8.41.0))
       has: 1.0.3
       is-core-module: 2.15.1
       is-glob: 4.0.3


### PR DESCRIPTION
## 背景
pdf-converter で pdf 変換を実行した時に tsed の logger が tsed/common から読み込めないエラーが生じる。

```
this.logger.error('Failed to convert html to pdf', err);
^

TypeError: Cannot read properties of undefined (reading 'error')
at PdfConvertService.readHtmlAndConvertToPdfUntilFinish 
```

(おそらく https://github.com/weseek/growi/pull/9535 の変更でパッケージ解決の方法が変わった

## 解決方法
最新の logger の使用方法としては個別にパッケージをインストールし、tsed/logger から直接 import するというものが提示されていたため、そちらに倣って修正。
https://tsed.dev/docs/logger.html

## task
https://redmine.weseek.co.jp/issues/160491