### PR TITLE
feat: Implementation of page selection method modal

### DIFF
--- a/apps/app/public/static/locales/en_US/translation.json
+++ b/apps/app/public/static/locales/en_US/translation.json
@@ -572,6 +572,9 @@
       "create_failed": "Failed to create assistant",
       "update_failed": "Failed to update assistant"
     },
+    "select_source_pages": "Select pages for the assistant to learn from",
+    "search_by_keyword": "Search by keyword",
+    "select_from_page_tree": "Select from page tree",
     "edit_page_description": "Edit pages that the assistant can reference.<br> The assistant can reference up to {{limitLearnablePageCountPerAssistant}} pages including child pages.",
     "default_instruction": "You are the knowledge assistant for this Wiki.\n\n## Multilingual Support:\nRespond in the same language the user uses in their input.\n",
     "add_page_button": "Add page",

--- a/apps/app/public/static/locales/en_US/translation.json
+++ b/apps/app/public/static/locales/en_US/translation.json
@@ -572,7 +572,7 @@
       "create_failed": "Failed to create assistant",
       "update_failed": "Failed to update assistant"
     },
-    "select_source_pages": "Select pages for the assistant to learn from",
+    "select_source_pages": "Select pages for the assistant to reference",
     "search_by_keyword": "Search by keyword",
     "select_from_page_tree": "Select from page tree",
     "edit_page_description": "Edit pages that the assistant can reference.<br> The assistant can reference up to {{limitLearnablePageCountPerAssistant}} pages including child pages.",

--- a/apps/app/public/static/locales/fr_FR/translation.json
+++ b/apps/app/public/static/locales/fr_FR/translation.json
@@ -566,6 +566,9 @@
       "create_failed": "Échec de la création de l'assistant",
       "update_failed": "Échec de la mise à jour de l'assistant"
     },
+    "select_source_pages": "Sélectionnez les pages sources pour l'apprentissage de l'assistant",
+    "search_by_keyword": "Rechercher par mot-clé",
+    "select_from_page_tree": "Sélectionner depuis l'arborescence des pages",
     "edit_page_description": "Modifier les pages que l'assistant peut référencer.<br> L'assistant peut référencer jusqu'à {{limitLearnablePageCountPerAssistant}} pages, y compris les pages enfants.",
     "default_instruction": "Vous êtes l'assistant de connaissances pour ce Wiki.\n\n## Support multilingue :\nRépondez dans la même langue que celle utilisée par l'utilisateur dans sa requête.\n",
     "add_page_button": "Ajouter une page",

--- a/apps/app/public/static/locales/fr_FR/translation.json
+++ b/apps/app/public/static/locales/fr_FR/translation.json
@@ -566,7 +566,7 @@
       "create_failed": "Échec de la création de l'assistant",
       "update_failed": "Échec de la mise à jour de l'assistant"
     },
-    "select_source_pages": "Sélectionnez les pages sources pour l'apprentissage de l'assistant",
+    "select_source_pages": "Sélectionnez les pages que l'assistant doit référencer",
     "search_by_keyword": "Rechercher par mot-clé",
     "select_from_page_tree": "Sélectionner depuis l'arborescence des pages",
     "edit_page_description": "Modifier les pages que l'assistant peut référencer.<br> L'assistant peut référencer jusqu'à {{limitLearnablePageCountPerAssistant}} pages, y compris les pages enfants.",

--- a/apps/app/public/static/locales/ja_JP/translation.json
+++ b/apps/app/public/static/locales/ja_JP/translation.json
@@ -604,7 +604,7 @@
       "create_failed": "アシスタントの作成に失敗しました",
       "update_failed": "アシスタントの更新に失敗しました"
     },
-    "select_source_pages": "アシスタントの学習元にするページを選択します",
+    "select_source_pages": "アシスタントが参照するページを選択します",
     "search_by_keyword": "キーワードで検索",
     "select_from_page_tree": "ページツリーから選択",
     "edit_page_description": " アシスタントが参照するページを編集します。<br> 参照できるページは配下ページも含めて {{limitLearnablePageCountPerAssistant}} ページまでです。",

--- a/apps/app/public/static/locales/ja_JP/translation.json
+++ b/apps/app/public/static/locales/ja_JP/translation.json
@@ -604,6 +604,9 @@
       "create_failed": "アシスタントの作成に失敗しました",
       "update_failed": "アシスタントの更新に失敗しました"
     },
+    "select_source_pages": "アシスタントの学習元にするページを選択します",
+    "search_by_keyword": "キーワードで検索",
+    "select_from_page_tree": "ページツリーから選択",
     "edit_page_description": " アシスタントが参照するページを編集します。<br> 参照できるページは配下ページも含めて {{limitLearnablePageCountPerAssistant}} ページまでです。",
     "default_instruction": "あなたはこのWikiの知識アシスタントです。\n\n## 多言語サポート:\nユーザーが入力で使用した言語と同じ言語で応答してください。\n",
     "add_page_button": "ページを追加する",

