### PR TITLE
feat: Send entire markdown to LLM when clickQuick button is clicked

### DIFF
--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar.tsx
@@ -38,6 +38,7 @@ const moduleClass = styles['grw-ai-assistant-sidebar'] ?? '';
 
 export type FormData = {
   input: string;
+  markdown?: string;
   summaryMode?: boolean;
 };
 
@@ -117,9 +118,9 @@ const AiAssistantSidebarSubstance: React.FC<AiAssistantSidebarSubstanceProps> = 
     return thread;
   }, [aiAssistantData, createThreadForEditorAssistant, createThreadForKnowledgeAssistant, isEditorAssistant]);
 
-  const postMessage = useCallback(async(currentThreadId: string, input: string, summaryMode?: boolean) => {
+  const postMessage = useCallback(async(currentThreadId: string, input: string, summaryMode?: boolean, markdown?: string) => {
     if (isEditorAssistant) {
-      const response = await postMessageForEditorAssistant(currentThreadId, input);
+      const response = await postMessageForEditorAssistant(currentThreadId, input, markdown);
       return response;
     }
     if (aiAssistantData?._id != null) {
@@ -178,7 +179,7 @@ const AiAssistantSidebarSubstance: React.FC<AiAssistantSidebarSubstanceProps> = 
         return;
       }
 
-      const response = await postMessage(currentThreadId_, data.input, data.summaryMode);
+      const response = await postMessage(currentThreadId_, data.input, data.summaryMode, data.markdown);
       if (response == null) {
         return;
       }

--- a/apps/app/src/features/openai/client/services/editor-assistant.tsx
+++ b/apps/app/src/features/openai/client/services/editor-assistant.tsx
@@ -160,7 +160,7 @@ export const useEditorAssistant: UseEditorAssistant = () => {
   }, [selectedAiAssistant?._id]);
 
   const postMessage: PostMessage = useCallback(async(threadId, userMessage, markdown) => {
-    const hoge = () => {
+    const getMarkdownForPost = () => {
       if (markdown != null) {
         return markdown;
       }
@@ -178,7 +178,7 @@ export const useEditorAssistant: UseEditorAssistant = () => {
       body: JSON.stringify({
         threadId,
         userMessage,
-        markdown: hoge(),
+        markdown: getMarkdownForPost(),
       }),
     });
 


### PR DESCRIPTION
# Task
- [#165074](https://redmine.weseek.co.jp/issues/165074) [GROWI AI Next][エディターアシスタント] QuickMenuList のボタン (この記事の要約をつくる)等) クリック時に markdown 全文を送信できる
  -  [#165076](https://redmine.weseek.co.jp/issues/165076) 実装