### PR TITLE
feat: Delete associated VectorStoreFile for attachments on page deletion

### DIFF
--- a/apps/app/src/features/openai/server/services/openai.ts
+++ b/apps/app/src/features/openai/server/services/openai.ts
@@ -437,6 +437,10 @@ class OpenaiService implements IOpenaiService {
   }
 
   private async deleteVectorStoreFileForAttachment(vectorStoreFileRelation: VectorStoreFileRelation): Promise<void> {
+    if (vectorStoreFileRelation.attachment == null) {
+      return;
+    }
+
     const deleteAllAttachmentVectorStoreFileRelations = async() => {
       await VectorStoreFileRelationModel.deleteMany({ attachment: vectorStoreFileRelation.attachment });
     };

--- a/apps/app/src/features/openai/server/services/openai.ts
+++ b/apps/app/src/features/openai/server/services/openai.ts
@@ -454,8 +454,7 @@ class OpenaiService implements IOpenaiService {
       // Delete related VectorStoreFileRelation document
       const attachmentId = vectorStoreFileRelation.attachment;
       if (attachmentId != null) {
-        await VectorStoreFileRelationModel.deleteMany({ attachment: attachmentId });
-        deleteAllAttachmentVectorStoreFileRelations();
+        await deleteAllAttachmentVectorStoreFileRelations();
       }
     }
     catch (err) {

--- a/apps/app/src/features/openai/server/services/openai.ts
+++ b/apps/app/src/features/openai/server/services/openai.ts
@@ -683,13 +683,12 @@ class OpenaiService implements IOpenaiService {
       }
 
       await this.client.createVectorStoreFile(vectorStoreRelation.vectorStoreId, uploadedFile.id);
-      await VectorStoreFileRelationModel.create({
-        vectorStoreRelationId: vectorStoreRelation._id,
-        page: page._id,
-        attachment: attachment._id,
-        fileIds: [uploadedFile.id],
-        isAttachedToVectorStore: true,
-      });
+
+      const vectorStoreFileRelationsMap: VectorStoreFileRelationsMap = new Map();
+      prepareVectorStoreFileRelations(vectorStoreRelation._id as Types.ObjectId, page._id, uploadedFile.id, vectorStoreFileRelationsMap, attachment._id);
+      const vectorStoreFileRelations = Array.from(vectorStoreFileRelationsMap.values());
+
+      await VectorStoreFileRelationModel.upsertVectorStoreFileRelations(vectorStoreFileRelations);
     }
   }
 

--- a/apps/app/src/features/openai/server/services/openai.ts
+++ b/apps/app/src/features/openai/server/services/openai.ts
@@ -24,7 +24,6 @@ import VectorStoreFileRelationModel, {
   prepareVectorStoreFileRelations,
 } from '~/features/openai/server/models/vector-store-file-relation';
 import type Crowi from '~/server/crowi';
-import { ObjectIdLike } from '~/server/interfaces/mongoose-utils';
 import type { IAttachmentDocument } from '~/server/models/attachment';
 import type { PageDocument, PageModel } from '~/server/models/page';
 import UserGroupRelation from '~/server/models/user-group-relation';


### PR DESCRIPTION
# Task
- [#166134](https://redmine.weseek.co.jp/issues/166134) [GROWI AI Next] ページが削除された時に関連する Attachment の VectorStoreFile を削除できる 
  - [#166136](https://redmine.weseek.co.jp/issues/166136) 実装