### PR TITLE
feat: Cange text of reject button

### DIFF
--- a/packages/editor/src/client/components-internal/CodeMirrorEditor/CodeMirrorEditor.module.scss
+++ b/packages/editor/src/client/components-internal/CodeMirrorEditor/CodeMirrorEditor.module.scss
@@ -39,6 +39,17 @@
       font-size: 1.2em;
     }
 
+    // @codemirror/merge style
+    .cm-chunkButtons {
+      button[name="reject"] {
+        font-size: 0;
+        &::after {
+          font-size: 16px;
+          content: 'Discard'
+        }
+      }
+    }
+
   }
 
 }


### PR DESCRIPTION
# Task
- 164966 [GROWI AI Next] [エディターアシスタント] codemirror/merge 由来の Reject ボタンの文言を "Discard" として表示できる 
  - [#164967](https://redmine.weseek.co.jp/issues/164967) 実装