### PR TITLE
imprv:Replace with the correct GROWI AI icon

### DIFF
--- a/apps/app/src/client/components/Sidebar/SidebarNav/PrimaryItems.tsx
+++ b/apps/app/src/client/components/Sidebar/SidebarNav/PrimaryItems.tsx
@@ -42,7 +42,7 @@ export const PrimaryItems = memo((props: Props) => {
           sidebarMode={sidebarMode}
           contents={SidebarContentsType.AI_ASSISTANT}
           label="AI Assistant"
-          iconName="ai_assistant"
+          iconName="growi_ai"
           isCustomIcon
           onHover={onItemHover}
         />

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementHome.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementHome.tsx
@@ -115,7 +115,7 @@ export const AiAssistantManagementHome = (props: Props): JSX.Element => {
   return (
     <>
       <ModalHeader tag="h4" toggle={closeAiAssistantManagementModal} className="pe-4">
-        <span className="growi-custom-icons growi-ai-assistant-icon me-3 fs-4">ai_assistant</span>
+        <span className="growi-custom-icons growi-ai-assistant-icon me-3 fs-4">growi_ai</span>
         <span className="fw-bold">{t(shouldEdit ? 'アシスタントの更新' : '新規アシスタントの追加')}</span> {/* TODO i18n */}
       </ModalHeader>
 


### PR DESCRIPTION
# Task
https://redmine.weseek.co.jp/issues/162763

# Summary
- GROWI AI のアイコンの使い分けを正しいものへ変更
  - GROWI AI の機能(サイドバーツールアイコン、アシスタント作成・編集) => growi_ai
  - チャット画面のアイコン => assistant_ai (変更なし)

<img width="215" alt="image" src="https://github.com/user-attachments/assets/562edc7a-d8ed-4264-95c2-4fdd4e358586" />
<img width="460" alt="image" src="https://github.com/user-attachments/assets/0a6efe39-936a-4ac2-a69f-73adfa08c1ee" />

