### PR TITLE
impv: Prevent rom users from issuing and using new access tokens

### DIFF
--- a/apps/app/config/logger/config.dev.js
+++ b/apps/app/config/logger/config.dev.js
@@ -44,4 +44,5 @@ module.exports = {
   // 'growi:cli:ItemsTree': 'debug',
   'growi:searchResultList': 'debug',
   'growi:service:openai': 'debug',
+  'growi:middleware:access-token-parser:access-token': 'debug',
 };

--- a/apps/app/src/client/components/Me/ApiSettings.tsx
+++ b/apps/app/src/client/components/Me/ApiSettings.tsx
@@ -11,7 +11,9 @@ import { ApiTokenSettings } from './ApiTokenSettings';
 const ApiSettings = React.memo((): JSX.Element => {
 
   const { t } = useTranslation();
-  const { data: currentUser } = useCurrentUser();
+  const { data: currentUser, isLoading: isLoadingCurrentUserData } = useCurrentUser();
+
+  const shouldHideAccessTokenSettings = isLoadingCurrentUserData || !currentUser?.readOnly;
 
   return (
     <>
@@ -19,7 +21,8 @@ const ApiSettings = React.memo((): JSX.Element => {
         <h2 className="border-bottom pb-2 my-4 fs-4">{ t('API Token Settings') }</h2>
         <ApiTokenSettings />
       </div>
-      {!currentUser?.readOnly && (
+
+      {shouldHideAccessTokenSettings && (
         <div className="mt-4">
           <h2 className="border-bottom pb-2 my-4 fs-4">{ t('Access Token Settings') }</h2>
           <AccessTokenSettings />

--- a/apps/app/src/client/components/Me/ApiSettings.tsx
+++ b/apps/app/src/client/components/Me/ApiSettings.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 
 import { useTranslation } from 'next-i18next';
 
+import { useCurrentUser } from '~/stores-universal/context';
+
 import { AccessTokenSettings } from './AccessTokenSettings';
 import { ApiTokenSettings } from './ApiTokenSettings';
 
@@ -9,6 +11,7 @@ import { ApiTokenSettings } from './ApiTokenSettings';
 const ApiSettings = React.memo((): JSX.Element => {
 
   const { t } = useTranslation();
+  const { data: currentUser } = useCurrentUser();
 
   return (
     <>
@@ -16,10 +19,12 @@ const ApiSettings = React.memo((): JSX.Element => {
         <h2 className="border-bottom pb-2 my-4 fs-4">{ t('API Token Settings') }</h2>
         <ApiTokenSettings />
       </div>
-      <div className="mt-4">
-        <h2 className="border-bottom pb-2 my-4 fs-4">{ t('Access Token Settings') }</h2>
-        <AccessTokenSettings />
-      </div>
+      {!currentUser?.readOnly && (
+        <div className="mt-4">
+          <h2 className="border-bottom pb-2 my-4 fs-4">{ t('Access Token Settings') }</h2>
+          <AccessTokenSettings />
+        </div>
+      )}
     </>
   );
 });

--- a/apps/app/src/server/middlewares/access-token-parser/access-token.ts
+++ b/apps/app/src/server/middlewares/access-token-parser/access-token.ts
@@ -36,6 +36,11 @@ export const parserForAccessToken = (scopes: Scope[]) => {
       return;
     }
 
+    if (userByAccessToken.readOnly) {
+      logger.debug('The access token\'s associated user is read-only');
+      return;
+    }
+
     // transforming attributes
     req.user = serializeUserSecurely(userByAccessToken);
     if (req.user == null) {

--- a/apps/app/src/server/routes/apiv3/personal-setting/delete-access-token.ts
+++ b/apps/app/src/server/routes/apiv3/personal-setting/delete-access-token.ts
@@ -8,6 +8,7 @@ import type Crowi from '~/server/crowi';
 import { accessTokenParser } from '~/server/middlewares/access-token-parser';
 import { generateAddActivityMiddleware } from '~/server/middlewares/add-activity';
 import { apiV3FormValidator } from '~/server/middlewares/apiv3-form-validator';
+import { excludeReadOnlyUser } from '~/server/middlewares/exclude-read-only-user';
 import { AccessToken } from '~/server/models/access-token';
 import loggerFactory from '~/utils/logger';
 
@@ -40,6 +41,7 @@ export const deleteAccessTokenHandlersFactory: DeleteAccessTokenHandlersFactory 
   return [
     accessTokenParser([SCOPE.WRITE.USER_SETTINGS.API.ACCESS_TOKEN]),
     loginRequiredStrictly,
+    excludeReadOnlyUser,
     addActivity,
     validator,
     apiV3FormValidator,

--- a/apps/app/src/server/routes/apiv3/personal-setting/delete-all-access-tokens.ts
+++ b/apps/app/src/server/routes/apiv3/personal-setting/delete-all-access-tokens.ts
@@ -7,6 +7,7 @@ import { SCOPE } from '~/interfaces/scope';
 import type Crowi from '~/server/crowi';
 import { accessTokenParser } from '~/server/middlewares/access-token-parser';
 import { generateAddActivityMiddleware } from '~/server/middlewares/add-activity';
+import { excludeReadOnlyUser } from '~/server/middlewares/exclude-read-only-user';
 import { AccessToken } from '~/server/models/access-token';
 import loggerFactory from '~/utils/logger';
 
@@ -29,6 +30,7 @@ export const deleteAllAccessTokensHandlersFactory: DeleteAllAccessTokensHandlers
   return [
     accessTokenParser([SCOPE.WRITE.USER_SETTINGS.API.ACCESS_TOKEN]),
     loginRequiredStrictly,
+    excludeReadOnlyUser,
     addActivity,
     async(req: DeleteAllAccessTokensRequest, res: ApiV3Response) => {
       const { user } = req;

--- a/apps/app/src/server/routes/apiv3/personal-setting/generate-access-token.ts
+++ b/apps/app/src/server/routes/apiv3/personal-setting/generate-access-token.ts
@@ -9,6 +9,7 @@ import { SupportedAction } from '~/interfaces/activity';
 import type { Scope } from '~/interfaces/scope';
 import type Crowi from '~/server/crowi';
 import { generateAddActivityMiddleware } from '~/server/middlewares/add-activity';
+import { excludeReadOnlyUser } from '~/server/middlewares/exclude-read-only-user';
 import { AccessToken } from '~/server/models/access-token';
 import { isValidScope } from '~/server/util/scope-utils';
 import loggerFactory from '~/utils/logger';
@@ -82,6 +83,7 @@ export const generateAccessTokenHandlerFactory: GenerateAccessTokenHandlerFactor
 
   return [
     loginRequiredStrictly,
+    excludeReadOnlyUser,
     addActivity,
     validator,
     apiV3FormValidator,

--- a/apps/app/src/server/routes/apiv3/personal-setting/get-access-tokens.ts
+++ b/apps/app/src/server/routes/apiv3/personal-setting/get-access-tokens.ts
@@ -6,6 +6,7 @@ import { SCOPE } from '~/interfaces/scope';
 import type Crowi from '~/server/crowi';
 import { accessTokenParser } from '~/server/middlewares/access-token-parser';
 import { generateAddActivityMiddleware } from '~/server/middlewares/add-activity';
+import { excludeReadOnlyUser } from '~/server/middlewares/exclude-read-only-user';
 import { AccessToken } from '~/server/models/access-token';
 import loggerFactory from '~/utils/logger';
 
@@ -27,6 +28,7 @@ export const getAccessTokenHandlerFactory: GetAccessTokenHandlerFactory = (crowi
   return [
     accessTokenParser([SCOPE.READ.USER_SETTINGS.API.ACCESS_TOKEN]),
     loginRequiredStrictly,
+    excludeReadOnlyUser,
     addActivity,
     async(req: GetAccessTokenRequest, res: ApiV3Response) => {
       const { user } = req;


### PR DESCRIPTION
# Task
- [#162830](https://redmine.weseek.co.jp/issues/162830) [Enhanced Access Token] ApiSettings から作成するアクセストークンの SCOPE を制限できる
  - [#167156](https://redmine.weseek.co.jp/issues/167156) Rom user は新アクセストークンの発行・利用をできないようにする