### PR TITLE
fix: Editor assistant button is being displayed when ai functionality is not enabled

### DIFF
--- a/apps/app/src/client/components/PageEditor/EditorNavbarBottom/EditorNavbarBottom.tsx
+++ b/apps/app/src/client/components/PageEditor/EditorNavbarBottom/EditorNavbarBottom.tsx
@@ -2,6 +2,7 @@ import type { JSX } from 'react';
 
 import dynamic from 'next/dynamic';
 
+import { useIsAiEnabled } from '~/stores-universal/context';
 import { useDrawerOpened } from '~/stores/ui';
 
 import { EditorAssistantToggleButton } from './EditorAssistantToggleButton';
@@ -15,6 +16,7 @@ const SavePageControls = dynamic(() => import('./SavePageControls').then(mod => 
 const OptionsSelector = dynamic(() => import('./OptionsSelector').then(mod => mod.OptionsSelector), { ssr: false });
 
 export const EditorNavbarBottom = (): JSX.Element => {
+  const { data: isAiEnabled } = useIsAiEnabled();
   const { mutate: mutateDrawerOpened } = useDrawerOpened();
 
   return (
@@ -29,7 +31,9 @@ export const EditorNavbarBottom = (): JSX.Element => {
         </a>
         <form className="me-auto d-flex gap-2">
           <OptionsSelector />
-          <EditorAssistantToggleButton />
+          {isAiEnabled && (
+            <EditorAssistantToggleButton />
+          )}
         </form>
         <form>
           <SavePageControls />

--- a/apps/app/src/client/components/PageEditor/EditorNavbarBottom/EditorNavbarBottom.tsx
+++ b/apps/app/src/client/components/PageEditor/EditorNavbarBottom/EditorNavbarBottom.tsx
@@ -1,6 +1,5 @@
 import type { JSX } from 'react';
 
-import { useTranslation } from 'next-i18next';
 import dynamic from 'next/dynamic';
 
 import { useDrawerOpened } from '~/stores/ui';
@@ -16,7 +15,6 @@ const SavePageControls = dynamic(() => import('./SavePageControls').then(mod => 
 const OptionsSelector = dynamic(() => import('./OptionsSelector').then(mod => mod.OptionsSelector), { ssr: false });
 
 export const EditorNavbarBottom = (): JSX.Element => {
-  const { t } = useTranslation();
   const { mutate: mutateDrawerOpened } = useDrawerOpened();
 
   return (


### PR DESCRIPTION
# Task
- [#166524](https://redmine.weseek.co.jp/issues/166524) [GROWI AI Next][エディターアシスタント] AI 機能が有効でない時にエディターアシスタントのボタンが表示されてしまっている
  - [#166525](https://redmine.weseek.co.jp/issues/166525) 修正