### PR TITLE
feat(ai): Send pre-message to client via SSE

### DIFF
--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar.tsx
@@ -249,6 +249,9 @@ const AiAssistantSidebarSubstance: React.FC<AiAssistantSidebarSubstanceProps> = 
             const data = JSON.parse(line.replace('data: ', ''));
 
             processMessageForKnowledgeAssistant(data, {
+              onPreMessage: (data) => {
+                textValues.push(data.text);
+              },
               onMessage: (data) => {
                 textValues.push(data.content[0].text.value);
               },

--- a/apps/app/src/features/openai/client/services/knowledge-assistant.tsx
+++ b/apps/app/src/features/openai/client/services/knowledge-assistant.tsx
@@ -10,7 +10,9 @@ import {
 } from 'reactstrap';
 
 import { apiv3Post } from '~/client/util/apiv3-client';
-import { SseMessageSchema, type SseMessage } from '~/features/openai/interfaces/knowledge-assistant/sse-schemas';
+import {
+  SseMessageSchema, type SseMessage, SsePreMessageSchema, type SsePreMessage,
+} from '~/features/openai/interfaces/knowledge-assistant/sse-schemas';
 import { handleIfSuccessfullyParsed } from '~/features/openai/utils/handle-if-successfully-parsed';
 
 import type { MessageLog, MessageWithCustomMetaData } from '../../interfaces/message';
@@ -31,7 +33,9 @@ interface PostMessage {
 
 interface ProcessMessage {
   (data: unknown, handler: {
-    onMessage: (data: SseMessage) => void}
+    onMessage: (data: SseMessage) => void
+    onPreMessage: (data: SsePreMessage) => void
+  }
   ): void;
 }
 
@@ -120,6 +124,10 @@ export const useKnowledgeAssistant: UseKnowledgeAssistant = () => {
   const processMessage: ProcessMessage = useCallback((data, handler) => {
     handleIfSuccessfullyParsed(data, SseMessageSchema, (data: SseMessage) => {
       handler.onMessage(data);
+    });
+
+    handleIfSuccessfullyParsed(data, SsePreMessageSchema, (data: SsePreMessage) => {
+      handler.onPreMessage(data);
     });
   }, []);
 

--- a/apps/app/src/features/openai/interfaces/knowledge-assistant/sse-schemas.ts
+++ b/apps/app/src/features/openai/interfaces/knowledge-assistant/sse-schemas.ts
@@ -11,6 +11,11 @@ export const SseMessageSchema = z.object({
   })),
 });
 
+export const SsePreMessageSchema = z.object({
+  text: z.string().describe('The pre-message that should be appended to the chat window'),
+});
+
 
 // Type definitions
 export type SseMessage = z.infer<typeof SseMessageSchema>;
+export type SsePreMessage = z.infer<typeof SsePreMessageSchema>;

--- a/apps/app/src/features/openai/server/services/client-delegator/azure-openai-client-delegator.ts
+++ b/apps/app/src/features/openai/server/services/client-delegator/azure-openai-client-delegator.ts
@@ -1,6 +1,7 @@
 import { DefaultAzureCredential, getBearerTokenProvider } from '@azure/identity';
 import type OpenAI from 'openai';
 import { AzureOpenAI } from 'openai';
+import { type Stream } from 'openai/streaming';
 import { type Uploadable } from 'openai/uploads';
 
 import type { MessageListParams } from '../../../interfaces/message';
@@ -94,7 +95,9 @@ export class AzureOpenaiClientDelegator implements IOpenaiClientDelegator {
     return this.client.vectorStores.fileBatches.uploadAndPoll(vectorStoreId, { files });
   }
 
