### PR TITLE
feat: Apply llm responses to unified merge view

### DIFF
--- a/apps/app/src/features/openai/client/services/editor-assistant.ts
+++ b/apps/app/src/features/openai/client/services/editor-assistant.ts
@@ -133,7 +133,7 @@ export const useEditorAssistant: UseEditorAssistant = () => {
 
     const lineInfo = view.state.doc.lineAt(selectionStart);
 
-    return lineInfo.number;
+    return lineInfo.number - 1; // 0-based index
   }, [codeMirrorEditor?.view]);
 
   const postMessage: PostMessage = useCallback(async(threadId, userMessage) => {
@@ -173,8 +173,10 @@ export const useEditorAssistant: UseEditorAssistant = () => {
   }, [mutateIsEnableUnifiedMergeView]);
 
   const accept = useCallback(() => {
-    acceptChange(codeMirrorEditor?.view);
-    mutateIsEnableUnifiedMergeView(false);
+    console.log('これビュー', codeMirrorEditor?.view);
+    const res = acceptChange(codeMirrorEditor?.view);
+    console.log('res', res);
+    // mutateIsEnableUnifiedMergeView(false);
   }, [codeMirrorEditor?.view, mutateIsEnableUnifiedMergeView]);
 
   const reject = useCallback(() => {

--- a/packages/editor/src/client/services/unified-merge-view/index.ts
+++ b/packages/editor/src/client/services/unified-merge-view/index.ts
@@ -1,9 +1,12 @@
+import { useEffect } from 'react';
+
 import {
   acceptChunk,
   rejectChunk,
 } from '@codemirror/merge';
+import { EditorView } from '@codemirror/view';
 
-import type { EditorView } from 'src';
+import type { UseCodeMirrorEditor } from '..';
 
 export const acceptChange = (view: EditorView): boolean => {
   return acceptChunk(view);
@@ -11,4 +14,30 @@ export const acceptChange = (view: EditorView): boolean => {
 
 export const rejectChange = (view: EditorView): boolean => {
   return rejectChunk(view);
+};
+
+
+type OnSelected = (selectedText?: string, selectedTextFirstLineNumber?: number) => void
+
+export const useTextSelectionEffect = (codeMirrorEditor?: UseCodeMirrorEditor, onSelected?: OnSelected): void => {
+  useEffect(() => {
+    if (codeMirrorEditor == null) {
+      return;
+    }
+
+    const extension = EditorView.updateListener.of((update) => {
+      if (update.selectionSet) {
+        const selection = update.state.selection.main;
+        const selectedText = update.state.sliceDoc(selection.from, selection.to);
+        const selectedTextFirstLineNumber = update.state.doc.lineAt(selection.from).number;
+        onSelected?.(selectedText, selectedTextFirstLineNumber);
+      }
+    });
+
+    const cleanup = codeMirrorEditor?.appendExtensions([extension]);
+
+    return () => {
+      cleanup?.();
+    };
+  }, [codeMirrorEditor, onSelected]);
 };


### PR DESCRIPTION
# Task
- [#162356](https://redmine.weseek.co.jp/issues/162356) [GROWI AI Next][エディターアシスタント] チャット欄への出力とエディタの変更をサーバーから一緒に stream で送信し、クライアント側でハンドリングできる
  - [#164348](https://redmine.weseek.co.jp/issues/164348) 範囲指定して送信した際のレスポンスを UnifiedMergeView に反映できる
