### PR TITLE
feat: Enable learning when a RESTRICTED page is accessed via its exact path

### DIFF
--- a/apps/app/src/features/openai/server/services/openai.ts
+++ b/apps/app/src/features/openai/server/services/openai.ts
@@ -408,6 +408,7 @@ class OpenaiService implements IOpenaiService {
       objectMode: true,
       async transform(chunk: HydratedDocument<PageDocument>[], encoding, callback) {
         try {
+          logger.debug('Search results of page paths', chunk.map(page => page.path));
           await createVectorStoreFile(vectorStoreRelation, chunk);
           this.push(chunk);
           callback();

--- a/apps/app/src/features/openai/server/services/openai.ts
+++ b/apps/app/src/features/openai/server/services/openai.ts
@@ -429,7 +429,7 @@ class OpenaiService implements IOpenaiService {
   ): Promise<mongoose.FilterQuery<PageDocument>> {
     const converterdPagePatgPatterns = convertPathPatternsToRegExp(pagePathPatterns);
 
-    // “Anyone with the link” If the page is specified directly, it is subject to learning
+    // Include pages in search targets when their paths with 'Anyone with the link' permission are directly specified instead of using glob pattern
     const nonGrabPagePathPatterns = pagePathPatterns.filter(pagePathPattern => !isGrobPatternPath(pagePathPattern));
     const baseCondition: mongoose.FilterQuery<PageDocument> = {
       grant: PageGrant.GRANT_RESTRICTED,


### PR DESCRIPTION
# Task
- [#159151](https://redmine.weseek.co.jp/issues/159151) [GROWI AI Next][特化型アシスタント] 新規作成モーダルから作成ボタンをクリックした時アシスタントデータが作成される
  - [#160518](https://redmine.weseek.co.jp/issues/160518) 「リンクを知っている人」の権限がついているページを直接指定した場合はそれをクエリに含められるようにする