### PR TITLE
fix: Puppeteer not launching in pdf-converter

### DIFF
--- a/apps/app/src/features/page-bulk-export/server/service/page-bulk-export-job-cron/steps/export-pages-to-fs-async.ts
+++ b/apps/app/src/features/page-bulk-export/server/service/page-bulk-export-job-cron/steps/export-pages-to-fs-async.ts
@@ -39,6 +39,7 @@ async function getPageWritable(this: IPageBulkExportJobCronService, pageBulkExpo
   // define before the stream starts to avoid creating multiple instances
   const htmlConverter = unified()
     .use(remarkParse)
+    // !!! DO NOT DISABLE HTML ESCAPING WHILE --no-sandbox IS PASSED TO PUPPETEER INSIDE pdf-converter !!!
     .use(remarkHtml);
   return new Writable({
     objectMode: true,

--- a/apps/pdf-converter/src/service/pdf-convert.ts
+++ b/apps/pdf-converter/src/service/pdf-convert.ts
@@ -285,6 +285,9 @@ class PdfConvertService implements OnInit {
       concurrency: Cluster.CONCURRENCY_PAGE,
       maxConcurrency: this.maxConcurrency,
       workerCreationDelay: 10000,
+      puppeteerOptions: {
+        args: ['--no-sandbox'],
+      },
     });
 
     await this.puppeteerCluster.task(async ({ page, data: htmlString }) => {

--- a/apps/pdf-converter/src/service/pdf-convert.ts
+++ b/apps/pdf-converter/src/service/pdf-convert.ts
@@ -286,6 +286,7 @@ class PdfConvertService implements OnInit {
       maxConcurrency: this.maxConcurrency,
       workerCreationDelay: 10000,
       puppeteerOptions: {
+        // c.f) https://github.com/weseek/growi/pull/10192
         args: ['--no-sandbox'],
       },
     });

--- a/apps/pdf-converter/src/service/pdf-convert.ts
+++ b/apps/pdf-converter/src/service/pdf-convert.ts
@@ -286,7 +286,7 @@ class PdfConvertService implements OnInit {
       maxConcurrency: this.maxConcurrency,
       workerCreationDelay: 10000,
       puppeteerOptions: {
-        // c.f) https://github.com/weseek/growi/pull/10192
+        // ref) https://github.com/weseek/growi/pull/10192
         args: ['--no-sandbox'],
       },
     });


### PR DESCRIPTION
## What
puppeteer が起動できない問題を解消する。

## Why
puppeteer を起動しようとすると、以下のエラーが生じる。
```
Error: Unable to launch browser, error message: Failed to launch the browser process! undefined
[12442:12442:0725/160442.482308:ERROR:zygote_host_impl_linux.cc(127)] No usable sandbox! If this is a Debian system, please install the chromium-sandbox package to solve this problem. If you want to live dangerously and need an immediate workaround, you can try using --no-sandbox.
```
エラー分通りに chromium-sandbox を入れると、今度は以下のエラーが生じる。
```
Failed to move to new namespace: PID namespaces supported, Network namespace supported, but failed: errno = Operation not permitted
[5076:5076:0725/161735.264977:FATAL:zygote_host_impl_linux.cc(200)] Check failed: . : Operation not permitted (1)
[0725/161735.285466:ERROR:file_io_posix.cc(145)] open /sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq: No such file or directory (2)
[0725/161735.285546:ERROR:file_io_posix.cc(145)] open /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq: No such file or directory (2)
```
これは docker コンテナのデフォルトの設定では sandbox 環境を作成するために必要なシステムコール (clone, setns, unshare) が [admin に限定されているため](https://github.com/moby/moby/blob/7dc46c6e0c727a746ecfb8427c0c3cbd998059bc/vendor/github.com/moby/profiles/seccomp/default.json#L635)。

## 解決方法一覧
1. コンテナ内で sandbox を作成するために必要なシステムコール (clone, setns, unshare) を admin 以外も使用できるように上書きを行う
    - [playwright 公式が行なっている方法](https://playwright.dev/docs/docker#crawling-and-scraping)
    - 上書きする場合、今回とは関係無い他のシステムコールの設定もこちらで管理する必要が出てくるため、難易度が高い
2. cap_add: SYS_ADMIN を付与して起動する
    - [puppeteer 公式が行なっている方法](https://pptr.dev/guides/docker#usage)
    - コンテナに admin 権限を付与してしまうため、かなり危険
3. chromium を --no-sandbox フラグで使用する
    - 今回はこちらを採用

## --no-sandbox を採用した理由
### chromium の sandbox の用途
前提として、chromium 自体様々なセキュリティ対策がされている。その前提があった上で、chromium の実装は複雑すぎるため、任意のウェブページを開く場合に信用できず、sandbox 内で開くことが[強く推奨されている](https://pptr.dev/troubleshooting#setting-up-chrome-linux-sandbox)。
参考) https://chromium.googlesource.com/chromium/src/+/master/docs/design/sandbox.md

### 採用理由
今回の pdf-converter のユースケースで、「攻撃者は pdf-converter へのアクセス権限は無く、攻撃経路は GROWI からの pdf エクスポートリクエストに限定される」とした場合、chromium で開かられるのは「任意のウェブページ」ではなく、以下の手順で作成された HTML ファイルとなる。
1. GROWI のページ作成機能からユーザが任意の md を作成 (HTML の記述含む)
2. [remark-html によって md から HTML への変換処理がされる](https://github.com/weseek/growi/blob/54baeaaaa919c5a54395ddb15e3981a25cf1f96a/apps/app/src/features/page-bulk-export/server/service/page-bulk-export-job-cron/steps/export-pages-to-fs-async.ts#L40-L42)
    - この時、md 内の HTML はエスケープされる (PDF 上は元の char で表示される)
        - 詳細) https://github.com/syntax-tree/hast-util-to-html?tab=readme-ov-file#options の sanitize と toHtmlOptions
    - 例) `&#x3C;object data="file:///etc/passwd" type="text/plain" width="500" height="200">Password file content&#x3C;/object>`

chromium のセキュリティ対策と上記エスケープ処理によって、no-sandbox でも攻撃が成功する可能性は十分低いと判断。

## task
https://redmine.weseek.co.jp/issues/169461