### PR TITLE
feat:  Implement dropdown to list available assistants in editor assistant

### DIFF
--- a/apps/app/public/static/locales/en_US/translation.json
+++ b/apps/app/public/static/locales/en_US/translation.json
@@ -512,6 +512,7 @@
     "show_error_detail": "Show error details",
     "discard": "Discard",
     "accept": "Accept",
+    "use_assistant": "Use Assistant",
     "preset_menu": {
       "summarize": {
         "title": "Summarize this article",

--- a/apps/app/public/static/locales/en_US/translation.json
+++ b/apps/app/public/static/locales/en_US/translation.json
@@ -513,6 +513,7 @@
     "discard": "Discard",
     "accept": "Accept",
     "use_assistant": "Use Assistant",
+    "remove_assistant": "Deselect the selected assistant",
     "preset_menu": {
       "summarize": {
         "title": "Summarize this article",

--- a/apps/app/public/static/locales/fr_FR/translation.json
+++ b/apps/app/public/static/locales/fr_FR/translation.json
@@ -506,6 +506,7 @@
     "show_error_detail": "Détails de l'exposition",
     "discard": "Annuler",
     "accept": "Accepter",
+    "use_assistant": "Utiliser l'assistant",
     "preset_menu": {
       "summarize": {
         "title": "Résumer cet article'",

--- a/apps/app/public/static/locales/fr_FR/translation.json
+++ b/apps/app/public/static/locales/fr_FR/translation.json
@@ -507,6 +507,7 @@
     "discard": "Annuler",
     "accept": "Accepter",
     "use_assistant": "Utiliser l'assistant",
+    "remove_assistant": "Désélectionner l'assistant sélectionné",
     "preset_menu": {
       "summarize": {
         "title": "Résumer cet article'",

--- a/apps/app/public/static/locales/ja_JP/translation.json
+++ b/apps/app/public/static/locales/ja_JP/translation.json
@@ -545,6 +545,7 @@
     "discard": "破棄",
     "accept": "採用",
     "use_assistant": "アシスタントを使用する",
+    "remove_assistant": "選択されているアシスタントの解除",
     "preset_menu": {
       "summarize": {
         "title": "この記事の要約をつくる",

--- a/apps/app/public/static/locales/ja_JP/translation.json
+++ b/apps/app/public/static/locales/ja_JP/translation.json
@@ -544,6 +544,7 @@
     "show_error_detail": "詳細を表示",
     "discard": "破棄",
     "accept": "採用",
+    "use_assistant": "アシスタントを使用する",
     "preset_menu": {
       "summarize": {
         "title": "この記事の要約をつくる",

--- a/apps/app/public/static/locales/zh_CN/translation.json
+++ b/apps/app/public/static/locales/zh_CN/translation.json
@@ -502,6 +502,7 @@
     "discard": "丢弃",
     "accept": "接受",
     "use_assistant": "使用助手",
+    "remove_assistant": "取消选定的助手",
     "preset_menu": {
       "summarize": {
         "title": "为此文章创建摘要",

--- a/apps/app/public/static/locales/zh_CN/translation.json
+++ b/apps/app/public/static/locales/zh_CN/translation.json
@@ -501,6 +501,7 @@
     "show_error_detail": "显示详情",
     "discard": "丢弃",
     "accept": "接受",
+    "use_assistant": "使用助手",
     "preset_menu": {
       "summarize": {
         "title": "为此文章创建摘要",

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantDropdown.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantDropdown.tsx
@@ -1,0 +1,69 @@
+
+import React, { useState, useMemo, useCallback } from 'react';
+
+import { useTranslation } from 'react-i18next';
+import {
+  UncontrolledDropdown,
+  DropdownToggle,
+  DropdownMenu,
+  DropdownItem,
+} from 'reactstrap';
+import 'bootstrap/dist/css/bootstrap.min.css';
+
+import type { AiAssistantHasId } from '../../../../interfaces/ai-assistant';
+import { useSWRxAiAssistants } from '../../../stores/ai-assistant';
+import { getShareScopeIcon } from '../../../utils/get-share-scope-Icon';
+
+
+type Props = {
+  //
+}
+
+export const AiAssistantDropdown = (props: Props): JSX.Element => {
+  const [selectedAiAssistant, setSelectedAiAssistant] = useState<AiAssistantHasId>();
+
+  const { t } = useTranslation();
+  const { data: aiAssistantData } = useSWRxAiAssistants();
+
+  const allAiAssistants = useMemo(() => {
+    if (aiAssistantData == null) {
+      return [];
+    }
+    return [...aiAssistantData.myAiAssistants, ...aiAssistantData.teamAiAssistants];
+  }, [aiAssistantData]);
+
+  const getAiAssistantLabel = useCallback((aiAssistant: AiAssistantHasId) => {
+    return (
+      <>
+        <span className="material-symbols-outlined fs-5 me-1">
+          {getShareScopeIcon(aiAssistant.shareScope, aiAssistant.accessScope)}
+        </span>
+        {aiAssistant.name}
+      </>
+    );
+  }, []);
+
+  return (
+    <UncontrolledDropdown>
+      <DropdownToggle className="btn btn-outline-secondary">
+        {selectedAiAssistant != null
+          ? getAiAssistantLabel(selectedAiAssistant)
+          : <><span className="material-symbols-outlined fs-5">Add</span>{t('sidebar_ai_assistant.use_assistant')}</>
+        }
+      </DropdownToggle>
+      <DropdownMenu>
+        {allAiAssistants.map((aiAssistant) => {
+          return (
+            <DropdownItem
+              key={aiAssistant._id}
+              active={selectedAiAssistant?._id === aiAssistant._id}
+              onClick={() => setSelectedAiAssistant(aiAssistant)}
+            >
+              {getAiAssistantLabel(aiAssistant)}
+            </DropdownItem>
+          );
+        })}
+      </DropdownMenu>
+    </UncontrolledDropdown>
+  );
+};

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantDropdown.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantDropdown.tsx
@@ -8,12 +8,10 @@ import {
   DropdownMenu,
   DropdownItem,
 } from 'reactstrap';
-import 'bootstrap/dist/css/bootstrap.min.css';
 
 import type { AiAssistantHasId } from '../../../../interfaces/ai-assistant';
 import { useSWRxAiAssistants } from '../../../stores/ai-assistant';
 import { getShareScopeIcon } from '../../../utils/get-share-scope-Icon';
-
 
 type Props = {
   //

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantDropdown.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantDropdown.tsx
@@ -43,6 +43,10 @@ export const AiAssistantDropdown = (props: Props): JSX.Element => {
     );
   }, []);
 
+  const selectAiAssistantHandler = useCallback((aiAssistant?: AiAssistantHasId) => {
+    setSelectedAiAssistant(aiAssistant);
+  }, []);
+
   return (
     <UncontrolledDropdown>
       <DropdownToggle className="btn btn-outline-secondary" disabled={allAiAssistants.length === 0}>
@@ -57,12 +61,16 @@ export const AiAssistantDropdown = (props: Props): JSX.Element => {
             <DropdownItem
               key={aiAssistant._id}
               active={selectedAiAssistant?._id === aiAssistant._id}
-              onClick={() => setSelectedAiAssistant(aiAssistant)}
+              onClick={() => selectAiAssistantHandler(aiAssistant)}
             >
               {getAiAssistantLabel(aiAssistant)}
             </DropdownItem>
           );
         })}
+        <DropdownItem divider />
+        <DropdownItem onClick={() => selectAiAssistantHandler()}>
+          {t('sidebar_ai_assistant.remove_assistant')}
+        </DropdownItem>
       </DropdownMenu>
     </UncontrolledDropdown>
   );

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantDropdown.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantDropdown.tsx
@@ -45,7 +45,7 @@ export const AiAssistantDropdown = (props: Props): JSX.Element => {
 
   return (
     <UncontrolledDropdown>
-      <DropdownToggle className="btn btn-outline-secondary">
+      <DropdownToggle className="btn btn-outline-secondary" disabled={allAiAssistants.length === 0}>
         {selectedAiAssistant != null
           ? getAiAssistantLabel(selectedAiAssistant)
           : <><span className="material-symbols-outlined fs-5">Add</span>{t('sidebar_ai_assistant.use_assistant')}</>

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar.tsx
@@ -360,12 +360,13 @@ const AiAssistantSidebarSubstance: React.FC<AiAssistantSidebarSubstanceProps> = 
               <>{isEditorAssistant
                 ? (
                   <>
-                    <AiAssistantDropdown />
+                    <div className="py-2">
+                      <AiAssistantDropdown />
+                    </div>
                     <QuickMenuList
                       onClick={clickQuickMenuHandler}
                     />
                   </>
-
                 )
                 : (
                   <AiAssistantChatInitialView

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar.tsx
@@ -23,6 +23,7 @@ import { useSWRMUTxMessages } from '../../../stores/message';
 import { useSWRMUTxThreads } from '../../../stores/thread';
 
 import { AiAssistantChatInitialView } from './AiAssistantChatInitialView';
+import { AiAssistantDropdown } from './AiAssistantDropdown';
 import { MessageCard } from './MessageCard';
 import { QuickMenuList } from './QuickMenuList';
 import { ResizableTextarea } from './ResizableTextArea';
@@ -358,9 +359,13 @@ const AiAssistantSidebarSubstance: React.FC<AiAssistantSidebarSubstanceProps> = 
             : (
               <>{isEditorAssistant
                 ? (
-                  <QuickMenuList
-                    onClick={clickQuickMenuHandler}
-                  />
+                  <>
+                    <AiAssistantDropdown />
+                    <QuickMenuList
+                      onClick={clickQuickMenuHandler}
+                    />
+                  </>
+
                 )
                 : (
                   <AiAssistantChatInitialView

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/QuickMenuList.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/QuickMenuList.tsx
@@ -19,7 +19,7 @@ export const QuickMenuList: React.FC<Props> = ({ onClick }: Props) => {
   }, [onClick, t]);
 
   return (
-    <div className="container py-4">
+    <div className="container">
       <div className="d-flex flex-column gap-3">
         {presetMenus.map(presetMenu => (
           <button

--- a/apps/app/src/features/openai/client/components/AiAssistant/Sidebar/AiAssistantTree.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/Sidebar/AiAssistantTree.tsx
@@ -9,13 +9,13 @@ import type { IThreadRelationHasId } from '~/features/openai/interfaces/thread-r
 import { useCurrentUser } from '~/stores-universal/context';
 import loggerFactory from '~/utils/logger';
 
-import type { AiAssistantAccessScope } from '../../../../interfaces/ai-assistant';
 import { AiAssistantShareScope, type AiAssistantHasId } from '../../../../interfaces/ai-assistant';
 import { determineShareScope } from '../../../../utils/determine-share-scope';
 import { deleteAiAssistant, setDefaultAiAssistant } from '../../../services/ai-assistant';
 import { deleteThread } from '../../../services/thread';
 import { useAiAssistantSidebar, useAiAssistantManagementModal } from '../../../stores/ai-assistant';
 import { useSWRMUTxThreads, useSWRxThreads } from '../../../stores/thread';
+import { getShareScopeIcon } from '../../../utils/get-share-scope-Icon';
 
 import styles from './AiAssistantTree.module.scss';
 
@@ -125,20 +125,6 @@ const ThreadItems: React.FC<ThreadItemsProps> = ({ aiAssistantData, onThreadClic
 /*
 *  AiAssistantItem
 */
-const getShareScopeIcon = (shareScope: AiAssistantShareScope, accessScope: AiAssistantAccessScope): string => {
-  const determinedSharedScope = determineShareScope(shareScope, accessScope);
-  switch (determinedSharedScope) {
-    case AiAssistantShareScope.OWNER:
-      return 'lock';
-    case AiAssistantShareScope.GROUPS:
-      return 'account_tree';
-    case AiAssistantShareScope.PUBLIC_ONLY:
-      return 'group';
-    case AiAssistantShareScope.SAME_AS_ACCESS_SCOPE:
-      return '';
-  }
-};
-
 type AiAssistantItemProps = {
   currentUser?: IUserHasId | null;
   aiAssistant: AiAssistantHasId;

--- a/apps/app/src/features/openai/client/utils/get-share-scope-Icon.ts
+++ b/apps/app/src/features/openai/client/utils/get-share-scope-Icon.ts
@@ -1,0 +1,17 @@
+import type { AiAssistantAccessScope } from '../../interfaces/ai-assistant';
+import { AiAssistantShareScope } from '../../interfaces/ai-assistant';
+import { determineShareScope } from '../../utils/determine-share-scope';
+
+export const getShareScopeIcon = (shareScope: AiAssistantShareScope, accessScope: AiAssistantAccessScope): string => {
+  const determinedSharedScope = determineShareScope(shareScope, accessScope);
+  switch (determinedSharedScope) {
+    case AiAssistantShareScope.OWNER:
+      return 'lock';
+    case AiAssistantShareScope.GROUPS:
+      return 'account_tree';
+    case AiAssistantShareScope.PUBLIC_ONLY:
+      return 'group';
+    case AiAssistantShareScope.SAME_AS_ACCESS_SCOPE:
+      return '';
+  }
+};


### PR DESCRIPTION
# Task
- [#163071](https://redmine.weseek.co.jp/issues/163071) [GROWI AI Next][エディターアシスタント] AiAssistantSidebar にエディターアシスタント用の画面を表示できる
  - [#163298](https://redmine.weseek.co.jp/issues/163298) アシスタントを表示するドロップダウンの実装

# Figma
https://www.figma.com/design/ZiEcjZ8sYt6YvowboA5Um6/GROWI-v7?node-id=2916-27239&t=u7lIdpxKlNE1D4eg-0

# Screenrecord
https://github.com/user-attachments/assets/3014312a-b892-446b-85b8-d4fe0f300872



