### PR TITLE
support(jsdoc): add swagger document to markdown-setting.js

### DIFF
--- a/apps/app/src/server/routes/apiv3/markdown-setting.js
+++ b/apps/app/src/server/routes/apiv3/markdown-setting.js
@@ -37,6 +37,37 @@ const validator = {
  *
  *  components:
  *    schemas:
+ *      MarkdownParams:
+ *        description: MarkdownParams
+ *        type: object
+ *        properties:
+ *          isEnabledLinebreaks:
+ *            type: boolean
+ *            description: enable lineBreak
+ *          isEnabledLinebreaksInComments:
+ *            type: boolean
+ *            description: enable lineBreak in comment
+ *          adminPreferredIndentSize:
+ *            type: number
+ *            description: preferred indent size
+ *          isIndentSizeForced:
+ *            type: boolean
+ *            description: force indent size
+ *          isEnabledXss:
+ *            type: boolean
+ *            description: enable xss
+ *          xssOption:
+ *            type: number
+ *            description: number of xss option
+ *          tagWhitelist:
+ *            type: array
+ *            description: array of tag whitelist
+ *            items:
+ *              type: string
+ *              description: tag whitelist
+ *          attrWhitelist:
+ *            type: string
+ *            description: attr whitelist
  *      LineBreakParams:
  *        description: LineBreakParams
  *        type: object
@@ -61,7 +92,7 @@ const validator = {
  *        description: XssParams
  *        type: object
  *        properties:
- *          isEnabledPrevention:
+ *          isEnabledXss:
  *            type: boolean
  *            description: enable xss
  *          xssOption:
@@ -74,11 +105,18 @@ const validator = {
  *              type: string
  *              description: tag whitelist
  *          attrWhitelist:
- *            type: array
- *            description: array of attr whitelist
- *            items:
- *              type: string
- *              description: attr whitelist
+ *            type: string
+ *            description: attr whitelist
+ *      IndentParams:
+ *        description: IndentParams
+ *        type: object
+ *        properties:
+ *          adminPreferredIndentSize:
+ *            type: number
+ *            description: preferred indent size
+ *          isIndentSizeForced:
+ *            type: boolean
+ *            description: force indent size
  */
 
 module.exports = (crowi) => {
@@ -94,9 +132,10 @@ module.exports = (crowi) => {
    *    /markdown-setting:
    *      get:
    *        tags: [MarkDownSetting]
+   *        security:
+   *          - cookieAuth: []
    *        operationId: getMarkdownSetting
-   *        summary: /markdown-setting
-   *        description: Get markdown parameters
+   *        summary: Get markdown parameters
    *        responses:
    *          200:
    *            description: params of markdown
@@ -107,6 +146,7 @@ module.exports = (crowi) => {
    *                    markdownParams:
    *                      type: object
    *                      description: markdown params
+   *                      $ref: '#/components/schemas/MarkdownParams'
    */
   router.get('/', loginRequiredStrictly, adminRequired, async(req, res) => {
     const markdownParams = {
@@ -129,9 +169,10 @@ module.exports = (crowi) => {
    *    /markdown-setting/lineBreak:
    *      put:
    *        tags: [MarkDownSetting]
+   *        security:
+   *          - cookieAuth: []
    *        operationId: updateLineBreakMarkdownSetting
-   *        summary: /markdown-setting/lineBreak
-   *        description: Update lineBreak setting
+   *        summary: Update lineBreak setting
    *        requestBody:
    *          required: true
    *          content:
@@ -144,7 +185,11 @@ module.exports = (crowi) => {
    *            content:
    *              application/json:
    *                schema:
-  *                   $ref: '#/components/schemas/LineBreakParams'
+   *                  type: object
+   *                  properties:
+   *                    lineBreaksParams:
+   *                      type: object
+   *                      $ref: '#/components/schemas/LineBreakParams'
    */
   router.put('/lineBreak', loginRequiredStrictly, adminRequired, addActivity, validator.lineBreak, apiV3FormValidator, async(req, res) => {
 
@@ -173,6 +218,35 @@ module.exports = (crowi) => {
 
   });
 
+  /**
+   * @swagger
+   *
+   *    /markdown-setting/indent:
+   *      put:
+   *        tags: [MarkDownSetting]
+   *        security:
+   *          - cookieAuth: []
+   *        operationId: updateIndentMarkdownSetting
+   *        summary: Update indent setting
+   *        requestBody:
+   *          required: true
+   *          content:
+   *            application/json:
+   *              schema:
+   *                $ref: '#/components/schemas/IndentParams'
+   *        responses:
+   *          200:
+   *            description: Succeeded to update indent setting
+   *            content:
+   *              application/json:
+   *                schema:
+   *                  type: object
+   *                  properties:
+   *                    indentParams:
+   *                      type: object
+   *                      description: indent params
+   *                      $ref: '#/components/schemas/IndentParams'
+   */
   router.put('/indent', loginRequiredStrictly, adminRequired, addActivity, validator.indent, apiV3FormValidator, async(req, res) => {
 
     const requestIndentParams = {
@@ -206,8 +280,10 @@ module.exports = (crowi) => {
    *    /markdown-setting/xss:
    *      put:
    *        tags: [MarkDownSetting]
+   *        security:
+   *          - cookieAuth: []
    *        operationId: updateXssMarkdownSetting
-   *        summary: /markdown-setting/xss
+   *        summary: Update XSS setting
    *        description: Update xss
    *        requestBody:
    *          required: true


### PR DESCRIPTION
- GET /_api/v3/markdown-setting/
- PUT /_api/v3/markdown-setting/lineBreak
- PUT /_api/v3/markdown-setting/indent
- PUT /_api/v3/markdown-setting/xss
