### PR TITLE
feat: Implement accept and discard buttons

### DIFF
--- a/apps/app/public/static/locales/en_US/translation.json
+++ b/apps/app/public/static/locales/en_US/translation.json
@@ -511,7 +511,7 @@
     "error_message": "An error has occurred",
     "show_error_detail": "Show error details",
     "discard": "Discard",
-    "adopt": "Adopt",
+    "accept": "Accept",
     "preset_menu": {
       "summarize": {
         "title": "Summarize this article",

--- a/apps/app/public/static/locales/en_US/translation.json
+++ b/apps/app/public/static/locales/en_US/translation.json
@@ -510,6 +510,8 @@
     "budget_exceeded_for_growi_cloud": "You have reached your OpenAI API usage limit. To use the Knowledge Assistant again, please add credits from the GROWI.cloud admin page for Hosted users or from the OpenAI billing page for Owned users.",
     "error_message": "An error has occurred",
     "show_error_detail": "Show error details",
+    "discard": "Discard",
+    "adopt": "Adopt",
     "preset_menu": {
       "summarize": {
         "title": "Summarize this article",

--- a/apps/app/public/static/locales/fr_FR/translation.json
+++ b/apps/app/public/static/locales/fr_FR/translation.json
@@ -505,7 +505,7 @@
     "error_message": "Erreur",
     "show_error_detail": "Détails de l'exposition",
     "discard": "Annuler",
-    "adopt": "Adopter",
+    "accept": "Accepter",
     "preset_menu": {
       "summarize": {
         "title": "Résumer cet article'",

--- a/apps/app/public/static/locales/fr_FR/translation.json
+++ b/apps/app/public/static/locales/fr_FR/translation.json
@@ -504,6 +504,8 @@
     "budget_exceeded_for_growi_cloud": "Vous avez atteint votre limite d'utilisation de l'API de l'OpenAI. Pour utiliser à nouveau l'assistant de connaissance, veuillez ajouter des crédits à partir de la page d'administration de GROWI.cloud pour les utilisateurs hébergés ou à partir de la page de facturation de l'OpenAI pour les utilisateurs propriétaires.",
     "error_message": "Erreur",
     "show_error_detail": "Détails de l'exposition",
+    "discard": "Annuler",
+    "adopt": "Adopter",
     "preset_menu": {
       "summarize": {
         "title": "Résumer cet article'",

--- a/apps/app/public/static/locales/ja_JP/translation.json
+++ b/apps/app/public/static/locales/ja_JP/translation.json
@@ -542,6 +542,8 @@
     "budget_exceeded_for_growi_cloud": "OpenAI の API の利用上限に達しました。ナレッジアシスタントを再度利用するには Hosted の場合は GROWI.cloud の管理画面から Owned の場合は OpenAI の請求ページからクレジットを追加してください。",
     "error_message": "エラーが発生しました",
     "show_error_detail": "詳細を表示",
+    "discard": "破棄",
+    "adopt": "採用",
     "preset_menu": {
       "summarize": {
         "title": "この記事の要約をつくる",

--- a/apps/app/public/static/locales/ja_JP/translation.json
+++ b/apps/app/public/static/locales/ja_JP/translation.json
@@ -543,7 +543,7 @@
     "error_message": "エラーが発生しました",
     "show_error_detail": "詳細を表示",
     "discard": "破棄",
-    "adopt": "採用",
+    "accept": "採用",
     "preset_menu": {
       "summarize": {
         "title": "この記事の要約をつくる",

--- a/apps/app/public/static/locales/zh_CN/translation.json
+++ b/apps/app/public/static/locales/zh_CN/translation.json
@@ -499,6 +499,8 @@
     "budget_exceeded_for_growi_cloud": "您已达到 OpenAI API 使用上限。如需再次使用知识助手，请从GROWI.cloud管理页面为托管用户添加点数，或从OpenAI计费页面为自有用户添加点数。",
     "error_message": "错误",
     "show_error_detail": "显示详情",
+    "discard": "丢弃",
+    "adopt": "采纳",
     "preset_menu": {
       "summarize": {
         "title": "为此文章创建摘要",

--- a/apps/app/public/static/locales/zh_CN/translation.json
+++ b/apps/app/public/static/locales/zh_CN/translation.json
@@ -500,7 +500,7 @@
     "error_message": "错误",
     "show_error_detail": "显示详情",
     "discard": "丢弃",
-    "adopt": "采纳",
+    "accept": "接受",
     "preset_menu": {
       "summarize": {
         "title": "为此文章创建摘要",

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar.tsx
@@ -304,11 +304,11 @@ const AiAssistantSidebarSubstance: React.FC<AiAssistantSidebarSubstanceProps> = 
   }, [submit]);
 
   const clickAdoptHandler = useCallback(() => {
-    console.log('clickAdoptHandler');
+    // todo: implement
   }, []);
 
   const clickDiscardHandler = useCallback(() => {
-    console.log('clickDiscardHandler');
+    // todo: implement
   }, []);
 
   return (

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar.tsx
@@ -303,6 +303,14 @@ const AiAssistantSidebarSubstance: React.FC<AiAssistantSidebarSubstanceProps> = 
     await submit({ input: quickMenu });
   }, [submit]);
 
+  const clickAdoptHandler = useCallback(() => {
+    console.log('clickAdoptHandler');
+  }, []);
+
+  const clickDiscardHandler = useCallback(() => {
+    console.log('clickDiscardHandler');
+  }, []);
+
   return (
     <>
       <div className="d-flex flex-column vh-100">
@@ -329,6 +337,8 @@ const AiAssistantSidebarSubstance: React.FC<AiAssistantSidebarSubstanceProps> = 
                     key={message.id}
                     role={message.isUserMessage ? 'user' : 'assistant'}
                     showActionButtons={isEditorAssistant}
+                    onAdopt={clickAdoptHandler}
+                    onDiscard={clickDiscardHandler}
                   >
                     {message.content}
                   </MessageCard>

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar.tsx
@@ -325,7 +325,13 @@ const AiAssistantSidebarSubstance: React.FC<AiAssistantSidebarSubstanceProps> = 
             ? (
               <div className="vstack gap-4 pb-2">
                 { messageLogs.map(message => (
-                  <MessageCard key={message.id} role={message.isUserMessage ? 'user' : 'assistant'}>{message.content}</MessageCard>
+                  <MessageCard
+                    key={message.id}
+                    role={message.isUserMessage ? 'user' : 'assistant'}
+                    showActionButtons={isEditorAssistant}
+                  >
+                    {message.content}
+                  </MessageCard>
                 )) }
                 { generatingAnswerMessage != null && (
                   <MessageCard role="assistant">{generatingAnswerMessage.content}</MessageCard>

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar.tsx
@@ -303,7 +303,7 @@ const AiAssistantSidebarSubstance: React.FC<AiAssistantSidebarSubstanceProps> = 
     await submit({ input: quickMenu });
   }, [submit]);
 
-  const clickAdoptHandler = useCallback(() => {
+  const clickAcceptHandler = useCallback(() => {
     // todo: implement
   }, []);
 
@@ -337,7 +337,7 @@ const AiAssistantSidebarSubstance: React.FC<AiAssistantSidebarSubstanceProps> = 
                     key={message.id}
                     role={message.isUserMessage ? 'user' : 'assistant'}
                     showActionButtons={isEditorAssistant}
-                    onAdopt={clickAdoptHandler}
+                    onAccept={clickAcceptHandler}
                     onDiscard={clickDiscardHandler}
                   >
                     {message.content}

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/MessageCard.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/MessageCard.tsx
@@ -41,11 +41,11 @@ const NextLinkWrapper = (props: LinkProps & {children: string, href: string}): J
 };
 
 const AssistantMessageCard = ({
-  children, showActionButtons, onAdopt, onDiscard,
+  children, showActionButtons, onAccept, onDiscard,
 }: {
   children: string,
   showActionButtons?: boolean
-  onAdopt?: () => void,
+  onAccept?: () => void,
   onDiscard?: () => void,
 }): JSX.Element => {
   const { t } = useTranslation();
@@ -74,9 +74,9 @@ const AssistantMessageCard = ({
                     <button
                       type="button"
                       className="btn btn-outline-secondary"
-                      onClick={onAdopt}
+                      onClick={onAccept}
                     >
-                      {t('sidebar_ai_assistant.adopt')}
+                      {t('sidebar_ai_assistant.accept')}
                     </button>
                   </div>
                 )}
@@ -99,12 +99,12 @@ type Props = {
   children: string,
   showActionButtons?: boolean,
   onDiscard?: () => void,
-  onAdopt?: () => void,
+  onAccept?: () => void,
 }
 
 export const MessageCard = (props: Props): JSX.Element => {
   const {
-    role, children, showActionButtons, onAdopt, onDiscard,
+    role, children, showActionButtons, onAccept, onDiscard,
   } = props;
 
   return role === 'user'
@@ -112,7 +112,7 @@ export const MessageCard = (props: Props): JSX.Element => {
     : (
       <AssistantMessageCard
         showActionButtons={showActionButtons}
-        onAdopt={onAdopt}
+        onAccept={onAccept}
         onDiscard={onDiscard}
       >{children}
       </AssistantMessageCard>

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/MessageCard.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/MessageCard.tsx
@@ -40,7 +40,14 @@ const NextLinkWrapper = (props: LinkProps & {children: string, href: string}): J
   );
 };
 
-const AssistantMessageCard = ({ children, showActionButtons }: { children: string, showActionButtons?: boolean }): JSX.Element => {
+const AssistantMessageCard = ({
+  children, showActionButtons, onAdopt, onDiscard,
+}: {
+  children: string,
+  showActionButtons?: boolean
+  onAdopt?: () => void,
+  onDiscard?: () => void,
+}): JSX.Element => {
   const { t } = useTranslation();
 
   return (
@@ -60,12 +67,14 @@ const AssistantMessageCard = ({ children, showActionButtons }: { children: strin
                     <button
                       type="button"
                       className="btn btn-outline-secondary me-2"
+                      onClick={onDiscard}
                     >
                       破棄
                     </button>
                     <button
                       type="button"
                       className="btn btn-outline-secondary"
+                      onClick={onAdopt}
                     >
                       採用
                     </button>
@@ -89,12 +98,23 @@ type Props = {
   role: 'user' | 'assistant',
   children: string,
   showActionButtons?: boolean,
+  onDiscard?: () => void,
+  onAdopt?: () => void,
 }
 
 export const MessageCard = (props: Props): JSX.Element => {
-  const { role, children, showActionButtons } = props;
+  const {
+    role, children, showActionButtons, onAdopt, onDiscard,
+  } = props;
 
   return role === 'user'
     ? <UserMessageCard>{children}</UserMessageCard>
-    : <AssistantMessageCard showActionButtons={showActionButtons}>{children}</AssistantMessageCard>;
+    : (
+      <AssistantMessageCard
+        showActionButtons={showActionButtons}
+        onAdopt={onAdopt}
+        onDiscard={onDiscard}
+      >{children}
+      </AssistantMessageCard>
+    );
 };

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/MessageCard.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/MessageCard.tsx
@@ -73,7 +73,7 @@ const AssistantMessageCard = ({
                     </button>
                     <button
                       type="button"
-                      className="btn btn-outline-secondary"
+                      className="btn btn-outline-success"
                       onClick={onAccept}
                     >
                       {t('sidebar_ai_assistant.accept')}

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/MessageCard.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/MessageCard.tsx
@@ -69,14 +69,14 @@ const AssistantMessageCard = ({
                       className="btn btn-outline-secondary me-2"
                       onClick={onDiscard}
                     >
-                      破棄
+                      {t('sidebar_ai_assistant.discard')}
                     </button>
                     <button
                       type="button"
                       className="btn btn-outline-secondary"
                       onClick={onAdopt}
                     >
-                      採用
+                      {t('sidebar_ai_assistant.adopt')}
                     </button>
                   </div>
                 )}

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/MessageCard.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/MessageCard.tsx
@@ -40,7 +40,7 @@ const NextLinkWrapper = (props: LinkProps & {children: string, href: string}): J
   );
 };
 
-const AssistantMessageCard = ({ children }: { children: string }): JSX.Element => {
+const AssistantMessageCard = ({ children, showActionButtons }: { children: string, showActionButtons?: boolean }): JSX.Element => {
   const { t } = useTranslation();
 
   return (
@@ -54,20 +54,23 @@ const AssistantMessageCard = ({ children }: { children: string }): JSX.Element =
             ? (
               <>
                 <ReactMarkdown components={{ a: NextLinkWrapper }}>{children}</ReactMarkdown>
-                <div className="d-flex mt-2 justify-content-start">
-                  <button
-                    type="button"
-                    className="btn btn-outline-secondary me-2"
-                  >
-                    破棄
-                  </button>
-                  <button
-                    type="button"
-                    className="btn btn-outline-secondary"
-                  >
-                    採用
-                  </button>
-                </div>
+
+                {showActionButtons && (
+                  <div className="d-flex mt-2 justify-content-start">
+                    <button
+                      type="button"
+                      className="btn btn-outline-secondary me-2"
+                    >
+                      破棄
+                    </button>
+                    <button
+                      type="button"
+                      className="btn btn-outline-secondary"
+                    >
+                      採用
+                    </button>
+                  </div>
+                )}
               </>
             )
             : (
@@ -85,12 +88,13 @@ const AssistantMessageCard = ({ children }: { children: string }): JSX.Element =
 type Props = {
   role: 'user' | 'assistant',
   children: string,
+  showActionButtons?: boolean,
 }
 
 export const MessageCard = (props: Props): JSX.Element => {
-  const { role, children } = props;
+  const { role, children, showActionButtons } = props;
 
   return role === 'user'
     ? <UserMessageCard>{children}</UserMessageCard>
-    : <AssistantMessageCard>{children}</AssistantMessageCard>;
+    : <AssistantMessageCard showActionButtons={showActionButtons}>{children}</AssistantMessageCard>;
 };

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/MessageCard.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/MessageCard.tsx
@@ -39,6 +39,7 @@ const NextLinkWrapper = (props: LinkProps & {children: string, href: string}): J
     </NextLink>
   );
 };
+
 const AssistantMessageCard = ({ children }: { children: string }): JSX.Element => {
   const { t } = useTranslation();
 
@@ -51,7 +52,23 @@ const AssistantMessageCard = ({ children }: { children: string }): JSX.Element =
         <div>
           { children.length > 0
             ? (
-              <ReactMarkdown components={{ a: NextLinkWrapper }}>{children}</ReactMarkdown>
+              <>
+                <ReactMarkdown components={{ a: NextLinkWrapper }}>{children}</ReactMarkdown>
+                <div className="d-flex mt-2 justify-content-start">
+                  <button
+                    type="button"
+                    className="btn btn-outline-secondary me-2"
+                  >
+                    破棄
+                  </button>
+                  <button
+                    type="button"
+                    className="btn btn-outline-secondary"
+                  >
+                    採用
+                  </button>
+                </div>
+              </>
             )
             : (
               <span className="text-thinking">


### PR DESCRIPTION
# Task
- [#163071](https://redmine.weseek.co.jp/issues/163071) [GROWI AI Next][エディターアシスタント] AiAssistantSidebar にエディターアシスタント用の画面を表示できる
  - [#163080](https://redmine.weseek.co.jp/issues/163080) 採用・破棄 ボタンの実装

# FIgma
https://www.figma.com/design/ZiEcjZ8sYt6YvowboA5Um6/GROWI-v7?node-id=2847-15685&t=SLJekWzJqfzfvFpz-0

# Screenshot
<img width="957" alt="スクリーンショット 2025-03-18 16 49 00" src="https://github.com/user-attachments/assets/6142e22b-d3d9-4b1c-a273-a53b3354e6b3" />

