### PR TITLE
imprv: Display behavior of accept and discard buttons

### DIFF
--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar.tsx
@@ -123,11 +123,11 @@ const AiAssistantSidebarSubstance: React.FC<AiAssistantSidebarSubstanceProps> = 
       return false;
     }
 
-    const latesAssistantMessageLogId = messageLogs
+    const latestAssistantMessageLogId = messageLogs
       .filter(message => !message.isUserMessage)
       .slice(-1)[0];
 
-    if (messageId === latesAssistantMessageLogId?.id) {
+    if (messageId === latestAssistantMessageLogId?.id) {
       return true;
     }
 

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar.tsx
@@ -114,6 +114,26 @@ const AiAssistantSidebarSubstance: React.FC<AiAssistantSidebarSubstanceProps> = 
     }
   }, [mutateMessageData, threadData]);
 
+  const isActionButtonShown = useCallback((messageId: string) => {
+    if (!isEditorAssistant) {
+      return false;
+    }
+
+    if (generatingAnswerMessage != null) {
+      return false;
+    }
+
+    const latesAssistantMessageLogId = messageLogs
+      .filter(message => !message.isUserMessage)
+      .slice(-1)[0];
+
+    if (messageId === latesAssistantMessageLogId?.id) {
+      return true;
+    }
+
+    return false;
+  }, [generatingAnswerMessage, isEditorAssistant, messageLogs]);
+
   const headerIcon = useMemo(() => {
     return isEditorAssistant
       ? <span className="material-symbols-outlined growi-ai-chat-icon me-3 fs-4">support_agent</span>
@@ -349,7 +369,7 @@ const AiAssistantSidebarSubstance: React.FC<AiAssistantSidebarSubstanceProps> = 
                   <MessageCard
                     key={message.id}
                     role={message.isUserMessage ? 'user' : 'assistant'}
-                    showActionButtons={isEditorAssistant}
+                    showActionButtons={isActionButtonShown(message.id)}
                     onAccept={clickAcceptHandler}
                     onDiscard={clickDiscardHandler}
                   >

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/MessageCard.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/MessageCard.tsx
@@ -56,6 +56,7 @@ const AssistantMessageCard = ({
     setIsActionButtonClick(true);
     if (action === 'accept') {
       onAccept?.();
+      return;
     }
 
     onDiscard?.();

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/MessageCard.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/MessageCard.tsx
@@ -1,4 +1,4 @@
-import { useCallback, type JSX } from 'react';
+import { useCallback, useState, type JSX } from 'react';
 
 import type { LinkProps } from 'next/link';
 import { useTranslation } from 'react-i18next';
@@ -50,6 +50,17 @@ const AssistantMessageCard = ({
 }): JSX.Element => {
   const { t } = useTranslation();
 
+  const [isActionButtonClicked, setIsActionButtonClick] = useState(false);
+
+  const clickActionButtonHandler = useCallback((action: 'accept' | 'discard') => {
+    setIsActionButtonClick(true);
+    if (action === 'accept') {
+      onAccept?.();
+    }
+
+    onDiscard?.();
+  }, [onAccept, onDiscard]);
+
   return (
     <div className={`card border-0 ${moduleClass} ${assistantMessageCardModuleClass}`}>
       <div className="card-body d-flex">
@@ -62,19 +73,19 @@ const AssistantMessageCard = ({
               <>
                 <ReactMarkdown components={{ a: NextLinkWrapper }}>{children}</ReactMarkdown>
 
-                {showActionButtons && (
+                {showActionButtons && !isActionButtonClicked && (
                   <div className="d-flex mt-2 justify-content-start">
                     <button
                       type="button"
                       className="btn btn-outline-secondary me-2"
-                      onClick={onDiscard}
+                      onClick={() => clickActionButtonHandler('discard')}
                     >
                       {t('sidebar_ai_assistant.discard')}
                     </button>
                     <button
                       type="button"
                       className="btn btn-outline-success"
-                      onClick={onAccept}
+                      onClick={() => clickActionButtonHandler('accept')}
                     >
                       {t('sidebar_ai_assistant.accept')}
                     </button>

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/MessageCard.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/MessageCard.tsx
@@ -50,10 +50,10 @@ const AssistantMessageCard = ({
 }): JSX.Element => {
   const { t } = useTranslation();
 
-  const [isActionButtonClicked, setIsActionButtonClick] = useState(false);
+  const [isActionButtonClicked, setIsActionButtonClicked] = useState(false);
 
   const clickActionButtonHandler = useCallback((action: 'accept' | 'discard') => {
-    setIsActionButtonClick(true);
+    setIsActionButtonClicked(true);
     if (action === 'accept') {
       onAccept?.();
       return;


### PR DESCRIPTION
# Task
- [#164758](https://redmine.weseek.co.jp/issues/164758) [GROWI AI Next][エディターアシスタント] 最新のメッセージにのみ採用・破棄ボタンを表示させ、いずれかのボタンクリック時にボタンを非表示にする
  - [#164698](https://redmine.weseek.co.jp/issues/164698) 実装