### PR TITLE
fix: Potential fix for code scanning alert no. 569: Information exposure through a stack trace

### DIFF
--- a/packages/remark-lsx/src/server/routes/list-pages/index.spec.ts
+++ b/packages/remark-lsx/src/server/routes/list-pages/index.spec.ts
@@ -128,7 +128,9 @@ describe('listPages', () => {
       expect(mocks.addNumConditionMock).toHaveBeenCalledOnce(); // throw an error
       expect(mocks.addSortConditionMock).not.toHaveBeenCalledOnce(); // does not called
       expect(resMock.status).toHaveBeenCalledOnce();
-      expect(resStatusMock.send).toHaveBeenCalledWith('error for test');
+      expect(resStatusMock.send).toHaveBeenCalledWith(
+        'An internal server error occurred.',
+      );
     });
 
     it('returns 400 HTTP response when the value is invalid', async () => {

--- a/packages/remark-lsx/src/server/routes/list-pages/index.ts
+++ b/packages/remark-lsx/src/server/routes/list-pages/index.ts
@@ -92,7 +92,8 @@ export const listPages = async (
   try {
     toppageViewersCount = await getToppageViewersCount();
   } catch (error) {
-    return res.status(500).send(error);
+    console.error('Error occurred in getToppageViewersCount:', error);
+    return res.status(500).send('An internal server error occurred.');
   }
 
   let query = builder.query;
@@ -132,9 +133,10 @@ export const listPages = async (
     };
     return res.status(200).send(responseData);
   } catch (error) {
+    console.error('Error occurred while processing listPages request:', error);
     if (isHttpError(error)) {
       return res.status(error.status).send(error.message);
     }
-    return res.status(500).send(error.message);
+    return res.status(500).send('An internal server error occurred.');
   }
 };


### PR DESCRIPTION
Potential fix for [https://github.com/weseek/growi/security/code-scanning/569](https://github.com/weseek/growi/security/code-scanning/569)

To fix the issue, the error handling logic should be updated to avoid sending the raw `error` object to the client. Instead:
1. Log the full error details (including the stack trace) on the server for debugging purposes.
2. Send a generic error message to the client, such as "An internal server error occurred."

This ensures that sensitive information is not exposed to the client while still allowing developers to debug issues using server-side logs.

The changes will be made to the `catch` block on lines 94–96 to log the error and send a generic message to the client.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
