### PR TITLE
fix: Vectorstore file not rebuilt after page update

### DIFF
--- a/apps/app/src/features/openai/server/services/openai.ts
+++ b/apps/app/src/features/openai/server/services/openai.ts
@@ -623,8 +623,8 @@ class OpenaiService implements IOpenaiService {
       logger.debug('-----------------------------------------------------');
 
       // Do not create a new VectorStoreFile if page is changed to a permission that AiAssistant does not have access to
-      await this.createVectorStoreFile(vectorStoreRelation as VectorStoreDocument, pagesToVectorize);
       await this.deleteVectorStoreFile((vectorStoreRelation as VectorStoreDocument)._id, page._id);
+      await this.createVectorStoreFile(vectorStoreRelation as VectorStoreDocument, pagesToVectorize);
     }
   }
 

--- a/apps/app/src/server/service/attachment.js
+++ b/apps/app/src/server/service/attachment.js
@@ -21,7 +21,7 @@ const createReadStream = (filePath) => {
  */
 class AttachmentService {
 
-  /** @type {Array<(pageId: string, file: Express.Multer.File, readable: Readable) => Promise<void>>} */
+  /** @type {Array<(pageId: string, attachment: Attachment, file: Express.Multer.File, readable: Readable) => Promise<void>>} */
   attachHandlers = [];
 
   /** @type {Array<(attachmentId: string) => Promise<void>>} */
@@ -130,7 +130,7 @@ class AttachmentService {
 
   /**
    * Register a handler that will be called after attachment creation
-   * @param {(pageId: string, file: Express.Multer.File, readable: Readable) => Promise<void>} handler
+   * @param {(pageId: string, attachment: Attachment, file: Express.Multer.File, readable: Readable) => Promise<void>} handler
    */
   addAttachHandler(handler) {
     this.attachHandlers.push(handler);


### PR DESCRIPTION
# Task
- [#166152](https://redmine.weseek.co.jp/issues/166152) [GROWI AI Next] アシスタント作成後に pagePathPatterns に合致する path でページを作成・更新した時に VectorStoreFile が再構築されない
  - [#166153](https://redmine.weseek.co.jp/issues/166153) 修正