### PR TITLE
imprv: Hide summary mode switch in editor assistant mode

### DIFF
--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar.tsx
@@ -71,7 +71,7 @@ const AiAssistantSidebarSubstance: React.FC<AiAssistantSidebarSubstanceProps> = 
     createThread: createThreadForKnowledgeAssistant,
     postMessage: postMessageForKnowledgeAssistant,
     processMessage: processMessageForKnowledgeAssistant,
-    form: formForForKnowledgeAssistant,
+    form: formForKnowledgeAssistant,
     resetForm: resetFormForKnowledgeAssistant,
 
     // Views
@@ -87,7 +87,7 @@ const AiAssistantSidebarSubstance: React.FC<AiAssistantSidebarSubstanceProps> = 
     createThread: createThreadForEditorAssistant,
     postMessage: postMessageForEditorAssistant,
     processMessage: processMessageForEditorAssistant,
-    form: formForForEditorAssistant,
+    form: formForEditorAssistant,
     resetForm: resetFormEditorAssistant,
     isTextSelected,
 
@@ -99,7 +99,7 @@ const AiAssistantSidebarSubstance: React.FC<AiAssistantSidebarSubstanceProps> = 
     placeHolder: placeHolderForEditorAssistant,
   } = useEditorAssistant();
 
-  const form = isEditorAssistant ? formForForEditorAssistant : formForForKnowledgeAssistant;
+  const form = isEditorAssistant ? formForEditorAssistant : formForKnowledgeAssistant;
 
   // Effects
   useFetchAndSetMessageDataEffect(setMessageLogs, threadData?.threadId);

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar.tsx
@@ -130,7 +130,7 @@ const AiAssistantSidebarSubstance: React.FC<AiAssistantSidebarSubstanceProps> = 
       return response;
     }
     if (aiAssistantData?._id != null) {
-      const response = postMessageForKnowledgeAssistant(aiAssistantData._id, currentThreadId, input);
+      const response = await postMessageForKnowledgeAssistant(aiAssistantData._id, currentThreadId, input);
       return response;
     }
   }, [aiAssistantData?._id, isEditorAssistant, postMessageForEditorAssistant, postMessageForKnowledgeAssistant]);

--- a/apps/app/src/features/openai/client/services/editor-assistant.tsx
+++ b/apps/app/src/features/openai/client/services/editor-assistant.tsx
@@ -8,6 +8,7 @@ import {
 } from '@growi/editor/dist/client/services/unified-merge-view';
 import { useCodeMirrorEditorIsolated } from '@growi/editor/dist/client/stores/codemirror-editor';
 import { useSecondaryYdocs } from '@growi/editor/dist/client/stores/use-secondary-ydocs';
+import { useForm, type UseFormReturn } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { type Text as YText } from 'yjs';
 
@@ -34,7 +35,7 @@ import type { MessageLog } from '../../interfaces/message';
 import type { IThreadRelationHasId } from '../../interfaces/thread-relation';
 import { ThreadType } from '../../interfaces/thread-relation';
 import { AiAssistantDropdown } from '../components/AiAssistant/AiAssistantSidebar/AiAssistantDropdown';
-import { type FormData } from '../components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar';
+// import { type FormData } from '../components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar';
 import { MessageCard, type MessageCardRole } from '../components/AiAssistant/AiAssistantSidebar/MessageCard';
 import { QuickMenuList } from '../components/AiAssistant/AiAssistantSidebar/QuickMenuList';
 import { useAiAssistantSidebar } from '../stores/ai-assistant';
@@ -59,6 +60,10 @@ interface GenerateInitialView {
 interface GenerateMessageCard {
   (role: MessageCardRole, children: string, messageId: string, messageLogs: MessageLog[], generatingAnswerMessage?: MessageLog): JSX.Element;
 }
+export interface FormData {
+  input: string
+  markdown?: string
+}
 
 type DetectedDiff = Array<{
   data: SseDetectedDiff,
@@ -70,6 +75,8 @@ type UseEditorAssistant = () => {
   createThread: CreateThread,
   postMessage: PostMessage,
   processMessage: ProcessMessage,
+  form: UseFormReturn<FormData>
+  resetForm: () => void
 
   // Views
   generateInitialView: GenerateInitialView,
@@ -150,7 +157,17 @@ export const useEditorAssistant: UseEditorAssistant = () => {
   const yDocs = useSecondaryYdocs(isEnableUnifiedMergeView ?? false, { pageId: currentPageId ?? undefined, useSecondary: isEnableUnifiedMergeView ?? false });
   const { data: aiAssistantSidebarData } = useAiAssistantSidebar();
 
+  const form = useForm<FormData>({
+    defaultValues: {
+      input: '',
+    },
+  });
+
   // Functions
+  const resetForm = useCallback(() => {
+    form.reset({ input: '', markdown: undefined });
+  }, [form]);
+
   const createThread: CreateThread = useCallback(async() => {
     const response = await apiv3Post<IThreadRelationHasId>('/openai/thread', {
       type: ThreadType.EDITOR,
@@ -365,6 +382,8 @@ export const useEditorAssistant: UseEditorAssistant = () => {
     createThread,
     postMessage,
     processMessage,
+    form,
+    resetForm,
 
     // Views
     generateInitialView,

--- a/apps/app/src/features/openai/client/services/knowledge-assistant.tsx
+++ b/apps/app/src/features/openai/client/services/knowledge-assistant.tsx
@@ -25,7 +25,7 @@ interface CreateThread {
 }
 
 interface PostMessage {
-  (aiAssistantId: string, threadId: string, userMessage: string): Promise<Response>;
+  (aiAssistantId: string, threadId: string, formData: FormData): Promise<Response>;
 }
 
 interface ProcessMessage {
@@ -103,14 +103,14 @@ export const useKnowledgeAssistant: UseKnowledgeAssistant = () => {
     return thread;
   }, [mutateThreadData]);
 
-  const postMessage: PostMessage = useCallback(async(aiAssistantId, threadId, userMessage) => {
+  const postMessage: PostMessage = useCallback(async(aiAssistantId, threadId, formData) => {
     const response = await fetch('/_api/v3/openai/message', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         aiAssistantId,
         threadId,
-        userMessage,
+        userMessage: formData.input,
         summaryMode: form.getValues('summaryMode'),
       }),
     });


### PR DESCRIPTION
# Task
- [#165074](https://redmine.weseek.co.jp/issues/165074) [GROWI AI Next][エディターアシスタント] QuickMenuList のボタン (この記事の要約をつくる)等) クリック時に markdown 全文を送信できる
  - [#165076](https://redmine.weseek.co.jp/issues/165076) 実装
- [#165075](https://redmine.weseek.co.jp/issues/165075) [GROWI AI Next][エディターアシスタント] エディターアシスタント時は要約モードの switch を表示しない
  -  [#165077](https://redmine.weseek.co.jp/issues/165077) 改善