### PR TITLE
fix(ai): First user message is not displayed

### DIFF
--- a/apps/app/src/features/openai/client/services/knowledge-assistant.tsx
+++ b/apps/app/src/features/openai/client/services/knowledge-assistant.tsx
@@ -295,6 +295,10 @@ export const useFetchAndSetMessageDataEffect = (
   );
 
   useEffect(() => {
+    if (aiAssistantSidebarData?.isEditorAssistant) {
+      return;
+    }
+
     if (threadId == null) {
       setMessageLogs([]);
       return; // Early return if no threadId


### PR DESCRIPTION
# Task
- [#166412](https://redmine.weseek.co.jp/issues/166412) [GROWI AI Next] [エディターアシスタント] 最初のユーザーからのメッセージが MessageCard として表示されない
  - [#166413](https://redmine.weseek.co.jp/issues/166413) 修正