-  async chatCompletion(body: OpenAI.Chat.Completions.ChatCompletionCreateParamsNonStreaming): Promise<OpenAI.Chat.Completions.ChatCompletion> {
+  async chatCompletion(
+      body: OpenAI.Chat.Completions.ChatCompletionCreateParams,
+  ): Promise<OpenAI.Chat.Completions.ChatCompletion | Stream<OpenAI.Chat.Completions.ChatCompletionChunk>> {
     return this.client.chat.completions.create(body);
   }
 

--- a/apps/app/src/features/openai/server/services/client-delegator/index.ts
+++ b/apps/app/src/features/openai/server/services/client-delegator/index.ts
@@ -1,1 +1,2 @@
 export * from './get-client';
+export * from './is-stream-response';

--- a/apps/app/src/features/openai/server/services/client-delegator/interfaces.ts
+++ b/apps/app/src/features/openai/server/services/client-delegator/interfaces.ts
@@ -1,4 +1,5 @@
 import type OpenAI from 'openai';
+import { type Stream } from 'openai/streaming';
 import type { Uploadable } from 'openai/uploads';
 
 import type { MessageListParams } from '../../../interfaces/message';
@@ -16,5 +17,7 @@ export interface IOpenaiClientDelegator {
   createVectorStoreFile(vectorStoreId: string, fileId: string): Promise<OpenAI.VectorStores.Files.VectorStoreFile>
   createVectorStoreFileBatch(vectorStoreId: string, fileIds: string[]): Promise<OpenAI.VectorStores.FileBatches.VectorStoreFileBatch>
   deleteFile(fileId: string): Promise<OpenAI.Files.FileDeleted>;
-  chatCompletion(body: OpenAI.Chat.Completions.ChatCompletionCreateParamsNonStreaming): Promise<OpenAI.Chat.Completions.ChatCompletion>
+  chatCompletion(
+    body: OpenAI.Chat.Completions.ChatCompletionCreateParams
+  ): Promise<OpenAI.Chat.Completions.ChatCompletion | Stream<OpenAI.Chat.Completions.ChatCompletionChunk>>
 }

--- a/apps/app/src/features/openai/server/services/client-delegator/is-stream-response.ts
+++ b/apps/app/src/features/openai/server/services/client-delegator/is-stream-response.ts
@@ -1,0 +1,12 @@
+import type OpenAI from 'openai';
+import { type Stream } from 'openai/streaming';
+
+type ChatCompletionResponse = OpenAI.Chat.Completions.ChatCompletion;
+type ChatCompletionStreamResponse = Stream<OpenAI.Chat.Completions.ChatCompletionChunk>
+
+// Type guard function
+export const isStreamResponse = (result: ChatCompletionResponse | ChatCompletionStreamResponse): result is ChatCompletionStreamResponse => {
+  // Type assertion is safe due to the constrained input types
+  const assertedResult = result as any;
+  return assertedResult.tee != null && assertedResult.toReadableStream != null;
+};

--- a/apps/app/src/features/openai/server/services/client-delegator/openai-client-delegator.ts
+++ b/apps/app/src/features/openai/server/services/client-delegator/openai-client-delegator.ts
@@ -1,4 +1,5 @@
 import OpenAI from 'openai';
+import { type Stream } from 'openai/streaming';
 import { type Uploadable } from 'openai/uploads';
 
 import { configManager } from '~/server/service/config-manager';
@@ -95,7 +96,9 @@ export class OpenaiClientDelegator implements IOpenaiClientDelegator {
     return this.client.vectorStores.fileBatches.uploadAndPoll(vectorStoreId, { files });
   }
 
-  async chatCompletion(body: OpenAI.Chat.Completions.ChatCompletionCreateParamsNonStreaming): Promise<OpenAI.Chat.Completions.ChatCompletion> {
+  async chatCompletion(
+      body: OpenAI.Chat.Completions.ChatCompletionCreateParams,
+  ): Promise<OpenAI.Chat.Completions.ChatCompletion | Stream<OpenAI.Chat.Completions.ChatCompletionChunk>> {
     return this.client.chat.completions.create(body);
   }
 


### PR DESCRIPTION
# Task
- [#167461](https://redmine.weseek.co.jp/issues/167461) [AI] [UX改善] メインレスポンスの取得前にリクエストに応じたプレメッセージを表示できる
  - [#167463](https://redmine.weseek.co.jp/issues/167463) [server] プレメッセージ作成ロジックを実装
  - [#167466](https://redmine.weseek.co.jp/issues/167466) [sever] クライアントに stream でレスポンスを返却できる
  - [#167467](https://redmine.weseek.co.jp/issues/167467) [client] SSE でメッセージを受け取れる
  - [#167597](https://redmine.weseek.co.jp/issues/167597) [client] SSE でメッセージを受けとったメッセージを表示できる

# Screenrecord
https://github.com/user-attachments/assets/7130678a-1e48-4d69-8a53-456fcf95f065


