### PR TITLE
support(jsdoc): add swagger document to security-settings/index.js

### DIFF
--- a/apps/app/src/server/routes/apiv3/security-settings/index.js
+++ b/apps/app/src/server/routes/apiv3/security-settings/index.js
@@ -122,6 +122,18 @@ const validator = {
  *          restrictGuestMode:
  *            type: string
  *            description: type of restrictGuestMode
+ *          pageDeletionAuthority:
+ *            type: string
+ *            description: type of pageDeletionAuthority
+ *          pageRecursiveDeletionAuthority:
+ *            type: string
+ *            description: type of pageRecursiveDeletionAuthority
+ *          pageRecursiveCompleteDeletionAuthority:
+ *            type: string
+ *            description: type of pageRecursiveCompleteDeletionAuthority
+ *          isAllGroupMembershipRequiredForPageCompleteDeletion:
+ *            type: boolean
+ *            description: enable all group membership required for page complete deletion
  *          pageCompleteDeletionAuthority:
  *            type: string
  *            description: type of pageDeletionAuthority
@@ -131,6 +143,21 @@ const validator = {
  *          hideRestrictedByGroup:
  *            type: boolean
  *            description: enable hide by group
+ *          isUsersHomepageDeletionEnabled:
+ *            type: boolean
+ *            description: enable user homepage deletion
+ *          isForceDeleteUserHomepageOnUserDeletion:
+ *            type: boolean
+ *            description: enable force delete user homepage on user deletion
+ *          isRomUserAllowedToComment:
+ *            type: boolean
+ *            description: enable rom user allowed to comment
+ *          wikiMode:
+ *            type: string
+ *            description: type of wikiMode
+ *          sessionMaxAge:
+ *            type: integer
+ *            description: max age of session
  *      ShareLinkSetting:
  *        type: object
  *        properties:
@@ -140,6 +167,15 @@ const validator = {
  *      LocalSetting:
  *        type: object
  *        properties:
+ *          useOnlyEnvVarsForSomeOptions:
+ *            type: boolean
+ *            description: use only env vars for some options
+ *          isPasswordResetEnabled:
+ *            type: boolean
+ *            description: enable password reset
+ *          isEmailAuthenticationEnabled:
+ *            type: boolean
+ *            description: enable email authentication
  *          isLocalEnabled:
  *            type: boolean
  *            description: local setting mode
@@ -152,6 +188,27 @@ const validator = {
  *            items:
  *              type: string
  *              description: registration whitelist
+ *      GeneralAuthSetting:
+ *        type: object
+ *        properties:
+ *          isLocalEnabled:
+ *            type: boolean
+ *            description: local setting mode
+ *          isLdapEnabled:
+ *            type: boolean
+ *            description: ldap setting mode
+ *          isSamlEnabled:
+ *            type: boolean
+ *            description: saml setting mode
+ *          isOidcEnabled:
+ *            type: boolean
+ *            description: oidc setting mode
+ *          isGoogleEnabled:
+ *            type: boolean
+ *            description: google setting mode
+ *          isGitHubEnabled:
+ *            type: boolean
+ *            description: github setting mode
  *      LdapAuthSetting:
  *        type: object
  *        properties:
@@ -194,15 +251,30 @@ const validator = {
  *      SamlAuthSetting:
  *        type: object
  *        properties:
+ *          missingMandatoryConfigKeys:
+ *            type: array
+ *            description: array of missing mandatory config keys
+ *            items:
+ *              type: string
+ *              description: missing mandatory config key
+ *          useOnlyEnvVarsForSomeOptions:
+ *            type: boolean
+ *            description: use only env vars for some options
  *          samlEntryPoint:
  *            type: string
  *            description: entry point for saml
  *          samlIssuer:
  *            type: string
  *            description: issuer for saml
+ *          samlEnvVarIssuer:
+ *            type: string
+ *            description: issuer for saml
  *          samlCert:
  *            type: string
  *            description: certificate for saml
+ *          samlEnvVarCert:
+ *            type: string
+ *            desription: certificate for saml
  *          samlAttrMapId:
  *            type: string
  *            description: attribute mapping id for saml
@@ -212,10 +284,25 @@ const validator = {
  *          samlAttrMapMail:
  *            type: string
  *            description: attribute mapping mail for saml
+ *          samlEnvVarAttrMapId:
+ *            type: string
+ *            description: attribute mapping id for saml
+ *          samlEnvVarAttrMapUserName:
+ *            type: string
+ *            description: attribute mapping user name for saml
+ *          samlEnvVarAttrMapMail:
+ *            type: string
+ *            description: attribute mapping mail for saml
  *          samlAttrMapFirstName:
  *            type: string
  *            description: attribute mapping first name for saml
  *          samlAttrMapLastName:
+ *            type: string
+ *            description: attribute mapping last name for saml
+ *          samlEnvVarAttrMapFirstName:
+ *            type: string
+ *            description: attribute mapping first name for saml
+ *          samlEnvVarAttrMapLastName:
  *            type: string
  *            description: attribute mapping last name for saml
  *          isSameUsernameTreatedAsIdenticalUser:
@@ -225,6 +312,9 @@ const validator = {
  *            type: boolean
  *            description: local account automatically linked the email matched
  *          samlABLCRule:
+ *            type: string
+ *            description: ABLCRule for saml
+ *          samlEnvVarABLCRule:
  *            type: string
  *            description: ABLCRule for saml
  *      OidcAuthSetting:
@@ -344,6 +434,25 @@ module.exports = (crowi) => {
    *                    securityParams:
    *                      type: object
    *                      description: security params
+   *                      properties:
+   *                        generalSetting:
+   *                          $ref: '#/components/schemas/GeneralSetting'
+   *                        shareLinkSetting:
+   *                          $ref: '#/components/schemas/ShareLinkSetting'
+   *                        localSetting:
+   *                          $ref: '#/components/schemas/LocalSetting'
+   *                        generalAuth:
+   *                          $ref: '#/components/schemas/GeneralAuthSetting'
+   *                        ldapAuth:
+   *                          $ref: '#/components/schemas/LdapAuthSetting'
+   *                        samlAuth:
+   *                          $ref: '#/components/schemas/SamlAuthSetting'
+   *                        oidcAuth:
+   *                          $ref: '#/components/schemas/OidcAuthSetting'
+   *                        googleOAuth:
+   *                          $ref: '#/components/schemas/GoogleOAuthSetting'
+   *                        githubOAuth:
+   *                          $ref: '#/components/schemas/GitHubOAuth
    */
   router.get('/', loginRequiredStrictly, adminRequired, async(req, res) => {
 
@@ -471,7 +580,7 @@ module.exports = (crowi) => {
    *                properties:
    *                  isEnabled:
    *                    type: boolean
-   *                  target:
+   *                  authId:
    *                    type: string
    *        responses:
    *          200:
@@ -576,6 +685,9 @@ module.exports = (crowi) => {
    *    /security-setting/authentication:
    *      get:
    *        tags: [SecuritySetting]
+   *        security:
+   *          - cookieAuth: []
+   *        summary: /security-setting/authentication
    *        description: Get setup strategies for passport
    *        responses:
    *          200:
@@ -604,6 +716,9 @@ module.exports = (crowi) => {
    *    /security-setting/general-setting:
    *      put:
    *        tags: [SecuritySetting]
+   *        security:
+   *          - cookieAuth: []
+   *        summary: /security-setting/general-setting
    *        description: Update GeneralSetting
    *        requestBody:
    *          required: true
@@ -690,6 +805,9 @@ module.exports = (crowi) => {
    *    /security-setting/share-link-setting:
    *      put:
    *        tags: [SecuritySetting]
+   *        security:
+   *          - cookieAuth: []
+   *        summary: /security-setting/share-link-setting
    *        description: Update ShareLink Setting
    *        requestBody:
    *          required: true
@@ -703,7 +821,9 @@ module.exports = (crowi) => {
    *            content:
    *              application/json:
    *                schema:
-   *                  $ref: '#/components/schemas/ShareLinkSetting'
+   *                  properties:
+   *                    securitySettingParams:
+   *                      $ref: '#/components/schemas/ShareLinkSetting'
    */
   router.put('/share-link-setting', loginRequiredStrictly, adminRequired, addActivity, validator.generalSetting, apiV3FormValidator, async(req, res) => {
     const updateData = {
@@ -733,6 +853,9 @@ module.exports = (crowi) => {
    *    /security-setting/all-share-links:
    *      get:
    *        tags: [SecuritySetting]
+   *        security:
+   *          - cookieAuth: []
+   *        summary: /security-setting/all-share-links
    *        description: Get All ShareLinks at Share Link Setting
    *        responses:
    *          200:
@@ -776,12 +899,21 @@ module.exports = (crowi) => {
    *    /security-setting/all-share-links:
    *      delete:
    *        tags: [SecuritySetting]
+   *        security:
+   *          - cookieAuth: []
+   *        summary: /security-setting/all-share-links
    *        description: Delete All ShareLinks at Share Link Setting
    *        responses:
    *          200:
    *            description: succeed to delete all share links
+   *            content:
+   *              application/json:
+   *                schema:
+   *                  properties:
+   *                    removeTotal:
+   *                      type: number
+   *                      description: total number of removed share links
    */
-
   router.delete('/all-share-links/', loginRequiredStrictly, adminRequired, async(req, res) => {
     try {
       const removedAct = await ShareLink.remove({});
@@ -801,6 +933,9 @@ module.exports = (crowi) => {
    *    /security-setting/local-setting:
    *      put:
    *        tags: [SecuritySetting]
+   *        security:
+   *          - cookieAuth: []
+   *        summary: /security-setting/local-setting
    *        description: Update LocalSetting
    *        requestBody:
    *          required: true
@@ -814,7 +949,9 @@ module.exports = (crowi) => {
    *            content:
    *              application/json:
    *                schema:
-   *                  $ref: '#/components/schemas/LocalSetting'
+   *                  properties:
+   *                    localSettingParams:
+   *                      $ref: '#/components/schemas/LocalSetting'
    */
   router.put('/local-setting', loginRequiredStrictly, adminRequired, addActivity, validator.localSetting, apiV3FormValidator, async(req, res) => {
     try {
@@ -853,6 +990,9 @@ module.exports = (crowi) => {
    *    /security-setting/ldap:
    *      put:
    *        tags: [SecuritySetting]
+   *        security:
+   *          - cookieAuth: []
+   *        summary: /security-setting/ldap
    *        description: Update LDAP setting
    *        requestBody:
    *          required: true
@@ -866,7 +1006,9 @@ module.exports = (crowi) => {
    *            content:
    *              application/json:
    *                schema:
-   *                  $ref: '#/components/schemas/LdapAuthSetting'
+   *                  properties:
+   *                    securitySettingParams:
+   *                      $ref: '#/components/schemas/LdapAuthSetting'
    */
   router.put('/ldap', loginRequiredStrictly, adminRequired, addActivity, validator.ldapAuth, apiV3FormValidator, async(req, res) => {
     const requestParams = {
@@ -918,6 +1060,9 @@ module.exports = (crowi) => {
    *    /security-setting/saml:
    *      put:
    *        tags: [SecuritySetting]
+   *        security:
+   *          - cookieAuth: []
+   *        summary: /security-setting/saml
    *        description: Update SAML setting
    *        requestBody:
    *          required: true
@@ -931,7 +1076,9 @@ module.exports = (crowi) => {
    *            content:
    *              application/json:
    *                schema:
-   *                  $ref: '#/components/schemas/SamlAuthSetting'
+   *                  properties:
+   *                    securitySettingParams:
+   *                      $ref: '#/components/schemas/SamlAuthSetting'
    */
   router.put('/saml', loginRequiredStrictly, adminRequired, addActivity, validator.samlAuth, apiV3FormValidator, async(req, res) => {
     const { t } = await getTranslation({ lang: req.user.lang, ns: ['translation', 'admin'] });
@@ -1012,6 +1159,9 @@ module.exports = (crowi) => {
    *    /security-setting/oidc:
    *      put:
    *        tags: [SecuritySetting]
+   *        security:
+   *          - cookieAuth: []
+   *        summary: /security-setting/oidc
    *        description: Update OpenID Connect setting
    *        requestBody:
    *          required: true
@@ -1025,7 +1175,9 @@ module.exports = (crowi) => {
    *            content:
    *              application/json:
    *                schema:
-   *                  $ref: '#/components/schemas/OidcAuthSetting'
+   *                  properties:
+   *                    securitySettingParams:
+   *                      $ref: '#/components/schemas/OidcAuthSetting'
    */
   router.put('/oidc', loginRequiredStrictly, adminRequired, addActivity, validator.oidcAuth, apiV3FormValidator, async(req, res) => {
     const requestParams = {
@@ -1089,6 +1241,9 @@ module.exports = (crowi) => {
    *    /security-setting/google-oauth:
    *      put:
    *        tags: [SecuritySetting]
+   *        security:
+   *          - cookieAuth: []
+   *        summary: /security-setting/google-oauth
    *        description: Update google OAuth
    *        requestBody:
    *          required: true
@@ -1102,7 +1257,9 @@ module.exports = (crowi) => {
    *            content:
    *              application/json:
    *                schema:
-   *                  $ref: '#/components/schemas/GoogleOAuthSetting'
+   *                  properties:
+   *                    securitySettingParams:
+   *                      $ref: '#/components/schemas/GoogleOAuthSetting'
    */
   router.put('/google-oauth', loginRequiredStrictly, adminRequired, addActivity, validator.googleOAuth, apiV3FormValidator, async(req, res) => {
     const requestParams = {
@@ -1137,6 +1294,9 @@ module.exports = (crowi) => {
    *    /security-setting/github-oauth:
    *      put:
    *        tags: [SecuritySetting]
+   *        security:
+   *          - cookieAuth: []
+   *        summary: /security-setting/github-oauth
    *        description: Update github OAuth
    *        requestBody:
    *          required: true
@@ -1150,7 +1310,9 @@ module.exports = (crowi) => {
    *            content:
    *              application/json:
    *                schema:
-   *                  $ref: '#/components/schemas/GitHubOAuthSetting'
+   *                  properties:
+   *                    securitySettingParams:
+   *                      $ref: '#/components/schemas/GitHubOAuthSetting'
    */
   router.put('/github-oauth', loginRequiredStrictly, adminRequired, addActivity, validator.githubOAuth, apiV3FormValidator, async(req, res) => {
     const requestParams = {


### PR DESCRIPTION
- GET /_api/v3/security-setting/
- PUT /_api/v3/security-setting/authentication/enabled
- GET /_api/v3/security-setting/authentication/
- PUT /_api/v3/security-setting/general-setting
- PUT /_api/v3/security-setting/share-link-setting
- GET /_api/v3/security-setting/all-share-links/
- DELETE /_api/v3/security-setting/all-share-links/
- PUT /_api/v3/security-setting/local-setting
- PUT /_api/v3/security-setting/ldap
- PUT /_api/v3/security-setting/saml
- PUT /_api/v3/security-setting/oidc
- PUT /_api/v3/security-setting/google-oauth
- PUT /_api/v3/security-setting/github-oauth
