### PR TITLE
feat: Delete associated vectorstore file on attachment deletion

### DIFF
--- a/apps/app/src/features/openai/server/models/vector-store-file-relation.ts
+++ b/apps/app/src/features/openai/server/models/vector-store-file-relation.ts
@@ -7,6 +7,7 @@ import { getOrCreateModel } from '~/server/util/mongoose-utils';
 export interface VectorStoreFileRelation {
   vectorStoreRelationId: mongoose.Types.ObjectId;
   page: mongoose.Types.ObjectId;
+  attachment?: mongoose.Types.ObjectId;
   fileIds: string[];
   isAttachedToVectorStore: boolean;
 }
@@ -19,7 +20,11 @@ interface VectorStoreFileRelationModel extends Model<VectorStoreFileRelation> {
 }
 
 export const prepareVectorStoreFileRelations = (
-    vectorStoreRelationId: Types.ObjectId, page: Types.ObjectId, fileId: string, relationsMap: Map<string, VectorStoreFileRelation>,
+    vectorStoreRelationId: Types.ObjectId,
+    page: Types.ObjectId,
+    fileId: string,
+    relationsMap: Map<string, VectorStoreFileRelation>,
+    attachment?: Types.ObjectId,
 ): Map<string, VectorStoreFileRelation> => {
   const pageIdStr = page.toHexString();
   const existingData = relationsMap.get(pageIdStr);
@@ -35,6 +40,7 @@ export const prepareVectorStoreFileRelations = (
       page,
       fileIds: [fileId],
       isAttachedToVectorStore: false,
+      attachment,
     });
   }
 
@@ -52,6 +58,10 @@ const schema = new Schema<VectorStoreFileRelationDocument, VectorStoreFileRelati
     ref: 'Page',
     required: true,
   },
+  attachment: {
+    type: Schema.Types.ObjectId,
+    ref: 'Attachment',
+  },
   fileIds: [{
     type: String,
     required: true,
@@ -64,7 +74,7 @@ const schema = new Schema<VectorStoreFileRelationDocument, VectorStoreFileRelati
 });
 
 // define unique compound index
-schema.index({ vectorStoreRelationId: 1, page: 1 }, { unique: true });
+schema.index({ vectorStoreRelationId: 1, page: 1, attachment: 1 }, { unique: true });
 
 schema.statics.upsertVectorStoreFileRelations = async function(vectorStoreFileRelations: VectorStoreFileRelation[]): Promise<void> {
   await this.bulkWrite(

--- a/apps/app/src/features/openai/server/services/openai.ts
+++ b/apps/app/src/features/openai/server/services/openai.ts
@@ -525,7 +525,7 @@ class OpenaiService implements IOpenaiService {
       }
     }
 
-    deleteAllRelationDocument();
+    await deleteAllRelationDocument();
   }
 
 

