### PR TITLE
fix(ai): Message gets sent when pressing Enter to confirm text conversion

### DIFF
--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar.tsx
@@ -316,6 +316,11 @@ const AiAssistantSidebarSubstance: React.FC<AiAssistantSidebarSubstanceProps> = 
   }, [isEditorAssistant, isTextSelected, submitSubstance]);
 
   const keyDownHandler = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    // Do nothing while composing
+    if (event.nativeEvent.isComposing) {
+      return;
+    }
+
     if (event.key === 'Enter' && !event.shiftKey) {
       event.preventDefault();
       form.handleSubmit(submit)();


### PR DESCRIPTION
# Task
- [#167647](https://redmine.weseek.co.jp/issues/167647) [AI] 右サイドバーのメッセージ入力フォームで変換確定のエンター押下時にメッセージが送信されてしまう
  - [#167648](https://redmine.weseek.co.jp/issues/167648) 修正