### PR TITLE
fix: Threads disappear on vectorstore rebuild

### DIFF
--- a/apps/app/src/features/openai/interfaces/thread-relation.ts
+++ b/apps/app/src/features/openai/interfaces/thread-relation.ts
@@ -1,10 +1,12 @@
 import type { IUser, Ref, HasObjectId } from '@growi/core';
 
+import type { AiAssistant } from './ai-assistant';
 import type { IVectorStore } from './vector-store';
 
 export interface IThreadRelation {
   userId: Ref<IUser>
   vectorStore: Ref<IVectorStore>
+  aiAssistant: Ref<AiAssistant>
   threadId: string;
   title?: string;
   expiredAt: Date;

--- a/apps/app/src/features/openai/interfaces/thread-relation.ts
+++ b/apps/app/src/features/openai/interfaces/thread-relation.ts
@@ -1,11 +1,9 @@
 import type { IUser, Ref, HasObjectId } from '@growi/core';
 
 import type { AiAssistant } from './ai-assistant';
-import type { IVectorStore } from './vector-store';
 
 export interface IThreadRelation {
   userId: Ref<IUser>
-  vectorStore: Ref<IVectorStore>
   aiAssistant: Ref<AiAssistant>
   threadId: string;
   title?: string;

--- a/apps/app/src/features/openai/server/models/thread-relation.ts
+++ b/apps/app/src/features/openai/server/models/thread-relation.ts
@@ -30,11 +30,6 @@ const schema = new Schema<ThreadRelationDocument, ThreadRelationModel>({
     ref: 'AiAssistant',
     required: true,
   },
-  vectorStore: {
-    type: Schema.Types.ObjectId,
-    ref: 'VectorStore',
-    required: true,
-  },
   threadId: {
     type: String,
     required: true,

--- a/apps/app/src/features/openai/server/models/thread-relation.ts
+++ b/apps/app/src/features/openai/server/models/thread-relation.ts
@@ -25,6 +25,11 @@ const schema = new Schema<ThreadRelationDocument, ThreadRelationModel>({
     ref: 'User',
     required: true,
   },
+  aiAssistant: {
+    type: Schema.Types.ObjectId,
+    ref: 'AiAssistant',
+    required: true,
+  },
   vectorStore: {
     type: Schema.Types.ObjectId,
     ref: 'VectorStore',

--- a/apps/app/src/features/openai/server/routes/get-threads.ts
+++ b/apps/app/src/features/openai/server/routes/get-threads.ts
@@ -48,8 +48,7 @@ export const getThreadsFactory: GetThreadsFactory = (crowi) => {
           return res.apiv3Err(new ErrorV3('The specified AI assistant is not usable'), 400);
         }
 
-        const vectorStoreRelation = await openaiService.getVectorStoreRelation(aiAssistantId);
-        const threads = await openaiService.getThreads(vectorStoreRelation._id);
+        const threads = await openaiService.getThreadsByAiAssistant(aiAssistantId);
 
         return res.apiv3({ threads });
       }

--- a/apps/app/src/features/openai/server/routes/thread.ts
+++ b/apps/app/src/features/openai/server/routes/thread.ts
@@ -51,7 +51,7 @@ export const createThreadHandlersFactory: CreateThreadFactory = (crowi) => {
         }
 
         const vectorStoreRelation = await openaiService.getVectorStoreRelation(aiAssistantId);
-        const thread = await openaiService.createThread(req.user._id, vectorStoreRelation, initialUserMessage);
+        const thread = await openaiService.createThread(req.user._id, aiAssistantId, vectorStoreRelation, initialUserMessage);
 
         return res.apiv3(thread);
       }

--- a/apps/app/src/features/openai/server/routes/thread.ts
+++ b/apps/app/src/features/openai/server/routes/thread.ts
@@ -50,8 +50,7 @@ export const createThreadHandlersFactory: CreateThreadFactory = (crowi) => {
           return res.apiv3Err(new ErrorV3('The specified AI assistant is not usable'), 400);
         }
 
-        const vectorStoreRelation = await openaiService.getVectorStoreRelation(aiAssistantId);
-        const thread = await openaiService.createThread(req.user._id, aiAssistantId, vectorStoreRelation, initialUserMessage);
+        const thread = await openaiService.createThread(req.user._id, aiAssistantId, initialUserMessage);
 
         return res.apiv3(thread);
       }

--- a/apps/app/src/features/openai/server/services/client-delegator/azure-openai-client-delegator.ts
+++ b/apps/app/src/features/openai/server/services/client-delegator/azure-openai-client-delegator.ts
@@ -33,6 +33,16 @@ export class AzureOpenaiClientDelegator implements IOpenaiClientDelegator {
     });
   }
 
+  async updateThread(threadId: string, vectorStoreId: string): Promise<OpenAI.Beta.Threads.Thread> {
+    return this.client.beta.threads.update(threadId, {
+      tool_resources: {
+        file_search: {
+          vector_store_ids: [vectorStoreId],
+        },
+      },
+    });
+  }
+
   async retrieveThread(threadId: string): Promise<OpenAI.Beta.Threads.Thread> {
     return this.client.beta.threads.retrieve(threadId);
   }

--- a/apps/app/src/features/openai/server/services/client-delegator/interfaces.ts
+++ b/apps/app/src/features/openai/server/services/client-delegator/interfaces.ts
@@ -5,6 +5,7 @@ import type { MessageListParams } from '../../../interfaces/message';
 
 export interface IOpenaiClientDelegator {
   createThread(vectorStoreId: string): Promise<OpenAI.Beta.Threads.Thread>
+  updateThread(threadId: string, vectorStoreId: string): Promise<OpenAI.Beta.Threads.Thread>
   retrieveThread(threadId: string): Promise<OpenAI.Beta.Threads.Thread>
   deleteThread(threadId: string): Promise<OpenAI.Beta.Threads.ThreadDeleted>
   getMessages(threadId: string, options?: MessageListParams): Promise<OpenAI.Beta.Threads.Messages.MessagesPage>

--- a/apps/app/src/features/openai/server/services/client-delegator/openai-client-delegator.ts
+++ b/apps/app/src/features/openai/server/services/client-delegator/openai-client-delegator.ts
@@ -38,6 +38,16 @@ export class OpenaiClientDelegator implements IOpenaiClientDelegator {
     return this.client.beta.threads.retrieve(threadId);
   }
 
+  async updateThread(threadId: string, vectorStoreId: string): Promise<OpenAI.Beta.Threads.Thread> {
+    return this.client.beta.threads.update(threadId, {
+      tool_resources: {
+        file_search: {
+          vector_store_ids: [vectorStoreId],
+        },
+      },
+    });
+  }
+
   async deleteThread(threadId: string): Promise<OpenAI.Beta.Threads.ThreadDeleted> {
     return this.client.beta.threads.del(threadId);
   }


### PR DESCRIPTION
# Task
- [#162725](https://redmine.weseek.co.jp/issues/162725) [GROWI AI Next][特化型アシスタント] VectorStore が rebuild されるタイミングで今までの thread が表示されなくなる
  - [#162726](https://redmine.weseek.co.jp/issues/162726) 修正  