### PR TITLE
fix:  Special strings displayed as sanitized

### DIFF
--- a/apps/app/src/features/openai/server/routes/middlewares/upsert-ai-assistant-validator.ts
+++ b/apps/app/src/features/openai/server/routes/middlewares/upsert-ai-assistant-validator.ts
@@ -10,20 +10,17 @@ export const upsertAiAssistantValidator: ValidationChain[] = [
     .withMessage('name must be a string')
     .not()
     .isEmpty()
-    .withMessage('name is required')
-    .escape(),
+    .withMessage('name is required'),
 
   body('description')
     .optional()
     .isString()
-    .withMessage('description must be a string')
-    .escape(),
+    .withMessage('description must be a string'),
 
   body('additionalInstruction')
     .optional()
     .isString()
-    .withMessage('additionalInstruction must be a string')
-    .escape(),
+    .withMessage('additionalInstruction must be a string'),
 
   body('pagePathPatterns')
     .isArray()


### PR DESCRIPTION
# Task
- [#162790](https://redmine.weseek.co.jp/issues/162790) [GROWI AI Next][特化型アシスタント] アシスタントの name, description, additonalInstruction を特殊文字列で登録すると、サニタイズされた文字列で表示される
  - [#162791](https://redmine.weseek.co.jp/issues/162791) 修正