### PR TITLE
feat: Include attachments as learning targets when creating Assistant

### DIFF
--- a/apps/app/src/features/openai/server/models/vector-store-file-relation.ts
+++ b/apps/app/src/features/openai/server/models/vector-store-file-relation.ts
@@ -26,8 +26,15 @@ export const prepareVectorStoreFileRelations = (
     relationsMap: Map<string, VectorStoreFileRelation>,
     attachment?: Types.ObjectId,
 ): Map<string, VectorStoreFileRelation> => {
-  const pageIdStr = page.toHexString();
-  const existingData = relationsMap.get(pageIdStr);
+
+  const key = (() => {
+    if (attachment == null) {
+      return page.toHexString();
+    }
+    return page.toHexString() + attachment.toHexString();
+  })();
+
+  const existingData = relationsMap.get(key);
 
   // If the data exists, add the fileId to the fileIds array
   if (existingData != null) {
@@ -35,7 +42,7 @@ export const prepareVectorStoreFileRelations = (
   }
   // If the data doesn't exist, create a new one and add it to the map
   else {
-    relationsMap.set(pageIdStr, {
+    relationsMap.set(key, {
       vectorStoreRelationId,
       page,
       fileIds: [fileId],

--- a/apps/app/src/features/openai/server/services/openai.ts
+++ b/apps/app/src/features/openai/server/services/openai.ts
@@ -79,7 +79,6 @@ export interface IOpenaiService {
   deleteObsoletedVectorStoreRelations(): Promise<void> // for CronJob
   deleteVectorStore(vectorStoreRelationId: string): Promise<void>;
   getMessageData(threadId: string, lang?: Lang, options?: MessageListParams): Promise<OpenAI.Beta.Threads.Messages.MessagesPage>;
-  createVectorStoreFile(vectorStoreRelation: VectorStoreDocument, pages: PageDocument[]): Promise<void>;
   createVectorStoreFileOnPageCreate(pages: PageDocument[]): Promise<void>;
   updateVectorStoreFileOnPageUpdate(page: HydratedDocument<PageDocument>): Promise<void>;
   createVectorStoreFileOnUploadAttachment(
@@ -348,7 +347,7 @@ class OpenaiService implements IOpenaiService {
     }
   }
 
-  async createVectorStoreFile(vectorStoreRelation: VectorStoreDocument, pages: Array<HydratedDocument<PageDocument>>): Promise<void> {
+  private async createVectorStoreFile(vectorStoreRelation: VectorStoreDocument, pages: Array<HydratedDocument<PageDocument>>): Promise<void> {
     // const vectorStore = await this.getOrCreateVectorStoreForPublicScope();
     const vectorStoreFileRelationsMap: VectorStoreFileRelationsMap = new Map();
     const processUploadFile = async(page: HydratedDocument<PageDocument>) => {

--- a/apps/app/src/features/openai/server/services/openai.ts
+++ b/apps/app/src/features/openai/server/services/openai.ts
@@ -323,7 +323,13 @@ class OpenaiService implements IOpenaiService {
   }
 
   private async uploadFileForAttachment(file: Buffer | NodeJS.ReadableStream, fileName: string): Promise<OpenAI.Files.FileObject> {
-    const uploadableFile = await toFile(Readable.from([file]), fileName);
+    const uploadableFile = await toFile(
+      file instanceof Readable
+        ? file
+        : Readable.from([file]),
+      fileName,
+    );
+
     const uploadedFile = await this.client.uploadFile(uploadableFile);
     return uploadedFile;
   }

--- a/apps/app/src/features/openai/server/services/openai.ts
+++ b/apps/app/src/features/openai/server/services/openai.ts
@@ -357,17 +357,18 @@ class OpenaiService implements IOpenaiService {
       objectMode: true,
       write: async(attachments: HydratedDocument<IAttachmentDocument>[], _encoding, callback) => {
         for await (const attachment of attachments) {
-          if (isVectorStoreCompatible(attachment.originalName, attachment.fileFormat)) {
-            try {
-              const fileStream = await this.crowi.fileUploadService.findDeliveryFile(attachment);
-              const uploadedFileForAttachment = await this.uploadFileForAttachment(fileStream, attachment.originalName);
-              prepareVectorStoreFileRelations(
-                vectorStoreRelationId, pageId, uploadedFileForAttachment.id, vectorStoreFileRelationsMap, attachment._id,
-              );
+          try {
+            if (!isVectorStoreCompatible(attachment.originalName, attachment.fileFormat)) {
+              continue;
             }
-            catch (err) {
-              logger.error(err);
-            }
+            const fileStream = await this.crowi.fileUploadService.findDeliveryFile(attachment);
+            const uploadedFileForAttachment = await this.uploadFileForAttachment(fileStream, attachment.originalName);
+            prepareVectorStoreFileRelations(
+              vectorStoreRelationId, pageId, uploadedFileForAttachment.id, vectorStoreFileRelationsMap, attachment._id,
+            );
+          }
+          catch (err) {
+            logger.error(err);
           }
         }
         callback();

--- a/apps/app/src/features/openai/server/services/openai.ts
+++ b/apps/app/src/features/openai/server/services/openai.ts
@@ -348,7 +348,6 @@ class OpenaiService implements IOpenaiService {
   }
 
   private async createVectorStoreFile(vectorStoreRelation: VectorStoreDocument, pages: Array<HydratedDocument<PageDocument>>): Promise<void> {
-    // const vectorStore = await this.getOrCreateVectorStoreForPublicScope();
     const vectorStoreFileRelationsMap: VectorStoreFileRelationsMap = new Map();
     const processUploadFile = async(page: HydratedDocument<PageDocument>) => {
       if (page._id != null && page.revision != null) {

--- a/apps/app/src/features/openai/server/services/openai.ts
+++ b/apps/app/src/features/openai/server/services/openai.ts
@@ -2,7 +2,6 @@ import assert from 'node:assert';
 import { Readable, Transform } from 'stream';
 import { pipeline } from 'stream/promises';
 
-
 import type {
   IUser, Ref, Lang, IPage,
 } from '@growi/core';
@@ -664,7 +663,7 @@ class OpenaiService implements IOpenaiService {
   private async createVectorStoreFileOnUploadAttachment(
       pageId: string, attachment: HydratedDocument<IAttachmentDocument>, file: Express.Multer.File, buffer: Buffer,
   ): Promise<void> {
-    if (!isVectorStoreCompatible(file)) {
+    if (!isVectorStoreCompatible(file.originalname, file.mimetype)) {
       return;
     }
 

--- a/apps/app/src/features/openai/server/services/openai.ts
+++ b/apps/app/src/features/openai/server/services/openai.ts
@@ -723,7 +723,7 @@ class OpenaiService implements IOpenaiService {
       objectMode: true,
       async transform(chunk: HydratedDocument<PageDocument>[], encoding, callback) {
         try {
-          logger.debug('Search results of page paths', chunk.map(page => page.path));
+          logger.debug('Target page path for VectorStoreFile generation: ', chunk.map(page => page.path));
           await createVectorStoreFile(vectorStoreRelation, chunk);
           this.push(chunk);
           callback();

--- a/apps/app/src/features/openai/server/services/openai.ts
+++ b/apps/app/src/features/openai/server/services/openai.ts
@@ -414,7 +414,6 @@ class OpenaiService implements IOpenaiService {
     });
 
     const vectorStoreFileRelations = Array.from(vectorStoreFileRelationsMap.values());
-    console.log('ectorStoreFileRelations', vectorStoreFileRelations);
     const uploadedFileIds = vectorStoreFileRelations.map(data => data.fileIds).flat();
 
     if (uploadedFileIds.length === 0) {

--- a/apps/app/src/features/openai/server/services/openai.ts
+++ b/apps/app/src/features/openai/server/services/openai.ts
@@ -345,7 +345,7 @@ class OpenaiService implements IOpenaiService {
     }
   }
 
-  private async createVectorStoreFileForAttachment(
+  private async createVectorStoreFileWithStreamForAttachment(
       pageId: Types.ObjectId, vectorStoreRelationId: Types.ObjectId, vectorStoreFileRelationsMap: VectorStoreFileRelationsMap,
   ): Promise<void> {
 
@@ -392,7 +392,7 @@ class OpenaiService implements IOpenaiService {
           prepareVectorStoreFileRelations(vectorStoreRelation._id, page._id, uploadedFile.id, vectorStoreFileRelationsMap);
 
           if (!ignoreAttachments) {
-            await this.createVectorStoreFileForAttachment(page._id, vectorStoreRelation._id, vectorStoreFileRelationsMap);
+            await this.createVectorStoreFileWithStreamForAttachment(page._id, vectorStoreRelation._id, vectorStoreFileRelationsMap);
           }
           return;
         }
@@ -403,7 +403,7 @@ class OpenaiService implements IOpenaiService {
           prepareVectorStoreFileRelations(vectorStoreRelation._id, page._id, uploadedFile.id, vectorStoreFileRelationsMap);
 
           if (!ignoreAttachments) {
-            await this.createVectorStoreFileForAttachment(page._id, vectorStoreRelation._id, vectorStoreFileRelationsMap);
+            await this.createVectorStoreFileWithStreamForAttachment(page._id, vectorStoreRelation._id, vectorStoreFileRelationsMap);
           }
         }
       }

--- a/apps/app/src/features/openai/server/utils/is-vector-store-compatible.ts
+++ b/apps/app/src/features/openai/server/utils/is-vector-store-compatible.ts
@@ -27,9 +27,9 @@ const supportedFormats = {
 
 type SupportedExtension = keyof typeof supportedFormats;
 
-export const isVectorStoreCompatible = (file: Express.Multer.File): boolean => {
+export const isVectorStoreCompatible = (originalName: string, mimeType: string): boolean => {
   // Get extension
-  const extension = path.extname(file.originalname).toLowerCase();
+  const extension = path.extname(originalName).toLowerCase();
 
   // Check if the file extension is supported
   if (!(extension in supportedFormats)) {
@@ -40,7 +40,6 @@ export const isVectorStoreCompatible = (file: Express.Multer.File): boolean => {
   const supportedMimeType = supportedFormats[extension as SupportedExtension];
 
   // Check if the mimeType is supported
-  const mimeType = file.mimetype;
   return Array.isArray(supportedMimeType)
     ? supportedMimeType.includes(mimeType)
     : supportedMimeType === mimeType;


### PR DESCRIPTION
# Task
- [#165504](https://redmine.weseek.co.jp/issues/165504) [GROWI AI Next] AiAssistant 作成時、学習対象のページに attachment がアップロードされていた場合は attachment も VectorStore に保存できる
  - [#165507](https://redmine.weseek.co.jp/issues/165507) 実装