### PR TITLE
feat: Apply LLM responses to UnifiedMergeView (without Markdown)

### DIFF
--- a/apps/app/src/features/openai/client/services/editor-assistant.ts
+++ b/apps/app/src/features/openai/client/services/editor-assistant.ts
@@ -119,7 +119,9 @@ export const useEditorAssistant: UseEditorAssistant = () => {
       body: JSON.stringify({
         threadId,
         userMessage,
-        markdown: selectedText,
+        markdown: selectedText != null && selectedText.length !== 0
+          ? selectedText
+          : undefined,
       }),
     });
 

--- a/apps/app/src/features/openai/client/services/editor-assistant.ts
+++ b/apps/app/src/features/openai/client/services/editor-assistant.ts
@@ -8,7 +8,6 @@ import { useCodeMirrorEditorIsolated } from '@growi/editor/dist/client/stores/co
 import { useSecondaryYdocs } from '@growi/editor/dist/client/stores/use-secondary-ydocs';
 import { type Text as YText } from 'yjs';
 
-
 import {
   SseMessageSchema,
   SseDetectedDiffSchema,
@@ -24,8 +23,6 @@ import {
 import { handleIfSuccessfullyParsed } from '~/features/openai/utils/handle-if-successfully-parsed';
 import { useIsEnableUnifiedMergeView } from '~/stores-universal/context';
 import { useCurrentPageId } from '~/stores/page';
-
-import type { IApiv3PostMessageParams } from '../../interfaces/apiv3/edit';
 
 interface PostMessage {
   (threadId: string, userMessage: string): Promise<Response>;
@@ -116,20 +113,14 @@ export const useEditorAssistant: UseEditorAssistant = () => {
 
   // Functions
   const postMessage: PostMessage = useCallback(async(threadId, userMessage) => {
-    const body: IApiv3PostMessageParams = {
-      threadId,
-      userMessage,
-    };
-
-    // Insert selectedText into object after null check since JSON.stringify returns empty string when selectedText is undefined
-    if (selectedText != null) {
-      body.markdown = selectedText;
-    }
-
     const response = await fetch('/_api/v3/openai/edit', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
+      body: JSON.stringify({
+        threadId,
+        userMessage,
+        markdown: selectedText,
+      }),
     });
 
     setSelectedText(undefined);

--- a/apps/app/src/features/openai/client/services/editor-assistant.ts
+++ b/apps/app/src/features/openai/client/services/editor-assistant.ts
@@ -8,6 +8,7 @@ import { useCodeMirrorEditorIsolated } from '@growi/editor/dist/client/stores/co
 import { useSecondaryYdocs } from '@growi/editor/dist/client/stores/use-secondary-ydocs';
 import { type Text as YText } from 'yjs';
 
+
 import {
   SseMessageSchema,
   SseDetectedDiffSchema,
@@ -23,6 +24,8 @@ import {
 import { handleIfSuccessfullyParsed } from '~/features/openai/utils/handle-if-successfully-parsed';
 import { useIsEnableUnifiedMergeView } from '~/stores-universal/context';
 import { useCurrentPageId } from '~/stores/page';
+
+import type { IApiv3PostMessageParams } from '../../interfaces/apiv3/edit';
 
 interface PostMessage {
   (threadId: string, userMessage: string): Promise<Response>;
@@ -113,14 +116,19 @@ export const useEditorAssistant: UseEditorAssistant = () => {
 
   // Functions
   const postMessage: PostMessage = useCallback(async(threadId, userMessage) => {
+    const body: IApiv3PostMessageParams = {
+      threadId,
+      userMessage,
+    };
+
+    if (selectedText != null) {
+      body.markdown = selectedText;
+    }
+
     const response = await fetch('/_api/v3/openai/edit', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        threadId,
-        userMessage,
-        markdown: selectedText,
-      }),
+      body: JSON.stringify(body),
     });
 
     setSelectedText(undefined);

--- a/apps/app/src/features/openai/client/services/editor-assistant.ts
+++ b/apps/app/src/features/openai/client/services/editor-assistant.ts
@@ -121,6 +121,7 @@ export const useEditorAssistant: UseEditorAssistant = () => {
       userMessage,
     };
 
+    // Insert selectedText into object after null check since JSON.stringify returns empty string when selectedText is undefined
     if (selectedText != null) {
       body.markdown = selectedText;
     }

--- a/apps/app/src/features/openai/interfaces/apiv3/edit.ts
+++ b/apps/app/src/features/openai/interfaces/apiv3/edit.ts
@@ -1,5 +1,0 @@
-export type IApiv3PostMessageParams = {
-  threadId?: string,
-  userMessage: string,
-  markdown?: string,
-}

--- a/apps/app/src/features/openai/interfaces/apiv3/edit.ts
+++ b/apps/app/src/features/openai/interfaces/apiv3/edit.ts
@@ -1,0 +1,5 @@
+export type IApiv3PostMessageParams = {
+  threadId?: string,
+  userMessage: string,
+  markdown?: string,
+}

--- a/apps/app/src/features/openai/server/routes/edit/index.ts
+++ b/apps/app/src/features/openai/server/routes/edit/index.ts
@@ -15,7 +15,6 @@ import { apiV3FormValidator } from '~/server/middlewares/apiv3-form-validator';
 import type { ApiV3Response } from '~/server/routes/apiv3/interfaces/apiv3-response';
 import loggerFactory from '~/utils/logger';
 
-import type { IApiv3PostMessageParams } from '../../../interfaces/apiv3/edit';
 import { LlmEditorAssistantDiffSchema, LlmEditorAssistantMessageSchema } from '../../../interfaces/editor-assistant/llm-response-schemas';
 import type { SseDetectedDiff, SseFinalized, SseMessage } from '../../../interfaces/editor-assistant/sse-schemas';
 import { MessageErrorCode } from '../../../interfaces/message-error';
@@ -41,7 +40,11 @@ const LlmEditorAssistantResponseSchema = z.object({
 }).describe('The response format for the editor assistant');
 
 
-type ReqBody = IApiv3PostMessageParams;
+type ReqBody = {
+  userMessage: string,
+  markdown?: string,
+  threadId?: string,
+}
 
 type Req = Request<undefined, Response, ReqBody> & {
   user: IUserHasId,

--- a/apps/app/src/features/openai/server/routes/edit/index.ts
+++ b/apps/app/src/features/openai/server/routes/edit/index.ts
@@ -68,7 +68,7 @@ const instructionWithMarkdown = `You are an Editor Assistant for GROWI, a markdo
     {
       "contents": [
         { "message": "Your brief message about the upcoming change or proposal.\n\n" },
-        { "replace": New text 1 },,
+        { "replace": "New text 1" },
         { "message": "Additional explanation if needed" },
         { "replace": "New text 2" },
         ...more items if needed

--- a/apps/app/src/features/openai/server/routes/edit/index.ts
+++ b/apps/app/src/features/openai/server/routes/edit/index.ts
@@ -90,7 +90,6 @@ const instructionWithMarkdown = `You are an Editor Assistant for GROWI, a markdo
 
 const instructionWithoutMarkdown = `You are an Editor Assistant for GROWI, a markdown wiki system.
     Your task is to help users edit their markdown content based on their requests.
-    Spaces and line breaks are also counted as individual characters.
 
     RESPONSE FORMAT:
     You must respond with a JSON object in the following format example:
@@ -108,12 +107,8 @@ const instructionWithoutMarkdown = `You are an Editor Assistant for GROWI, a mar
     The array should contain:
     - [At the beginning of the list] A "message" object that has your brief message about the upcoming change or proposal. Be sure to add two consecutive line feeds ('\n\n') at the end.
     - Objects with a "message" key for explanatory text to the user if needed.
-    - Edit markdown according to user instructions and include it line by line in the 'replace' object. Return original text for lines that do not need editing.
+    - Edit markdown according to user instructions and include it line by line in the 'replace' object.
     - [At the end of the list] A "message" object that contains your friendly message explaining that the operation was completed and what changes were made.
-
-    IMPORTANT:
-    - The text for lines that do not need correction must be returned exactly as in the original text.
-    - Include original text in the replace object even if it contains only spaces or line breaks
 
     Always provide messages in the same language as the user's request.`;
 /* eslint-disable max-len */
@@ -203,7 +198,9 @@ export const postMessageToEditHandlersFactory: PostMessageHandlersFactory = (cro
           additional_messages: [
             {
               role: 'assistant',
-              content: markdown == null ? instructionWithoutMarkdown : instructionWithMarkdown,
+              content: markdown != null
+                ? instructionWithMarkdown
+                : instructionWithoutMarkdown,
             },
             // {
             //   role: 'assistant',

--- a/apps/app/src/features/openai/server/routes/edit/index.ts
+++ b/apps/app/src/features/openai/server/routes/edit/index.ts
@@ -96,7 +96,7 @@ const instructionWithoutMarkdown = `You are an Editor Assistant for GROWI, a mar
     {
       "contents": [
         { "message": "Your brief message about the upcoming change or proposal.\n\n" },
-        { "replace": New text 1 },,
+        { "replace": New text 1 },
         { "message": "Additional explanation if needed" },
         { "replace": "New text 2" },
         ...more items if needed

--- a/apps/app/src/features/openai/server/routes/edit/index.ts
+++ b/apps/app/src/features/openai/server/routes/edit/index.ts
@@ -15,6 +15,7 @@ import { apiV3FormValidator } from '~/server/middlewares/apiv3-form-validator';
 import type { ApiV3Response } from '~/server/routes/apiv3/interfaces/apiv3-response';
 import loggerFactory from '~/utils/logger';
 
+import type { IApiv3PostMessageParams } from '../../../interfaces/apiv3/edit';
 import { LlmEditorAssistantDiffSchema, LlmEditorAssistantMessageSchema } from '../../../interfaces/editor-assistant/llm-response-schemas';
 import type { SseDetectedDiff, SseFinalized, SseMessage } from '../../../interfaces/editor-assistant/sse-schemas';
 import { MessageErrorCode } from '../../../interfaces/message-error';
@@ -40,11 +41,7 @@ const LlmEditorAssistantResponseSchema = z.object({
 }).describe('The response format for the editor assistant');
 
 
-type ReqBody = {
-  userMessage: string,
-  markdown?: string,
-  threadId?: string,
-}
+type ReqBody = IApiv3PostMessageParams;
 
 type Req = Request<undefined, Response, ReqBody> & {
   user: IUserHasId,

--- a/apps/app/src/features/openai/server/routes/edit/index.ts
+++ b/apps/app/src/features/openai/server/routes/edit/index.ts
@@ -42,7 +42,7 @@ const LlmEditorAssistantResponseSchema = z.object({
 
 type ReqBody = {
   userMessage: string,
-  markdown: string,
+  markdown?: string,
   threadId?: string,
 }
 
@@ -71,10 +71,9 @@ export const postMessageToEditHandlersFactory: PostMessageHandlersFactory = (cro
       .notEmpty()
       .withMessage('userMessage must be set'),
     body('markdown')
+      .optional()
       .isString()
-      .withMessage('markdown must be string')
-      .notEmpty()
-      .withMessage('markdown must be set'),
+      .withMessage('markdown must be string'),
     body('threadId').optional().isString().withMessage('threadId must be string'),
   ];
 

--- a/apps/app/src/features/openai/server/routes/edit/index.ts
+++ b/apps/app/src/features/openai/server/routes/edit/index.ts
@@ -57,6 +57,70 @@ type Req = Request<undefined, Response, ReqBody> & {
 
 type PostMessageHandlersFactory = (crowi: Crowi) => RequestHandler[];
 
+
+// -----------------------------------------------------------------------------
+// Instructions
+// -----------------------------------------------------------------------------
+/* eslint-disable max-len */
+const instructionWithMarkdown = `You are an Editor Assistant for GROWI, a markdown wiki system.
+    Your task is to help users edit their markdown content based on their requests.
+    Spaces and line breaks are also counted as individual characters.
+
+    RESPONSE FORMAT:
+    You must respond with a JSON object in the following format example:
+    {
+      "contents": [
+        { "message": "Your brief message about the upcoming change or proposal.\n\n" },
+        { "replace": New text 1 },,
+        { "message": "Additional explanation if needed" },
+        { "replace": "New text 2" },
+        ...more items if needed
+        { "message": "Your friendly message explaining what changes were made or suggested." }
+      ]
+    }
+
+    The array should contain:
+    - [At the beginning of the list] A "message" object that has your brief message about the upcoming change or proposal. Be sure to add two consecutive line feeds ('\n\n') at the end.
+    - Objects with a "message" key for explanatory text to the user if needed.
+    - Edit markdown according to user instructions and include it line by line in the 'replace' object. Return original text for lines that do not need editing.
+    - [At the end of the list] A "message" object that contains your friendly message explaining that the operation was completed and what changes were made.
+
+    IMPORTANT:
+    - The text for lines that do not need correction must be returned exactly as in the original text.
+    - Include original text in the replace object even if it contains only spaces or line breaks
+
+    Always provide messages in the same language as the user's request.`;
+
+const instructionWithoutMarkdown = `You are an Editor Assistant for GROWI, a markdown wiki system.
+    Your task is to help users edit their markdown content based on their requests.
+    Spaces and line breaks are also counted as individual characters.
+
+    RESPONSE FORMAT:
+    You must respond with a JSON object in the following format example:
+    {
+      "contents": [
+        { "message": "Your brief message about the upcoming change or proposal.\n\n" },
+        { "replace": New text 1 },,
+        { "message": "Additional explanation if needed" },
+        { "replace": "New text 2" },
+        ...more items if needed
+        { "message": "Your friendly message explaining what changes were made or suggested." }
+      ]
+    }
+
+    The array should contain:
+    - [At the beginning of the list] A "message" object that has your brief message about the upcoming change or proposal. Be sure to add two consecutive line feeds ('\n\n') at the end.
+    - Objects with a "message" key for explanatory text to the user if needed.
+    - Edit markdown according to user instructions and include it line by line in the 'replace' object. Return original text for lines that do not need editing.
+    - [At the end of the list] A "message" object that contains your friendly message explaining that the operation was completed and what changes were made.
+
+    IMPORTANT:
+    - The text for lines that do not need correction must be returned exactly as in the original text.
+    - Include original text in the replace object even if it contains only spaces or line breaks
+
+    Always provide messages in the same language as the user's request.`;
+/* eslint-disable max-len */
+
 /**
  * Create endpoint handlers for editor assistant
  */
@@ -137,40 +201,12 @@ export const postMessageToEditHandlersFactory: PostMessageHandlersFactory = (cro
         const thread = await openaiClient.beta.threads.retrieve(threadId);
 
         // Create stream
-        /* eslint-disable max-len */
         const stream = openaiClient.beta.threads.runs.stream(thread.id, {
           assistant_id: assistant.id,
           additional_messages: [
             {
               role: 'assistant',
-              content: `You are an Editor Assistant for GROWI, a markdown wiki system.
-              Your task is to help users edit their markdown content based on their requests.
-              Spaces and line breaks are also counted as individual characters.
-
-              RESPONSE FORMAT:
-              You must respond with a JSON object in the following format example:
-              {
-                "contents": [
-                  { "message": "Your brief message about the upcoming change or proposal.\n\n" },
-                  { "replace": New text 1 },,
-                  { "message": "Additional explanation if needed" },
-                  { "replace": "New text 2" },
-                  ...more items if needed
-                  { "message": "Your friendly message explaining what changes were made or suggested." }
-                ]
-              }
-
-              The array should contain:
-              - [At the beginning of the list] A "message" object that has your brief message about the upcoming change or proposal. Be sure to add two consecutive line feeds ('\n\n') at the end.
-              - Objects with a "message" key for explanatory text to the user if needed.
-              - Edit markdown according to user instructions and include it line by line in the 'replace' object. Return original text for lines that do not need editing.
-              - [At the end of the list] A "message" object that contains your friendly message explaining that the operation was completed and what changes were made.
-
-              IMPORTANT:
-              - The text for lines that do not need correction must be returned exactly as in the original text.
-              - Include original text in the replace object even if it contains only spaces or line breaks
-
-              Always provide messages in the same language as the user's request.`,
+              content: markdown == null ? instructionWithoutMarkdown : instructionWithMarkdown,
             },
             // {
             //   role: 'assistant',
@@ -209,7 +245,6 @@ export const postMessageToEditHandlersFactory: PostMessageHandlersFactory = (cro
           ],
           response_format: zodResponseFormat(LlmEditorAssistantResponseSchema, 'editor_assistant_response'),
         });
-        /* eslint-disable max-len */
 
         // Message delta handler
         const messageDeltaHandler = async(delta: MessageDelta) => {


### PR DESCRIPTION
# Task
- [#162356](https://redmine.weseek.co.jp/issues/162356) [GROWI AI Next][エディターアシスタント] チャット欄への出力とエディタの変更をサーバーから一緒に stream で送信し、クライアント側でハンドリングできる
  - [#164617](https://redmine.weseek.co.jp/issues/164617) LLM からのレスポンスを UnifiedMergeView に反映できる (markdown 選択無しのケース)