### PR TITLE
feat: Add util method to get react instance of growi via growifacade

### DIFF
--- a/.changeset/eighty-pots-approve.md
+++ b/.changeset/eighty-pots-approve.md
@@ -1,0 +1,5 @@
+---
+'@growi/pluginkit': minor
+---
+
+feat: Add util function to get react instance of GROWI via GrowiFacade

--- a/packages/pluginkit/package.json
+++ b/packages/pluginkit/package.json
@@ -21,7 +21,10 @@
     "test": "vitest run --coverage"
   },
   "dependencies": {
-    "@growi/core": "^1.4.0",
+    "@growi/core": "^1.5.0",
     "extensible-custom-error": "^0.0.7"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.14"
   }
 }

--- a/packages/pluginkit/src/index.ts
+++ b/packages/pluginkit/src/index.ts
@@ -1,1 +1,2 @@
 export * from './model';
+export * from './v4/client';

--- a/packages/pluginkit/src/v4/client/index.ts
+++ b/packages/pluginkit/src/v4/client/index.ts
@@ -1,0 +1,1 @@
+export * from './utils';

--- a/packages/pluginkit/src/v4/client/utils/growi-facade/growi-react.spec.ts
+++ b/packages/pluginkit/src/v4/client/utils/growi-facade/growi-react.spec.ts
@@ -1,0 +1,42 @@
+import type React from 'react';
+
+import { growiReact } from './growi-react';
+
+describe('growiReact()', () => {
+  const mockReact = { useState: () => {} } as unknown as typeof React;
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+    delete (global as any).window.GrowiFacade;
+  });
+
+  it('returns window.GrowiFacade.react in production mode', () => {
+    // given
+    process.env.NODE_ENV = 'production';
+    const mockProductionReact = { useEffect: () => {} } as unknown as typeof React;
+
+    (global as any).window = {
+      GrowiFacade: {
+        react: mockProductionReact,
+      },
+    };
+
+    // when
+    const result = growiReact(mockReact);
+
+    // then
+    expect(result).toBe(mockProductionReact);
+  });
+
+  it('returns the given react instance in development mode', () => {
+    // given
+    process.env.NODE_ENV = 'development';
+
+    // when
+    const result = growiReact(mockReact);
+
+    // then
+    expect(result).toBe(mockReact);
+  });
+});

--- a/packages/pluginkit/src/v4/client/utils/growi-facade/growi-react.ts
+++ b/packages/pluginkit/src/v4/client/utils/growi-facade/growi-react.ts
@@ -1,0 +1,33 @@
+import type React from 'react';
+
+import type { GrowiFacade } from '@growi/core';
+
+
+declare global {
+  interface Window {
+    GrowiFacade: GrowiFacade
+  }
+}
+
+/**
+ * Retrieves the React instance that this package should use.
+ *
+ * - **Production Mode**: Returns the React instance from `window.GrowiFacade.react`
+ *   to ensure consistency with GROWI's main React version.
+ * - **Development Mode**: Returns the React instance passed as an argument,
+ *   which typically allows local/hot reload development without conflicts.
+ *
+ * @param react - The React instance to use during development
+ * @returns A React instance to be used in the current environment
+ *
+ * @remarks
+ * This approach prevents bundling multiple React versions and avoids Hook conflicts.
+ * Make sure the `window.GrowiFacade.react` object is set before calling this function
+ * in a production environment.
+ */
+export const growiReact = (react: typeof React): typeof React => {
+  if (process.env.NODE_ENV === 'production') {
+    return window.GrowiFacade.react as typeof React;
+  }
+  return react as typeof React;
+};

