### PR TITLE
fix:using-default-rendererconfig-when-it-is-undefied

### DIFF
--- a/apps/app/src/services/renderer/default-renderer-config.ts
+++ b/apps/app/src/services/renderer/default-renderer-config.ts
@@ -1,0 +1,18 @@
+import type { RendererConfig } from '~/interfaces/services/renderer';
+
+export const DEFAULT_RENDERER_CONFIG: RendererConfig = {
+  isEnabledLinebreaks: false,
+  isEnabledLinebreaksInComments: true,
+  adminPreferredIndentSize: 4,
+  isIndentSizeForced: false,
+  highlightJsStyleBorder: false,
+  isEnabledMarp: false,
+
+  drawioUri: 'https://embed.diagrams.net/',
+  plantumlUri: 'https://www.plantuml.com/plantuml',
+
+  isEnabledXssPrevention: true,
+  sanitizeType: 'Recommended' as const,
+  customTagWhitelist: [],
+  customAttrWhitelist: {},
+};

--- a/apps/app/src/stores/renderer.tsx
+++ b/apps/app/src/stores/renderer.tsx
@@ -1,10 +1,11 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 
 import type { HtmlElementNode } from 'rehype-toc';
 import useSWR, { type SWRConfiguration, type SWRResponse } from 'swr';
 
 import { getGrowiFacade } from '~/features/growi-plugin/client/utils/growi-facade-utils';
 import type { RendererOptions } from '~/interfaces/renderer-options';
+import { DEFAULT_RENDERER_CONFIG } from '~/services/renderer/default-renderer-config';
 import {
   useRendererConfig,
 } from '~/stores-universal/context';
@@ -170,9 +171,18 @@ export const useCustomSidebarOptions = (config?: SWRConfiguration): SWRResponse<
 
 export const usePresentationViewOptions = (): SWRResponse<RendererOptions, Error> => {
   const { data: currentPagePath } = useCurrentPagePath();
-  const { data: rendererConfig } = useRendererConfig();
+  const { data: rendererConfigRaw } = useRendererConfig();
 
-  const isAllDataValid = currentPagePath != null && rendererConfig != null;
+  const rendererConfig = rendererConfigRaw ?? DEFAULT_RENDERER_CONFIG;
+
+  useEffect(() => {
+    if (!rendererConfigRaw) {
+      // eslint-disable-next-line no-console
+      console.warn('RendererConfig is undefined or missing. Using DEFAULT_RENDERER_CONFIG.');
+    }
+  }, [rendererConfigRaw]);
+
+  const isAllDataValid = currentPagePath != null;
 
   return useSWR(
     isAllDataValid


### PR DESCRIPTION
# Task
- \#132599 useRendererConfig が初期化されていないと PagePresentationModal 内の要素がレンダリングされない問題を修正する
    - \#153963 修正

# 変更点
- DEFAULT_RENDERER_CONFIGを追加し、RendererConfigがundefiedの時はconsole.warnにメッセージを出力し、追加したデフォルトのものを使うようにした。