--- a/apps/app/public/static/locales/zh_CN/translation.json
+++ b/apps/app/public/static/locales/zh_CN/translation.json
@@ -561,6 +561,9 @@
       "create_failed": "创建助手失败",
       "update_failed": "更新助手失败"
     },
+    "select_source_pages": "选择助手学习的源页面",
+    "search_by_keyword": "按关键词搜索",
+    "select_from_page_tree": "从页面树选择",
     "edit_page_description": "编辑助手可以参考的页面。<br> 助手可以参考最多 {{limitLearnablePageCountPerAssistant}} 个页面，包括子页面。",
     "default_instruction": "您是这个Wiki的知识助手。\n\n## 多语言支持：\n请使用用户输入中使用的相同语言进行回复。\n",
     "add_page_button": "添加页面",

--- a/apps/app/public/static/locales/zh_CN/translation.json
+++ b/apps/app/public/static/locales/zh_CN/translation.json
@@ -561,7 +561,7 @@
       "create_failed": "创建助手失败",
       "update_failed": "更新助手失败"
     },
-    "select_source_pages": "选择助手学习的源页面",
+    "select_source_pages": "选择助手要参考的页面",
     "search_by_keyword": "按关键词搜索",
     "select_from_page_tree": "从页面树选择",
     "edit_page_description": "编辑助手可以参考的页面。<br> 助手可以参考最多 {{limitLearnablePageCountPerAssistant}} 个页面，包括子页面。",

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementEditInstruction.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementEditInstruction.tsx
@@ -18,7 +18,7 @@ export const AiAssistantManagementEditInstruction = (props: Props): JSX.Element 
 
   return (
     <>
-      <AiAssistantManagementHeader />
+      <AiAssistantManagementHeader labelTranslationKey="modal_ai_assistant.page_mode_title.instruction" />
 
       <ModalBody className="px-4">
         <p className="text-secondary py-1">

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementEditPages.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementEditPages.tsx
@@ -33,7 +33,7 @@ export const AiAssistantManagementEditPages = (props: Props): JSX.Element => {
 
   return (
     <>
-      <AiAssistantManagementHeader />
+      <AiAssistantManagementHeader labelTranslationKey="modal_ai_assistant.page_mode_title.pages" />
 
       <ModalBody className="px-4">
         <p

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementEditShare.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementEditShare.tsx
@@ -98,7 +98,7 @@ export const AiAssistantManagementEditShare = (props: Props): JSX.Element => {
 
   return (
     <>
-      <AiAssistantManagementHeader />
+      <AiAssistantManagementHeader labelTranslationKey="modal_ai_assistant.page_mode_title.share" />
 
       <ModalBody className="px-4">
         <div className="form-check form-switch mb-4">

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementHeader.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementHeader.tsx
@@ -19,6 +19,7 @@ export const AiAssistantManagementHeader = (props: Props): JSX.Element => {
 
   return (
     <ModalHeader
+      tag="h4"
       close={(
         <button type="button" className="btn p-0" onClick={close}>
           <span className="material-symbols-outlined">close</span>
@@ -26,12 +27,17 @@ export const AiAssistantManagementHeader = (props: Props): JSX.Element => {
       )}
     >
       <div className="d-flex align-items-center">
-        { !hideBackButton && (
-          <button type="button" className="btn p-0 me-3" onClick={() => changePageMode(backToPageMode ?? AiAssistantManagementModalPageMode.HOME)}>
-            <span className="material-symbols-outlined text-primary">chevron_left</span>
-          </button>
-        )}
-        <span>{t(`modal_ai_assistant.page_mode_title.${data?.pageMode}`)}</span>
+        { hideBackButton
+          ? (
+            <span className="growi-custom-icons growi-ai-assistant-icon me-3 fs-4">growi_ai</span>
+          )
+          : (
+            <button type="button" className="btn p-0 me-3" onClick={() => changePageMode(backToPageMode ?? AiAssistantManagementModalPageMode.HOME)}>
+              <span className="material-symbols-outlined text-primary">chevron_left</span>
+            </button>
+          )
+        }
+        <span className='fw-bold'>{label ?? t(`modal_ai_assistant.page_mode_title.${data?.pageMode}`)}</span>
       </div>
     </ModalHeader>
   );

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementHeader.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementHeader.tsx
@@ -7,14 +7,17 @@ import { useAiAssistantManagementModal, AiAssistantManagementModalPageMode } fro
 
 type Props = {
   labelTranslationKey: string;
-  backToPageMode?: AiAssistantManagementModalPageMode;
   hideBackButton?: boolean;
   backButtonColor?: 'primary' | 'secondary';
+  backToPageMode?: AiAssistantManagementModalPageMode;
 }
 
 export const AiAssistantManagementHeader = (props: Props): JSX.Element => {
   const {
-    labelTranslationKey, backToPageMode, hideBackButton, backButtonColor = 'primary',
+    labelTranslationKey,
+    hideBackButton,
+    backButtonColor = 'primary',
+    backToPageMode = AiAssistantManagementModalPageMode.HOME,
   } = props;
 
   const { t } = useTranslation();
@@ -35,7 +38,7 @@ export const AiAssistantManagementHeader = (props: Props): JSX.Element => {
             <span className="growi-custom-icons growi-ai-assistant-icon me-3 fs-4">growi_ai</span>
           )
           : (
-            <button type="button" className="btn p-0 me-3" onClick={() => changePageMode(backToPageMode ?? AiAssistantManagementModalPageMode.HOME)}>
+            <button type="button" className="btn p-0 me-3" onClick={() => changePageMode(backToPageMode)}>
               <span className={`material-symbols-outlined text-${backButtonColor}`}>chevron_left</span>
             </button>
           )

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementHeader.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementHeader.tsx
@@ -6,7 +6,7 @@ import { ModalHeader } from 'reactstrap';
 import { useAiAssistantManagementModal, AiAssistantManagementModalPageMode } from '../../../stores/ai-assistant';
 
 type Props = {
-  label?: string;
+  labelTranslationKey: string;
   backToPageMode?: AiAssistantManagementModalPageMode;
   hideBackButton?: boolean;
   backButtonColor?: 'primary' | 'secondary';
@@ -14,11 +14,11 @@ type Props = {
 
 export const AiAssistantManagementHeader = (props: Props): JSX.Element => {
   const {
-    label, backToPageMode, hideBackButton, backButtonColor = 'primary',
+    labelTranslationKey, backToPageMode, hideBackButton, backButtonColor = 'primary',
   } = props;
 
   const { t } = useTranslation();
-  const { data, close, changePageMode } = useAiAssistantManagementModal();
+  const { close, changePageMode } = useAiAssistantManagementModal();
 
   return (
     <ModalHeader
@@ -40,7 +40,7 @@ export const AiAssistantManagementHeader = (props: Props): JSX.Element => {
             </button>
           )
         }
-        <span className="fw-bold">{label ?? t(`modal_ai_assistant.page_mode_title.${data?.pageMode}`)}</span>
+        <span className="fw-bold">{t(labelTranslationKey)}</span>
       </div>
     </ModalHeader>
   );

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementHeader.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementHeader.tsx
@@ -1,4 +1,4 @@
-import { type JSX, useMemo } from 'react';
+import { type JSX } from 'react';
 
 import { useTranslation } from 'react-i18next';
 import { ModalHeader } from 'reactstrap';
@@ -9,10 +9,13 @@ type Props = {
   label?: string;
   backToPageMode?: AiAssistantManagementModalPageMode;
   hideBackButton?: boolean;
+  backButtonColor?: 'primary' | 'secondary';
 }
 
 export const AiAssistantManagementHeader = (props: Props): JSX.Element => {
-  const { label, backToPageMode, hideBackButton } = props;
+  const {
+    label, backToPageMode, hideBackButton, backButtonColor = 'primary',
+  } = props;
 
   const { t } = useTranslation();
   const { data, close, changePageMode } = useAiAssistantManagementModal();
@@ -33,11 +36,11 @@ export const AiAssistantManagementHeader = (props: Props): JSX.Element => {
           )
           : (
             <button type="button" className="btn p-0 me-3" onClick={() => changePageMode(backToPageMode ?? AiAssistantManagementModalPageMode.HOME)}>
-              <span className="material-symbols-outlined text-primary">chevron_left</span>
+              <span className={`material-symbols-outlined text-${backButtonColor}`}>chevron_left</span>
             </button>
           )
         }
-        <span className='fw-bold'>{label ?? t(`modal_ai_assistant.page_mode_title.${data?.pageMode}`)}</span>
+        <span className="fw-bold">{label ?? t(`modal_ai_assistant.page_mode_title.${data?.pageMode}`)}</span>
       </div>
     </ModalHeader>
   );

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementHeader.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementHeader.tsx
@@ -1,12 +1,19 @@
-import type { JSX } from 'react';
+import { type JSX, useMemo } from 'react';
 
 import { useTranslation } from 'react-i18next';
 import { ModalHeader } from 'reactstrap';
 
 import { useAiAssistantManagementModal, AiAssistantManagementModalPageMode } from '../../../stores/ai-assistant';
 
+type Props = {
+  label?: string;
+  backToPageMode?: AiAssistantManagementModalPageMode;
+  hideBackButton?: boolean;
+}
 
-export const AiAssistantManagementHeader = (): JSX.Element => {
+export const AiAssistantManagementHeader = (props: Props): JSX.Element => {
+  const { label, backToPageMode, hideBackButton } = props;
+
   const { t } = useTranslation();
   const { data, close, changePageMode } = useAiAssistantManagementModal();
 
@@ -19,9 +26,11 @@ export const AiAssistantManagementHeader = (): JSX.Element => {
       )}
     >
       <div className="d-flex align-items-center">
-        <button type="button" className="btn p-0 me-3" onClick={() => changePageMode(AiAssistantManagementModalPageMode.HOME)}>
-          <span className="material-symbols-outlined text-primary">chevron_left</span>
-        </button>
+        { !hideBackButton && (
+          <button type="button" className="btn p-0 me-3" onClick={() => changePageMode(backToPageMode ?? AiAssistantManagementModalPageMode.HOME)}>
+            <span className="material-symbols-outlined text-primary">chevron_left</span>
+          </button>
+        )}
         <span>{t(`modal_ai_assistant.page_mode_title.${data?.pageMode}`)}</span>
       </div>
     </ModalHeader>

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementHome.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementHome.tsx
@@ -14,8 +14,8 @@ import { useCurrentUser, useLimitLearnablePageCountPerAssistant } from '~/stores
 import type { SelectedPage } from '../../../../interfaces/selected-page';
 import { determineShareScope } from '../../../../utils/determine-share-scope';
 import { useAiAssistantManagementModal, AiAssistantManagementModalPageMode } from '../../../stores/ai-assistant';
-import { AiAssistantManagementHeader } from './AiAssistantManagementHeader';
 
+import { AiAssistantManagementHeader } from './AiAssistantManagementHeader';
 import { ShareScopeWarningModal } from './ShareScopeWarningModal';
 
 type Props = {
@@ -167,7 +167,7 @@ export const AiAssistantManagementHome = (props: Props): JSX.Element => {
 
             <button
               type="button"
-              onClick={() => { changePageMode(AiAssistantManagementModalPageMode.PAGE_SELECTION_METHOD) }}
+              onClick={() => { changePageMode(AiAssistantManagementModalPageMode.PAGES) }}
               className="btn w-100 d-flex justify-content-between align-items-center py-3 mb-2 border-0"
             >
               <span className="fw-normal">{t('modal_ai_assistant.page_mode_title.pages')}</span>

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementHome.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementHome.tsx
@@ -166,7 +166,7 @@ export const AiAssistantManagementHome = (props: Props): JSX.Element => {
 
             <button
               type="button"
-              onClick={() => { changePageMode(AiAssistantManagementModalPageMode.PAGES) }}
+              onClick={() => { changePageMode(AiAssistantManagementModalPageMode.PAGE_SELECTION_METHOD) }}
               className="btn w-100 d-flex justify-content-between align-items-center py-3 mb-2 border-0"
             >
               <span className="fw-normal">{t('modal_ai_assistant.page_mode_title.pages')}</span>

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementHome.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementHome.tsx
@@ -119,7 +119,7 @@ export const AiAssistantManagementHome = (props: Props): JSX.Element => {
     <>
       <AiAssistantManagementHeader
         hideBackButton
-        label={t(shouldEdit ? 'modal_ai_assistant.header.update_assistant' : 'modal_ai_assistant.header.add_new_assistant')}
+        labelTranslationKey={shouldEdit ? 'modal_ai_assistant.header.update_assistant' : 'modal_ai_assistant.header.add_new_assistant'}
       />
 
       <div className="px-4">

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementHome.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementHome.tsx
@@ -14,6 +14,7 @@ import { useCurrentUser, useLimitLearnablePageCountPerAssistant } from '~/stores
 import type { SelectedPage } from '../../../../interfaces/selected-page';
 import { determineShareScope } from '../../../../utils/determine-share-scope';
 import { useAiAssistantManagementModal, AiAssistantManagementModalPageMode } from '../../../stores/ai-assistant';
+import { AiAssistantManagementHeader } from './AiAssistantManagementHeader';
 
 import { ShareScopeWarningModal } from './ShareScopeWarningModal';
 
@@ -116,10 +117,10 @@ export const AiAssistantManagementHome = (props: Props): JSX.Element => {
 
   return (
     <>
-      <ModalHeader tag="h4" toggle={closeAiAssistantManagementModal} className="pe-4">
-        <span className="growi-custom-icons growi-ai-assistant-icon me-3 fs-4">growi_ai</span>
-        <span className="fw-bold">{t(shouldEdit ? 'modal_ai_assistant.header.update_assistant' : 'modal_ai_assistant.header.add_new_assistant')}</span>
-      </ModalHeader>
+      <AiAssistantManagementHeader
+        hideBackButton
+        label={t(shouldEdit ? 'modal_ai_assistant.header.update_assistant' : 'modal_ai_assistant.header.add_new_assistant')}
+      />
 
       <div className="px-4">
         <ModalBody>

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementHome.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementHome.tsx
@@ -4,7 +4,7 @@ import React, {
 
 import { useTranslation } from 'react-i18next';
 import {
-  ModalHeader, ModalBody, ModalFooter, Input,
+  ModalBody, ModalFooter, Input,
 } from 'reactstrap';
 
 import { AiAssistantShareScope, AiAssistantAccessScope } from '~/features/openai/interfaces/ai-assistant';

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementModal.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementModal.tsx
@@ -30,6 +30,7 @@ import { AiAssistantManagementEditInstruction } from './AiAssistantManagementEdi
 import { AiAssistantManagementEditPages } from './AiAssistantManagementEditPages';
 import { AiAssistantManagementEditShare } from './AiAssistantManagementEditShare';
 import { AiAssistantManagementHome } from './AiAssistantManagementHome';
+import { AiAssistantManagementPageSelectionMethod } from './AiAssistantManagementPageSelectionMethod';
 
 import styles from './AiAssistantManagementModal.module.scss';
 
@@ -272,6 +273,10 @@ const AiAssistantManagementModalSubstance = (): JSX.Element => {
             onSelect={selectPageHandler}
             onRemove={removePageHandler}
           />
+        </TabPane>
+
+        <TabPane tabId={AiAssistantManagementModalPageMode.PAGE_SELECTION_METHOD}>
+          <AiAssistantManagementPageSelectionMethod />
         </TabPane>
 
         <TabPane tabId={AiAssistantManagementModalPageMode.INSTRUCTION}>

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementModal.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementModal.tsx
@@ -168,8 +168,11 @@ const AiAssistantManagementModalSubstance = (): JSX.Element => {
       toastError(shouldEdit ? t('modal_ai_assistant.toaster.update_failed') : t('modal_ai_assistant.toaster.create_failed'));
       logger.error(err);
     }
-  // eslint-disable-next-line max-len
-  }, [t, selectedPages, selectedShareScope, selectedUserGroupsForShareScope, selectedAccessScope, selectedUserGroupsForAccessScope, name, description, instruction, shouldEdit, aiAssistant?._id, mutateAiAssistants, closeAiAssistantManagementModal]);
+  }, [
+    selectedPages, selectedShareScope, selectedUserGroupsForShareScope, selectedAccessScope,
+    selectedUserGroupsForAccessScope, name, description, instruction, shouldEdit, t, mutateAiAssistants,
+    closeAiAssistantManagementModal, aiAssistant?._id, aiAssistantSidebarData?.aiAssistantData?._id, refreshAiAssistantData,
+  ]);
 
 
   /*

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementPageSelectionMethod.module.scss
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementPageSelectionMethod.module.scss
@@ -1,0 +1,20 @@
+@use '@growi/core-styles/scss/bootstrap/init' as bs;
+
+.grw-ai-assistant-management-page-selection-method :global {
+  .page-selection-method-btn {
+      width: 280px;
+  }
+}
+
+
+// == Colors
+.grw-ai-assistant-management-page-selection-method :global {
+  .page-selection-method-btn {
+      border: 2px solid bs.$gray-300;
+      &:hover {
+        color: var(--bs-primary);
+        background-color: rgba(var(--bs-primary-rgb), 0.1);
+        border-color: var(--bs-primary)
+      }
+    }
+}

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementPageSelectionMethod.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementPageSelectionMethod.tsx
@@ -46,7 +46,7 @@ export const AiAssistantManagementPageSelectionMethod = (): JSX.Element => {
       />
 
       <ModalBody className="px-4">
-        <h4 className="text-center mb-4">
+        <h4 className="text-center mb-4 fw-bold">
           {t('modal_ai_assistant.select_source_pages')}
         </h4>
         <div className="row justify-content-center">

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementPageSelectionMethod.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementPageSelectionMethod.tsx
@@ -44,7 +44,7 @@ export const AiAssistantManagementPageSelectionMethod = (): JSX.Element => {
     <>
       <AiAssistantManagementHeader
         hideBackButton={isNewAiAssistant}
-        label={t(isNewAiAssistant ? 'modal_ai_assistant.header.add_new_assistant' : 'modal_ai_assistant.header.update_assistant')}
+        labelTranslationKey={isNewAiAssistant ? 'modal_ai_assistant.header.add_new_assistant' : 'modal_ai_assistant.header.update_assistant'}
       />
 
       <ModalBody className="px-4">

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementPageSelectionMethod.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementPageSelectionMethod.tsx
@@ -5,6 +5,7 @@ import {
 } from 'reactstrap';
 
 import { AiAssistantManagementHeader } from './AiAssistantManagementHeader';
+import { useAiAssistantManagementModal  } from '../../../stores/ai-assistant';
 
 
 const SelectionButton = (props: { icon: string, label: string, onClick: () => void }): JSX.Element => {
@@ -33,9 +34,12 @@ const SelectionButton = (props: { icon: string, label: string, onClick: () => vo
 
 
 export const AiAssistantManagementPageSelectionMethod = (): JSX.Element => {
+  const { data: aiAssistantManagementModalData } = useAiAssistantManagementModal();
+  const isNewAiAssistant  = aiAssistantManagementModalData?.aiAssistantData == null;
+
   return (
     <>
-      <AiAssistantManagementHeader hideBackButton/>
+      <AiAssistantManagementHeader hideBackButton={isNewAiAssistant} />
 
       <ModalBody className="px-4">
         <h4 className="text-center mb-4">

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementPageSelectionMethod.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementPageSelectionMethod.tsx
@@ -4,6 +4,7 @@ import {
   ModalBody,
 } from 'reactstrap';
 
+import { useTranslation } from 'react-i18next';
 import { AiAssistantManagementHeader } from './AiAssistantManagementHeader';
 import { useAiAssistantManagementModal  } from '../../../stores/ai-assistant';
 
@@ -34,12 +35,16 @@ const SelectionButton = (props: { icon: string, label: string, onClick: () => vo
 
 
 export const AiAssistantManagementPageSelectionMethod = (): JSX.Element => {
+  const { t } = useTranslation();
   const { data: aiAssistantManagementModalData } = useAiAssistantManagementModal();
   const isNewAiAssistant  = aiAssistantManagementModalData?.aiAssistantData == null;
 
   return (
     <>
-      <AiAssistantManagementHeader hideBackButton={isNewAiAssistant} />
+      <AiAssistantManagementHeader
+        hideBackButton={isNewAiAssistant}
+        label={t(isNewAiAssistant ? 'modal_ai_assistant.header.add_new_assistant' : 'modal_ai_assistant.header.update_assistant')}
+      />
 
       <ModalBody className="px-4">
         <h4 className="text-center mb-4">
@@ -52,7 +57,6 @@ export const AiAssistantManagementPageSelectionMethod = (): JSX.Element => {
 
           <div className="col-auto">
             <SelectionButton icon="account_tree" label="ページツリーから選択" onClick={() => {}} />
-
           </div>
         </div>
       </ModalBody>

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementPageSelectionMethod.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementPageSelectionMethod.tsx
@@ -1,12 +1,13 @@
 import React, { useState } from 'react';
 
+import { useTranslation } from 'react-i18next';
 import {
   ModalBody,
 } from 'reactstrap';
 
-import { useTranslation } from 'react-i18next';
+import { useAiAssistantManagementModal } from '../../../stores/ai-assistant';
+
 import { AiAssistantManagementHeader } from './AiAssistantManagementHeader';
-import { useAiAssistantManagementModal  } from '../../../stores/ai-assistant';
 
 
 const SelectionButton = (props: { icon: string, label: string, onClick: () => void }): JSX.Element => {
@@ -37,7 +38,7 @@ const SelectionButton = (props: { icon: string, label: string, onClick: () => vo
 export const AiAssistantManagementPageSelectionMethod = (): JSX.Element => {
   const { t } = useTranslation();
   const { data: aiAssistantManagementModalData } = useAiAssistantManagementModal();
-  const isNewAiAssistant  = aiAssistantManagementModalData?.aiAssistantData == null;
+  const isNewAiAssistant = aiAssistantManagementModalData?.aiAssistantData == null;
 
   return (
     <>

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementPageSelectionMethod.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementPageSelectionMethod.tsx
@@ -1,0 +1,61 @@
+import React, { useState } from 'react';
+
+import {
+  ModalBody,
+} from 'reactstrap';
+
+import { AiAssistantManagementHeader } from './AiAssistantManagementHeader';
+
+
+const SelectionButton = (props: { icon: string, label: string, onClick: () => void }): JSX.Element => {
+  const { icon, label, onClick } = props;
+  const [isHovered, setIsHovered] = useState(false);
+
+  return (
+    <button
+      type="button"
+      className={`btn p-4 text-center ${isHovered ? 'btn-outline-primary' : 'btn-outline-secondary'}`}
+      style={{ width: '280px' }}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+      onClick={onClick}
+    >
+      <span
+        className="material-symbols-outlined d-block mb-3"
+        style={{ fontSize: '48px' }}
+      >
+        {icon}
+      </span>
+      <div>{label}</div>
+    </button>
+  );
+};
+
+
+type Props = {
+  //
+}
+
+export const AiAssistantManagementPageSelectionMethod = (props: Props): JSX.Element => {
+  return (
+    <>
+      <AiAssistantManagementHeader />
+
+      <ModalBody className="px-4">
+        <h4 className="text-center mb-4">
+          アシスタントの学習元にするページを選択します
+        </h4>
+        <div className="row justify-content-center">
+          <div className="col-auto">
+            <SelectionButton icon="manage_search" label="キーワードで検索" onClick={() => {}} />
+          </div>
+
+          <div className="col-auto">
+            <SelectionButton icon="account_tree" label="ページツリーから選択" onClick={() => {}} />
+
+          </div>
+        </div>
+      </ModalBody>
+    </>
+  );
+};

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementPageSelectionMethod.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementPageSelectionMethod.tsx
@@ -32,11 +32,7 @@ const SelectionButton = (props: { icon: string, label: string, onClick: () => vo
 };
 
 
-type Props = {
-  //
-}
-
-export const AiAssistantManagementPageSelectionMethod = (props: Props): JSX.Element => {
+export const AiAssistantManagementPageSelectionMethod = (): JSX.Element => {
   return (
     <>
       <AiAssistantManagementHeader />

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementPageSelectionMethod.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementPageSelectionMethod.tsx
@@ -48,15 +48,15 @@ export const AiAssistantManagementPageSelectionMethod = (): JSX.Element => {
 
       <ModalBody className="px-4">
         <h4 className="text-center mb-4">
-          アシスタントの学習元にするページを選択します
+          {t('modal_ai_assistant.select_source_pages')}
         </h4>
         <div className="row justify-content-center">
           <div className="col-auto">
-            <SelectionButton icon="manage_search" label="キーワードで検索" onClick={() => {}} />
+            <SelectionButton icon="manage_search" label={t('modal_ai_assistant.search_by_keyword')} onClick={() => {}} />
           </div>
 
           <div className="col-auto">
-            <SelectionButton icon="account_tree" label="ページツリーから選択" onClick={() => {}} />
+            <SelectionButton icon="account_tree" label={t('modal_ai_assistant.select_from_page_tree')} onClick={() => {}} />
           </div>
         </div>
       </ModalBody>

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementPageSelectionMethod.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementPageSelectionMethod.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 
 import { useTranslation } from 'react-i18next';
 import {
@@ -9,23 +9,21 @@ import { useAiAssistantManagementModal } from '../../../stores/ai-assistant';
 
 import { AiAssistantManagementHeader } from './AiAssistantManagementHeader';
 
+import styles from './AiAssistantManagementPageSelectionMethod.module.scss';
+
+const moduleClass = styles['grw-ai-assistant-management-page-selection-method'] ?? '';
 
 const SelectionButton = (props: { icon: string, label: string, onClick: () => void }): JSX.Element => {
   const { icon, label, onClick } = props;
-  const [isHovered, setIsHovered] = useState(false);
 
   return (
     <button
       type="button"
-      className={`btn p-4 text-center ${isHovered ? 'btn-outline-primary' : 'btn-outline-secondary'}`}
-      style={{ width: '280px' }}
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
+      className="btn p-4 text-center page-selection-method-btn"
       onClick={onClick}
     >
       <span
-        className="material-symbols-outlined d-block mb-3"
-        style={{ fontSize: '48px' }}
+        className="material-symbols-outlined d-block mb-3 fs-1"
       >
         {icon}
       </span>
@@ -41,7 +39,7 @@ export const AiAssistantManagementPageSelectionMethod = (): JSX.Element => {
   const isNewAiAssistant = aiAssistantManagementModalData?.aiAssistantData == null;
 
   return (
-    <>
+    <div className={moduleClass}>
       <AiAssistantManagementHeader
         hideBackButton={isNewAiAssistant}
         labelTranslationKey={isNewAiAssistant ? 'modal_ai_assistant.header.add_new_assistant' : 'modal_ai_assistant.header.update_assistant'}
@@ -61,6 +59,6 @@ export const AiAssistantManagementPageSelectionMethod = (): JSX.Element => {
           </div>
         </div>
       </ModalBody>
-    </>
+    </div>
   );
 };

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementPageSelectionMethod.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementPageSelectionMethod.tsx
@@ -35,7 +35,7 @@ const SelectionButton = (props: { icon: string, label: string, onClick: () => vo
 export const AiAssistantManagementPageSelectionMethod = (): JSX.Element => {
   return (
     <>
-      <AiAssistantManagementHeader />
+      <AiAssistantManagementHeader hideBackButton/>
 
       <ModalBody className="px-4">
         <h4 className="text-center mb-4">

--- a/apps/app/src/features/openai/client/stores/ai-assistant.tsx
+++ b/apps/app/src/features/openai/client/stores/ai-assistant.tsx
@@ -9,6 +9,10 @@ import { apiv3Get } from '~/client/util/apiv3-client';
 import { type AccessibleAiAssistantsHasId, type AiAssistantHasId } from '../../interfaces/ai-assistant';
 import type { IThreadRelationHasId } from '../../interfaces/thread-relation'; // IThreadHasId を削除
 
+
+/*
+*  useAiAssistantManagementModal
+*/
 export const AiAssistantManagementModalPageMode = {
   HOME: 'home',
   SHARE: 'share',
@@ -34,7 +38,7 @@ type AiAssistantManagementModalUtils = {
 export const useAiAssistantManagementModal = (
     status?: AiAssistantManagementModalStatus,
 ): SWRResponse<AiAssistantManagementModalStatus, Error> & AiAssistantManagementModalUtils => {
-  const initialStatus = { isOpened: false, pageType: AiAssistantManagementModalPageMode.PAGES };
+  const initialStatus = { isOpened: false, pageType: AiAssistantManagementModalPageMode.HOME };
   const swrResponse = useSWRStatic<AiAssistantManagementModalStatus, Error>('AiAssistantManagementModal', status, { fallbackData: initialStatus });
 
   return {

--- a/apps/app/src/features/openai/client/stores/ai-assistant.tsx
+++ b/apps/app/src/features/openai/client/stores/ai-assistant.tsx
@@ -17,7 +17,7 @@ export const AiAssistantManagementModalPageMode = {
   PAGE_SELECTION_METHOD: 'page-selection-method',
 } as const;
 
-type AiAssistantManagementModalPageMode = typeof AiAssistantManagementModalPageMode[keyof typeof AiAssistantManagementModalPageMode];
+export type AiAssistantManagementModalPageMode = typeof AiAssistantManagementModalPageMode[keyof typeof AiAssistantManagementModalPageMode];
 
 type AiAssistantManagementModalStatus = {
   isOpened: boolean,

--- a/apps/app/src/features/openai/client/stores/ai-assistant.tsx
+++ b/apps/app/src/features/openai/client/stores/ai-assistant.tsx
@@ -14,6 +14,7 @@ export const AiAssistantManagementModalPageMode = {
   SHARE: 'share',
   PAGES: 'pages',
   INSTRUCTION: 'instruction',
+  PAGE_SELECTION_METHOD: 'page-selection-method',
 } as const;
 
 type AiAssistantManagementModalPageMode = typeof AiAssistantManagementModalPageMode[keyof typeof AiAssistantManagementModalPageMode];
@@ -33,12 +34,20 @@ type AiAssistantManagementModalUtils = {
 export const useAiAssistantManagementModal = (
     status?: AiAssistantManagementModalStatus,
 ): SWRResponse<AiAssistantManagementModalStatus, Error> & AiAssistantManagementModalUtils => {
-  const initialStatus = { isOpened: false, pageType: AiAssistantManagementModalPageMode.HOME };
+  const initialStatus = { isOpened: false, pageType: AiAssistantManagementModalPageMode.PAGES };
   const swrResponse = useSWRStatic<AiAssistantManagementModalStatus, Error>('AiAssistantManagementModal', status, { fallbackData: initialStatus });
 
   return {
     ...swrResponse,
-    open: useCallback((aiAssistantData) => { swrResponse.mutate({ isOpened: true, aiAssistantData }) }, [swrResponse]),
+    open: useCallback((aiAssistantData) => {
+      swrResponse.mutate({
+        isOpened: true,
+        aiAssistantData,
+        pageMode: aiAssistantData != null
+          ? AiAssistantManagementModalPageMode.HOME
+          : AiAssistantManagementModalPageMode.PAGE_SELECTION_METHOD,
+      });
+    }, [swrResponse]),
     close: useCallback(() => swrResponse.mutate({ isOpened: false, aiAssistantData: undefined }), [swrResponse]),
     changePageMode: useCallback((pageMode: AiAssistantManagementModalPageMode) => {
       swrResponse.mutate({ isOpened: swrResponse.data?.isOpened ?? false, pageMode, aiAssistantData: swrResponse.data?.aiAssistantData });


### PR DESCRIPTION
## Task
- [#163538](https://redmine.weseek.co.jp/issues/163538) [GROWI AI Next] アシスタント作成ウィザードを利用できる
  - [#169233](https://redmine.weseek.co.jp/issues/169233) アシスタント追加ボタンクリック時に「キーワードで検索」or「ページツリーから選択」を選択するモーダルの実装

## Figma
<img width="566" height="281" alt="スクリーンショット 2025-07-23 18 10 13" src="https://github.com/user-attachments/assets/e8e12b4d-1e03-4a69-87cd-b97768f9b90b" />

https://www.figma.com/design/ZiEcjZ8sYt6YvowboA5Um6/GROWI-v7?node-id=4468-3926&t=PRuMGgSnhJ9RMuTW-0

## ScreenRecord
https://github.com/user-attachments/assets/94570502-138b-4e27-9b20-d50fa8dabb1b


