### PR TITLE
fix: Prevent empty compose.extend.yml

### DIFF
--- a/.devcontainer/app/initializeCommand.sh
+++ b/.devcontainer/app/initializeCommand.sh
@@ -1,4 +1,9 @@
 # prevent file not found error on docker compose up
 if [ ! -f ".devcontainer/compose.extend.yml" ]; then
-  touch .devcontainer/compose.extend.yml
+
+cat > ".devcontainer/compose.extend.yml" <<EOF
+services:
+  {}
+EOF
+
 fi

--- a/.devcontainer/pdf-converter/initializeCommand.sh
+++ b/.devcontainer/pdf-converter/initializeCommand.sh
@@ -1,4 +1,9 @@
 # prevent file not found error on docker compose up
 if [ ! -f ".devcontainer/compose.extend.yml" ]; then
-  touch .devcontainer/compose.extend.yml
+
+cat > ".devcontainer/compose.extend.yml" <<EOF
+services:
+  {}
+EOF
+
 fi


### PR DESCRIPTION
compose.extend.yml が空の場合、devcontainer の作成に失敗することがあるため、空ファイルの作成を避ける。

## task
https://redmine.weseek.co.jp/issues/163533