### PR TITLE
support: Display brand logo when editor mode

### DIFF
--- a/apps/app/src/client/components/Sidebar/AppTitle/AppTitle.module.scss
+++ b/apps/app/src/client/components/Sidebar/AppTitle/AppTitle.module.scss
@@ -5,21 +5,6 @@
 
 // GROWI Logo
 .grw-app-title :global {
-  .grw-logo {
-    $width: var.$grw-sidebar-nav-width;
-    $height: var.$grw-sidebar-nav-width; // declare $height with the same value as the sidebar nav width
-    $logomark-width: 27.7px;
-    $logomark-height: 24px;
-
-    width: $width;
-
-    svg {
-      width: $width;
-      height: $height;
-      padding: (($height - $logomark-height) / 2) (($width - $logomark-width) / 2);
-    }
-  }
-
   .confidential-tooltip {
     max-width: 180px;
   }

--- a/apps/app/src/client/components/Sidebar/AppTitle/AppTitle.tsx
+++ b/apps/app/src/client/components/Sidebar/AppTitle/AppTitle.tsx
@@ -23,6 +23,7 @@ const AppTitleSubstance = memo((props: Props): JSX.Element => {
   const { data: confidential } = useConfidential();
 
   return (
+    // TODO: https://redmine.weseek.co.jp/issues/145184
     <div className={`${styles['grw-app-title']} ${className} d-flex d-edit-none`}>
       {/* Brand Logo  */}
       <Link href="/" className="grw-logo d-block">

--- a/apps/app/src/client/components/Sidebar/SidebarBrandLogo.module.scss
+++ b/apps/app/src/client/components/Sidebar/SidebarBrandLogo.module.scss
@@ -1,0 +1,19 @@
+@use '~/styles/variables' as var;
+
+// GROWI Logo
+.grw-logo {
+  $width: var.$grw-sidebar-nav-width;
+  $height: var.$grw-sidebar-nav-width;
+  $logomark-width: 27.7px;
+  $logomark-height: 24px;
+
+  width: $width;
+
+  :global {
+    svg {
+      width: $width;
+      height: $height;
+      padding: (($height - $logomark-height) / 2) (($width - $logomark-width) / 2);
+    }
+  }
+}

--- a/apps/app/src/client/components/Sidebar/SidebarBrandLogo.tsx
+++ b/apps/app/src/client/components/Sidebar/SidebarBrandLogo.tsx
@@ -2,6 +2,8 @@ import { memo } from 'react';
 
 import GrowiLogo from '../../../components/Common/GrowiLogo';
 
+import styles from './SidebarBrandLogo.module.scss';
+
 type SidebarBrandLogoProps = {
   isDefaultLogo?: boolean
 }
@@ -10,7 +12,7 @@ export const SidebarBrandLogo = memo((props: SidebarBrandLogoProps) => {
   const { isDefaultLogo } = props;
 
   return isDefaultLogo
-    ? <GrowiLogo />
+    ? <div className={styles['grw-logo']}><GrowiLogo /></div>
     // eslint-disable-next-line @next/next/no-img-element
     : (<div><img src="/attachment/brand-logo" alt="custom logo" className="picture picture-lg p-2" id="settingBrandLogo" /></div>);
 });

--- a/apps/app/src/client/components/Sidebar/SidebarHead/SidebarHead.module.scss
+++ b/apps/app/src/client/components/Sidebar/SidebarHead/SidebarHead.module.scss
@@ -25,3 +25,12 @@
     );
   }
 }
+
+// == Editor mode logo
+@include bs.media-breakpoint-down(xl) {
+  .grw-sidebar-head :global {
+    .grw-editor-logo {
+      visibility: hidden;
+    }
+  }
+}

--- a/apps/app/src/client/components/Sidebar/SidebarHead/SidebarHead.tsx
+++ b/apps/app/src/client/components/Sidebar/SidebarHead/SidebarHead.tsx
@@ -2,15 +2,35 @@ import React, {
   type FC, memo,
 } from 'react';
 
+import Link from 'next/link';
+
+import { useIsDefaultLogo } from '~/stores-universal/context';
+import { EditorMode, useEditorMode } from '~/stores-universal/ui';
+
+
+import { SidebarBrandLogo } from '../SidebarBrandLogo';
+
 import { ToggleCollapseButton } from './ToggleCollapseButton';
 
 import styles from './SidebarHead.module.scss';
 
 
 export const SidebarHead: FC = memo(() => {
+  const { data: editorMode } = useEditorMode();
+  const { data: isDefaultLogo } = useIsDefaultLogo();
   return (
     <div className={`${styles['grw-sidebar-head']} d-flex justify-content-end w-100`}>
-      <ToggleCollapseButton />
+      {editorMode === EditorMode.Editor ? (
+        <Link
+          href="/"
+          className="p-2"
+          data-testid="btn-brand-logo"
+        >
+          <SidebarBrandLogo isDefaultLogo={isDefaultLogo} />
+        </Link>
+      ) : (
+        <ToggleCollapseButton />
+      )}
     </div>
   );
 

--- a/apps/app/src/client/components/Sidebar/SidebarHead/SidebarHead.tsx
+++ b/apps/app/src/client/components/Sidebar/SidebarHead/SidebarHead.tsx
@@ -23,7 +23,7 @@ export const SidebarHead: FC = memo(() => {
       {editorMode === EditorMode.Editor ? (
         <Link
           href="/"
-          className="p-2"
+          className="grw-editor-logo p-2"
           data-testid="btn-brand-logo"
         >
           <SidebarBrandLogo isDefaultLogo={isDefaultLogo} />

--- a/apps/app/src/client/components/Sidebar/SidebarHead/SidebarHead.tsx
+++ b/apps/app/src/client/components/Sidebar/SidebarHead/SidebarHead.tsx
@@ -23,7 +23,7 @@ export const SidebarHead: FC = memo(() => {
       {editorMode === EditorMode.Editor ? (
         <Link
           href="/"
-          className="grw-editor-logo p-2"
+          className="grw-editor-logo"
           data-testid="btn-brand-logo"
         >
           <SidebarBrandLogo isDefaultLogo={isDefaultLogo} />

--- a/apps/app/src/components/Common/GrowiLogo.module.scss
+++ b/apps/app/src/components/Common/GrowiLogo.module.scss
@@ -1,4 +1,6 @@
 @use '@growi/core-styles/scss/variables/growi-official-colors';
+@use '~/styles/mixins';
+@use '@growi/core-styles/scss/bootstrap/init' as bs;
 
 // == Colors
 .grw-logo :global {
@@ -24,3 +26,18 @@
   }
 }
 
+// == Editor mode
+@include mixins.at-editing() {
+  @include bs.media-breakpoint-up(xl) {
+    .grw-logo {
+      &:global {
+        opacity: 0.5;
+        transition: opacity 0.8s ease;
+
+        &:hover {
+          opacity: 1;
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Task
https://redmine.weseek.co.jp/issues/160589

# Summary
* エディタモード時に左上にブランドロゴを表示
* lg以下でサイドバーを開いた時にロゴとAppTitleを表示させるタスクは別ストーリーで対応
  - https://redmine.weseek.co.jp/issues/145184
- AppTitle とロゴの見た目を揃えるため、AppTitle.module.scss に記述してあった、`.grw-logo`のサイズ・パディング設定を SidebarBrandLogo.module.scss に移行

# Screenshot
<img width="1027" alt="スクリーンショット 2025-01-29 14 47 13" src="https://github.com/user-attachments/assets/16db2e00-61f2-4157-a8c1-9b6303837b8d" />
<img width="1027" alt="image" src="https://github.com/user-attachments/assets/c38ee466-c6f5-4f66-bde3-3d54d9cac177" />