### PR TITLE
feat: Show individual assistant thread history

### DIFF
--- a/apps/app/public/static/locales/en_US/translation.json
+++ b/apps/app/public/static/locales/en_US/translation.json
@@ -498,6 +498,7 @@
   "sidebar_ai_assistant": {
     "reference_pages_label": "Reference pages",
     "recent_chat": "Recent chat",
+    "no_recent_chat": "No recent chat",
     "placeholder": "Ask me anything.",
     "knowledge_assistant_placeholder": "Ask me anything.",
     "editor_assistant_placeholder": "Can I help you with anything?",

--- a/apps/app/public/static/locales/en_US/translation.json
+++ b/apps/app/public/static/locales/en_US/translation.json
@@ -497,6 +497,7 @@
   },
   "sidebar_ai_assistant": {
     "reference_pages_label": "Reference pages",
+    "recent_chat": "Recent chat",
     "placeholder": "Ask me anything.",
     "knowledge_assistant_placeholder": "Ask me anything.",
     "editor_assistant_placeholder": "Can I help you with anything?",

--- a/apps/app/public/static/locales/fr_FR/translation.json
+++ b/apps/app/public/static/locales/fr_FR/translation.json
@@ -493,6 +493,7 @@
   "sidebar_ai_assistant": {
     "reference_pages_label": "Pages de référence",
     "recent_chat": "Chat récent",
+    "no_recent_chat": "Pas de chat récent",
     "knowledge_assistant_placeholder": "Demandez-moi n'importe quoi.",
     "editor_assistant_placeholder": "Puis-je vous aider ?",
     "summary_mode_label": "Mode résumé",

--- a/apps/app/public/static/locales/fr_FR/translation.json
+++ b/apps/app/public/static/locales/fr_FR/translation.json
@@ -492,6 +492,7 @@
   },
   "sidebar_ai_assistant": {
     "reference_pages_label": "Pages de référence",
+    "recent_chat": "Chat récent",
     "knowledge_assistant_placeholder": "Demandez-moi n'importe quoi.",
     "editor_assistant_placeholder": "Puis-je vous aider ?",
     "summary_mode_label": "Mode résumé",

--- a/apps/app/public/static/locales/ja_JP/translation.json
+++ b/apps/app/public/static/locales/ja_JP/translation.json
@@ -531,6 +531,7 @@
   "sidebar_ai_assistant": {
     "reference_pages_label": "参照するページ",
     "recent_chat": "最近のチャット",
+    "no_recent_chat": "チャットがありません",
     "knowledge_assistant_placeholder": "ききたいことを入力してください",
     "editor_assistant_placeholder": "お手伝いできることはありますか？",
     "summary_mode_label": "要約モード",

--- a/apps/app/public/static/locales/ja_JP/translation.json
+++ b/apps/app/public/static/locales/ja_JP/translation.json
@@ -530,6 +530,7 @@
   },
   "sidebar_ai_assistant": {
     "reference_pages_label": "参照するページ",
+    "recent_chat": "最近のチャット",
     "knowledge_assistant_placeholder": "ききたいことを入力してください",
     "editor_assistant_placeholder": "お手伝いできることはありますか？",
     "summary_mode_label": "要約モード",

--- a/apps/app/public/static/locales/zh_CN/translation.json
+++ b/apps/app/public/static/locales/zh_CN/translation.json
@@ -487,6 +487,7 @@
   },
   "sidebar_ai_assistant": {
     "reference_pages_label": "参考页面",
+    "recent_chat": "最近聊天",
     "knowledge_assistant_placeholder": "问我任何问题。",
     "editor_assistant_placeholder": "有什么需要帮忙的吗？",
     "summary_mode_label": "摘要模式",

--- a/apps/app/public/static/locales/zh_CN/translation.json
+++ b/apps/app/public/static/locales/zh_CN/translation.json
@@ -488,6 +488,7 @@
   "sidebar_ai_assistant": {
     "reference_pages_label": "参考页面",
     "recent_chat": "最近聊天",
+    "No recent chat": "最近没有聊天",
     "knowledge_assistant_placeholder": "问我任何问题。",
     "editor_assistant_placeholder": "有什么需要帮忙的吗？",
     "summary_mode_label": "摘要模式",

--- a/apps/app/public/static/locales/zh_CN/translation.json
+++ b/apps/app/public/static/locales/zh_CN/translation.json
@@ -488,7 +488,7 @@
   "sidebar_ai_assistant": {
     "reference_pages_label": "参考页面",
     "recent_chat": "最近聊天",
-    "No recent chat": "最近没有聊天",
+    "no_recent_chat": "最近没有聊天",
     "knowledge_assistant_placeholder": "问我任何问题。",
     "editor_assistant_placeholder": "有什么需要帮忙的吗？",
     "summary_mode_label": "摘要模式",

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementModal.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementModal.tsx
@@ -20,6 +20,7 @@ import type { SelectedPage } from '../../../../interfaces/selected-page';
 import { removeGlobPath } from '../../../../utils/remove-glob-path';
 import { createAiAssistant, updateAiAssistant } from '../../../services/ai-assistant';
 import { useAiAssistantManagementModal, AiAssistantManagementModalPageMode, useSWRxAiAssistants } from '../../../stores/ai-assistant';
+import { useAiAssistantSidebar } from '../../../stores/ai-assistant';
 
 import { AiAssistantManagementEditInstruction } from './AiAssistantManagementEditInstruction';
 import { AiAssistantManagementEditPages } from './AiAssistantManagementEditPages';
@@ -63,6 +64,7 @@ const AiAssistantManagementModalSubstance = (): JSX.Element => {
   const { t } = useTranslation();
   const { mutate: mutateAiAssistants } = useSWRxAiAssistants();
   const { data: aiAssistantManagementModalData, close: closeAiAssistantManagementModal } = useAiAssistantManagementModal();
+  const { data: aiAssistantSidebarData, refreshAiAssistantData } = useAiAssistantSidebar();
   const { data: pagePathsWithDescendantCount } = useSWRxPagePathsWithDescendantCount(
     removeGlobPath(aiAssistantManagementModalData?.aiAssistantData?.pagePathPatterns) ?? null,
     undefined,
@@ -144,7 +146,10 @@ const AiAssistantManagementModalSubstance = (): JSX.Element => {
       };
 
       if (shouldEdit) {
-        await updateAiAssistant(aiAssistant._id, reqBody);
+        const updatedAiAssistant = await updateAiAssistant(aiAssistant._id, reqBody);
+        if (aiAssistantSidebarData?.aiAssistantData?._id === updatedAiAssistant._id) {
+          refreshAiAssistantData(updatedAiAssistant);
+        }
       }
       else {
         await createAiAssistant(reqBody);

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementModal.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementModal.tsx
@@ -23,8 +23,8 @@ import {
   useSWRxAiAssistants,
   useAiAssistantSidebar,
   useAiAssistantManagementModal,
-  AiAssistantManagementModalPageMode
- } from '../../../stores/ai-assistant';
+  AiAssistantManagementModalPageMode,
+} from '../../../stores/ai-assistant';
 
 import { AiAssistantManagementEditInstruction } from './AiAssistantManagementEditInstruction';
 import { AiAssistantManagementEditPages } from './AiAssistantManagementEditPages';

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementModal.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementModal.tsx
@@ -19,8 +19,12 @@ import loggerFactory from '~/utils/logger';
 import type { SelectedPage } from '../../../../interfaces/selected-page';
 import { removeGlobPath } from '../../../../utils/remove-glob-path';
 import { createAiAssistant, updateAiAssistant } from '../../../services/ai-assistant';
-import { useAiAssistantManagementModal, AiAssistantManagementModalPageMode, useSWRxAiAssistants } from '../../../stores/ai-assistant';
-import { useAiAssistantSidebar } from '../../../stores/ai-assistant';
+import {
+  useSWRxAiAssistants,
+  useAiAssistantSidebar,
+  useAiAssistantManagementModal,
+  AiAssistantManagementModalPageMode
+ } from '../../../stores/ai-assistant';
 
 import { AiAssistantManagementEditInstruction } from './AiAssistantManagementEditInstruction';
 import { AiAssistantManagementEditPages } from './AiAssistantManagementEditPages';

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantChatInitialView.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantChatInitialView.tsx
@@ -1,4 +1,7 @@
+import Link from 'next/link';
 import { useTranslation } from 'react-i18next';
+
+import { removeGlobPath } from '../../../../utils/remove-glob-path';
 
 import { ThreadList } from './ThreadList';
 
@@ -24,13 +27,13 @@ export const AiAssistantChatInitialView: React.FC<Props> = ({ description, pageP
         </p>
         <div className="d-flex flex-column gap-1">
           { pagePathPatterns.map(pagePathPattern => (
-            <a
+            <Link
               key={pagePathPattern}
-              href="#"
-              className="fs-6 text-body-secondary text-decoration-none"
+              href={removeGlobPath([pagePathPattern])[0]}
+              className="text-body-secondary text-decoration-underline link-underline-secondary"
             >
               {pagePathPattern}
-            </a>
+            </Link>
           ))}
         </div>
       </div>

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantChatInitialView.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantChatInitialView.tsx
@@ -34,7 +34,9 @@ export const AiAssistantChatInitialView: React.FC<Props> = ({ description, pageP
         </div>
 
         <div className="mt-3">
-          <p className="text-body-secondary mb-0">最近のチャット</p>
+          <p className="text-body-secondary mb-0">
+            {t('sidebar_ai_assistant.recent_chat')}
+          </p>
           <ThreadList />
         </div>
 

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantChatInitialView.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantChatInitialView.tsx
@@ -1,5 +1,7 @@
 import { useTranslation } from 'react-i18next';
 
+import { ThreadList } from './ThreadList';
+
 type Props = {
   description: string,
   pagePathPatterns: string[],
@@ -15,20 +17,26 @@ export const AiAssistantChatInitialView: React.FC<Props> = ({ description, pageP
       </p>
 
       <div>
-        <div className="d-flex align-items-center">
+        <div className="mb-3">
           <p className="text-body-secondary mb-0">{t('sidebar_ai_assistant.reference_pages_label')}</p>
+          <div className="d-flex flex-column gap-1">
+            { pagePathPatterns.map(pagePathPattern => (
+              <a
+                key={pagePathPattern}
+                href="#"
+                className="fs-6 text-body-secondary text-decoration-none"
+              >
+                {pagePathPattern}
+              </a>
+            ))}
+          </div>
         </div>
-        <div className="d-flex flex-column gap-1">
-          { pagePathPatterns.map(pagePathPattern => (
-            <a
-              key={pagePathPattern}
-              href="#"
-              className="fs-6 text-body-secondary text-decoration-none"
-            >
-              {pagePathPattern}
-            </a>
-          ))}
+
+        <div className="mt-3">
+          <p className="text-body-secondary mb-0">最近のチャット</p>
+          <ThreadList />
         </div>
+
       </div>
     </>
   );

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantChatInitialView.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantChatInitialView.tsx
@@ -13,33 +13,33 @@ export const AiAssistantChatInitialView: React.FC<Props> = ({ description, pageP
   return (
     <>
       {description.length !== 0 && (
-        <p className="fs-6 text-body-secondary mb-0">
+        <p className="text-body-secondary mb-0">
           {description}
         </p>
       )}
+
       <div>
-        <div className="mb-3">
-          <p className="text-body-secondary mb-0">{t('sidebar_ai_assistant.reference_pages_label')}</p>
-          <div className="d-flex flex-column gap-1">
-            { pagePathPatterns.map(pagePathPattern => (
-              <a
-                key={pagePathPattern}
-                href="#"
-                className="fs-6 text-body-secondary text-decoration-none"
-              >
-                {pagePathPattern}
-              </a>
-            ))}
-          </div>
+        <p className="text-body-secondary mb-1">
+          {t('sidebar_ai_assistant.reference_pages_label')}
+        </p>
+        <div className="d-flex flex-column gap-1">
+          { pagePathPatterns.map(pagePathPattern => (
+            <a
+              key={pagePathPattern}
+              href="#"
+              className="fs-6 text-body-secondary text-decoration-none"
+            >
+              {pagePathPattern}
+            </a>
+          ))}
         </div>
+      </div>
 
-        <div className="mt-3">
-          <p className="text-body-secondary mb-0">
-            {t('sidebar_ai_assistant.recent_chat')}
-          </p>
-          <ThreadList />
-        </div>
-
+      <div>
+        <p className="text-body-secondary mb-1">
+          {t('sidebar_ai_assistant.recent_chat')}
+        </p>
+        <ThreadList />
       </div>
     </>
   );

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantChatInitialView.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantChatInitialView.tsx
@@ -12,10 +12,11 @@ export const AiAssistantChatInitialView: React.FC<Props> = ({ description, pageP
 
   return (
     <>
-      <p className="fs-6 text-body-secondary mb-0">
-        {description}
-      </p>
-
+      {description.length !== 0 && (
+        <p className="fs-6 text-body-secondary mb-0">
+          {description}
+        </p>
+      )}
       <div>
         <div className="mb-3">
           <p className="text-body-secondary mb-0">{t('sidebar_ai_assistant.reference_pages_label')}</p>

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/ThreadList.module.scss
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/ThreadList.module.scss
@@ -1,0 +1,7 @@
+.thread-list :global {
+  li {
+    &:hover {
+      background-color: var(--bs-secondary-bg) !important;
+    }
+  }
+}

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/ThreadList.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/ThreadList.tsx
@@ -1,0 +1,41 @@
+import React, { useCallback } from 'react';
+
+import type { IThreadRelationHasId } from '~/features/openai/interfaces/thread-relation';
+
+import { useAiAssistantSidebar } from '../../../stores/ai-assistant';
+import { useSWRxThreads } from '../../../stores/thread';
+
+
+export const ThreadList: React.FC = () => {
+  const { openChat, data: aiAssistantSidebarData } = useAiAssistantSidebar();
+  const { data: threads } = useSWRxThreads(aiAssistantSidebarData?.aiAssistantData?._id);
+
+  const openChatHandler = useCallback((threadData: IThreadRelationHasId) => {
+    const aiAssistantData = aiAssistantSidebarData?.aiAssistantData;
+    if (aiAssistantData == null) {
+      return;
+    }
+
+    openChat(aiAssistantData, threadData);
+  }, [aiAssistantSidebarData?.aiAssistantData, openChat]);
+
+  return (
+    <>
+      <ul className="list-group">
+        {threads?.map(thread => (
+          <li
+            onClick={() => { openChatHandler(thread) }}
+            key={thread._id}
+            role="button"
+            className="d-flex align-items-center list-group-item list-group-item-action border-0 rounded-1 bg-body-tertiary mb-2"
+          >
+            <div className="text-body-secondary">
+              <span className="material-symbols-outlined fs-5 me-2">chat</span>
+              <span className="flex-grow-1">{thread.title}</span>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </>
+  );
+};

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/ThreadList.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/ThreadList.tsx
@@ -42,6 +42,7 @@ export const ThreadList: React.FC = () => {
             onClick={() => { openChatHandler(thread) }}
             key={thread._id}
             role="button"
+            tabIndex={0}
             className="d-flex align-items-center list-group-item list-group-item-action border-0 rounded-1 bg-body-tertiary mb-2"
           >
             <div className="text-body-secondary">

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/ThreadList.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/ThreadList.tsx
@@ -1,5 +1,7 @@
 import React, { useCallback } from 'react';
 
+import { useTranslation } from 'react-i18next';
+
 import type { IThreadRelationHasId } from '~/features/openai/interfaces/thread-relation';
 
 import { useAiAssistantSidebar } from '../../../stores/ai-assistant';
@@ -11,6 +13,7 @@ const moduleClass = styles['thread-list'] ?? '';
 
 
 export const ThreadList: React.FC = () => {
+  const { t } = useTranslation();
   const { openChat, data: aiAssistantSidebarData } = useAiAssistantSidebar();
   const { data: threads } = useSWRxThreads(aiAssistantSidebarData?.aiAssistantData?._id);
 
@@ -23,10 +26,18 @@ export const ThreadList: React.FC = () => {
     openChat(aiAssistantData, threadData);
   }, [aiAssistantSidebarData?.aiAssistantData, openChat]);
 
+  if (threads == null || threads.length === 0) {
+    return (
+      <p className="text-body-secondary">
+        {t('sidebar_ai_assistant.no_recent_chat')}
+      </p>
+    );
+  }
+
   return (
     <>
       <ul className={`list-group ${moduleClass}`}>
-        {threads?.map(thread => (
+        {threads.map(thread => (
           <li
             onClick={() => { openChatHandler(thread) }}
             key={thread._id}

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/ThreadList.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/ThreadList.tsx
@@ -5,6 +5,10 @@ import type { IThreadRelationHasId } from '~/features/openai/interfaces/thread-r
 import { useAiAssistantSidebar } from '../../../stores/ai-assistant';
 import { useSWRxThreads } from '../../../stores/thread';
 
+import styles from './ThreadList.module.scss';
+
+const moduleClass = styles['thread-list'] ?? '';
+
 
 export const ThreadList: React.FC = () => {
   const { openChat, data: aiAssistantSidebarData } = useAiAssistantSidebar();
@@ -21,7 +25,7 @@ export const ThreadList: React.FC = () => {
 
   return (
     <>
-      <ul className="list-group">
+      <ul className={`list-group ${moduleClass}`}>
         {threads?.map(thread => (
           <li
             onClick={() => { openChatHandler(thread) }}

--- a/apps/app/src/features/openai/client/services/ai-assistant.ts
+++ b/apps/app/src/features/openai/client/services/ai-assistant.ts
@@ -7,7 +7,7 @@ export const createAiAssistant = async(body: UpsertAiAssistantData): Promise<voi
 };
 
 export const updateAiAssistant = async(id: string, body: UpsertAiAssistantData): Promise<AiAssistantHasId> => {
-  const res  = await apiv3Put<{updatedAiAssistant: AiAssistantHasId}>(`/openai/ai-assistant/${id}`, body);
+  const res = await apiv3Put<{updatedAiAssistant: AiAssistantHasId}>(`/openai/ai-assistant/${id}`, body);
   return res.data.updatedAiAssistant;
 };
 

--- a/apps/app/src/features/openai/client/services/ai-assistant.ts
+++ b/apps/app/src/features/openai/client/services/ai-assistant.ts
@@ -1,13 +1,14 @@
 import { apiv3Post, apiv3Put, apiv3Delete } from '~/client/util/apiv3-client';
 
-import type { UpsertAiAssistantData } from '../../interfaces/ai-assistant';
+import type { UpsertAiAssistantData, AiAssistantHasId } from '../../interfaces/ai-assistant';
 
 export const createAiAssistant = async(body: UpsertAiAssistantData): Promise<void> => {
   await apiv3Post('/openai/ai-assistant', body);
 };
 
-export const updateAiAssistant = async(id: string, body: UpsertAiAssistantData): Promise<void> => {
-  await apiv3Put(`/openai/ai-assistant/${id}`, body);
+export const updateAiAssistant = async(id: string, body: UpsertAiAssistantData): Promise<AiAssistantHasId> => {
+  const res  = await apiv3Put<{updatedAiAssistant: AiAssistantHasId}>(`/openai/ai-assistant/${id}`, body);
+  return res.data.updatedAiAssistant;
 };
 
 export const setDefaultAiAssistant = async(id: string, isDefault: boolean): Promise<void> => {

--- a/apps/app/src/features/openai/client/stores/ai-assistant.tsx
+++ b/apps/app/src/features/openai/client/stores/ai-assistant.tsx
@@ -72,6 +72,7 @@ type AiAssistantSidebarUtils = {
   ): void
   openEditor(): void
   close(): void
+  refreshAiAssistantData(aiAssistantData?: AiAssistantHasId): void
   refreshThreadData(threadData?: IThreadRelationHasId): void
 }
 
@@ -99,6 +100,13 @@ export const useAiAssistantSidebar = (
       () => swrResponse.mutate({
         isOpened: false, isEditorAssistant: false, aiAssistantData: undefined, threadData: undefined,
       }), [swrResponse],
+    ),
+    refreshAiAssistantData: useCallback(
+      (aiAssistantData) => {
+        swrResponse.mutate((currentState = { isOpened: false }) => {
+          return { ...currentState, aiAssistantData };
+        });
+      }, [swrResponse],
     ),
     refreshThreadData: useCallback(
       (threadData?: IThreadRelationHasId) => {

--- a/apps/app/src/features/openai/server/services/openai.ts
+++ b/apps/app/src/features/openai/server/services/openai.ts
@@ -217,7 +217,9 @@ class OpenaiService implements IOpenaiService {
   }
 
   async getThreadsByAiAssistantId(aiAssistantId: string, type: ThreadType = ThreadType.KNOWLEDGE): Promise<ThreadRelationDocument[]> {
-    const threadRelations = await ThreadRelationModel.find({ aiAssistant: aiAssistantId, type });
+    const threadRelations = await ThreadRelationModel
+      .find({ aiAssistant: aiAssistantId, type })
+      .sort({ updatedAt: -1 })
     return threadRelations;
   }
 

--- a/apps/app/src/features/openai/server/services/openai.ts
+++ b/apps/app/src/features/openai/server/services/openai.ts
@@ -219,7 +219,7 @@ class OpenaiService implements IOpenaiService {
   async getThreadsByAiAssistantId(aiAssistantId: string, type: ThreadType = ThreadType.KNOWLEDGE): Promise<ThreadRelationDocument[]> {
     const threadRelations = await ThreadRelationModel
       .find({ aiAssistant: aiAssistantId, type })
-      .sort({ updatedAt: -1 })
+      .sort({ updatedAt: -1 });
     return threadRelations;
   }
 


### PR DESCRIPTION
# Task
- [#164109](https://redmine.weseek.co.jp/issues/164109) [GROWI AI Next][UIUX]チャットスレッド履歴の表示が改善されている
  - [#167668](https://redmine.weseek.co.jp/issues/167668) [client] アシスタントクリック時の画面 (AiAssistantChatInitialView) にアシスタント個別のチャット履歴一覧を表示できる
  - [#167745](https://redmine.weseek.co.jp/issues/167745) 統合ブランチを master にマージする前に不要なコメントを削除する

# Figma
<img width="1219" alt="スクリーンショット 2025-06-25 11 25 23" src="https://github.com/user-attachments/assets/f3d8e160-3255-4c56-ac02-683dc2a8ca62" />

https://www.figma.com/design/ZiEcjZ8sYt6YvowboA5Um6/GROWI-v7?node-id=2815-8270&t=02jciM97JjYuGBiY-0

# Screenrecord
https://github.com/user-attachments/assets/05cc791e-cf7c-44c6-9a6a-3f5eb7e21eed



