### PR TITLE
feat: Send message to assistant on preset prompt click

### DIFF
--- a/apps/app/public/static/locales/en_US/translation.json
+++ b/apps/app/public/static/locales/en_US/translation.json
@@ -513,11 +513,11 @@
     "preset_menu": {
       "summarize": {
         "title": "Summarize this article",
-        "prompt": ""
+        "prompt": "Please summarize the markdown content"
       },
       "correct": {
         "title": "Correct errors in the text",
-        "prompt": ""
+        "prompt": "Please correct the errors in the markdown text"
       }
     }
   },

--- a/apps/app/public/static/locales/fr_FR/translation.json
+++ b/apps/app/public/static/locales/fr_FR/translation.json
@@ -507,11 +507,11 @@
     "preset_menu": {
       "summarize": {
         "title": "Résumer cet article'",
-        "prompt": ""
+        "prompt": "Veuillez résumer le contenu markdown"
       },
       "correct": {
         "title": "Corriger les erreurs du texte",
-        "prompt": ""
+        "prompt": "Veuillez corriger les erreurs dans le texte markdown"
       }
     }
   },

--- a/apps/app/public/static/locales/ja_JP/translation.json
+++ b/apps/app/public/static/locales/ja_JP/translation.json
@@ -545,11 +545,11 @@
     "preset_menu": {
       "summarize": {
         "title": "この記事の要約をつくる",
-        "prompt": ""
+        "prompt": "マークダウンの内容を要約してください"
       },
       "correct": {
         "title": "文章の誤りを修正する",
-        "prompt": ""
+        "prompt": "マークダウンの内の文章の誤りを修正してください"
       }
     }
   },

--- a/apps/app/public/static/locales/zh_CN/translation.json
+++ b/apps/app/public/static/locales/zh_CN/translation.json
@@ -502,11 +502,11 @@
     "preset_menu": {
       "summarize": {
         "title": "为此文章创建摘要",
-        "prompt": ""
+        "prompt": "请总结这个 markdown 内容"
       },
       "correct": {
         "title": "修正文本中的错误",
-        "prompt": ""
+        "prompt": "请修正 markdown 中的文本错误"
       }
     }
   },

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar.tsx
@@ -127,10 +127,6 @@ const AiAssistantSidebarSubstance: React.FC<AiAssistantSidebarSubstanceProps> = 
       : 'sidebar_ai_assistant.knowledge_assistant_placeholder');
   }, [form.formState.isSubmitting, isEditorAssistant, t]);
 
-  const clickQuickMenuHandler = useCallback((quickMenu: string) => {
-    // todo: https://redmine.weseek.co.jp/issues/163264
-  }, []);
-
   const isGenerating = generatingAnswerMessage != null;
   const submit = useCallback(async(data: FormData) => {
     // do nothing when the assistant is generating an answer
@@ -302,6 +298,10 @@ const AiAssistantSidebarSubstance: React.FC<AiAssistantSidebarSubstanceProps> = 
       form.handleSubmit(submit)();
     }
   };
+
+  const clickQuickMenuHandler = useCallback(async(quickMenu: string) => {
+    await submit({ input: quickMenu });
+  }, [submit]);
 
   return (
     <>


### PR DESCRIPTION
# Task
- [#163071](https://redmine.weseek.co.jp/issues/163071) [GROWI AI Next][エディターアシスタント] AiAssistantSidebar にエディターアシスタント用の画面を表示できる
  - [#163264](https://redmine.weseek.co.jp/issues/163264) プリセットプロンプトをクリックした時にアシスタントにメッセージを送信できる

# Screenrecord
https://github.com/user-attachments/assets/5bda68af-3883-4982-b65f-c4f1d43b01ee


