### PR TITLE
configure bulk export shared volume in dockerfile

### DIFF
--- a/apps/app/docker/Dockerfile
+++ b/apps/app/docker/Dockerfile
@@ -71,6 +71,9 @@ ENV NODE_ENV="production"
 ENV optDir=/opt
 ENV appDir=${optDir}/growi
 
+# create shared directory for bulk export and set permission
+RUN mkdir -p /tmp/page-bulk-export && chown -R node:node /tmp/page-bulk-export && chmod 700 /tmp/page-bulk-export
+
 # Add gosu
 # see: https://github.com/tianon/gosu/blob/1.13/INSTALL.md
 RUN set -eux; \

--- a/apps/app/docker/Dockerfile
+++ b/apps/app/docker/Dockerfile
@@ -71,9 +71,6 @@ ENV NODE_ENV="production"
 ENV optDir=/opt
 ENV appDir=${optDir}/growi
 
-# create shared directory for bulk export and set permission
-RUN mkdir -p /tmp/page-bulk-export && chown -R node:node /tmp/page-bulk-export && chmod 700 /tmp/page-bulk-export
-
 # Add gosu
 # see: https://github.com/tianon/gosu/blob/1.13/INSTALL.md
 RUN set -eux; \

--- a/apps/app/docker/docker-entrypoint.sh
+++ b/apps/app/docker/docker-entrypoint.sh
@@ -7,8 +7,12 @@ mkdir -p /data/uploads
 if [ ! -e "./public/uploads" ]; then
   ln -s /data/uploads ./public/uploads
 fi
-
 chown -R node:node /data/uploads
 chown -h node:node ./public/uploads
+
+# Set permissions for shared directory for bulk export
+mkdir -p /tmp/page-bulk-export
+chown -R node:node /tmp/page-bulk-export
+chmod 700 /tmp/page-bulk-export
 
 exec gosu node /bin/bash -c "$@"

--- a/apps/pdf-converter/docker/Dockerfile
+++ b/apps/pdf-converter/docker/Dockerfile
@@ -81,4 +81,3 @@ WORKDIR ${appDir}/apps/pdf-converter
 EXPOSE 3010
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
-CMD ["node", "dist/index.js"]

--- a/apps/pdf-converter/docker/Dockerfile
+++ b/apps/pdf-converter/docker/Dockerfile
@@ -62,9 +62,6 @@ ENV LANG="ja_JP.UTF-8"
 ENV optDir="/opt"
 ENV appDir="${optDir}/pdf-converter"
 
-# create shared directory for bulk export and set permission
-RUN mkdir -p /tmp/page-bulk-export && chown -R node:node /tmp/page-bulk-export && chmod 700 /tmp/page-bulk-export
-
 RUN apt-get update && apt-get install -y chromium fonts-lato fonts-ipafont-gothic fonts-noto-cjk \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*;
@@ -76,6 +73,8 @@ COPY --from=builder --chown=node:node \
 USER node
 WORKDIR ${appDir}
 RUN tar -xf packages.tar.gz && rm packages.tar.gz
+
+COPY --chown=node:node --chmod=700 apps/pdf-converter/docker/docker-entrypoint.sh /
 
 WORKDIR ${appDir}/apps/pdf-converter
 

--- a/apps/pdf-converter/docker/Dockerfile
+++ b/apps/pdf-converter/docker/Dockerfile
@@ -80,4 +80,5 @@ WORKDIR ${appDir}/apps/pdf-converter
 
 EXPOSE 3010
 
+ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["node", "dist/index.js"]

--- a/apps/pdf-converter/docker/Dockerfile
+++ b/apps/pdf-converter/docker/Dockerfile
@@ -34,6 +34,7 @@ COPY . .
 RUN pnpm install ---frozen-lockfile
 
 # build
+RUN turbo run clean
 RUN turbo run build --filter @growi/pdf-converter
 
 # make artifacts
@@ -60,6 +61,9 @@ ENV LANG="ja_JP.UTF-8"
 
 ENV optDir="/opt"
 ENV appDir="${optDir}/pdf-converter"
+
+# create shared directory for bulk export and set permission
+RUN mkdir -p /tmp/page-bulk-export && chown -R node:node /tmp/page-bulk-export && chmod 700 /tmp/page-bulk-export
 
 RUN apt-get update && apt-get install -y chromium fonts-lato fonts-ipafont-gothic fonts-noto-cjk \
     && apt-get clean \

--- a/apps/pdf-converter/docker/docker-entrypoint.sh
+++ b/apps/pdf-converter/docker/docker-entrypoint.sh
@@ -7,4 +7,4 @@ mkdir -p /tmp/page-bulk-export
 chown -R node:node /tmp/page-bulk-export
 chmod 700 /tmp/page-bulk-export
 
-exec /bin/bash -c "$@"
+node dist/index.js

--- a/apps/pdf-converter/docker/docker-entrypoint.sh
+++ b/apps/pdf-converter/docker/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -e
+
+# Set permissions for shared directory for bulk export
+mkdir -p /tmp/page-bulk-export
+chown -R node:node /tmp/page-bulk-export
+chmod 700 /tmp/page-bulk-export
+
+exec /bin/bash -c "$@"


### PR DESCRIPTION
prod 環境だと bulk export 用の shared volume のパーミッションを app, pdf-converter それぞれで設定しないと書き込みができないため、それぞれの Dockerfile 内で実施

## task
https://redmine.weseek.co.jp/rb/taskboards/1287