### PR TITLE
imprv: Adjust pagetitle spacing

### DIFF
--- a/apps/app/src/components/Common/PagePathNav/PagePathNavLayout.tsx
+++ b/apps/app/src/components/Common/PagePathNav/PagePathNavLayout.tsx
@@ -42,7 +42,7 @@ export const PagePathNavLayout = (props: Props): JSX.Element => {
 
   const copyDropdownId = `copydropdown-in-pagepathnavlayout-${pageId}`;
 
-  const containerLayoutClass = inline ? '' : 'd-flex align-items-center';
+  const containerLayoutClass = inline ? 'mt-2' : 'd-flex align-items-center';
 
   return (
     <div


### PR DESCRIPTION
# Task
https://redmine.weseek.co.jp/issues/169041

# Summary
View画面においてページ名とページパスの間を調整(上マージンを追加)

<img width="340" height="170" alt="image" src="https://github.com/user-attachments/assets/7a78d4c3-a5ea-4396-a43e-43e465f647e4" />