### PR TITLE
fix: Data migration script for CSV and TSV

### DIFF
--- a/bin/data-migrations/src/migrations/v60x/csv.js
+++ b/bin/data-migrations/src/migrations/v60x/csv.js
@@ -7,7 +7,7 @@ module.exports = [
    * @type {MigrationModule}
    */
   (body) => {
-    const oldCsvTableRegExp = /::: csv(-h)?\n([\s\S]*?)\n:::/g; // CSV old format
+    const oldCsvTableRegExp = /:::\s?csv(-h)?\n([\s\S]*?)\n:::/g; // CSV old format
     return body.replace(oldCsvTableRegExp, '``` csv$1\n$2\n```');
   },
 ];

--- a/bin/data-migrations/src/migrations/v60x/tsv.js
+++ b/bin/data-migrations/src/migrations/v60x/tsv.js
@@ -7,7 +7,7 @@ module.exports = [
    * @type {MigrationModule}
    */
   (body) => {
-    const oldTsvTableRegExp = /::: tsv(-h)?\n([\s\S]*?)\n:::/g; // TSV old format
+    const oldTsvTableRegExp = /:::\s?tsv(-h)?\n([\s\S]*?)\n:::/g; // TSV old format
     return body.replace(oldTsvTableRegExp, '``` tsv$1\n$2\n```');
   },
 ];


### PR DESCRIPTION
# Task
- [#161642](https://redmine.weseek.co.jp/issues/161642) csv, tsv の data-migration において ::: 直後にスペースが入っていない場合置換されない
  - [#161572](https://redmine.weseek.co.jp/issues/161572) 修正
