### PR TITLE
feat: Apply editor assistant responses to editor (only insert)

### DIFF
--- a/apps/app/src/client/components/PageEditor/PageEditor.tsx
+++ b/apps/app/src/client/components/PageEditor/PageEditor.tsx
@@ -13,7 +13,7 @@ import { GlobalCodeMirrorEditorKey } from '@growi/editor';
 import { CodeMirrorEditorMain } from '@growi/editor/dist/client/components/CodeMirrorEditorMain';
 import { useCodeMirrorEditorIsolated } from '@growi/editor/dist/client/stores/codemirror-editor';
 import { useResolvedThemeForEditor } from '@growi/editor/dist/client/stores/use-resolved-theme';
-import { useIsEnableUnifiedMergeView } from '@growi/editor/src/client/stores/use-is-enable-unified-merge-view';
+import { useUnifiedMergeViewConfig } from '@growi/editor/dist/client/stores/use-unified-merge-view-config';
 import { useRect } from '@growi/ui/dist/utils';
 import detectIndent from 'detect-indent';
 import { useTranslation } from 'next-i18next';
@@ -112,7 +112,7 @@ export const PageEditorSubstance = (props: Props): JSX.Element => {
   const { mutate: mutateEditingUsers } = useEditingClients();
   const onConflict = useConflictResolver();
   const { data: reservedNextCaretLine, mutate: mutateReservedNextCaretLine } = useReservedNextCaretLine();
-  const { data: isEnableUnifiedMergeView } = useIsEnableUnifiedMergeView();
+  const { data: unifiedMergeViewConfig } = useUnifiedMergeViewConfig();
 
   const { data: rendererOptions } = usePreviewOptions();
 
@@ -367,7 +367,8 @@ export const PageEditorSubstance = (props: Props): JSX.Element => {
     <div className={`flex-expand-horiz ${props.visibility ? '' : 'd-none'}`}>
       <div className="page-editor-editor-container flex-expand-vert border-end">
         <CodeMirrorEditorMain
-          enableUnifiedMergeView={isEnableUnifiedMergeView}
+          insertText={unifiedMergeViewConfig?.insertText}
+          enableUnifiedMergeView={unifiedMergeViewConfig?.isEnabled}
           enableCollaboration={editorMode === EditorMode.Editor}
           onSave={saveWithShortcut}
           onUpload={uploadHandler}

--- a/apps/app/src/client/components/PageEditor/PageEditor.tsx
+++ b/apps/app/src/client/components/PageEditor/PageEditor.tsx
@@ -13,6 +13,7 @@ import { GlobalCodeMirrorEditorKey } from '@growi/editor';
 import { CodeMirrorEditorMain } from '@growi/editor/dist/client/components/CodeMirrorEditorMain';
 import { useCodeMirrorEditorIsolated } from '@growi/editor/dist/client/stores/codemirror-editor';
 import { useResolvedThemeForEditor } from '@growi/editor/dist/client/stores/use-resolved-theme';
+import { useIsEnableUnifiedMergeView } from '@growi/editor/src/client/stores/use-is-enable-unified-merge-view';
 import { useRect } from '@growi/ui/dist/utils';
 import detectIndent from 'detect-indent';
 import { useTranslation } from 'next-i18next';
@@ -111,6 +112,7 @@ export const PageEditorSubstance = (props: Props): JSX.Element => {
   const { mutate: mutateEditingUsers } = useEditingClients();
   const onConflict = useConflictResolver();
   const { data: reservedNextCaretLine, mutate: mutateReservedNextCaretLine } = useReservedNextCaretLine();
+  const { data: isEnableUnifiedMergeView } = useIsEnableUnifiedMergeView();
 
   const { data: rendererOptions } = usePreviewOptions();
 
@@ -365,6 +367,7 @@ export const PageEditorSubstance = (props: Props): JSX.Element => {
     <div className={`flex-expand-horiz ${props.visibility ? '' : 'd-none'}`}>
       <div className="page-editor-editor-container flex-expand-vert border-end">
         <CodeMirrorEditorMain
+          enableUnifiedMergeView={isEnableUnifiedMergeView}
           enableCollaboration={editorMode === EditorMode.Editor}
           onSave={saveWithShortcut}
           onUpload={uploadHandler}

--- a/apps/app/src/client/components/PageEditor/PageEditor.tsx
+++ b/apps/app/src/client/components/PageEditor/PageEditor.tsx
@@ -367,7 +367,7 @@ export const PageEditorSubstance = (props: Props): JSX.Element => {
     <div className={`flex-expand-horiz ${props.visibility ? '' : 'd-none'}`}>
       <div className="page-editor-editor-container flex-expand-vert border-end">
         <CodeMirrorEditorMain
-          insertText={unifiedMergeViewConfig?.insertText}
+          unifiedMergeViewConfig={unifiedMergeViewConfig?.detectedDiff}
           enableUnifiedMergeView={unifiedMergeViewConfig?.isEnabled}
           enableCollaboration={editorMode === EditorMode.Editor}
           onSave={saveWithShortcut}

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar.tsx
@@ -500,6 +500,7 @@ export const AiAssistantSidebar: FC = memo((): JSX.Element => {
   const sidebarScrollerRef = useRef<HTMLDivElement>(null);
 
   const { data: aiAssistantSidebarData, close: closeAiAssistantSidebar } = useAiAssistantSidebar();
+  const { mutate: mutateUnifiedMergeViewConfig } = useUnifiedMergeViewConfig();
 
   const aiAssistantData = aiAssistantSidebarData?.aiAssistantData;
   const threadData = aiAssistantSidebarData?.threadData;
@@ -518,6 +519,12 @@ export const AiAssistantSidebar: FC = memo((): JSX.Element => {
       document.removeEventListener('mousedown', handleClickOutside);
     };
   }, [closeAiAssistantSidebar, isOpened]);
+
+  useEffect(() => {
+    if (!aiAssistantSidebarData?.isOpened) {
+      mutateUnifiedMergeViewConfig({ isEnabled: false });
+    }
+  }, [aiAssistantSidebarData?.isOpened, mutateUnifiedMergeViewConfig]);
 
   if (!isOpened) {
     return <></>;

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar.tsx
@@ -18,6 +18,7 @@ import { useGrowiCloudUri } from '~/stores-universal/context';
 import loggerFactory from '~/utils/logger';
 
 import type { AiAssistantHasId } from '../../../../interfaces/ai-assistant';
+import { isInsertDiff } from '../../../../interfaces/editor-assistant/sse-schemas';
 import { MessageErrorCode, StreamErrorCode } from '../../../../interfaces/message-error';
 import type { IThreadRelationHasId } from '../../../../interfaces/thread-relation';
 import { useEditorAssistant } from '../../../services/editor-assistant';
@@ -262,11 +263,7 @@ const AiAssistantSidebarSubstance: React.FC<AiAssistantSidebarSubstanceProps> = 
                 textValues.push(data.appendedMessage);
               },
               onDetectedDiff: (data) => {
-                const typeGuard = (diff): diff is { insert: string } => {
-                  return 'insert' in diff;
-                };
-
-                if (typeGuard(data.diff)) {
+                if (isInsertDiff(data)) {
                   console.log('detected diff (insert) ', { data });
                   mutateUnifiedMergeViewConfig({ isEnabled: true, insertText: data.diff.insert });
                 }

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar.tsx
@@ -3,6 +3,7 @@ import {
   type FC, memo, useRef, useEffect, useState, useCallback, useMemo,
 } from 'react';
 
+import { useIsEnableUnifiedMergeView } from '@growi/editor/src/client/stores/use-is-enable-unified-merge-view';
 import { useForm, Controller } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { Collapse, UncontrolledTooltip } from 'reactstrap';
@@ -487,6 +488,7 @@ export const AiAssistantSidebar: FC = memo((): JSX.Element => {
   const sidebarScrollerRef = useRef<HTMLDivElement>(null);
 
   const { data: aiAssistantSidebarData, close: closeAiAssistantSidebar } = useAiAssistantSidebar();
+  const { data: isEnableUnifiedMergeView, mutate: mutateIsEnableUnifiedMergeView } = useIsEnableUnifiedMergeView();
 
   const aiAssistantData = aiAssistantSidebarData?.aiAssistantData;
   const threadData = aiAssistantSidebarData?.threadData;
@@ -505,6 +507,17 @@ export const AiAssistantSidebar: FC = memo((): JSX.Element => {
       document.removeEventListener('mousedown', handleClickOutside);
     };
   }, [closeAiAssistantSidebar, isOpened]);
+
+  useEffect(() => {
+    if (isOpened && isEditorAssistant) {
+      mutateIsEnableUnifiedMergeView(true);
+      return;
+    }
+
+    if (!isOpened) {
+      mutateIsEnableUnifiedMergeView(false);
+    }
+  }, [isEditorAssistant, isEnableUnifiedMergeView, isOpened, mutateIsEnableUnifiedMergeView]);
 
   if (!isOpened) {
     return <></>;

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar.tsx
@@ -519,18 +519,6 @@ export const AiAssistantSidebar: FC = memo((): JSX.Element => {
     };
   }, [closeAiAssistantSidebar, isOpened]);
 
-  // useEffect(() => {
-  //   if (isOpened && isEditorAssistant) {
-  //     mutateIsEnableUnifiedMergeView(true);
-  //     return;
-  //   }
-
-  //   if (!isOpened) {
-  //     mutateIsEnableUnifiedMergeView(false);
-  //   }
-  // }, [isEditorAssistant, isEnableUnifiedMergeView, isOpened, mutateIsEnableUnifiedMergeView]);
-
-
   if (!isOpened) {
     return <></>;
   }

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar.tsx
@@ -265,7 +265,7 @@ const AiAssistantSidebarSubstance: React.FC<AiAssistantSidebarSubstanceProps> = 
               onDetectedDiff: (data) => {
                 if (isInsertDiff(data)) {
                   console.log('detected diff (insert) ', { data });
-                  mutateUnifiedMergeViewConfig({ isEnabled: true, insertText: data.diff.insert });
+                  mutateUnifiedMergeViewConfig({ isEnabled: true, detectedDiff: { insert: data.diff.insert } });
                 }
               },
               onFinalized: (data) => {
@@ -323,7 +323,8 @@ const AiAssistantSidebarSubstance: React.FC<AiAssistantSidebarSubstanceProps> = 
 
   const clickDiscardHandler = useCallback(() => {
     rejectChange(codeMirrorEditor?.view);
-  }, [codeMirrorEditor?.view]);
+    mutateUnifiedMergeViewConfig({ isEnabled: false });
+  }, [codeMirrorEditor?.view, mutateUnifiedMergeViewConfig]);
 
   const selectAiAssistantHandler = useCallback((aiAssistant?: AiAssistantHasId) => {
     setSelectedAiAssistant(aiAssistant);

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar.tsx
@@ -4,6 +4,7 @@ import {
 } from 'react';
 
 import { GlobalCodeMirrorEditorKey } from '@growi/editor';
+import { acceptChange, rejectChange } from '@growi/editor/dist/client/services/unified-merge-view';
 import { useCodeMirrorEditorIsolated } from '@growi/editor/dist/client/stores/codemirror-editor';
 import { useUnifiedMergeViewConfig } from '@growi/editor/dist/client/stores/use-unified-merge-view-config';
 import { useForm, Controller } from 'react-hook-form';
@@ -319,12 +320,13 @@ const AiAssistantSidebarSubstance: React.FC<AiAssistantSidebarSubstanceProps> = 
   }, [submit]);
 
   const clickAcceptHandler = useCallback(() => {
-    // todo: implement
-  }, []);
+    acceptChange(codeMirrorEditor?.view);
+    mutateUnifiedMergeViewConfig({ isEnabled: false });
+  }, [codeMirrorEditor?.view, mutateUnifiedMergeViewConfig]);
 
   const clickDiscardHandler = useCallback(() => {
-    // todo: implement
-  }, []);
+    rejectChange(codeMirrorEditor?.view);
+  }, [codeMirrorEditor?.view]);
 
   const selectAiAssistantHandler = useCallback((aiAssistant?: AiAssistantHasId) => {
     setSelectedAiAssistant(aiAssistant);

--- a/apps/app/src/features/openai/interfaces/editor-assistant/sse-schemas.ts
+++ b/apps/app/src/features/openai/interfaces/editor-assistant/sse-schemas.ts
@@ -28,3 +28,16 @@ export const SseFinalizedSchema = z
 export type SseMessage = z.infer<typeof SseMessageSchema>;
 export type SseDetectedDiff = z.infer<typeof SseDetectedDiffSchema>;
 export type SseFinalized = z.infer<typeof SseFinalizedSchema>;
+
+// Type guard for SseDetectedDiff
+export const isInsertDiff = (diff: SseDetectedDiff): diff is { diff: { insert: string } } => {
+  return 'insert' in diff.diff;
+};
+
+export const isDeleteDiff = (diff: SseDetectedDiff): diff is { diff: { delete: number } } => {
+  return 'delete' in diff;
+};
+
+export const isRetainDiff = (diff: SseDetectedDiff): diff is { diff : { retain: number} } => {
+  return 'retain' in diff;
+};

--- a/packages/editor/src/client/components/CodeMirrorEditorMain.tsx
+++ b/packages/editor/src/client/components/CodeMirrorEditorMain.tsx
@@ -12,6 +12,7 @@ import { CodeMirrorEditor, type CodeMirrorEditorProps } from '../components-inte
 import { setDataLine, useUnifiedMergeView } from '../services-internal';
 import { useCodeMirrorEditorIsolated } from '../stores/codemirror-editor';
 import { useCollaborativeEditorMode } from '../stores/use-collaborative-editor-mode';
+import { type DetectedDiff } from '../stores/use-unified-merge-view-config';
 
 
 const additionalExtensions: Extension[] = [
@@ -27,7 +28,7 @@ type Props = CodeMirrorEditorProps & {
   initialValue?: string,
   enableCollaboration?: boolean,
   enableUnifiedMergeView?: boolean,
-  insertText?: string,
+  unifiedMergeViewConfig?: DetectedDiff,
   onEditorsUpdated?: (clientList: EditingClient[]) => void,
 }
 
@@ -35,7 +36,7 @@ export const CodeMirrorEditorMain = (props: Props): JSX.Element => {
   const {
     user, pageId,
     enableCollaboration = false, enableUnifiedMergeView = false,
-    cmProps, insertText,
+    cmProps, unifiedMergeViewConfig,
     onSave, onEditorsUpdated, ...otherProps
   } = props;
 
@@ -48,7 +49,7 @@ export const CodeMirrorEditorMain = (props: Props): JSX.Element => {
     reviewMode: enableUnifiedMergeView,
   });
 
-  useUnifiedMergeView(enableUnifiedMergeView, codeMirrorEditor, { pageId, insertText });
+  useUnifiedMergeView(enableUnifiedMergeView, codeMirrorEditor, { pageId, detectedDiff: unifiedMergeViewConfig });
 
   // setup additional extensions
   useEffect(() => {

--- a/packages/editor/src/client/components/CodeMirrorEditorMain.tsx
+++ b/packages/editor/src/client/components/CodeMirrorEditorMain.tsx
@@ -27,6 +27,7 @@ type Props = CodeMirrorEditorProps & {
   initialValue?: string,
   enableCollaboration?: boolean,
   enableUnifiedMergeView?: boolean,
+  insertText?: string,
   onEditorsUpdated?: (clientList: EditingClient[]) => void,
 }
 
@@ -34,7 +35,7 @@ export const CodeMirrorEditorMain = (props: Props): JSX.Element => {
   const {
     user, pageId,
     enableCollaboration = false, enableUnifiedMergeView = false,
-    cmProps,
+    cmProps, insertText,
     onSave, onEditorsUpdated, ...otherProps
   } = props;
 
@@ -47,7 +48,7 @@ export const CodeMirrorEditorMain = (props: Props): JSX.Element => {
     reviewMode: enableUnifiedMergeView,
   });
 
-  useUnifiedMergeView(enableUnifiedMergeView, codeMirrorEditor, { pageId });
+  useUnifiedMergeView(enableUnifiedMergeView, codeMirrorEditor, { pageId, insertText });
 
   // setup additional extensions
   useEffect(() => {

--- a/packages/editor/src/client/services-internal/unified-merge-view/use-unified-merge-view.ts
+++ b/packages/editor/src/client/services-internal/unified-merge-view/use-unified-merge-view.ts
@@ -16,6 +16,7 @@ import * as Y from 'yjs';
 import { deltaToChangeSpecs } from '../../../utils/delta-to-changespecs';
 import type { UseCodeMirrorEditor } from '../../services';
 import { useSecondaryYdocs } from '../../stores/use-secondary-ydocs';
+import { type DetectedDiff } from '../../stores/use-unified-merge-view-config';
 
 
 // for avoiding apply update from primaryDoc to secondaryDoc twice
@@ -24,8 +25,7 @@ const SYNC_BY_ACCEPT_CHUNK = 'synkByAcceptChunk';
 
 type Configuration = {
   pageId?: string,
-  insertText?: string,
-}
+} & { detectedDiff?: DetectedDiff };
 
 export const useUnifiedMergeView = (
     isEnabled: boolean,
@@ -33,7 +33,7 @@ export const useUnifiedMergeView = (
     configuration?: Configuration,
 ): void => {
 
-  const { pageId, insertText } = configuration ?? {};
+  const { pageId, detectedDiff } = configuration ?? {};
 
   const [setupMergeViewEffectExecuted, setSetupMergeViewEffectExecuted] = useState(false);
   const [setupSyncFromPrimaryDocToSecondaryDocEffectExecuted, setSetupSyncFromPrimaryDocToSecondaryDocEffectExecuted] = useState(false);
@@ -152,10 +152,13 @@ export const useUnifiedMergeView = (
 
 
   useEffect(() => {
-    // eslint-disable-next-line max-len
-    if (setupMergeViewEffectExecuted && setupSyncFromPrimaryDocToSecondaryDocEffectExecuted && setupSyncFromSecondaryDocToPrimaryDocEffectExecuted && insertText != null) {
-      codeMirrorEditor?.insertText(insertText);
+    if (setupMergeViewEffectExecuted
+      && setupSyncFromPrimaryDocToSecondaryDocEffectExecuted
+      && setupSyncFromSecondaryDocToPrimaryDocEffectExecuted
+      && detectedDiff?.insert != null
+    ) {
+      codeMirrorEditor?.insertText(detectedDiff.insert);
     }
   // eslint-disable-next-line max-len
-  }, [codeMirrorEditor, insertText, setupMergeViewEffectExecuted, setupSyncFromPrimaryDocToSecondaryDocEffectExecuted, setupSyncFromSecondaryDocToPrimaryDocEffectExecuted]);
+  }, [codeMirrorEditor, detectedDiff?.insert, setupMergeViewEffectExecuted, setupSyncFromPrimaryDocToSecondaryDocEffectExecuted, setupSyncFromSecondaryDocToPrimaryDocEffectExecuted]);
 };

--- a/packages/editor/src/client/services/unified-merge-view/index.ts
+++ b/packages/editor/src/client/services/unified-merge-view/index.ts
@@ -1,0 +1,15 @@
+import {
+  acceptChunk,
+  rejectChunk,
+} from '@codemirror/merge';
+
+import type { EditorView } from 'src';
+
+
+export const acceptChange = (view: EditorView): boolean => {
+  return acceptChunk(view);
+};
+
+export const rejectChange = (view: EditorView): boolean => {
+  return rejectChunk(view);
+};

--- a/packages/editor/src/client/stores/use-is-enable-unified-merge-view.ts
+++ b/packages/editor/src/client/stores/use-is-enable-unified-merge-view.ts
@@ -1,6 +1,0 @@
-import { useSWRStatic } from '@growi/core/dist/swr';
-import type { SWRResponse } from 'swr';
-
-export const useIsEnableUnifiedMergeView = (initialData?: boolean): SWRResponse<boolean, Error> => {
-  return useSWRStatic<boolean, Error>('isEnableUnifiedMergeView', initialData, { fallbackData: false });
-};

--- a/packages/editor/src/client/stores/use-is-enable-unified-merge-view.ts
+++ b/packages/editor/src/client/stores/use-is-enable-unified-merge-view.ts
@@ -1,0 +1,6 @@
+import { useSWRStatic } from '@growi/core/dist/swr';
+import type { SWRResponse } from 'swr';
+
+export const useIsEnableUnifiedMergeView = (initialData?: boolean): SWRResponse<boolean, Error> => {
+  return useSWRStatic<boolean, Error>('isEnableUnifiedMergeView', initialData, { fallbackData: false });
+};

--- a/packages/editor/src/client/stores/use-unified-merge-view-config.ts
+++ b/packages/editor/src/client/stores/use-unified-merge-view-config.ts
@@ -1,9 +1,15 @@
 import { useSWRStatic } from '@growi/core/dist/swr';
 import type { SWRResponse } from 'swr';
 
+export type DetectedDiff = {
+  insert?: string,
+  delete?: number,
+  retain?: number,
+}
+
 type UnifiedMergeViewConfig = {
-  isEnabled: boolean
-  insertText?: string
+  isEnabled: boolean,
+  detectedDiff?: DetectedDiff,
 }
 
 export const useUnifiedMergeViewConfig = (initialData?: UnifiedMergeViewConfig): SWRResponse<UnifiedMergeViewConfig, Error> => {

--- a/packages/editor/src/client/stores/use-unified-merge-view-config.ts
+++ b/packages/editor/src/client/stores/use-unified-merge-view-config.ts
@@ -1,0 +1,11 @@
+import { useSWRStatic } from '@growi/core/dist/swr';
+import type { SWRResponse } from 'swr';
+
+type UnifiedMergeViewConfig = {
+  isEnabled: boolean
+  insertText?: string
+}
+
+export const useUnifiedMergeViewConfig = (initialData?: UnifiedMergeViewConfig): SWRResponse<UnifiedMergeViewConfig, Error> => {
+  return useSWRStatic<UnifiedMergeViewConfig, Error>('unifiedMergeViewConfig', initialData);
+};


### PR DESCRIPTION
# Task
- [#162356](https://redmine.weseek.co.jp/issues/162356) [GROWI AI Next][エディターアシスタント] チャット欄への出力とエディタの変更をサーバーから一緒に stream で送信し、クライアント側でハンドリングできる
  - [#163549](https://redmine.weseek.co.jp/issues/163549) アシスタントのレスポンスをエディターに反映できる

# Screenrecord 
https://github.com/user-attachments/assets/1b3990a9-2654-4c2b-80bb-53fb272199ce


