### PR TITLE
fix:  Prevent GrowiPlugin from being downloaded outside the plugin directory

### DIFF
--- a/apps/app/src/features/growi-plugin/server/services/growi-plugin/growi-plugin.ts
+++ b/apps/app/src/features/growi-plugin/server/services/growi-plugin/growi-plugin.ts
@@ -435,7 +435,10 @@ export class GrowiPluginService implements IGrowiPluginService {
   private joinAndValidatePath(baseDir: string, ...paths: string[]):fs.PathLike {
     const joinedPath = path.join(baseDir, ...paths);
     if (!joinedPath.startsWith(baseDir)) {
-      throw new Error(`Invalid path: Outside of allowed directory - ${joinedPath}`);
+      throw new Error(
+        'Invalid plugin path detected! Access outside of the allowed directory is not permitted.'
+        + `\nAttempted Path: ${joinedPath}`,
+      );
     }
     return joinedPath;
   }

--- a/apps/app/src/features/growi-plugin/server/services/growi-plugin/growi-plugin.ts
+++ b/apps/app/src/features/growi-plugin/server/services/growi-plugin/growi-plugin.ts
@@ -402,6 +402,14 @@ export class GrowiPluginService implements IGrowiPluginService {
     return entries;
   }
 
+  private joinAndValidatePath(baseDir: string, ...paths: string[]):fs.PathLike {
+    const joinedPath = path.join(baseDir, ...paths);
+    if (!joinedPath.startsWith(baseDir)) {
+      throw new Error(`Invalid path: Outside of allowed directory - ${joinedPath}`);
+    }
+    return joinedPath;
+  }
+
 }
 
 

--- a/apps/app/src/features/growi-plugin/server/services/growi-plugin/growi-plugin.ts
+++ b/apps/app/src/features/growi-plugin/server/services/growi-plugin/growi-plugin.ts
@@ -315,8 +315,16 @@ export class GrowiPluginService implements IGrowiPluginService {
       throw new Error('No plugin found for this ID.');
     }
 
+    let growiPluginsPath: fs.PathLike | undefined;
     try {
-      const growiPluginsPath = path.join(PLUGIN_STORING_PATH, growiPlugins.installedPath);
+      growiPluginsPath = this.joinAndValidatePath(PLUGIN_STORING_PATH, growiPlugins.installedPath);
+    }
+    catch (err) {
+      logger.error(err);
+      throw new Error('Failed to constract plugin path');
+    }
+
+    try {
       await deleteFolder(growiPluginsPath);
     }
     catch (err) {

--- a/apps/app/src/features/growi-plugin/server/services/growi-plugin/growi-plugin.ts
+++ b/apps/app/src/features/growi-plugin/server/services/growi-plugin/growi-plugin.ts
@@ -308,22 +308,21 @@ export class GrowiPluginService implements IGrowiPluginService {
       throw new Error('No plugin found for this ID.');
     }
 
+    try {
+      await GrowiPlugin.deleteOne({ _id: pluginId });
+    }
+    catch (err) {
+      logger.error(err);
+      throw new Error('Failed to delete plugin from GrowiPlugin documents.');
+    }
+
     let growiPluginsPath: fs.PathLike | undefined;
     try {
       growiPluginsPath = this.joinAndValidatePath(PLUGIN_STORING_PATH, growiPlugins.installedPath);
     }
     catch (err) {
       logger.error(err);
-
-      try {
-        await GrowiPlugin.deleteOne({ _id: pluginId });
-        logger.warn(`Deleted invalid plugin (ID: ${pluginId}) from database. Skipped directory removal.`);
-      }
-      catch (deleteErr) {
-        logger.error(deleteErr);
-        throw new Error('Failed to delete invalid plugin from GrowiPlugin documents.');
-      }
-      return growiPlugins.meta.name;
+      throw new Error('The installedPath for the plugin is invalid, and the plugin has already been removed.');
     }
 
     if (growiPluginsPath && fs.existsSync(growiPluginsPath)) {
@@ -338,15 +337,6 @@ export class GrowiPluginService implements IGrowiPluginService {
     else {
       logger.warn(`Plugin path does not exist : ${growiPluginsPath}`);
     }
-
-    try {
-      await GrowiPlugin.deleteOne({ _id: pluginId });
-    }
-    catch (err) {
-      logger.error(err);
-      throw new Error('Failed to delete plugin from GrowiPlugin documents.');
-    }
-
     return growiPlugins.meta.name;
   }
 

--- a/apps/app/src/features/growi-plugin/server/services/growi-plugin/growi-plugin.ts
+++ b/apps/app/src/features/growi-plugin/server/services/growi-plugin/growi-plugin.ts
@@ -314,7 +314,16 @@ export class GrowiPluginService implements IGrowiPluginService {
     }
     catch (err) {
       logger.error(err);
-      throw new Error('Failed to constract plugin path');
+
+      try {
+        await GrowiPlugin.deleteOne({ _id: pluginId });
+        logger.warn(`Deleted invalid plugin (ID: ${pluginId}) from database. Skipped directory removal.`);
+      }
+      catch (deleteErr) {
+        logger.error(deleteErr);
+        throw new Error('Failed to delete invalid plugin from GrowiPlugin documents.');
+      }
+      return growiPlugins.meta.name;
     }
 
     try {

--- a/apps/app/src/features/growi-plugin/server/services/growi-plugin/growi-plugin.ts
+++ b/apps/app/src/features/growi-plugin/server/services/growi-plugin/growi-plugin.ts
@@ -80,14 +80,7 @@ export class GrowiPluginService implements IGrowiPluginService {
         }
         catch (err) {
           logger.error(err);
-          try {
-            await GrowiPlugin.deleteOne({ _id: growiPlugin.id });
-          }
-          catch (deleteErr) {
-            logger.error(deleteErr);
-            throw new Error(`Failed to delete plugin from GrowiPlugin documents. Original error: ${deleteErr.message}`);
-          }
-          throw new Error('Failed to construct plugin path. The plugin document is also deleted.');
+          continue;
         }
         if (fs.existsSync(pluginPath)) {
           continue;

--- a/apps/app/src/features/growi-plugin/server/services/growi-plugin/growi-plugin.ts
+++ b/apps/app/src/features/growi-plugin/server/services/growi-plugin/growi-plugin.ts
@@ -326,12 +326,17 @@ export class GrowiPluginService implements IGrowiPluginService {
       return growiPlugins.meta.name;
     }
 
-    try {
-      await deleteFolder(growiPluginsPath);
+    if (growiPluginsPath && fs.existsSync(growiPluginsPath)) {
+      try {
+        await deleteFolder(growiPluginsPath);
+      }
+      catch (err) {
+        logger.error(err);
+        throw new Error('Failed to delete plugin repository.');
+      }
     }
-    catch (err) {
-      logger.error(err);
-      throw new Error('Failed to delete plugin repository.');
+    else {
+      logger.warn(`Plugin path does not exist : ${growiPluginsPath}`);
     }
 
     try {


### PR DESCRIPTION
# Task
- [#161423](https://redmine.weseek.co.jp/issues/161423)プラグインのinstalledPathにおけるパストラバーサル/コード実行についての問題を解決する
  - [#161554](https://redmine.weseek.co.jp/issues/161554) 修正