### PR TITLE
fix: AiAssistantSidebar layout in smartphone mode

### DIFF
--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantChatSidebar/AiAssistantChatSidebar.module.scss
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantChatSidebar/AiAssistantChatSidebar.module.scss
@@ -3,6 +3,12 @@
 @use '@growi/ui/scss/atoms/btn-muted';
 
 .grw-ai-assistant-chat-sidebar :global {
+  z-index: bs.$zindex-fixed + 2;
+  width: 100%;
+
+  @include bs.media-breakpoint-up(sm) {
+    width: 500px;
+  }
 
   .textarea-ask {
     max-height: 30vh;

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantChatSidebar/AiAssistantChatSidebar.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantChatSidebar/AiAssistantChatSidebar.tsx
@@ -13,7 +13,6 @@ import { toastError } from '~/client/util/toastr';
 import { MessageErrorCode, StreamErrorCode } from '~/features/openai/interfaces/message-error';
 import type { IThreadRelationHasId } from '~/features/openai/interfaces/thread-relation';
 import { useGrowiCloudUri } from '~/stores-universal/context';
-import { useIsMobile } from '~/stores/ui';
 import loggerFactory from '~/utils/logger';
 
 import type { AiAssistantHasId } from '../../../../interfaces/ai-assistant';
@@ -29,8 +28,6 @@ import styles from './AiAssistantChatSidebar.module.scss';
 const logger = loggerFactory('growi:openai:client:components:AiAssistantChatSidebar');
 
 const moduleClass = styles['grw-ai-assistant-chat-sidebar'] ?? '';
-
-const RIGHT_SIDEBAR_WIDTH = 500;
 
 type Message = {
   id: string,
@@ -412,7 +409,6 @@ export const AiAssistantChatSidebar: FC = memo((): JSX.Element => {
   const sidebarScrollerRef = useRef<HTMLDivElement>(null);
 
   const { data: aiAssistantChatSidebarData, close: closeAiAssistantChatSidebar } = useAiAssistantChatSidebar();
-  const { data: isMobile } = useIsMobile();
 
   const aiAssistantData = aiAssistantChatSidebarData?.aiAssistantData;
   const threadData = aiAssistantChatSidebarData?.threadData;
@@ -438,12 +434,7 @@ export const AiAssistantChatSidebar: FC = memo((): JSX.Element => {
   return (
     <div
       ref={sidebarRef}
-      className={`position-fixed top-0 end-0 h-100 border-start bg-body shadow-sm ${moduleClass}`}
-      style={{
-        zIndex: 1500,
-        width: isMobile ? '100%' : `${RIGHT_SIDEBAR_WIDTH}px`,
-        overflow: 'hidden',
-      }}
+      className={`position-fixed top-0 end-0 h-100 border-start bg-body shadow-sm overflow-hidden ${moduleClass}`}
       data-testid="grw-right-sidebar"
     >
       <SimpleBar

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantChatSidebar/AiAssistantChatSidebar.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantChatSidebar/AiAssistantChatSidebar.tsx
@@ -13,6 +13,7 @@ import { toastError } from '~/client/util/toastr';
 import { MessageErrorCode, StreamErrorCode } from '~/features/openai/interfaces/message-error';
 import type { IThreadRelationHasId } from '~/features/openai/interfaces/thread-relation';
 import { useGrowiCloudUri } from '~/stores-universal/context';
+import { useIsMobile } from '~/stores/ui';
 import loggerFactory from '~/utils/logger';
 
 import type { AiAssistantHasId } from '../../../../interfaces/ai-assistant';
@@ -411,6 +412,7 @@ export const AiAssistantChatSidebar: FC = memo((): JSX.Element => {
   const sidebarScrollerRef = useRef<HTMLDivElement>(null);
 
   const { data: aiAssistantChatSidebarData, close: closeAiAssistantChatSidebar } = useAiAssistantChatSidebar();
+  const { data: isMobile } = useIsMobile();
 
   const aiAssistantData = aiAssistantChatSidebarData?.aiAssistantData;
   const threadData = aiAssistantChatSidebarData?.threadData;
@@ -437,7 +439,11 @@ export const AiAssistantChatSidebar: FC = memo((): JSX.Element => {
     <div
       ref={sidebarRef}
       className={`position-fixed top-0 end-0 h-100 border-start bg-body shadow-sm ${moduleClass}`}
-      style={{ zIndex: 1500, width: `${RIGHT_SIDEBAR_WIDTH}px` }}
+      style={{
+        zIndex: 1500,
+        width: isMobile ? '100%' : `${RIGHT_SIDEBAR_WIDTH}px`,
+        overflow: 'hidden',
+      }}
       data-testid="grw-right-sidebar"
     >
       <SimpleBar


### PR DESCRIPTION
# Task
- [#162735](https://redmine.weseek.co.jp/issues/162735) [GROWI AI Next][特化型アシスタント] ナレッジアシスタントのチャット画面(右サイドバー)が500px以下で左側の内容が画面外に表示されてしまう
  -  [#162826](https://redmine.weseek.co.jp/issues/162826) 修正

# Screenrecord


https://github.com/user-attachments/assets/dc86e5ce-1b55-422c-9767-ad792e8c25ec

