### PR TITLE
fix: Fix layout when safari browse

### DIFF
--- a/apps/app/src/client/components/Bookmarks/BookmarkFolderMenuItem.tsx
+++ b/apps/app/src/client/components/Bookmarks/BookmarkFolderMenuItem.tsx
@@ -10,7 +10,7 @@ export const BookmarkFolderMenuItem: React.FC<{
   isSelected,
 }) => {
   return (
-    <div className="d-flex justify-content-start grw-bookmark-folder-menu-item-title">
+    <div className="d-flex align-items-center grw-bookmark-folder-menu-item-title">
       <input
         type="radio"
         checked={isSelected}


### PR DESCRIPTION
# Task
https://redmine.weseek.co.jp/issues/163021

# Summary
- Safari でのブックマークボタンから出るドロップダウンのラジオボタンのレイアウト崩れを修正

<img width="436" alt="スクリーンショット 2025-03-13 20 51 33" src="https://github.com/user-attachments/assets/0819e8ae-4111-4690-b945-114859b11334" />
