### PR TITLE
feat: Exclude threads of deleted assistants from GET: /openai/threads/recent response

### DIFF
--- a/apps/app/src/features/openai/interfaces/thread-relation.ts
+++ b/apps/app/src/features/openai/interfaces/thread-relation.ts
@@ -17,6 +17,7 @@ export interface IThreadRelation {
   title?: string;
   type: ThreadType;
   expiredAt: Date;
+  isActive: boolean;
 }
 
 export type IThreadRelationHasId = IThreadRelation & HasObjectId;

--- a/apps/app/src/features/openai/server/routes/get-recent-threads.ts
+++ b/apps/app/src/features/openai/server/routes/get-recent-threads.ts
@@ -49,7 +49,10 @@ export const getRecentThreadsFactory: GetRecentThreadsFactory = (crowi) => {
 
       try {
         const paginateResult: PaginateResult<ThreadRelationDocument> = await ThreadRelationModel.paginate(
-          { userId: req.user._id },
+          {
+            isActive: true,
+            userId: req.user._id,
+          },
           {
             page: req.query.page ?? 1,
             limit: req.query.limit ?? 10,

--- a/apps/app/src/features/openai/server/services/delete-ai-assistant.ts
+++ b/apps/app/src/features/openai/server/services/delete-ai-assistant.ts
@@ -7,6 +7,7 @@ import loggerFactory from '~/utils/logger';
 
 import type { AiAssistantDocument } from '../models/ai-assistant';
 import AiAssistantModel from '../models/ai-assistant';
+import ThreadRelationModel from '../models/thread-relation';
 
 import { isAiEnabled } from './is-ai-enabled';
 import { getOpenaiService } from './openai';
@@ -27,6 +28,7 @@ export const deleteAiAssistant = async(ownerId: string, aiAssistantId: string): 
 
   const vectorStoreRelationId = getIdStringForRef(aiAssistant.vectorStore);
   await openaiService.deleteVectorStore(vectorStoreRelationId);
+  await ThreadRelationModel.deactivateByAiAssistantId(aiAssistant._id);
 
   const deletedAiAssistant = await aiAssistant.remove();
   return deletedAiAssistant;


### PR DESCRIPTION
# Task
- [#164109](https://redmine.weseek.co.jp/issues/164109) [GROWI AI Next][UIUX]チャットスレッド履歴の表示が改善されている
  - [#167709](https://redmine.weseek.co.jp/issues/167709) [server] GET: /openai/threads/recent のレスポンスに削除されたアシスタントのスレッドを含めいないようする