### PR TITLE
imprv: Border color for dark mode

### DIFF
--- a/packages/preset-themes/src/styles/classic.scss
+++ b/packages/preset-themes/src/styles/classic.scss
@@ -45,7 +45,7 @@
   $body-secondary-bg-dark: $gray-800;
   $body-tertiary-color-dark: rgba($body-color-dark, .5);
   $body-tertiary-bg-dark: color.mix($gray-800, $gray-900, 50%);
-  $border-color-dark: var(--grw-highlight-200);
+  $border-color-dark: var(--grw-highlight-700);
   $link-color-dark: color.mix(#68829D, white, 80%);
 
   @import 'bootstrap/scss/variables';

--- a/packages/preset-themes/src/styles/default.scss
+++ b/packages/preset-themes/src/styles/default.scss
@@ -47,7 +47,7 @@
   $body-secondary-bg-dark: $gray-800;
   $body-tertiary-color-dark: rgba($body-color-dark, .5);
   $body-tertiary-bg-dark: color.mix($gray-800, $gray-900, 50%);
-  $border-color-dark: var(--grw-highlight-200);
+  $border-color-dark: var(--grw-highlight-800);
   $link-color-dark: $gray-500;
 
   @import 'bootstrap/scss/variables';


### PR DESCRIPTION
# Task
https://redmine.weseek.co.jp/issues/162426

# Summary
- ダークモードのborder においてコントラストが高すぎた2点のテーマの色を修正
  - default
  - classic

# Screenshot
<img width="837" alt="image" src="https://github.com/user-attachments/assets/106dbbfc-38e6-4cd2-9bb7-c2ce7b5734ca" />
<img width="642" alt="image" src="https://github.com/user-attachments/assets/c385ea9d-c4a0-4839-b335-b30fac328313" />
