### PR TITLE
fix: drawio-viewer style (box-sizing)

### DIFF
--- a/packages/remark-drawio/src/components/DrawioViewer.module.scss
+++ b/packages/remark-drawio/src/components/DrawioViewer.module.scss
@@ -3,3 +3,7 @@
   border: 1px solid transparent;
   border-radius: 4px;
 }
+
+.drawio-viewer * {
+  box-sizing: content-box;
+}


### PR DESCRIPTION
DrawioViewer内の要素については `box-sizing: content-box;` にすることで、コンテンツ領域が潰れて表示が崩れる現象を防ぐ。

Issue #9593 の修正。

fix #9593