### PR TITLE
fix(ai): Thread title on the right sidebar syncing

### DIFF
--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantSidebar/AiAssistantSidebar.tsx
@@ -360,13 +360,10 @@ const AiAssistantSidebarSubstance: React.FC<AiAssistantSidebarSubstanceProps> = 
   }, [headerIconForEditorAssistant, headerIconForKnowledgeAssistant, isEditorAssistant]);
 
   const headerText = useMemo(() => {
-    if (threadData?.title) {
-      return threadData.title;
-    }
     return isEditorAssistant
       ? headerTextForEditorAssistant
       : headerTextForKnowledgeAssistant;
-  }, [threadData?.title, isEditorAssistant, headerTextForEditorAssistant, headerTextForKnowledgeAssistant]);
+  }, [isEditorAssistant, headerTextForEditorAssistant, headerTextForKnowledgeAssistant]);
 
   const placeHolder = useMemo(() => {
     if (form.formState.isSubmitting) {

--- a/apps/app/src/features/openai/client/components/AiAssistant/Sidebar/AiAssistantList.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/Sidebar/AiAssistantList.tsx
@@ -6,7 +6,6 @@ import { useTranslation } from 'react-i18next';
 import { Collapse } from 'reactstrap';
 
 import { toastError, toastSuccess } from '~/client/util/toastr';
-import type { IThreadRelationHasId } from '~/features/openai/interfaces/thread-relation';
 import { useCurrentUser } from '~/stores-universal/context';
 import loggerFactory from '~/utils/logger';
 
@@ -25,7 +24,7 @@ type AiAssistantItemProps = {
   currentUser?: IUserHasId | null;
   aiAssistant: AiAssistantHasId;
   onEditClick: (aiAssistantData: AiAssistantHasId) => void;
-  onItemClick: (aiAssistantData: AiAssistantHasId, threadData?: IThreadRelationHasId) => void;
+  onItemClick: (aiAssistantData: AiAssistantHasId) => void;
   onUpdated?: () => void;
   onDeleted?: () => void;
 };

--- a/apps/app/src/features/openai/client/services/knowledge-assistant.tsx
+++ b/apps/app/src/features/openai/client/services/knowledge-assistant.tsx
@@ -67,7 +67,7 @@ type UseKnowledgeAssistant = () => {
 export const useKnowledgeAssistant: UseKnowledgeAssistant = () => {
   // Hooks
   const { data: aiAssistantSidebarData } = useAiAssistantSidebar();
-  const { aiAssistantData } = aiAssistantSidebarData ?? {};
+  const { aiAssistantData, threadData } = aiAssistantSidebarData ?? {};
   const { mutate: mutateRecentThreads } = useSWRINFxRecentThreads();
   const { trigger: mutateThreadData } = useSWRMUTxThreads(aiAssistantData?._id);
   const { t } = useTranslation();
@@ -79,9 +79,6 @@ export const useKnowledgeAssistant: UseKnowledgeAssistant = () => {
       extendedThinkingMode: false,
     },
   });
-
-  // States
-  const [currentThreadTitle, setCurrentThreadTitle] = useState<string | undefined>(undefined);
 
   // Functions
   const resetForm = useCallback(() => {
@@ -97,8 +94,6 @@ export const useKnowledgeAssistant: UseKnowledgeAssistant = () => {
       initialUserMessage,
     });
     const thread = response.data;
-
-    setCurrentThreadTitle(thread.title);
 
     // No need to await because data is not used
     mutateThreadData();
@@ -140,8 +135,8 @@ export const useKnowledgeAssistant: UseKnowledgeAssistant = () => {
   }, []);
 
   const headerText = useMemo(() => {
-    return <>{currentThreadTitle ?? aiAssistantData?.name}</>;
-  }, [aiAssistantData?.name, currentThreadTitle]);
+    return <>{threadData?.title ?? aiAssistantData?.name}</>;
+  }, [aiAssistantData?.name, threadData?.title]);
 
   const placeHolder = useMemo(() => { return 'sidebar_ai_assistant.knowledge_assistant_placeholder' }, []);
 

--- a/apps/app/src/features/openai/client/services/knowledge-assistant.tsx
+++ b/apps/app/src/features/openai/client/services/knowledge-assistant.tsx
@@ -68,7 +68,6 @@ export const useKnowledgeAssistant: UseKnowledgeAssistant = () => {
   // Hooks
   const { data: aiAssistantSidebarData } = useAiAssistantSidebar();
   const { aiAssistantData } = aiAssistantSidebarData ?? {};
-  // const { threadData } = aiAssistantSidebarData ?? {};
   const { mutate: mutateRecentThreads } = useSWRINFxRecentThreads();
   const { trigger: mutateThreadData } = useSWRMUTxThreads(aiAssistantData?._id);
   const { t } = useTranslation();

--- a/apps/app/src/features/openai/client/services/knowledge-assistant.tsx
+++ b/apps/app/src/features/openai/client/services/knowledge-assistant.tsx
@@ -68,7 +68,7 @@ export const useKnowledgeAssistant: UseKnowledgeAssistant = () => {
   // Hooks
   const { data: aiAssistantSidebarData } = useAiAssistantSidebar();
   const { aiAssistantData } = aiAssistantSidebarData ?? {};
-  const { threadData } = aiAssistantSidebarData ?? {};
+  // const { threadData } = aiAssistantSidebarData ?? {};
   const { mutate: mutateRecentThreads } = useSWRINFxRecentThreads();
   const { trigger: mutateThreadData } = useSWRMUTxThreads(aiAssistantData?._id);
   const { t } = useTranslation();
@@ -82,7 +82,7 @@ export const useKnowledgeAssistant: UseKnowledgeAssistant = () => {
   });
 
   // States
-  const [currentThreadTitle, setCurrentThreadId] = useState(threadData?.title);
+  const [currentThreadTitle, setCurrentThreadTitle] = useState<string | undefined>(undefined);
 
   // Functions
   const resetForm = useCallback(() => {
@@ -99,7 +99,7 @@ export const useKnowledgeAssistant: UseKnowledgeAssistant = () => {
     });
     const thread = response.data;
 
-    setCurrentThreadId(thread.title);
+    setCurrentThreadTitle(thread.title);
 
     // No need to await because data is not used
     mutateThreadData();


### PR DESCRIPTION
# Task
- [#164109](https://redmine.weseek.co.jp/issues/164109) [GROWI AI Next][UIUX]チャットスレッド履歴の表示が改善されている
  - [#167800](https://redmine.weseek.co.jp/issues/167800) [client] スレッド -> アシスタントの順番で右サイドバーを開いた時に右サイドバーのヘッダーがスレッドのタイトルになっている問題の修正