### PR TITLE
imprv: Behavior when pre message and main message arrive

### DIFF
--- a/apps/app/src/features/openai/server/routes/message/post-message.ts
+++ b/apps/app/src/features/openai/server/routes/message/post-message.ts
@@ -126,9 +126,6 @@ export const postMessageHandlersFactory: PostMessageHandlersFactory = (crowi) =>
         res.write(`data: ${JSON.stringify(content)}\n\n`);
       };
 
-      // Don't add await since SSE is performed asynchronously with main message
-      openaiService.generateAndProcessPreMessage(req.body.userMessage, preMessageDeltaHandler);
-
       const messageDeltaHandler = async(delta: MessageDelta) => {
         const content = delta.content?.[0];
 
@@ -143,6 +140,9 @@ export const postMessageHandlersFactory: PostMessageHandlersFactory = (crowi) =>
       const sendError = (message: string, code?: StreamErrorCode) => {
         res.write(`error: ${JSON.stringify({ code, message })}\n\n`);
       };
+
+      // Don't add await since SSE is performed asynchronously with main message
+      openaiService.generateAndProcessPreMessage(req.body.userMessage, preMessageDeltaHandler);
 
       stream.on('event', (delta) => {
         if (delta.event === 'thread.run.failed') {

--- a/apps/app/src/features/openai/server/services/openai.ts
+++ b/apps/app/src/features/openai/server/services/openai.ts
@@ -73,10 +73,7 @@ const convertPathPatternsToRegExp = (pagePathPatterns: string[]): Array<string |
 };
 
 export interface IOpenaiService {
-  generateAndProcessPreMessage(
-      message: string,
-      deltaProcessor: (delta: ChatCompletionChunk.Choice.Delta) => void,
-  ): Promise<void>
+  generateAndProcessPreMessage(message: string, deltaProcessor: (delta: ChatCompletionChunk.Choice.Delta) => void): Promise<void>
   createThread(userId: string, type: ThreadType, aiAssistantId?: string, initialUserMessage?: string): Promise<ThreadRelationDocument>;
   getThreadsByAiAssistantId(aiAssistantId: string): Promise<ThreadRelationDocument[]>
   deleteThread(threadRelationId: string): Promise<ThreadRelationDocument>;
@@ -113,10 +110,7 @@ class OpenaiService implements IOpenaiService {
     return getClient({ openaiServiceType });
   }
 
-  async generateAndProcessPreMessage(
-      message: string,
-      deltaProcessor: (delta: ChatCompletionChunk.Choice.Delta) => void,
-  ): Promise<void> {
+  async generateAndProcessPreMessage(message: string, deltaProcessor: (delta: ChatCompletionChunk.Choice.Delta) => void): Promise<void> {
     const systemMessage = [
       "Generate a message briefly confirming the user's question.",
       'Please generate up to 20 characters',

--- a/apps/app/src/features/openai/server/services/openai.ts
+++ b/apps/app/src/features/openai/server/services/openai.ts
@@ -16,7 +16,6 @@ import createError from 'http-errors';
 import mongoose, { type HydratedDocument, type Types } from 'mongoose';
 import { type OpenAI, toFile } from 'openai';
 import { type ChatCompletionChunk } from 'openai/resources/chat/completions';
-import { type Stream } from 'openai/streaming';
 
 import ExternalUserGroupRelation from '~/features/external-user-group/server/models/external-user-group-relation';
 import ThreadRelationModel, { type ThreadRelationDocument } from '~/features/openai/server/models/thread-relation';
@@ -77,7 +76,7 @@ export interface IOpenaiService {
   generateAndProcessPreMessage(
       message: string,
       deltaProcessor: (delta: ChatCompletionChunk.Choice.Delta) => void,
-  ): Promise<Nullable<Stream<OpenAI.Chat.Completions.ChatCompletionChunk>>>
+  ): Promise<void>
   createThread(userId: string, type: ThreadType, aiAssistantId?: string, initialUserMessage?: string): Promise<ThreadRelationDocument>;
   getThreadsByAiAssistantId(aiAssistantId: string): Promise<ThreadRelationDocument[]>
   deleteThread(threadRelationId: string): Promise<ThreadRelationDocument>;
@@ -117,7 +116,7 @@ class OpenaiService implements IOpenaiService {
   async generateAndProcessPreMessage(
       message: string,
       deltaProcessor: (delta: ChatCompletionChunk.Choice.Delta) => void,
-  ): Promise<Nullable<Stream<OpenAI.Chat.Completions.ChatCompletionChunk>>> {
+  ): Promise<void> {
     const systemMessage = [
       "Generate a message briefly confirming the user's question.",
       'Please generate up to 20 characters',


### PR DESCRIPTION
# Task
- [#167461](https://redmine.weseek.co.jp/issues/167461) [AI] [UX改善] メインレスポンスの取得前にリクエストに応じたプレメッセージを表示できる
   - [#167603](https://redmine.weseek.co.jp/issues/167603) プレメッセージとメインメッセージの到着時の挙動の改善