### PR TITLE
imprv: Make data migration type safe

### DIFF
--- a/bin/data-migrations/src/index.js
+++ b/bin/data-migrations/src/index.js
@@ -5,13 +5,14 @@
 /**
  * @typedef {import('./types').MigrationModule} MigrationModule
  * @typedef {import('./types').ReplaceLatestRevisions} ReplaceLatestRevisions
+ * @typedef {import('./types').Operatioins } Operations
  */
 
 var pagesCollection = db.getCollection('pages');
 var revisionsCollection = db.getCollection('revisions');
 
-var batchSize = process.env.BATCH_SIZE ?? 100; // default 100 revisions in 1 bulkwrite
-var batchSizeInterval = process.env.BATCH_INTERVAL ?? 3000; // default 3 sec
+var batchSize = Number(process.env.BATCH_SIZE ?? 100); // default 100 revisions in 1 bulkwrite
+var batchSizeInterval = Number(process.env.BATCH_INTERVAL ?? 3000); // default 3 sec
 
 var migrationModule = process.env.MIGRATION_MODULE;
 
@@ -31,8 +32,9 @@ function replaceLatestRevisions(body, migrationModules) {
   return replacedBody;
 }
 
+/** @type {Operations} */
 var operations = [];
-pagesCollection.find({}).forEach((doc) => {
+pagesCollection.find({}).forEach((/** @type {any} */ doc) => {
   if (doc.revision) {
     try {
       var revision = revisionsCollection.findOne({ _id: doc.revision });

--- a/bin/data-migrations/src/migrations/custom.js
+++ b/bin/data-migrations/src/migrations/custom.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {import('../../types').MigrationModule} MigrationModule
+ * @typedef {import('../types').MigrationModule} MigrationModule
  */
 
 module.exports = [

--- a/bin/data-migrations/src/types.d.ts
+++ b/bin/data-migrations/src/types.d.ts
@@ -1,2 +1,18 @@
 export type MigrationModule = (body: string) => string;
 export type ReplaceLatestRevisions = (body: string, migrationModules: MigrationModule[]) => string;
+
+export type Operatioins = Array<
+  {
+    updateOne: {
+      filter: { _id: string }
+      update: { $set: { body: string }}
+    }
+  }
+>
+
+export declare global {
+  const db;
+  const sleep;
+
+  function print(arg: string): void;
+}

--- a/bin/data-migrations/tsconfig.json
+++ b/bin/data-migrations/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json.schemastore.org/tsconfig",
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "checkJs": true,
+    "strict": true,
+  }
+}


### PR DESCRIPTION
# Task
- [#160696](https://redmine.weseek.co.jp/issues/160696) MongoDB 内に意図しない page や revision のデータが存在する時に、途中で data migration の実行が止まってしまい、処理が継続できない
  -  [#160722](https://redmine.weseek.co.jp/issues/160722) bin/data-migrations/src/index.js を type safe にする