### PR TITLE
feat: Send only selected markdown range to server

### DIFF
--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar.tsx
@@ -504,7 +504,7 @@ export const AiAssistantSidebar: FC = memo((): JSX.Element => {
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
-      if (isOpened && sidebarRef.current && !sidebarRef.current.contains(event.target as Node)) {
+      if (isOpened && sidebarRef.current && !sidebarRef.current.contains(event.target as Node) && !isEditorAssistant) {
         closeAiAssistantSidebar();
       }
     };
@@ -513,7 +513,7 @@ export const AiAssistantSidebar: FC = memo((): JSX.Element => {
     return () => {
       document.removeEventListener('mousedown', handleClickOutside);
     };
-  }, [closeAiAssistantSidebar, isOpened]);
+  }, [closeAiAssistantSidebar, isEditorAssistant, isOpened]);
 
   useEffect(() => {
     if (!aiAssistantSidebarData?.isOpened) {

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar.tsx
@@ -76,7 +76,10 @@ const AiAssistantSidebarSubstance: React.FC<AiAssistantSidebarSubstanceProps> = 
 
   const { postMessage: postMessageForKnowledgeAssistant, processMessage: processMessageForKnowledgeAssistant } = useKnowledgeAssistant();
   const {
-    postMessage: postMessageForEditorAssistant, processMessage: processMessageForEditorAssistant, accept, reject,
+    postMessage: postMessageForEditorAssistant,
+    processMessage: processMessageForEditorAssistant,
+    accept,
+    reject,
   } = useEditorAssistant();
 
   const form = useForm<FormData>({

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar.tsx
@@ -3,8 +3,6 @@ import {
   type FC, memo, useRef, useEffect, useState, useCallback, useMemo,
 } from 'react';
 
-import { GlobalCodeMirrorEditorKey } from '@growi/editor';
-import { useCodeMirrorEditorIsolated } from '@growi/editor/dist/client/stores/codemirror-editor';
 import { useForm, Controller } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { Collapse, UncontrolledTooltip } from 'reactstrap';
@@ -75,7 +73,6 @@ const AiAssistantSidebarSubstance: React.FC<AiAssistantSidebarSubstanceProps> = 
   const { data: growiCloudUri } = useGrowiCloudUri();
   const { trigger: mutateThreadData } = useSWRMUTxThreads(aiAssistantData?._id);
   const { trigger: mutateMessageData } = useSWRMUTxMessages(aiAssistantData?._id, threadData?.threadId);
-  const { data: codeMirrorEditor } = useCodeMirrorEditorIsolated(GlobalCodeMirrorEditorKey.MAIN);
 
   const { postMessage: postMessageForKnowledgeAssistant, processMessage: processMessageForKnowledgeAssistant } = useKnowledgeAssistant();
   const {
@@ -197,8 +194,7 @@ const AiAssistantSidebarSubstance: React.FC<AiAssistantSidebarSubstanceProps> = 
 
       const response = await (async() => {
         if (isEditorAssistant) {
-          const markdown = codeMirrorEditor?.getDoc();
-          return postMessageForEditorAssistant(currentThreadId_, data.input, markdown ?? '');
+          return postMessageForEditorAssistant(currentThreadId_, data.input);
         }
         if (aiAssistantData?._id != null) {
           return postMessageForKnowledgeAssistant(aiAssistantData._id, currentThreadId_, data.input, data.summaryMode);
@@ -301,7 +297,7 @@ const AiAssistantSidebarSubstance: React.FC<AiAssistantSidebarSubstanceProps> = 
     }
 
   // eslint-disable-next-line max-len
-  }, [isGenerating, messageLogs, form, currentThreadId, isEditorAssistant, selectedAiAssistant?._id, aiAssistantData?._id, mutateThreadData, t, codeMirrorEditor, postMessageForEditorAssistant, postMessageForKnowledgeAssistant, processMessageForKnowledgeAssistant, processMessageForEditorAssistant, growiCloudUri]);
+  }, [isGenerating, messageLogs, form, currentThreadId, isEditorAssistant, selectedAiAssistant?._id, aiAssistantData?._id, mutateThreadData, t, postMessageForEditorAssistant, postMessageForKnowledgeAssistant, processMessageForKnowledgeAssistant, processMessageForEditorAssistant, growiCloudUri]);
 
   const keyDownHandler = (event: KeyboardEvent<HTMLTextAreaElement>) => {
     if (event.key === 'Enter' && (event.ctrlKey || event.metaKey)) {

--- a/apps/app/src/features/openai/client/services/editor-assistant.ts
+++ b/apps/app/src/features/openai/client/services/editor-assistant.ts
@@ -52,6 +52,7 @@ export const useEditorAssistant: UseEditorAssistant = () => {
   const positionRef = useRef<number>(0);
 
   // State
+  const [selectedTextFirstLineNumber, setSelectedTextFirstLineNumber] = useState<number | undefined>();
   const [detectedDiff, setDetectedDiff] = useState<DetectedDiff>();
 
   // SWR Hooks
@@ -87,6 +88,7 @@ export const useEditorAssistant: UseEditorAssistant = () => {
   }, [codeMirrorEditor?.view]);
 
   const postMessage: PostMessage = useCallback(async(threadId, userMessage) => {
+    setSelectedTextFirstLineNumber(getSelectedTextFirstLineNumber());
     const selectedMarkdown = getSelectedText();
     const response = await fetch('/_api/v3/openai/edit', {
       method: 'POST',
@@ -98,7 +100,7 @@ export const useEditorAssistant: UseEditorAssistant = () => {
       }),
     });
     return response;
-  }, [getSelectedText]);
+  }, [getSelectedText, getSelectedTextFirstLineNumber]);
 
   const processMessage: ProcessMessage = useCallback((data, handler) => {
     handleIfSuccessfullyParsed(data, SseMessageSchema, (data: SseMessage) => {
@@ -130,6 +132,9 @@ export const useEditorAssistant: UseEditorAssistant = () => {
     mutateIsEnableUnifiedMergeView(false);
   }, [codeMirrorEditor?.view, mutateIsEnableUnifiedMergeView]);
 
+  useEffect(() => {
+
+  });
 
   // Effects
   useEffect(() => {

--- a/apps/app/src/features/openai/client/services/editor-assistant.ts
+++ b/apps/app/src/features/openai/client/services/editor-assistant.ts
@@ -24,7 +24,7 @@ import { useIsEnableUnifiedMergeView } from '~/stores-universal/context';
 import { useCurrentPageId } from '~/stores/page';
 
 interface PostMessage {
-  (threadId: string, userMessage: string, markdown: string): Promise<Response>;
+  (threadId: string, userMessage: string): Promise<Response>;
 }
 interface ProcessMessage {
   (data: unknown, handler: {
@@ -86,18 +86,19 @@ export const useEditorAssistant: UseEditorAssistant = () => {
     return lineInfo.number;
   }, [codeMirrorEditor?.view]);
 
-  const postMessage: PostMessage = useCallback(async(threadId, userMessage, markdown) => {
+  const postMessage: PostMessage = useCallback(async(threadId, userMessage) => {
+    const selectedMarkdown = getSelectedText();
     const response = await fetch('/_api/v3/openai/edit', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         threadId,
         userMessage,
-        markdown,
+        markdown: selectedMarkdown,
       }),
     });
     return response;
-  }, []);
+  }, [getSelectedText]);
 
   const processMessage: ProcessMessage = useCallback((data, handler) => {
     handleIfSuccessfullyParsed(data, SseMessageSchema, (data: SseMessage) => {

--- a/apps/app/src/features/openai/client/services/editor-assistant.ts
+++ b/apps/app/src/features/openai/client/services/editor-assistant.ts
@@ -54,7 +54,6 @@ export const useEditorAssistant: UseEditorAssistant = () => {
   const lineRef = useRef<number>(0);
 
   // States
-  const [selectedTextFirstLineNumber, setSelectedTextFirstLineNumber] = useState<number | undefined>();
   const [detectedDiff, setDetectedDiff] = useState<DetectedDiff>();
 
   // SWR Hooks
@@ -90,7 +89,8 @@ export const useEditorAssistant: UseEditorAssistant = () => {
   }, [codeMirrorEditor?.view]);
 
   const postMessage: PostMessage = useCallback(async(threadId, userMessage) => {
-    setSelectedTextFirstLineNumber(getSelectedTextFirstLineNumber());
+    lineRef.current = getSelectedTextFirstLineNumber() ?? 0;
+
     const selectedMarkdown = getSelectedText();
     const response = await fetch('/_api/v3/openai/edit', {
       method: 'POST',

--- a/apps/app/src/features/openai/client/services/editor-assistant.ts
+++ b/apps/app/src/features/openai/client/services/editor-assistant.ts
@@ -51,7 +51,7 @@ export const useEditorAssistant: UseEditorAssistant = () => {
   // Refs
   const positionRef = useRef<number>(0);
 
-  // State
+  // States
   const [selectedTextFirstLineNumber, setSelectedTextFirstLineNumber] = useState<number | undefined>();
   const [detectedDiff, setDetectedDiff] = useState<DetectedDiff>();
 
@@ -131,10 +131,6 @@ export const useEditorAssistant: UseEditorAssistant = () => {
     rejectChange(codeMirrorEditor?.view);
     mutateIsEnableUnifiedMergeView(false);
   }, [codeMirrorEditor?.view, mutateIsEnableUnifiedMergeView]);
-
-  useEffect(() => {
-
-  });
 
   // Effects
   useEffect(() => {

--- a/apps/app/src/features/openai/client/services/editor-assistant.ts
+++ b/apps/app/src/features/openai/client/services/editor-assistant.ts
@@ -40,7 +40,14 @@ type DetectedDiff = Array<{
   id: string,
 }>
 
-export const useEditorAssistant = (): {postMessage: PostMessage, processMessage: ProcessMessage, accept: () => void, reject: () => void } => {
+type UseEditorAssistant = () => {
+  postMessage: PostMessage,
+  processMessage: ProcessMessage,
+  accept: () => void,
+  reject: () => void,
+}
+
+export const useEditorAssistant: UseEditorAssistant = () => {
   const positionRef = useRef<number>(0);
 
   const [detectedDiff, setDetectedDiff] = useState<DetectedDiff>();


### PR DESCRIPTION
# Task
- [#162356](https://redmine.weseek.co.jp/issues/162356) [GROWI AI Next][エディターアシスタント] チャット欄への出力とエディタの変更をサーバーから一緒に stream で送信し、クライアント側でハンドリングできる
  - [#164347](https://redmine.weseek.co.jp/issues/164347) エディターから範囲指定して markdown を送信できる