### PR TITLE
feat: Add error handling for data migration

### DIFF
--- a/bin/data-migrations/src/index.js
+++ b/bin/data-migrations/src/index.js
@@ -36,6 +36,11 @@ pagesCollection.find({}).forEach((doc) => {
   if (doc.revision) {
     try {
       var revision = revisionsCollection.findOne({ _id: doc.revision });
+
+      if (revision == null || revision.body == null) {
+        return;
+      }
+
       var replacedBody = replaceLatestRevisions(revision.body, [...migrationModules]);
       var operation = {
         updateOne: {


### PR DESCRIPTION
# Task
- [#160696](https://redmine.weseek.co.jp/issues/160696) MongoDB 内に意図しない page や revision のデータが存在する時に、途中で data migration の実行が止まってしまい、処理が継続できない
  - [#160698](https://redmine.weseek.co.jp/issues/160698) 修正