### PR TITLE
fix: Profile image upload functionality and accepted file types

### DIFF
--- a/apps/app/src/client/components/Me/ProfileImageSettings.tsx
+++ b/apps/app/src/client/components/Me/ProfileImageSettings.tsx
@@ -147,7 +147,12 @@ const ProfileImageSettings = (): JSX.Element => {
               {t('Upload new image')}
             </label>
             <div className="col-md-6 col-lg-8">
-              <input type="file" onChange={selectFileHandler} name="profileImage" accept="image/*" />
+              <input
+                type="file"
+                onChange={selectFileHandler}
+                name="profileImage"
+                accept="image/png,image/jpeg,image/jpg,image/gif,image/webp,image/avif,image/heic,image/heif,image/tiff,image/svg+xml"
+              />
             </div>
           </div>
         </div>

--- a/apps/app/src/server/routes/attachment/api.js
+++ b/apps/app/src/server/routes/attachment/api.js
@@ -4,6 +4,8 @@ import { AttachmentType } from '~/server/interfaces/attachment';
 import loggerFactory from '~/utils/logger';
 
 import { Attachment } from '../../models/attachment';
+
+import { validateImageContentType } from './image-content-type-validator';
 /* eslint-disable no-use-before-define */
 
 
@@ -246,30 +248,11 @@ export const routesFactory = (crowi) => {
 
     const file = req.file;
 
-    // check type
-    // Define explicitly allowed image types
-    // Keep supporting wide range of formats as ImageCropModal can handle them:
-    // - When cropping: converts to PNG
-    // - When not cropping: maintains original format
-    const acceptableFileTypes = [
-      'image/png', // Universal web format
-      'image/jpeg', // Universal web format
-      'image/jpg', // Universal web format
-      'image/gif', // Universal web format
-      'image/webp', // Modern efficient format
-      'image/avif', // Next-gen format
-      'image/heic', // iOS format
-      'image/heif', // iOS format
-      'image/tiff', // High quality format
-      'image/svg+xml', // Vector format
-    ];
+    // Validate file type
+    const { isValid, error } = validateImageContentType(file.mimetype);
 
-    // Security: Extract the actual content type from potentially multiple values
-    const contentType = file.mimetype.split(',').map(type => type.trim()).pop();
-
-    if (!acceptableFileTypes.includes(contentType)) {
-      const supportedFormats = 'PNG, JPEG, GIF, WebP, AVIF, HEIC/HEIF, TIFF, SVG';
-      return res.json(ApiResponse.error(`Invalid file type. Supported formats: ${supportedFormats}`));
+    if (!isValid) {
+      return res.json(ApiResponse.error(error));
     }
 
     let attachment;

--- a/apps/app/src/server/routes/attachment/api.js
+++ b/apps/app/src/server/routes/attachment/api.js
@@ -247,9 +247,29 @@ export const routesFactory = (crowi) => {
     const file = req.file;
 
     // check type
-    const acceptableFileType = /image\/.+/;
-    if (!file.mimetype.match(acceptableFileType)) {
-      return res.json(ApiResponse.error('File type error. Only image files is allowed to set as user picture.'));
+    // Define explicitly allowed image types
+    // Keep supporting wide range of formats as ImageCropModal can handle them:
+    // - When cropping: converts to PNG
+    // - When not cropping: maintains original format
+    const acceptableFileTypes = [
+      'image/png', // Universal web format
+      'image/jpeg', // Universal web format
+      'image/jpg', // Universal web format
+      'image/gif', // Universal web format
+      'image/webp', // Modern efficient format
+      'image/avif', // Next-gen format
+      'image/heic', // iOS format
+      'image/heif', // iOS format
+      'image/tiff', // High quality format
+      'image/svg+xml', // Vector format
+    ];
+
+    // Security: Extract the actual content type from potentially multiple values
+    const contentType = file.mimetype.split(',').map(type => type.trim()).pop();
+
+    if (!acceptableFileTypes.includes(contentType)) {
+      const supportedFormats = 'PNG, JPEG, GIF, WebP, AVIF, HEIC/HEIF, TIFF, SVG';
+      return res.json(ApiResponse.error(`Invalid file type. Supported formats: ${supportedFormats}`));
     }
 
     let attachment;

--- a/apps/app/src/server/routes/attachment/image-content-type-validator.spec.ts
+++ b/apps/app/src/server/routes/attachment/image-content-type-validator.spec.ts
@@ -1,79 +1,71 @@
 import { describe, test, expect } from 'vitest';
 
-import { validateImageContentType } from './image-content-type-validator';
+import { validateImageContentType, type SupportedImageMimeType } from './image-content-type-validator';
 
 describe('imageContentTypeValidator', () => {
   describe('validateImageContentType', () => {
-    test('should accept valid single MIME type', () => {
-      const result = validateImageContentType('image/png');
-      expect(result.isValid).toBe(true);
-      expect(result.contentType).toBe('image/png');
-      expect(result.error).toBeUndefined();
-    });
-
-    test('should accept valid MIME type when multiple types are provided (last type is valid)', () => {
-      const result = validateImageContentType('text/html, image/jpeg');
-      expect(result.isValid).toBe(true);
-      expect(result.contentType).toBe('image/jpeg');
-      expect(result.error).toBeUndefined();
-    });
-
-    test('should reject when last MIME type is invalid', () => {
-      const result = validateImageContentType('image/png, text/html');
-      expect(result.isValid).toBe(false);
-      expect(result.contentType).toBe('text/html');
-      expect(result.error).toContain('Invalid file type');
-    });
-
-    test('should handle empty string', () => {
-      const result = validateImageContentType('');
-      expect(result.isValid).toBe(false);
-      expect(result.contentType).toBe('');
-      expect(result.error).toContain('Invalid file type');
-    });
-
-    test('should handle whitespace in MIME types', () => {
-      const result = validateImageContentType('image/png , image/jpeg');
-      expect(result.isValid).toBe(true);
-      expect(result.contentType).toBe('image/jpeg');
-      expect(result.error).toBeUndefined();
-    });
-
-    test('should reject non-image MIME types', () => {
-      const result = validateImageContentType('application/json');
-      expect(result.isValid).toBe(false);
-      expect(result.contentType).toBe('application/json');
-      expect(result.error).toContain('Invalid file type');
-    });
-
-    test('should reject non-string input', () => {
-      const result = validateImageContentType(undefined as unknown as string);
-      expect(result.isValid).toBe(false);
-      expect(result.contentType).toBeNull();
-      expect(result.error).toBe('Invalid MIME type format');
-    });
-
-    test('should accept all supported image types', () => {
-      const supportedTypes = [
-        'image/png',
-        'image/jpeg',
-        'image/jpg',
-        'image/gif',
-        'image/webp',
-        'image/avif',
-        'image/heic',
-        'image/heif',
-        'image/tiff',
-        'image/svg+xml',
-      ];
-
-      // Use for...of instead of forEach to avoid extra argument
-      for (const mimeType of supportedTypes) {
-        const result = validateImageContentType(mimeType);
-        expect(result.isValid).toBe(true, `${mimeType} should be valid`);
-        expect(result.contentType).toBe(mimeType);
+    describe('valid cases', () => {
+      test.each([
+        ['single MIME type', 'image/png'],
+        ['MIME type with whitespace', 'image/png '],
+        ['multiple MIME types (last is valid)', 'text/html, image/jpeg'],
+        ['multiple MIME types with whitespace', 'image/png , image/jpeg'],
+      ])('should accept %s', (_, input) => {
+        const result = validateImageContentType(input);
+        expect(result.isValid).toBe(true);
         expect(result.error).toBeUndefined();
-      }
+      });
+
+      describe('should accept all supported image types', () => {
+        const supportedTypes: SupportedImageMimeType[] = [
+          'image/png',
+          'image/jpeg',
+          'image/jpg',
+          'image/gif',
+          'image/webp',
+          'image/avif',
+          'image/heic',
+          'image/heif',
+          'image/tiff',
+          'image/svg+xml',
+        ];
+
+        test.each(supportedTypes)('%s', (mimeType) => {
+          const result = validateImageContentType(mimeType);
+          expect(result.isValid).toBe(true);
+          expect(result.contentType).toBe(mimeType);
+          expect(result.error).toBeUndefined();
+        });
+      });
+    });
+
+    describe('invalid cases', () => {
+      describe('invalid MIME types', () => {
+        test.each([
+          ['non-image MIME type', 'application/json'],
+          ['multiple MIME types (last is invalid)', 'image/png, text/html'],
+          ['empty string', ''],
+          ['unknown image type', 'image/unknown'],
+        ])('should reject %s', (_, input) => {
+          const result = validateImageContentType(input);
+          expect(result.isValid).toBe(false);
+          expect(result.error).toContain('Invalid file type');
+        });
+      });
+
+      describe('invalid input types', () => {
+        test.each([
+          ['undefined', undefined],
+          ['null', null],
+          ['number', 42],
+          ['object', {}],
+        ])('should reject %s', (_, input) => {
+          const result = validateImageContentType(input as unknown as string);
+          expect(result.isValid).toBe(false);
+          expect(result.contentType).toBeNull();
+          expect(result.error).toBe('Invalid MIME type format');
+        });
+      });
     });
   });
 });

--- a/apps/app/src/server/routes/attachment/image-content-type-validator.spec.ts
+++ b/apps/app/src/server/routes/attachment/image-content-type-validator.spec.ts
@@ -1,0 +1,79 @@
+import { describe, test, expect } from 'vitest';
+
+import { validateImageContentType } from './image-content-type-validator';
+
+describe('imageContentTypeValidator', () => {
+  describe('validateImageContentType', () => {
+    test('should accept valid single MIME type', () => {
+      const result = validateImageContentType('image/png');
+      expect(result.isValid).toBe(true);
+      expect(result.contentType).toBe('image/png');
+      expect(result.error).toBeUndefined();
+    });
+
+    test('should accept valid MIME type when multiple types are provided (last type is valid)', () => {
+      const result = validateImageContentType('text/html, image/jpeg');
+      expect(result.isValid).toBe(true);
+      expect(result.contentType).toBe('image/jpeg');
+      expect(result.error).toBeUndefined();
+    });
+
+    test('should reject when last MIME type is invalid', () => {
+      const result = validateImageContentType('image/png, text/html');
+      expect(result.isValid).toBe(false);
+      expect(result.contentType).toBe('text/html');
+      expect(result.error).toContain('Invalid file type');
+    });
+
+    test('should handle empty string', () => {
+      const result = validateImageContentType('');
+      expect(result.isValid).toBe(false);
+      expect(result.contentType).toBe('');
+      expect(result.error).toContain('Invalid file type');
+    });
+
+    test('should handle whitespace in MIME types', () => {
+      const result = validateImageContentType('image/png , image/jpeg');
+      expect(result.isValid).toBe(true);
+      expect(result.contentType).toBe('image/jpeg');
+      expect(result.error).toBeUndefined();
+    });
+
+    test('should reject non-image MIME types', () => {
+      const result = validateImageContentType('application/json');
+      expect(result.isValid).toBe(false);
+      expect(result.contentType).toBe('application/json');
+      expect(result.error).toContain('Invalid file type');
+    });
+
+    test('should reject non-string input', () => {
+      const result = validateImageContentType(undefined as unknown as string);
+      expect(result.isValid).toBe(false);
+      expect(result.contentType).toBeNull();
+      expect(result.error).toBe('Invalid MIME type format');
+    });
+
+    test('should accept all supported image types', () => {
+      const supportedTypes = [
+        'image/png',
+        'image/jpeg',
+        'image/jpg',
+        'image/gif',
+        'image/webp',
+        'image/avif',
+        'image/heic',
+        'image/heif',
+        'image/tiff',
+        'image/svg+xml',
+      ];
+
+      // Use for...of instead of forEach to avoid extra argument
+      for (const mimeType of supportedTypes) {
+        const result = validateImageContentType(mimeType);
+        expect(result.isValid).toBe(true, `${mimeType} should be valid`);
+        expect(result.contentType).toBe(mimeType);
+        expect(result.error).toBeUndefined();
+      }
+    });
+  });
+});

--- a/apps/app/src/server/routes/attachment/image-content-type-validator.spec.ts
+++ b/apps/app/src/server/routes/attachment/image-content-type-validator.spec.ts
@@ -2,70 +2,64 @@ import { describe, test, expect } from 'vitest';
 
 import { validateImageContentType, type SupportedImageMimeType } from './image-content-type-validator';
 
-describe('imageContentTypeValidator', () => {
-  describe('validateImageContentType', () => {
-    describe('valid cases', () => {
-      test.each([
-        ['single MIME type', 'image/png'],
-        ['MIME type with whitespace', 'image/png '],
-        ['multiple MIME types (last is valid)', 'text/html, image/jpeg'],
-        ['multiple MIME types with whitespace', 'image/png , image/jpeg'],
-      ])('should accept %s', (_, input) => {
-        const result = validateImageContentType(input);
-        expect(result.isValid).toBe(true);
-        expect(result.error).toBeUndefined();
-      });
+describe('validateImageContentType', () => {
+  describe('valid cases', () => {
+    // Test supported MIME types
+    const supportedTypes: SupportedImageMimeType[] = [
+      'image/png',
+      'image/jpeg',
+      'image/jpg',
+      'image/gif',
+      'image/webp',
+      'image/avif',
+      'image/heic',
+      'image/heif',
+      'image/tiff',
+      'image/svg+xml',
+    ];
 
-      describe('should accept all supported image types', () => {
-        const supportedTypes: SupportedImageMimeType[] = [
-          'image/png',
-          'image/jpeg',
-          'image/jpg',
-          'image/gif',
-          'image/webp',
-          'image/avif',
-          'image/heic',
-          'image/heif',
-          'image/tiff',
-          'image/svg+xml',
-        ];
-
-        test.each(supportedTypes)('%s', (mimeType) => {
-          const result = validateImageContentType(mimeType);
-          expect(result.isValid).toBe(true);
-          expect(result.contentType).toBe(mimeType);
-          expect(result.error).toBeUndefined();
-        });
-      });
+    test.each(supportedTypes)('should accept %s', (mimeType) => {
+      const result = validateImageContentType(mimeType);
+      expect(result.isValid).toBe(true);
+      expect(result.contentType).toBe(mimeType);
+      expect(result.error).toBeUndefined();
     });
 
-    describe('invalid cases', () => {
-      describe('invalid MIME types', () => {
-        test.each([
-          ['non-image MIME type', 'application/json'],
-          ['multiple MIME types (last is invalid)', 'image/png, text/html'],
-          ['empty string', ''],
-          ['unknown image type', 'image/unknown'],
-        ])('should reject %s', (_, input) => {
-          const result = validateImageContentType(input);
-          expect(result.isValid).toBe(false);
-          expect(result.error).toContain('Invalid file type');
-        });
-      });
+    test('should accept MIME type with surrounding whitespace', () => {
+      const result = validateImageContentType('  image/png  ');
+      expect(result.isValid).toBe(true);
+      expect(result.contentType).toBe('image/png');
+      expect(result.error).toBeUndefined();
+    });
+  });
 
-      describe('invalid input types', () => {
-        test.each([
-          ['undefined', undefined],
-          ['null', null],
-          ['number', 42],
-          ['object', {}],
-        ])('should reject %s', (_, input) => {
-          const result = validateImageContentType(input as unknown as string);
-          expect(result.isValid).toBe(false);
-          expect(result.contentType).toBeNull();
-          expect(result.error).toBe('Invalid MIME type format');
-        });
-      });
+  describe('invalid cases', () => {
+    // Test invalid input types
+    test.each([
+      ['undefined', undefined],
+      ['null', null],
+      ['number', 42],
+      ['object', {}],
+    ])('should reject %s', (_, input) => {
+      const result = validateImageContentType(input as unknown as string);
+      expect(result.isValid).toBe(false);
+      expect(result.contentType).toBeNull();
+      expect(result.error).toBe('Invalid MIME type format');
+    });
+
+    // Test invalid MIME types
+    test.each([
+      ['empty string', ''],
+      ['whitespace only', '   '],
+      ['non-image type', 'text/plain'],
+      ['unknown image type', 'image/unknown'],
+      ['multiple MIME types', 'text/plain, image/png'],
+      ['multiple image types', 'image/png, image/jpeg'],
+      ['MIME type with comma', 'image/png,'],
+    ])('should reject %s', (_, input) => {
+      const result = validateImageContentType(input);
+      expect(result.isValid).toBe(false);
+      expect(result.error).toContain('Invalid file type');
     });
   });
 });

--- a/apps/app/src/server/routes/attachment/image-content-type-validator.ts
+++ b/apps/app/src/server/routes/attachment/image-content-type-validator.ts
@@ -25,7 +25,7 @@ export interface ImageContentTypeValidatorResult {
 
 /**
  * Validate and extract content type from MIME type string
- * @param mimeType MIME type string, possibly containing multiple values
+ * @param mimeType MIME type string
  * @returns Validation result containing isValid flag and extracted content type
  */
 export const validateImageContentType = (mimeType: string): ImageContentTypeValidatorResult => {
@@ -37,25 +37,20 @@ export const validateImageContentType = (mimeType: string): ImageContentTypeVali
     };
   }
 
-  // Extract the last content type from comma-separated values
-  const contentType = mimeType.split(',')
-    .map(type => type.trim())
-    .pop() ?? '';
-
-  // Check if the content type is in supported list
-  const isValid = SUPPORTED_IMAGE_MIME_TYPES.includes(contentType as SupportedImageMimeType);
+  const trimmedType = mimeType.trim();
+  const isValid = SUPPORTED_IMAGE_MIME_TYPES.includes(trimmedType as SupportedImageMimeType);
 
   if (!isValid) {
     const supportedFormats = 'PNG, JPEG, GIF, WebP, AVIF, HEIC/HEIF, TIFF, SVG';
     return {
       isValid: false,
-      contentType,
+      contentType: trimmedType,
       error: `Invalid file type. Supported formats: ${supportedFormats}`,
     };
   }
 
   return {
     isValid: true,
-    contentType,
+    contentType: trimmedType,
   };
 };

--- a/apps/app/src/server/routes/attachment/image-content-type-validator.ts
+++ b/apps/app/src/server/routes/attachment/image-content-type-validator.ts
@@ -1,0 +1,61 @@
+/**
+ * Define supported image MIME types
+ */
+export const SUPPORTED_IMAGE_MIME_TYPES = [
+  'image/png', // Universal web format
+  'image/jpeg', // Universal web format
+  'image/jpg', // Universal web format
+  'image/gif', // Universal web format
+  'image/webp', // Modern efficient format
+  'image/avif', // Next-gen format
+  'image/heic', // iOS format
+  'image/heif', // iOS format
+  'image/tiff', // High quality format
+  'image/svg+xml', // Vector format
+] as const;
+
+// Create a type for supported MIME types
+export type SupportedImageMimeType = typeof SUPPORTED_IMAGE_MIME_TYPES[number];
+
+export interface ImageContentTypeValidatorResult {
+  isValid: boolean;
+  contentType: string | null;
+  error?: string;
+}
+
+/**
+ * Validate and extract content type from MIME type string
+ * @param mimeType MIME type string, possibly containing multiple values
+ * @returns Validation result containing isValid flag and extracted content type
+ */
+export const validateImageContentType = (mimeType: string): ImageContentTypeValidatorResult => {
+  if (typeof mimeType !== 'string') {
+    return {
+      isValid: false,
+      contentType: null,
+      error: 'Invalid MIME type format',
+    };
+  }
+
+  // Extract the last content type from comma-separated values
+  const contentType = mimeType.split(',')
+    .map(type => type.trim())
+    .pop() ?? '';
+
+  // Check if the content type is in supported list
+  const isValid = SUPPORTED_IMAGE_MIME_TYPES.includes(contentType as SupportedImageMimeType);
+
+  if (!isValid) {
+    const supportedFormats = 'PNG, JPEG, GIF, WebP, AVIF, HEIC/HEIF, TIFF, SVG';
+    return {
+      isValid: false,
+      contentType,
+      error: `Invalid file type. Supported formats: ${supportedFormats}`,
+    };
+  }
+
+  return {
+    isValid: true,
+    contentType,
+  };
+};


### PR DESCRIPTION
Update the profile image upload input to accept a wider range of image formats and improve validation for uploaded files. This ensures better compatibility and user experience when uploading profile images.

## Task
- https://redmine.weseek.co.jp/issues/164939