### PR TITLE
fix: Redirection after login does not work on systems with guest mode enabled

### DIFF
--- a/apps/app/src/pages/login/index.page.tsx
+++ b/apps/app/src/pages/login/index.page.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { pagePathUtils } from '@growi/core/dist/utils';
 import type {
   NextPage, GetServerSideProps, GetServerSidePropsContext,
 } from 'next';
@@ -23,6 +24,8 @@ import {
 
 import styles from './index.module.scss';
 
+
+const { isPermalink, isUserPage, isUsersTopPage } = pagePathUtils;
 
 const LoginForm = dynamic(() => import('~/client/components/LoginForm').then(mod => mod.LoginForm), { ssr: false });
 
@@ -127,7 +130,14 @@ async function injectServerConfigurations(context: GetServerSidePropsContext, pr
 export const getServerSideProps: GetServerSideProps = async(context: GetServerSidePropsContext) => {
   const result = await getServerSideCommonProps(context);
 
-  (context.req as CrowiRequest).session.redirectTo = context.req.headers.referer;
+
+  // redirect to the page the user was on before moving to the Login Page
+  if (context.req.headers.referer != null) {
+    const urlBeforeLogin = new URL(context.req.headers.referer);
+    if (isPermalink(urlBeforeLogin.pathname) || isUserPage(urlBeforeLogin.pathname) || isUsersTopPage(urlBeforeLogin.pathname)) {
+      (context.req as CrowiRequest).session.redirectTo = urlBeforeLogin.href;
+    }
+  }
 
   // check for presence
   // see: https://github.com/vercel/next.js/issues/19271#issuecomment-730006862

--- a/apps/app/src/pages/login/index.page.tsx
+++ b/apps/app/src/pages/login/index.page.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import { pagePathUtils } from '@growi/core/dist/utils';
 import type {
   NextPage, GetServerSideProps, GetServerSidePropsContext,
 } from 'next';
@@ -128,15 +127,7 @@ async function injectServerConfigurations(context: GetServerSidePropsContext, pr
 export const getServerSideProps: GetServerSideProps = async(context: GetServerSidePropsContext) => {
   const result = await getServerSideCommonProps(context);
 
-  const { isPermalink, isUserPage, isUsersTopPage } = pagePathUtils;
-
-  // redirect to the page the user was on before moving to the Login Page
-  if (context.req.headers.referer != null) {
-    const urlBeforeLogin = new URL(context.req.headers.referer);
-    if (isPermalink(urlBeforeLogin.pathname) || isUserPage(urlBeforeLogin.pathname) || isUsersTopPage(urlBeforeLogin.pathname)) {
-      (context.req as CrowiRequest).session.redirectTo = urlBeforeLogin.href;
-    }
-  }
+  (context.req as CrowiRequest).session.redirectTo = context.req.headers.referer;
 
   // check for presence
   // see: https://github.com/vercel/next.js/issues/19271#issuecomment-730006862

--- a/apps/app/src/pages/login/index.page.tsx
+++ b/apps/app/src/pages/login/index.page.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { pagePathUtils } from '@growi/core/dist/utils';
 import type {
   NextPage, GetServerSideProps, GetServerSidePropsContext,
 } from 'next';
@@ -127,7 +128,15 @@ async function injectServerConfigurations(context: GetServerSidePropsContext, pr
 export const getServerSideProps: GetServerSideProps = async(context: GetServerSidePropsContext) => {
   const result = await getServerSideCommonProps(context);
 
-  (context.req as CrowiRequest).session.redirectTo = context.req.headers.referer;
+  const { isPermalink, isUserPage, isUsersTopPage } = pagePathUtils;
+
+  // redirect to the page the user was on before moving to the Login Page
+  if (context.req.headers.referer != null) {
+    const urlBeforeLogin = new URL(context.req.headers.referer);
+    if (isPermalink(urlBeforeLogin.pathname) || isUserPage(urlBeforeLogin.pathname) || isUsersTopPage(urlBeforeLogin.pathname)) {
+      (context.req as CrowiRequest).session.redirectTo = urlBeforeLogin.href;
+    }
+  }
 
   // check for presence
   // see: https://github.com/vercel/next.js/issues/19271#issuecomment-730006862

--- a/apps/app/src/pages/login/index.page.tsx
+++ b/apps/app/src/pages/login/index.page.tsx
@@ -127,6 +127,8 @@ async function injectServerConfigurations(context: GetServerSidePropsContext, pr
 export const getServerSideProps: GetServerSideProps = async(context: GetServerSidePropsContext) => {
   const result = await getServerSideCommonProps(context);
 
+  (context.req as CrowiRequest).session.redirectTo = context.req.headers.referer;
+
   // check for presence
   // see: https://github.com/vercel/next.js/issues/19271#issuecomment-730006862
   if (!('props' in result)) {


### PR DESCRIPTION
# Summary
- ゲストモードが有効化されている GROWI において、ログイン後に元いたページにリダイレクトされない問題の修正

# Task
- https://redmine.weseek.co.jp/issues/160681
  - https://redmine.weseek.co.jp/issues/161831

# Note
`example.com/login#login` に遷移する前のページにリダイレクトする実装。遷移する前のページの情報は URL しか使ってないため、「permalink, /user 配下のみ」リダイレクト可能。別のサイトや empty page, /forgot-password へはリダイレクトしない。