--- a/packages/pluginkit/src/v4/client/utils/growi-facade/growi-react.ts
+++ b/packages/pluginkit/src/v4/client/utils/growi-facade/growi-react.ts
@@ -13,17 +13,18 @@ declare global {
  * Retrieves the React instance that this package should use.
  *
  * - **Production Mode**: Returns the React instance from `window.GrowiFacade.react`
- *   to ensure consistency with GROWI's main React version.
+ *   to ensure a single shared React instance across the app.
  * - **Development Mode**: Returns the React instance passed as an argument,
- *   which typically allows local/hot reload development without conflicts.
+ *   which allows local development and hot reload without issues.
  *
  * @param react - The React instance to use during development
  * @returns A React instance to be used in the current environment
  *
  * @remarks
- * This approach prevents bundling multiple React versions and avoids Hook conflicts.
- * Make sure the `window.GrowiFacade.react` object is set before calling this function
- * in a production environment.
+ * Using multiple React instances in a single app can cause serious issues,
+ * especially with features like Hooks, which rely on a consistent internal state.
+ * This function ensures that only one React instance is used in production
+ * to avoid such problems.
  */
 export const growiReact = (react: typeof React): typeof React => {
   if (process.env.NODE_ENV === 'production') {

--- a/packages/pluginkit/src/v4/client/utils/growi-facade/index.ts
+++ b/packages/pluginkit/src/v4/client/utils/growi-facade/index.ts
@@ -1,0 +1,1 @@
+export * from './growi-react';

--- a/packages/pluginkit/src/v4/client/utils/index.ts
+++ b/packages/pluginkit/src/v4/client/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './growi-facade';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1376,11 +1376,15 @@ importers:
   packages/pluginkit:
     dependencies:
       '@growi/core':
-        specifier: ^1.4.0
-        version: 1.4.0
+        specifier: ^1.5.0
+        version: 1.5.0
       extensible-custom-error:
         specifier: ^0.0.7
         version: 0.0.7
+    devDependencies:
+      '@types/react':
+        specifier: ^18.2.14
+        version: 18.3.3
 
   packages/presentation:
     dependencies:
@@ -2574,6 +2578,9 @@ packages:
   '@codemirror/language@6.10.8':
     resolution: {integrity: sha512-wcP8XPPhDH2vTqf181U8MbZnW+tDyPYy0UzVOa+oHORjyT+mhhom9vBd7dApJwoDz9Nb/a8kHjJIsuA/t8vNFw==}
 
+  '@codemirror/language@6.11.0':
+    resolution: {integrity: sha512-A7+f++LodNNc1wGgoRDTt78cOwWm9KVezApgjOMp1W4hM0898nsqBXwF+sbePE7ZRcjN7Sa1Z5m2oN27XkmEjQ==}
+
   '@codemirror/legacy-modes@6.4.1':
     resolution: {integrity: sha512-vdg3XY7OAs5uLDx2Iw+cGfnwtd7kM+Et/eMsqAGTfT/JKiVBQZXosTzjEbWAi/FrY6DcQIz8mQjBozFHZEUWQA==}
 
@@ -2997,8 +3004,8 @@ packages:
     resolution: {integrity: sha512-lOs/dCyveVF8TkVFnFSF7IGd0CJrTm91qiK6JLu+Z8qiT+7Ag0RyVhxZIWkhiACqwABo7kSHDm8FdH8p2wxSSw==}
     engines: {node: '>=10'}
 
-  '@growi/core@1.4.0':
-    resolution: {integrity: sha512-Jg6T5zYWyD07NOsYGcDyZrrEEAI59CiyFiJwsaIUi5Tadc6lh8QUAIpu+iLTbqxJ81yzNIzq5nkj4EyMhRZylw==}
+  '@growi/core@1.5.0':
+    resolution: {integrity: sha512-c1Rrui9efxX/7f1r0brb8IVjsY45tGUnuJNbXHWCR5hVkDkXuz63MJ3CgLco8x0A744Vn7W67a/FKgAEvPts1A==}
 
   '@grpc/grpc-js@1.12.2':
     resolution: {integrity: sha512-bgxdZmgTrJZX50OjyVwz3+mNEnCTNkh3cIqGPWVNeW9jX6bn1ZkU80uPd+67/ZpIJIjRQ9qaHCjhavyoWYxumg==}
@@ -3217,6 +3224,9 @@ packages:
 
   '@lezer/common@1.2.2':
     resolution: {integrity: sha512-Z+R3hN6kXbgBWAuejUNPihylAL1Z5CaFqnIe0nTX8Ej+XlIy3EGtXxn6WtLMO+os2hRkQvm2yvaGMYliUzlJaw==}
+
+  '@lezer/common@1.2.3':
+    resolution: {integrity: sha512-w7ojc8ejBqr2REPsWxJjrMFsA/ysDCFICn8zEOR9mrqzOu2amhITYuLD8ag6XZf0CFXDrhKqw7+tW8cX66NaDA==}
 
   '@lezer/cpp@1.1.1':
     resolution: {integrity: sha512-eS1M3L3U2mDowoFVPG7tEp01SWu9/68Nx3HEBgLJVn3N9ku7g5S7WdFv0jzmcTipAyONYfZJ+7x4WRkfdB2Ung==}
@@ -5297,6 +5307,9 @@ packages:
   '@types/eslint@8.37.0':
     resolution: {integrity: sha512-Piet7dG2JBuDIfohBngQ3rCt7MgO9xCO4xIMKxBThCq5PNRB91IjlJ10eJVwfoNtvTErmxLzwBZ7rHZtbOMmFQ==}
 
+  '@types/eslint@9.6.1':
+    resolution: {integrity: sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==}
+
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
@@ -5305,6 +5318,9 @@ packages:
 
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
+
+  '@types/estree@1.0.7':
+    resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
 
   '@types/express-serve-static-core@4.19.5':
     resolution: {integrity: sha512-y6W03tvrACO72aijJ5uF02FRq5cgDR9lUxddQ8vyF+GvmjJQqbzDcJngEjURc+ZsG31VI3hODNZJ2URj86pzmg==}
@@ -5422,6 +5438,9 @@ packages:
 
   '@types/node@20.14.0':
     resolution: {integrity: sha512-5cHBxFGJx6L4s56Bubp4fglrEpmyJypsqI6RgzMfBHWUJQGWAAi8cWcgetEbZXHYXo9C2Fa4EEds/uSyS4cxmA==}
+
+  '@types/node@22.13.13':
+    resolution: {integrity: sha512-ClsL5nMwKaBRwPcCvH8E7+nU4GxHVx1axNvMZTFHMEfNI7oahimt26P5zjVCRrjiIWj6YFXfE1v3dEp94wLcGQ==}
 
   '@types/node@22.8.7':
     resolution: {integrity: sha512-LidcG+2UeYIWcMuMUpBKOnryBWG/rnmOHQR5apjn8myTQcx3rinFRn7DcIFhMnS0PPFSC6OafdIKEad0lj6U0Q==}
@@ -10294,6 +10313,7 @@ packages:
 
   lodash.omit@4.5.0:
     resolution: {integrity: sha512-XeqSp49hNGmlkj2EJlfrQFIzQ6lXdNro9sddtQzcJY8QaoC2GO0DT7xaIokHeyM+mIT0mPMlPvkYzg2xCuHdZg==}
+    deprecated: This package is deprecated. Use destructuring assignment syntax instead.
 
   lodash.omitby@4.6.0:
     resolution: {integrity: sha512-5OrRcIVR75M288p4nbI2WLAf3ndw2GD9fyNv3Bc15+WCxJDdZ4lYndSxGd7hnG6PVjiJTeJE2dHEGhIuKGicIQ==}
@@ -13413,8 +13433,8 @@ packages:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
 
-  terser-webpack-plugin@5.3.11:
-    resolution: {integrity: sha512-RVCsMfuD0+cTt3EwX8hSl2Ks56EbFHWmhluwcqoPKtBnfjiT6olaq7PRIRfhyU8nnC2MrnDrBLfrD/RGE+cVXQ==}
+  terser-webpack-plugin@5.3.14:
+    resolution: {integrity: sha512-vkZjpUjb6OMS7dhV+tILUW6BhpDR7P2L/aQSAv+Uwk+m8KATX9EccViHTJR2qDtACKPIYndLGCyl3FMo+r2LMw==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
       '@swc/core': '*'
@@ -13660,6 +13680,9 @@ packages:
 
   tslib@2.8.0:
     resolution: {integrity: sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA==}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   tspc@1.1.2:
     resolution: {integrity: sha512-2a6CildDvcLB7VCHUTPgT3jdGUfoX0QfgTWQ4F6czwED8o4rAMK4P/ZSUpTJAOpdTOqlsTojj05hyu3F1Wm85g==}
@@ -13928,6 +13951,9 @@ packages:
 
   undici-types@6.19.8:
     resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
+
+  undici-types@6.20.0:
+    resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
 
   undici@6.19.2:
     resolution: {integrity: sha512-JfjKqIauur3Q6biAtHJ564e3bWa8VvT+7cSiOJHFbX4Erv6CLGDpg8z+Fmg/1OI/47RA+GI2QZaF48SSaLvyBA==}
@@ -16437,6 +16463,15 @@ snapshots:
       '@lezer/lr': 1.4.2
       style-mod: 4.1.2
 
+  '@codemirror/language@6.11.0':
+    dependencies:
+      '@codemirror/state': 6.5.2
+      '@codemirror/view': 6.36.4
+      '@lezer/common': 1.2.3
+      '@lezer/highlight': 1.2.1
+      '@lezer/lr': 1.4.2
+      style-mod: 4.1.2
+
   '@codemirror/legacy-modes@6.4.1':
     dependencies:
       '@codemirror/language': 6.10.8
@@ -16467,7 +16502,7 @@ snapshots:
 
   '@codemirror/theme-one-dark@6.1.2':
     dependencies:
-      '@codemirror/language': 6.10.8
+      '@codemirror/language': 6.11.0
       '@codemirror/state': 6.5.2
       '@codemirror/view': 6.36.4
       '@lezer/highlight': 1.2.1
@@ -16770,7 +16805,7 @@ snapshots:
       - encoding
       - supports-color
 
-  '@growi/core@1.4.0':
+  '@growi/core@1.5.0':
     dependencies:
       bson-objectid: 2.0.4
       escape-string-regexp: 4.0.0
@@ -17121,6 +17156,8 @@ snapshots:
   '@ldapjs/protocol@1.2.1': {}
 
   '@lezer/common@1.2.2': {}
+
+  '@lezer/common@1.2.3': {}
 
   '@lezer/cpp@1.1.1':
     dependencies:
@@ -19512,7 +19549,7 @@ snapshots:
 
   '@swc/helpers@0.5.15':
     dependencies:
-      tslib: 2.8.0
+      tslib: 2.8.1
     optional: true
 
   '@swc/helpers@0.5.5':
@@ -20138,12 +20175,17 @@ snapshots:
 
   '@types/eslint-scope@3.7.7':
     dependencies:
-      '@types/eslint': 8.37.0
-      '@types/estree': 1.0.6
+      '@types/eslint': 9.6.1
+      '@types/estree': 1.0.7
 
   '@types/eslint@8.37.0':
     dependencies:
       '@types/estree': 1.0.6
+      '@types/json-schema': 7.0.15
+
+  '@types/eslint@9.6.1':
+    dependencies:
+      '@types/estree': 1.0.7
       '@types/json-schema': 7.0.15
 
   '@types/estree-jsx@1.0.5':
@@ -20153,6 +20195,8 @@ snapshots:
   '@types/estree@1.0.5': {}
 
   '@types/estree@1.0.6': {}
+
+  '@types/estree@1.0.7': {}
 
   '@types/express-serve-static-core@4.19.5':
     dependencies:
@@ -20291,6 +20335,10 @@ snapshots:
   '@types/node@20.14.0':
     dependencies:
       undici-types: 5.26.5
+
+  '@types/node@22.13.13':
+    dependencies:
+      undici-types: 6.20.0
 
   '@types/node@22.8.7':
     dependencies:
@@ -24609,7 +24657,7 @@ snapshots:
       depd: 1.1.2
       inherits: 2.0.3
       setprototypeof: 1.1.0
-      statuses: 1.5.0
+      statuses: 1.4.0
 
   http-errors@1.7.3:
     dependencies:
@@ -25436,7 +25484,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 22.8.7
+      '@types/node': 22.13.13
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -29898,7 +29946,7 @@ snapshots:
 
   term-size@2.2.1: {}
 
-  terser-webpack-plugin@5.3.11(@swc/core@1.10.7(@swc/helpers@0.5.15))(webpack@5.92.1(@swc/core@1.10.7(@swc/helpers@0.5.15))):
+  terser-webpack-plugin@5.3.14(@swc/core@1.10.7(@swc/helpers@0.5.15))(webpack@5.92.1(@swc/core@1.10.7(@swc/helpers@0.5.15))):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
@@ -30139,6 +30187,9 @@ snapshots:
   tslib@2.7.0: {}
 
   tslib@2.8.0: {}
+
+  tslib@2.8.1:
+    optional: true
 
   tspc@1.1.2: {}
 
@@ -30384,6 +30435,8 @@ snapshots:
   undici-types@5.26.5: {}
 
   undici-types@6.19.8: {}
+
+  undici-types@6.20.0: {}
 
   undici@6.19.2: {}
 
@@ -30858,7 +30911,7 @@ snapshots:
   webpack@5.92.1(@swc/core@1.10.7(@swc/helpers@0.5.15)):
     dependencies:
       '@types/eslint-scope': 3.7.7
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
       '@webassemblyjs/ast': 1.14.1
       '@webassemblyjs/wasm-edit': 1.14.1
       '@webassemblyjs/wasm-parser': 1.14.1
@@ -30878,7 +30931,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.11(@swc/core@1.10.7(@swc/helpers@0.5.15))(webpack@5.92.1(@swc/core@1.10.7(@swc/helpers@0.5.15)))
+      terser-webpack-plugin: 5.3.14(@swc/core@1.10.7(@swc/helpers@0.5.15))(webpack@5.92.1(@swc/core@1.10.7(@swc/helpers@0.5.15)))
       watchpack: 2.4.2
       webpack-sources: 3.2.3
     transitivePeerDependencies:


### PR DESCRIPTION
[#156916[Plugin] react hook が使えない問題を解決する](https://redmine.weseek.co.jp/issues/156916)
└[#163185@growi/plugin kit に GrowiFacade から、react インスタンスをとってこれる util を追加する](https://redmine.weseek.co.jp/issues/163185)

## review task 
- https://redmine.weseek.co.jp/issues/163557

## usage 

``` typescript
import React from 'react';
import { growiReact } from '@growi/pluginkit';
const growiReactInstance = growiReact(React);
```