### PR TITLE
imprv: Reorganize ai assistant sidebar

### DIFF
--- a/apps/app/src/features/openai/client/services/knowledge-assistant.ts
+++ b/apps/app/src/features/openai/client/services/knowledge-assistant.ts
@@ -1,18 +1,44 @@
 import { useCallback } from 'react';
 
+import { apiv3Post } from '~/client/util/apiv3-client';
 import { SseMessageSchema, type SseMessage } from '~/features/openai/interfaces/knowledge-assistant/sse-schemas';
 import { handleIfSuccessfullyParsed } from '~/features/openai/utils/handle-if-successfully-parsed';
+
+import type { IThreadRelationHasId } from '../../interfaces/thread-relation';
+import { ThreadType } from '../../interfaces/thread-relation';
+
+interface CreateThread {
+  (aiAssistantId: string, initialUserMessage: string): Promise<IThreadRelationHasId>;
+}
 
 interface PostMessage {
   (aiAssistantId: string, threadId: string, userMessage: string, summaryMode?: boolean): Promise<Response>;
 }
+
 interface ProcessMessage {
   (data: unknown, handler: {
     onMessage: (data: SseMessage) => void}
   ): void;
 }
 
-export const useKnowledgeAssistant = (): { postMessage: PostMessage, processMessage: ProcessMessage } => {
+type UseKnowledgeAssistant = () => {
+  createThread: CreateThread
+  postMessage: PostMessage
+  processMessage: ProcessMessage
+}
+
+export const useKnowledgeAssistant: UseKnowledgeAssistant = () => {
+
+  const createThread: CreateThread = useCallback(async(aiAssistantId, initialUserMessage) => {
+    const response = await apiv3Post<IThreadRelationHasId>('/openai/thread', {
+      type: ThreadType.KNOWLEDGE,
+      aiAssistantId,
+      initialUserMessage,
+    });
+    const thread = response.data;
+    return thread;
+  }, []);
+
   const postMessage: PostMessage = useCallback(async(aiAssistantId, threadId, userMessage, summaryMode) => {
     const response = await fetch('/_api/v3/openai/message', {
       method: 'POST',
@@ -34,6 +60,7 @@ export const useKnowledgeAssistant = (): { postMessage: PostMessage, processMess
   }, []);
 
   return {
+    createThread,
     postMessage,
     processMessage,
   };


### PR DESCRIPTION
# Task
- [#162808](https://redmine.weseek.co.jp/issues/162808) [GROWI AI Next][エディターアシスタント] AiAssistantChatSidebar をリファクタし、チャットアシスタントとエディターアシスタントで共用できるようにする
  - [#163216](https://redmine.weseek.co.jp/issues/163216) AiAssistantSidebar から各アシスタントごとの処理周りのを引き剥がし useKnowledgeAssistant (useEditAssistant) に移す