### PR TITLE
fix: Memory leak prevention

### DIFF
--- a/apps/app/src/features/openai/server/services/openai.ts
+++ b/apps/app/src/features/openai/server/services/openai.ts
@@ -82,7 +82,7 @@ export interface IOpenaiService {
   createVectorStoreFileOnPageCreate(pages: PageDocument[]): Promise<void>;
   updateVectorStoreFileOnPageUpdate(page: HydratedDocument<PageDocument>): Promise<void>;
   createVectorStoreFileOnUploadAttachment(
-    pageId: string, attachment:HydratedDocument<IAttachmentDocument>, file: Express.Multer.File, buffer: Buffer
+    pageId: string, attachment: HydratedDocument<IAttachmentDocument>, file: Express.Multer.File, buffer: Buffer
   ): Promise<void>;
   deleteVectorStoreFile(vectorStoreRelationId: Types.ObjectId, pageId: Types.ObjectId): Promise<void>;
   deleteVectorStoreFilesByPageIds(pageIds: Types.ObjectId[]): Promise<void>;

--- a/apps/app/src/features/openai/server/services/openai.ts
+++ b/apps/app/src/features/openai/server/services/openai.ts
@@ -630,7 +630,7 @@ class OpenaiService implements IOpenaiService {
   }
 
   async createVectorStoreFileOnUploadAttachment(
-      pageId: string, attachment:HydratedDocument<IAttachmentDocument>, file: Express.Multer.File, buffer: Buffer,
+      pageId: string, attachment: HydratedDocument<IAttachmentDocument>, file: Express.Multer.File, buffer: Buffer,
   ): Promise<void> {
     if (!isVectorStoreCompatible(file)) {
       return;

--- a/apps/app/src/features/openai/server/services/openai.ts
+++ b/apps/app/src/features/openai/server/services/openai.ts
@@ -325,7 +325,7 @@ class OpenaiService implements IOpenaiService {
   }
 
   private async uploadFileForAttachment(buffer: Buffer, fileName: string): Promise<OpenAI.Files.FileObject> {
-    const uploadableFile = await toFile(Readable.from(buffer), fileName);
+    const uploadableFile = await toFile(Readable.from([buffer]), fileName);
     const uploadedFile = await this.client.uploadFile(uploadableFile);
     return uploadedFile;
   }

--- a/apps/app/src/server/service/attachment.js
+++ b/apps/app/src/server/service/attachment.js
@@ -56,7 +56,7 @@ class AttachmentService {
       await fileUploadService.uploadAttachment(readStreamForCreateAttachmentDocument, attachment);
       await attachment.save();
 
-      const attachedHandlerPromises = this.attachHandlers.map(async(handler) => {
+      this.attachHandlers.forEach(async(handler) => {
         //  Creates a new stream for each operation instead of reusing the original stream.
         //  REASON: Node.js Readable streams cannot be reused after consumption.
         //  When a stream is piped or consumed, its internal state changes and the data pointers

--- a/apps/app/src/server/service/attachment.js
+++ b/apps/app/src/server/service/attachment.js
@@ -56,6 +56,11 @@ class AttachmentService {
       await fileUploadService.uploadAttachment(readStreamForCreateAttachmentDocument, attachment);
       await attachment.save();
 
+      if (this.attachHandlers.length === 0) {
+        disposeTmpFileCallback?.(file);
+        return attachment;
+      }
+
       const readStreamForAttacheHandler = createReadStream(file.path);
       const chunks = [];
       const attachHandlers = this.attachHandlers;

--- a/apps/app/src/server/service/attachment.js
+++ b/apps/app/src/server/service/attachment.js
@@ -61,7 +61,7 @@ class AttachmentService {
         return attachment;
       }
 
-      const readStreamForAttacheHandler = createReadStream(file.path);
+      const readStreamForAttachHandler = createReadStream(file.path);
       const chunks = [];
       const attachHandlers = this.attachHandlers;
 
@@ -93,7 +93,7 @@ class AttachmentService {
       });
 
       // Do not await, run in background
-      pipeline(readStreamForAttacheHandler, attachedHandlerStream)
+      pipeline(readStreamForAttachHandler, attachedHandlerStream)
         .catch((err) => {
           logger.error('Error in stream processing', err);
         })

--- a/apps/app/src/server/service/attachment.js
+++ b/apps/app/src/server/service/attachment.js
@@ -72,6 +72,8 @@ class AttachmentService {
           },
           async flush(callback) {
             try {
+              // At this point we have the complete file as a Buffer
+              // This approach assumes handler needs the complete file data
               const completeData = Buffer.concat(chunks);
               await handler(pageId, attachment, file, completeData);
               callback();

--- a/apps/app/src/server/service/attachment.js
+++ b/apps/app/src/server/service/attachment.js
@@ -92,9 +92,6 @@ class AttachmentService {
         catch (err) {
           logger.error('Error in stream processing:', err);
         }
-        finally {
-          readStreamForHandler.destroy();
-        }
       });
 
       // Do not await, run in background

--- a/apps/app/src/server/service/attachment.js
+++ b/apps/app/src/server/service/attachment.js
@@ -70,18 +70,19 @@ class AttachmentService {
             chunks.push(chunk);
             callback(null, chunk);
           },
+
           async flush(callback) {
-            try {
-              // At this point we have the complete file as a Buffer
-              // This approach assumes handler needs the complete file data
-              const completeData = Buffer.concat(chunks);
-              await handler(pageId, attachment, file, completeData);
-              callback();
-            }
-            catch (err) {
-              logger.error('Error in attach handler:', err);
-              callback(err);
-            }
+            // At this point we have the complete file as a Buffer
+            // This approach assumes handler needs the complete file data
+            const completeData = Buffer.concat(chunks);
+            handler(pageId, attachment, file, completeData)
+              .then(() => {
+                callback();
+              })
+              .catch((err) => {
+                logger.error('Error in attach handler:', err);
+                callback(err);
+              });
           },
         });
 

--- a/apps/app/src/server/service/attachment.js
+++ b/apps/app/src/server/service/attachment.js
@@ -24,7 +24,7 @@ const createReadStream = (filePath) => {
  */
 class AttachmentService {
 
-  /** @type {Array<(pageId: string, attachment: Attachment file: Express.Multer.File, buffer: Buffer) => Promise<void>>} */
+  /** @type {Array<(pageId: string, attachment: Attachment, file: Express.Multer.File, buffer: Buffer) => Promise<void>>} */
   attachHandlers = [];
 
   /** @type {Array<(attachmentId: string) => Promise<void>>} */
@@ -166,7 +166,7 @@ class AttachmentService {
 
   /**
    * Register a handler that will be called after attachment creation
-   * @param {(pageId: string, attachment: Attachment file: Express.Multer.File, buffer: Buffer) => Promise<void>} handler
+   * @param {(pageId: string, attachment: Attachment, file: Express.Multer.File, buffer: Buffer) => Promise<void>} handler
    */
   addAttachHandler(handler) {
     this.attachHandlers.push(handler);

--- a/apps/app/src/server/service/attachment.js
+++ b/apps/app/src/server/service/attachment.js
@@ -56,12 +56,10 @@ class AttachmentService {
       //  REASON: Node.js Readable streams cannot be reused after consumption.
       //  When a stream is piped or consumed, its internal state changes and the data pointers
       //  are advanced to the end, making it impossible to read the same data again.
-      let readStreamForAttachedHandler;
-      if (this.attachHandlers.length !== 0) {
-        readStreamForAttachedHandler = createReadStream(file.path);
-      }
-
+      const readStreamForAttachedHandlers = [];
       const attachedHandlerPromises = this.attachHandlers.map((handler) => {
+        const readStreamForAttachedHandler = createReadStream(file.path);
+        readStreamForAttachedHandlers.push(readStreamForAttachedHandler);
         return handler(pageId, file, readStreamForAttachedHandler);
       });
 
@@ -71,7 +69,8 @@ class AttachmentService {
           logger.error('Error while executing attach handler', err);
         })
         .finally(() => {
-          readStreamForAttachedHandler?.destroy();
+          // readStreamForAttachedHandler?.destroy();
+          readStreamForAttachedHandlers.forEach(readStream => readStream.destroy());
           disposeTmpFileCallback?.(file);
         });
     }

--- a/apps/app/src/server/service/attachment.js
+++ b/apps/app/src/server/service/attachment.js
@@ -43,14 +43,14 @@ class AttachmentService {
       throw new Error(res.errorMessage);
     }
 
+    const readStreamForCreateAttachmentDocument = createReadStream(file.path);
+
     // create an Attachment document and upload file
     let attachment;
     try {
-      const readStreamForCreateAttachmentDocument = createReadStream(file.path);
       attachment = Attachment.createWithoutSave(pageId, user, file.originalname, file.mimetype, file.size, attachmentType);
       await fileUploadService.uploadAttachment(readStreamForCreateAttachmentDocument, attachment);
       await attachment.save();
-      readStreamForCreateAttachmentDocument.destroy();
 
       //  Creates a new stream for each operation instead of reusing the original stream.
       //  REASON: Node.js Readable streams cannot be reused after consumption.
@@ -79,6 +79,9 @@ class AttachmentService {
       logger.error('Error while creating attachment', err);
       disposeTmpFileCallback?.(file);
       throw err;
+    }
+    finally {
+      readStreamForCreateAttachmentDocument.destroy();
     }
 
     return attachment;


### PR DESCRIPTION
# Task
- [#165323](https://redmine.weseek.co.jp/issues/165323) [GROWI AI Next] Attachment データを VectorStore に保存できる
  - [#165372](https://redmine.weseek.co.jp/issues/165372) attachmentService.createAttachment のメモリリーク対策