### PR TITLE
feat: Implement preset prompt view

### DIFF
--- a/apps/app/public/static/locales/en_US/translation.json
+++ b/apps/app/public/static/locales/en_US/translation.json
@@ -511,10 +511,14 @@
     "error_message": "An error has occurred",
     "show_error_detail": "Show error details",
     "preset_prompt": {
-      "summarize": "Summarize this article",
-      "replace": "Replace specific text",
-      "correct": "Correct errors in the text",
-      "create": "Create text"
+      "summarize": {
+        "title": "Summarize this article",
+        "prompt": ""
+      },
+      "correct": {
+        "title": "Correct errors in the text",
+        "prompt": ""
+      }
     }
   },
   "modal_ai_assistant": {

--- a/apps/app/public/static/locales/en_US/translation.json
+++ b/apps/app/public/static/locales/en_US/translation.json
@@ -509,7 +509,13 @@
     "budget_exceeded": "You have reached your usage limit for OpenAI's API. To use the Knowledge Assistant again, please add credits from the OpenAI billing page.",
     "budget_exceeded_for_growi_cloud": "You have reached your OpenAI API usage limit. To use the Knowledge Assistant again, please add credits from the GROWI.cloud admin page for Hosted users or from the OpenAI billing page for Owned users.",
     "error_message": "An error has occurred",
-    "show_error_detail": "Show error details"
+    "show_error_detail": "Show error details",
+    "preset_prompt": {
+      "summarize": "Summarize this article",
+      "replace": "Replace specific text",
+      "correct": "Correct errors in the text",
+      "create": "Create text"
+    }
   },
   "modal_ai_assistant": {
     "header": {

--- a/apps/app/public/static/locales/en_US/translation.json
+++ b/apps/app/public/static/locales/en_US/translation.json
@@ -510,7 +510,7 @@
     "budget_exceeded_for_growi_cloud": "You have reached your OpenAI API usage limit. To use the Knowledge Assistant again, please add credits from the GROWI.cloud admin page for Hosted users or from the OpenAI billing page for Owned users.",
     "error_message": "An error has occurred",
     "show_error_detail": "Show error details",
-    "preset_prompt": {
+    "preset_menu": {
       "summarize": {
         "title": "Summarize this article",
         "prompt": ""

--- a/apps/app/public/static/locales/fr_FR/translation.json
+++ b/apps/app/public/static/locales/fr_FR/translation.json
@@ -503,7 +503,13 @@
     "budget_exceeded": "Vous avez atteint votre limite d'utilisation de l'API de l'OpenAI. Pour utiliser à nouveau l'assistant de connaissance, veuillez ajouter des crédits à partir de la page de facturation d'OpenAI.",
     "budget_exceeded_for_growi_cloud": "Vous avez atteint votre limite d'utilisation de l'API de l'OpenAI. Pour utiliser à nouveau l'assistant de connaissance, veuillez ajouter des crédits à partir de la page d'administration de GROWI.cloud pour les utilisateurs hébergés ou à partir de la page de facturation de l'OpenAI pour les utilisateurs propriétaires.",
     "error_message": "Erreur",
-    "show_error_detail": "Détails de l'exposition"
+    "show_error_detail": "Détails de l'exposition",
+    "preset_prompt": {
+      "summarize": "Résumer cet article'",
+      "replace": "Remplacer un texte spécifique",
+      "correct": "Corriger les erreurs du texte",
+      "create": "Créer un texte"
+    }
   },
   "modal_ai_assistant": {
     "header": {

--- a/apps/app/public/static/locales/fr_FR/translation.json
+++ b/apps/app/public/static/locales/fr_FR/translation.json
@@ -505,10 +505,14 @@
     "error_message": "Erreur",
     "show_error_detail": "Détails de l'exposition",
     "preset_prompt": {
-      "summarize": "Résumer cet article'",
-      "replace": "Remplacer un texte spécifique",
-      "correct": "Corriger les erreurs du texte",
-      "create": "Créer un texte"
+      "summarize": {
+        "title": "Résumer cet article'",
+        "prompt": ""
+      },
+      "correct": {
+        "title": "Corriger les erreurs du texte",
+        "prompt": ""
+      }
     }
   },
   "modal_ai_assistant": {

--- a/apps/app/public/static/locales/fr_FR/translation.json
+++ b/apps/app/public/static/locales/fr_FR/translation.json
@@ -504,7 +504,7 @@
     "budget_exceeded_for_growi_cloud": "Vous avez atteint votre limite d'utilisation de l'API de l'OpenAI. Pour utiliser à nouveau l'assistant de connaissance, veuillez ajouter des crédits à partir de la page d'administration de GROWI.cloud pour les utilisateurs hébergés ou à partir de la page de facturation de l'OpenAI pour les utilisateurs propriétaires.",
     "error_message": "Erreur",
     "show_error_detail": "Détails de l'exposition",
-    "preset_prompt": {
+    "preset_menu": {
       "summarize": {
         "title": "Résumer cet article'",
         "prompt": ""

--- a/apps/app/public/static/locales/ja_JP/translation.json
+++ b/apps/app/public/static/locales/ja_JP/translation.json
@@ -542,7 +542,7 @@
     "budget_exceeded_for_growi_cloud": "OpenAI の API の利用上限に達しました。ナレッジアシスタントを再度利用するには Hosted の場合は GROWI.cloud の管理画面から Owned の場合は OpenAI の請求ページからクレジットを追加してください。",
     "error_message": "エラーが発生しました",
     "show_error_detail": "詳細を表示",
-    "preset_prompt": {
+    "preset_menu": {
       "summarize": {
         "title": "この記事の要約をつくる",
         "prompt": ""

--- a/apps/app/public/static/locales/ja_JP/translation.json
+++ b/apps/app/public/static/locales/ja_JP/translation.json
@@ -541,7 +541,13 @@
     "budget_exceeded": "OpenAI の API の利用上限に達しました。ナレッジアシスタントを再度利用するには OpenAI の請求ページからクレジットを追加してください。",
     "budget_exceeded_for_growi_cloud": "OpenAI の API の利用上限に達しました。ナレッジアシスタントを再度利用するには Hosted の場合は GROWI.cloud の管理画面から Owned の場合は OpenAI の請求ページからクレジットを追加してください。",
     "error_message": "エラーが発生しました",
-    "show_error_detail": "詳細を表示"
+    "show_error_detail": "詳細を表示",
+    "preset_prompt": {
+      "summarize": "この記事の要約をつくる",
+      "replace": "特定の文章を要約する",
+      "correct": "文章の誤りを修正する",
+      "create": "文章を作成する"
+    }
   },
   "modal_ai_assistant": {
     "header": {

--- a/apps/app/public/static/locales/ja_JP/translation.json
+++ b/apps/app/public/static/locales/ja_JP/translation.json
@@ -543,10 +543,14 @@
     "error_message": "エラーが発生しました",
     "show_error_detail": "詳細を表示",
     "preset_prompt": {
-      "summarize": "この記事の要約をつくる",
-      "replace": "特定の文章を要約する",
-      "correct": "文章の誤りを修正する",
-      "create": "文章を作成する"
+      "summarize": {
+        "title": "この記事の要約をつくる",
+        "prompt": ""
+      },
+      "correct": {
+        "title": "文章の誤りを修正する",
+        "prompt": ""
+      }
     }
   },
   "modal_ai_assistant": {

--- a/apps/app/public/static/locales/zh_CN/translation.json
+++ b/apps/app/public/static/locales/zh_CN/translation.json
@@ -498,7 +498,13 @@
     "budget_exceeded": "您已达到 OpenAI API 的使用上限。要再次使用知识助手，请从 OpenAI 账单页面添加点数。",
     "budget_exceeded_for_growi_cloud": "您已达到 OpenAI API 使用上限。如需再次使用知识助手，请从GROWI.cloud管理页面为托管用户添加点数，或从OpenAI计费页面为自有用户添加点数。",
     "error_message": "错误",
-    "show_error_detail": "显示详情"
+    "show_error_detail": "显示详情",
+    "preset_prompt": {
+      "summarize": "为此文章创建摘要",
+      "replace": "替换特定文本",
+      "correct": "修正文本中的错误",
+      "create": "创建文本"
+    }
   },
   "modal_ai_assistant": {
     "header": {

--- a/apps/app/public/static/locales/zh_CN/translation.json
+++ b/apps/app/public/static/locales/zh_CN/translation.json
@@ -499,7 +499,7 @@
     "budget_exceeded_for_growi_cloud": "您已达到 OpenAI API 使用上限。如需再次使用知识助手，请从GROWI.cloud管理页面为托管用户添加点数，或从OpenAI计费页面为自有用户添加点数。",
     "error_message": "错误",
     "show_error_detail": "显示详情",
-    "preset_prompt": {
+    "preset_menu": {
       "summarize": {
         "title": "为此文章创建摘要",
         "prompt": ""

--- a/apps/app/public/static/locales/zh_CN/translation.json
+++ b/apps/app/public/static/locales/zh_CN/translation.json
@@ -500,10 +500,14 @@
     "error_message": "错误",
     "show_error_detail": "显示详情",
     "preset_prompt": {
-      "summarize": "为此文章创建摘要",
-      "replace": "替换特定文本",
-      "correct": "修正文本中的错误",
-      "create": "创建文本"
+      "summarize": {
+        "title": "为此文章创建摘要",
+        "prompt": ""
+      },
+      "correct": {
+        "title": "修正文本中的错误",
+        "prompt": ""
+      }
     }
   },
   "modal_ai_assistant": {

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar.tsx
@@ -24,6 +24,7 @@ import { useSWRMUTxThreads } from '../../../stores/thread';
 
 import { AiAssistantChatInitialView } from './AiAssistantChatInitialView';
 import { MessageCard } from './MessageCard';
+import { PresetPromptList } from './PresetPromptList';
 import { ResizableTextarea } from './ResizableTextArea';
 
 import styles from './AiAssistantSidebar.module.scss';
@@ -336,7 +337,7 @@ const AiAssistantSidebarSubstance: React.FC<AiAssistantSidebarSubstanceProps> = 
             )
             : (
               <>{isEditorAssistant
-                ? <></> // TODO https://redmine.weseek.co.jp/issues/163079
+                ? <PresetPromptList />
                 : (
                   <AiAssistantChatInitialView
                     description={aiAssistantData?.description ?? ''}

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar.tsx
@@ -127,6 +127,11 @@ const AiAssistantSidebarSubstance: React.FC<AiAssistantSidebarSubstanceProps> = 
       : 'sidebar_ai_assistant.knowledge_assistant_placeholder');
   }, [form.formState.isSubmitting, isEditorAssistant, t]);
 
+  const clickPresetPromptHandler = useCallback((presetPrompt: string) => {
+    console.log('presetPrompt', { presetPrompt });
+    // todo: https://redmine.weseek.co.jp/issues/163264
+  }, []);
+
   const isGenerating = generatingAnswerMessage != null;
   const submit = useCallback(async(data: FormData) => {
     // do nothing when the assistant is generating an answer
@@ -337,7 +342,11 @@ const AiAssistantSidebarSubstance: React.FC<AiAssistantSidebarSubstanceProps> = 
             )
             : (
               <>{isEditorAssistant
-                ? <PresetPromptList />
+                ? (
+                  <PresetPromptList
+                    onClick={clickPresetPromptHandler}
+                  />
+                )
                 : (
                   <AiAssistantChatInitialView
                     description={aiAssistantData?.description ?? ''}

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar.tsx
@@ -128,7 +128,6 @@ const AiAssistantSidebarSubstance: React.FC<AiAssistantSidebarSubstanceProps> = 
   }, [form.formState.isSubmitting, isEditorAssistant, t]);
 
   const clickPresetPromptHandler = useCallback((presetPrompt: string) => {
-    console.log('presetPrompt', { presetPrompt });
     // todo: https://redmine.weseek.co.jp/issues/163264
   }, []);
 

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar.tsx
@@ -127,7 +127,7 @@ const AiAssistantSidebarSubstance: React.FC<AiAssistantSidebarSubstanceProps> = 
       : 'sidebar_ai_assistant.knowledge_assistant_placeholder');
   }, [form.formState.isSubmitting, isEditorAssistant, t]);
 
-  const clickPresetPromptHandler = useCallback((presetPrompt: string) => {
+  const clickQuickMenuHandler = useCallback((quickMenu: string) => {
     // todo: https://redmine.weseek.co.jp/issues/163264
   }, []);
 
@@ -343,7 +343,7 @@ const AiAssistantSidebarSubstance: React.FC<AiAssistantSidebarSubstanceProps> = 
               <>{isEditorAssistant
                 ? (
                   <QuickMenuList
-                    onClick={clickPresetPromptHandler}
+                    onClick={clickQuickMenuHandler}
                   />
                 )
                 : (

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar.tsx
@@ -24,7 +24,7 @@ import { useSWRMUTxThreads } from '../../../stores/thread';
 
 import { AiAssistantChatInitialView } from './AiAssistantChatInitialView';
 import { MessageCard } from './MessageCard';
-import { PresetPromptList } from './PresetPromptList';
+import { QuickMenuList } from './QuickMenuList';
 import { ResizableTextarea } from './ResizableTextArea';
 
 import styles from './AiAssistantSidebar.module.scss';
@@ -342,7 +342,7 @@ const AiAssistantSidebarSubstance: React.FC<AiAssistantSidebarSubstanceProps> = 
             : (
               <>{isEditorAssistant
                 ? (
-                  <PresetPromptList
+                  <QuickMenuList
                     onClick={clickPresetPromptHandler}
                   />
                 )

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/PresetPromptList.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/PresetPromptList.tsx
@@ -1,3 +1,5 @@
+import { useCallback } from 'react';
+
 import { useTranslation } from 'react-i18next';
 
 type Props = {
@@ -5,10 +7,8 @@ type Props = {
 }
 
 const presetPrompts = [
-  'sidebar_ai_assistant.preset_prompt.summarize',
-  'sidebar_ai_assistant.preset_prompt.replace',
-  'sidebar_ai_assistant.preset_prompt.correct',
-  'sidebar_ai_assistant.preset_prompt.create',
+  'summarize',
+  'correct',
 ];
 
 export const PresetPromptList: React.FC<Props> = () => {
@@ -21,11 +21,11 @@ export const PresetPromptList: React.FC<Props> = () => {
           <button
             type="button"
             key={presetPrompt}
-            className="btn  text-body-secondary p-3 rounded-3 border border-1"
+            className="btn text-body-secondary p-3 rounded-3 border border-1"
           >
             <div className="d-flex align-items-center">
               <span className="material-symbols-outlined fs-5 me-3">lightbulb</span>
-              <span className="fs-6">{t(presetPrompt)}</span>
+              <span className="fs-6">{t(`sidebar_ai_assistant.preset_prompt.${presetPrompt}.title`)}</span>
             </div>
           </button>
         ))}

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/PresetPromptList.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/PresetPromptList.tsx
@@ -1,10 +1,35 @@
+import { useTranslation } from 'react-i18next';
+
 type Props = {
   //
 }
 
+const presetPrompts = [
+  'sidebar_ai_assistant.preset_prompt.summarize',
+  'sidebar_ai_assistant.preset_prompt.replace',
+  'sidebar_ai_assistant.preset_prompt.correct',
+  'sidebar_ai_assistant.preset_prompt.create',
+];
+
 export const PresetPromptList: React.FC<Props> = () => {
+  const { t } = useTranslation();
 
   return (
-    <>PresetPromptList</>
+    <div className="container py-4">
+      <div className="d-flex flex-column gap-3">
+        {presetPrompts.map(presetPrompt => (
+          <button
+            type="button"
+            key={presetPrompt}
+            className="btn  text-body-secondary p-3 rounded-3 border border-1"
+          >
+            <div className="d-flex align-items-center">
+              <span className="material-symbols-outlined fs-5 me-3">lightbulb</span>
+              <span className="fs-6">{t(presetPrompt)}</span>
+            </div>
+          </button>
+        ))}
+      </div>
+    </div>
   );
 };

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/PresetPromptList.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/PresetPromptList.tsx
@@ -14,11 +14,9 @@ const presetPrompts = [
 export const PresetPromptList: React.FC<Props> = ({ onClick }) => {
   const { t } = useTranslation();
 
-
   const clickPresetPromptHandler = useCallback((presetPrompt: string) => {
     onClick(t(`sidebar_ai_assistant.preset_prompt.${presetPrompt}.prompt`));
   }, [onClick, t]);
-
 
   return (
     <div className="container py-4">

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/PresetPromptList.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/PresetPromptList.tsx
@@ -1,0 +1,10 @@
+type Props = {
+  //
+}
+
+export const PresetPromptList: React.FC<Props> = () => {
+
+  return (
+    <>PresetPromptList</>
+  );
+};

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/PresetPromptList.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/PresetPromptList.tsx
@@ -3,7 +3,7 @@ import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
 type Props = {
-  //
+  onClick: (presetPrompt: string) => void
 }
 
 const presetPrompts = [
@@ -11,8 +11,14 @@ const presetPrompts = [
   'correct',
 ];
 
-export const PresetPromptList: React.FC<Props> = () => {
+export const PresetPromptList: React.FC<Props> = ({ onClick }) => {
   const { t } = useTranslation();
+
+
+  const clickPresetPromptHandler = useCallback((presetPrompt: string) => {
+    onClick(t(`sidebar_ai_assistant.preset_prompt.${presetPrompt}.prompt`));
+  }, [onClick, t]);
+
 
   return (
     <div className="container py-4">
@@ -21,6 +27,7 @@ export const PresetPromptList: React.FC<Props> = () => {
           <button
             type="button"
             key={presetPrompt}
+            onClick={() => clickPresetPromptHandler(presetPrompt)}
             className="btn text-body-secondary p-3 rounded-3 border border-1"
           >
             <div className="d-flex align-items-center">

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/QuickMenuList.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/QuickMenuList.tsx
@@ -6,31 +6,31 @@ type Props = {
   onClick: (presetPrompt: string) => void
 }
 
-const presetPrompts = [
+const presetMenus = [
   'summarize',
   'correct',
 ];
 
-export const QuickMenuList: React.FC<Props> = ({ onClick }) => {
+export const QuickMenuList: React.FC<Props> = ({ onClick }: Props) => {
   const { t } = useTranslation();
 
-  const clickPresetPromptHandler = useCallback((presetPrompt: string) => {
-    onClick(t(`sidebar_ai_assistant.preset_prompt.${presetPrompt}.prompt`));
+  const clickQuickMenuHandler = useCallback((quickMenu: string) => {
+    onClick(t(`sidebar_ai_assistant.preset_menu.${quickMenu}.prompt`));
   }, [onClick, t]);
 
   return (
     <div className="container py-4">
       <div className="d-flex flex-column gap-3">
-        {presetPrompts.map(presetPrompt => (
+        {presetMenus.map(presetMenu => (
           <button
             type="button"
-            key={presetPrompt}
-            onClick={() => clickPresetPromptHandler(presetPrompt)}
+            key={presetMenu}
+            onClick={() => clickQuickMenuHandler(presetMenu)}
             className="btn text-body-secondary p-3 rounded-3 border border-1"
           >
             <div className="d-flex align-items-center">
               <span className="material-symbols-outlined fs-5 me-3">lightbulb</span>
-              <span className="fs-6">{t(`sidebar_ai_assistant.preset_prompt.${presetPrompt}.title`)}</span>
+              <span className="fs-6">{t(`sidebar_ai_assistant.preset_menu.${presetMenu}.title`)}</span>
             </div>
           </button>
         ))}

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/QuickMenuList.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/QuickMenuList.tsx
@@ -11,7 +11,7 @@ const presetPrompts = [
   'correct',
 ];
 
-export const PresetPromptList: React.FC<Props> = ({ onClick }) => {
+export const QuickMenuList: React.FC<Props> = ({ onClick }) => {
   const { t } = useTranslation();
 
   const clickPresetPromptHandler = useCallback((presetPrompt: string) => {


### PR DESCRIPTION
# Task
- [#163071](https://redmine.weseek.co.jp/issues/163071) [GROWI AI Next][エディターアシスタント] AiAssistantSidebar にエディターアシスタント用の画面を表示できる
  - [#163079](https://redmine.weseek.co.jp/issues/163079) デフォルトの指示画面の実装

# Figma
https://www.figma.com/design/ZiEcjZ8sYt6YvowboA5Um6/GROWI-v7?node-id=2847-15252&t=cNyjVFoQDQfxZ0wa-0

# Screenshot
<img width="1357" alt="スクリーンショット 2025-03-17 16 40 35" src="https://github.com/user-attachments/assets/cacb505a-4365-41c2-beee-f0be9719445a" />

