### PR TITLE
fix: Cannot change file upload destination to "MongoDB ()" or "local"

### DIFF
--- a/apps/app/src/server/routes/apiv3/app-settings.js
+++ b/apps/app/src/server/routes/apiv3/app-settings.js
@@ -890,6 +890,19 @@ module.exports = (crowi) => {
   router.put('/file-upload-setting', loginRequiredStrictly, adminRequired, addActivity, validator.fileUploadSetting, apiV3FormValidator, async(req, res) => {
     const { fileUploadType } = req.body;
 
+    if (fileUploadType === 'local' || fileUploadType === 'gridfs') {
+      try {
+        await configManager.updateConfigs({
+          'app:fileUploadType': fileUploadType,
+        }, { skipPubsub: true });
+      }
+      catch (err) {
+        const msg = `Error occurred in updating file upload type to ${fileUploadType}: ${err.message}`;
+        logger.error('Error', err);
+        return res.apiv3Err(new ErrorV3(msg, 'update-fileUploadType-failed'));
+      }
+    }
+
     if (fileUploadType === 'aws') {
       try {
         try {


### PR DESCRIPTION
# Task
- [#168146](https://redmine.weseek.co.jp/issues/168146) ファイルアップロード先を MongoDB or local に変更できない
  - [#168147](https://redmine.weseek.co.jp/issues/168147) 修正