### PR TITLE
feat: Implement API to return threads created by user in creation order

### DIFF
--- a/apps/app/src/features/openai/server/routes/get-recent-threads.ts
+++ b/apps/app/src/features/openai/server/routes/get-recent-threads.ts
@@ -1,0 +1,53 @@
+import { type IUserHasId } from '@growi/core';
+import { ErrorV3 } from '@growi/core/dist/models';
+import type { Request, RequestHandler } from 'express';
+import { type ValidationChain, param } from 'express-validator';
+
+import type Crowi from '~/server/crowi';
+import { accessTokenParser } from '~/server/middlewares/access-token-parser';
+import { apiV3FormValidator } from '~/server/middlewares/apiv3-form-validator';
+import type { ApiV3Response } from '~/server/routes/apiv3/interfaces/apiv3-response';
+import loggerFactory from '~/utils/logger';
+
+import { getOpenaiService } from '../services/openai';
+
+import { certifyAiService } from './middlewares/certify-ai-service';
+
+const logger = loggerFactory('growi:routes:apiv3:openai:get-recent-threads');
+
+type GetRecentThreadsFactory = (crowi: Crowi) => RequestHandler[];
+
+type ReqParams = {
+  //
+}
+
+type Req = Request<ReqParams, Response, undefined> & {
+  user: IUserHasId,
+}
+
+export const getRecentThreadsFactory: GetRecentThreadsFactory = (crowi) => {
+  const loginRequiredStrictly = require('~/server/middlewares/login-required')(crowi);
+
+  const validator: ValidationChain[] = [
+    //
+  ];
+
+  return [
+    accessTokenParser, loginRequiredStrictly, certifyAiService, validator, apiV3FormValidator,
+    async(req: Req, res: ApiV3Response) => {
+      const openaiService = getOpenaiService();
+      if (openaiService == null) {
+        return res.apiv3Err(new ErrorV3('GROWI AI is not enabled'), 501);
+      }
+
+      try {
+        const threads = await openaiService.getRecentThreads(req.user);
+        return res.apiv3({ threads });
+      }
+      catch (err) {
+        logger.error(err);
+        return res.apiv3Err(new ErrorV3('Failed to get threads'));
+      }
+    },
+  ];
+};

--- a/apps/app/src/features/openai/server/routes/index.ts
+++ b/apps/app/src/features/openai/server/routes/index.ts
@@ -23,6 +23,10 @@ export const factory = (crowi: Crowi): express.Router => {
       router.post('/thread', createThreadHandlersFactory(crowi));
     });
 
+    import('./get-recent-threads').then(({ getRecentThreadsFactory }) => {
+      router.get('/threads/recent', getRecentThreadsFactory(crowi));
+    });
+
     import('./get-threads').then(({ getThreadsFactory }) => {
       router.get('/threads/:aiAssistantId', getThreadsFactory(crowi));
     });

--- a/apps/app/src/features/openai/server/services/openai.ts
+++ b/apps/app/src/features/openai/server/services/openai.ts
@@ -74,6 +74,7 @@ const convertPathPatternsToRegExp = (pagePathPatterns: string[]): Array<string |
 export interface IOpenaiService {
   createThread(userId: string, type: ThreadType, aiAssistantId?: string, initialUserMessage?: string): Promise<ThreadRelationDocument>;
   getThreadsByAiAssistantId(aiAssistantId: string): Promise<ThreadRelationDocument[]>
+  getRecentThreads(user: IUserHasId): Promise<ThreadRelationDocument[]>;
   deleteThread(threadRelationId: string): Promise<ThreadRelationDocument>;
   deleteExpiredThreads(limit: number, apiCallInterval: number): Promise<void>; // for CronJob
   deleteObsoletedVectorStoreRelations(): Promise<void> // for CronJob
@@ -184,6 +185,11 @@ class OpenaiService implements IOpenaiService {
 
   async getThreadsByAiAssistantId(aiAssistantId: string, type: ThreadType = ThreadType.KNOWLEDGE): Promise<ThreadRelationDocument[]> {
     const threadRelations = await ThreadRelationModel.find({ aiAssistant: aiAssistantId, type });
+    return threadRelations;
+  }
+
+  async getRecentThreads(user: IUserHasId): Promise<ThreadRelationDocument[]> {
+    const threadRelations = await ThreadRelationModel.find({ userId: user._id });
     return threadRelations;
   }
 


### PR DESCRIPTION
# Task
- [#164109](https://redmine.weseek.co.jp/issues/164109) [GROWI AI Next][UIUX]チャットスレッド履歴の表示が改善されている
  - [#167664](https://redmine.weseek.co.jp/issues/167664) [server] 自分が作成したスレッドを作成・更新順で返却する API の実装