### PR TITLE
fix: S3 upload failing

### DIFF
--- a/apps/app/src/server/service/file-uploader/aws/index.ts
+++ b/apps/app/src/server/service/file-uploader/aws/index.ts
@@ -86,7 +86,7 @@ const getS3Bucket = (): string | undefined => {
 const S3Factory = (): S3Client => {
   const accessKeyId = configManager.getConfig('aws:s3AccessKeyId');
   const secretAccessKey = configManager.getConfig('aws:s3SecretAccessKey');
-  const s3CustomEndpoint = configManager.getConfig('aws:s3CustomEndpoint') || undefined
+  const s3CustomEndpoint = configManager.getConfig('aws:s3CustomEndpoint') || undefined;
 
   return new S3Client({
     credentials: accessKeyId != null && secretAccessKey != null

--- a/apps/app/src/server/service/file-uploader/aws/index.ts
+++ b/apps/app/src/server/service/file-uploader/aws/index.ts
@@ -86,6 +86,7 @@ const getS3Bucket = (): string | undefined => {
 const S3Factory = (): S3Client => {
   const accessKeyId = configManager.getConfig('aws:s3AccessKeyId');
   const secretAccessKey = configManager.getConfig('aws:s3SecretAccessKey');
+  const s3CustomEndpoint = configManager.getConfig('aws:s3CustomEndpoint') || undefined
 
   return new S3Client({
     credentials: accessKeyId != null && secretAccessKey != null
@@ -95,8 +96,8 @@ const S3Factory = (): S3Client => {
       }
       : undefined,
     region: configManager.getConfig('aws:s3Region'),
-    endpoint: configManager.getConfig('aws:s3CustomEndpoint'),
-    forcePathStyle: configManager.getConfig('aws:s3CustomEndpoint') != null, // s3ForcePathStyle renamed to forcePathStyle in v3
+    endpoint: s3CustomEndpoint,
+    forcePathStyle: !!s3CustomEndpoint, // s3ForcePathStyle renamed to forcePathStyle in v3
   });
 };
 


### PR DESCRIPTION
resolve #10010

# 変更概要

- `s3CustomEndpoint` に空文字や `null` が設定されている場合 `undefined` に変換してから `S3Client` に渡すように変更。

# 動作確認

- ロゴとプロフィール画像のアップロードに成功することを確認しました。

# 補足

- `null` にすると `endpoint` の型検査でエラーになるため `undefined` に強制しました。
   cf.) [AWS SDK for JavaScript v3](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-smithy-middleware-endpoint/Interface/EndpointInputConfig/)
- そもそも GROWI の config `aws:s3CustomEndpoint` として、空文字列よりも `null` or `undefined` で持つ方が適切かもしれません。しかし全体の設計感・実装感までは分からずでしたので、一旦影響範囲の小さいであろう変更で Pull Request 上げています。