--- a/apps/app/src/features/openai/server/services/openai.ts
+++ b/apps/app/src/features/openai/server/services/openai.ts
@@ -505,6 +505,8 @@ class OpenaiService implements IOpenaiService {
   }
 
   async deleteVectorStoreFileOnDeleteAttachment(attachmentId: string) {
+    // An Attachment has only one VectorStoreFile. This means the id of VectorStoreFile linked to VectorStore is one per Attachment.
+    // Therefore, retrieve only one VectorStoreFile Relation with the target attachmentId.
     const vectorStoreFileRelation = await VectorStoreFileRelationModel.findOne({ attachment: attachmentId });
     if (vectorStoreFileRelation == null) {
       return;

--- a/apps/app/src/features/openai/server/services/openai.ts
+++ b/apps/app/src/features/openai/server/services/openai.ts
@@ -86,6 +86,7 @@ export interface IOpenaiService {
   deleteVectorStoreFile(vectorStoreRelationId: Types.ObjectId, pageId: Types.ObjectId): Promise<void>;
   deleteVectorStoreFilesByPageIds(pageIds: Types.ObjectId[]): Promise<void>;
   deleteObsoleteVectorStoreFile(limit: number, apiCallInterval: number): Promise<void>; // for CronJob
+  deleteVectorStoreFileOnDeleteAttachment(attachmentId: string): Promise<void>;
   isAiAssistantUsable(aiAssistantId: string, user: IUserHasId): Promise<boolean>;
   createAiAssistant(data: UpsertAiAssistantData, user: IUserHasId): Promise<AiAssistantDocument>;
   updateAiAssistant(aiAssistantId: string, data: UpsertAiAssistantData, user: IUserHasId): Promise<AiAssistantDocument>;
@@ -97,6 +98,9 @@ class OpenaiService implements IOpenaiService {
   constructor(crowi: Crowi) {
     this.createVectorStoreFileOnUploadAttachment = this.createVectorStoreFileOnUploadAttachment.bind(this);
     crowi.attachmentService.addAttachHandler(this.createVectorStoreFileOnUploadAttachment);
+
+    this.deleteVectorStoreFileOnDeleteAttachment = this.deleteVectorStoreFileOnDeleteAttachment.bind(this);
+    crowi.attachmentService.addDetachHandler(this.deleteVectorStoreFileOnDeleteAttachment);
   }
 
   private get client() {
@@ -498,6 +502,20 @@ class OpenaiService implements IOpenaiService {
         logger.error(err);
       }
     }
+  }
+
+  async deleteVectorStoreFileOnDeleteAttachment(attachmentId: string) {
+    const vectorStoreFileRelation = await VectorStoreFileRelationModel.findOne({ attachment: attachmentId });
+    if (vectorStoreFileRelation == null) {
+      return;
+    }
+
+    for await (const fileId of vectorStoreFileRelation.fileIds) {
+      const response = await this.client.deleteFile(fileId);
+      logger.debug('Delete vector store file', response);
+    }
+
+    await VectorStoreFileRelationModel.deleteMany({ attachment: attachmentId });
   }
 
   async filterPagesByAccessScope(aiAssistant: AiAssistantDocument, pages: HydratedDocument<PageDocument>[]) {

--- a/apps/app/src/server/service/attachment.js
+++ b/apps/app/src/server/service/attachment.js
@@ -24,7 +24,7 @@ class AttachmentService {
   /** @type {Array<(pageId: string, file: Express.Multer.File, readable: Readable) => Promise<void>>} */
   attachHandlers = [];
 
-  /** @type {Array<(attachmentId: string) => Promise<void>} */
+  /** @type {Array<(attachmentId: string) => Promise<void>>} */
   detachHandlers = [];
 
   /** @type {import('~/server/crowi').default} Crowi instance */

--- a/apps/app/src/server/service/attachment.js
+++ b/apps/app/src/server/service/attachment.js
@@ -107,6 +107,16 @@ class AttachmentService {
     await fileUploadService.deleteFile(attachment);
     await attachment.remove();
 
+    const detachedHandlerPromises = this.detachHandlers.map((handler) => {
+      return handler(attachment._id);
+    });
+
+    // Do not await, run in background
+    Promise.all(detachedHandlerPromises)
+      .catch((err) => {
+        logger.error('Error while executing detached handler', err);
+      });
+
     return;
   }
 

--- a/apps/app/src/server/service/attachment.js
+++ b/apps/app/src/server/service/attachment.js
@@ -24,6 +24,7 @@ class AttachmentService {
   /** @type {Array<(pageId: string, file: Express.Multer.File, readable: Readable) => Promise<void>>} */
   attachHandlers = [];
 
+  /** @type {Array<(attachmentId: string) => Promise<void>} */
   detachHandlers = [];
 
   /** @type {import('~/server/crowi').default} Crowi instance */
@@ -137,7 +138,7 @@ class AttachmentService {
 
   /**
    * Register a handler that will be called before attachment deletion
-   * @param {(attachment: Attachment) => Promise<void>} handler
+   * @param {(attachmentId: string) => Promise<void>} handler
    */
   addDetachHandler(handler) {
     this.detachHandlers.push(handler);

--- a/apps/app/src/server/service/attachment.js
+++ b/apps/app/src/server/service/attachment.js
@@ -60,7 +60,7 @@ class AttachmentService {
       }
 
       const attachedHandlerPromises = this.attachHandlers.map((handler) => {
-        return handler(pageId, file, fileStreamForAttachedHandler);
+        return handler(pageId, attachment, file, fileStreamForAttachedHandler);
       });
 
       // Do not await, run in background


### PR DESCRIPTION
# Task
- [#165505](https://redmine.weseek.co.jp/issues/165505) [GROWI AI Next] attachment 削除時に attachment に紐つく VectorStoreFile を削除できる
  -  [#165507](https://redmine.weseek.co.jp/issues/165507) 実装