### PR TITLE
feat: Show SelectedPageList in dark mode

### DIFF
--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/SelectedPageList.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/SelectedPageList.tsx
@@ -17,9 +17,9 @@ const SelectedPageListBase: React.FC<SelectedPageListProps> = ({ selectedPages, 
       {selectedPages.map(({ page, isIncludeSubPage }) => (
         <div
           key={page.path}
-          className="mb-2 d-flex justify-content-between align-items-center bg-light rounded py-2 px-3"
+          className="mb-2 d-flex justify-content-between align-items-center bg-body-tertiary rounded py-2 px-3"
         >
-          <div className="d-flex align-items-center overflow-hidden">
+          <div className="d-flex align-items-center overflow-hidden text-body">
             { isIncludeSubPage
               ? <>{`${page.path}/*`}</>
               : <>{page.path}</>
@@ -28,7 +28,7 @@ const SelectedPageListBase: React.FC<SelectedPageListProps> = ({ selectedPages, 
           {onRemove != null && page.path != null && (
             <button
               type="button"
-              className="btn p-0 ms-3 text-secondary"
+              className="btn p-0 ms-3 text-body-secondary"
               onClick={() => onRemove(page.path)}
             >
               <span className="material-symbols-outlined fs-4">delete</span>


### PR DESCRIPTION
# Task
- [#162625](https://redmine.weseek.co.jp/issues/162625) [GROWI AI Next][特化型アシスタント] 選択されているページリスト (SelectedPageList.tsx) をダークモードで表示できる
  - [#162626](https://redmine.weseek.co.jp/issues/162626) 実装

# Screenshot
## Before
<img width="543" alt="スクリーンショット 2025-03-04 11 25 44" src="https://github.com/user-attachments/assets/e1ca7a39-5ea6-47a3-8039-09b9c4f107ed" />

## After
<img width="550" alt="スクリーンショット 2025-03-04 11 24 45" src="https://github.com/user-attachments/assets/5423b61a-98ca-4c11-b1e6-211f4d8bc657" />
