### PR TITLE
feat(ai): Implementation of keyword search modal

### DIFF
--- a/apps/app/public/static/locales/en_US/translation.json
+++ b/apps/app/public/static/locales/en_US/translation.json
@@ -572,6 +572,7 @@
       "update_failed": "Failed to update assistant"
     },
     "select_source_pages": "Select pages for the assistant to reference",
+    "search_reference_pages_by_keyword": "Search for pages the assistant will reference by keyword",
     "search_by_keyword": "Search by keyword",
     "select_from_page_tree": "Select from page tree",
     "edit_page_description": "Edit pages that the assistant can reference.<br> The assistant can reference up to {{limitLearnablePageCountPerAssistant}} pages including child pages.",

--- a/apps/app/public/static/locales/en_US/translation.json
+++ b/apps/app/public/static/locales/en_US/translation.json
@@ -575,6 +575,7 @@
     "search_reference_pages_by_keyword": "Search for pages the assistant will reference by keyword",
     "search_by_keyword": "Search by keyword",
     "enter_keywords": "Enter keywords",
+    "max_items_space_separated_hint": "Enter up to 5 items separated by spaces",
     "select_from_page_tree": "Select from page tree",
     "edit_page_description": "Edit pages that the assistant can reference.<br> The assistant can reference up to {{limitLearnablePageCountPerAssistant}} pages including child pages.",
     "default_instruction": "You are the knowledge assistant for this Wiki.\n\n## Multilingual Support:\nRespond in the same language the user uses in their input.\n",

--- a/apps/app/public/static/locales/en_US/translation.json
+++ b/apps/app/public/static/locales/en_US/translation.json
@@ -574,6 +574,7 @@
     "select_source_pages": "Select pages for the assistant to reference",
     "search_reference_pages_by_keyword": "Search for pages the assistant will reference by keyword",
     "search_by_keyword": "Search by keyword",
+    "enter_keywords": "Enter keywords",
     "select_from_page_tree": "Select from page tree",
     "edit_page_description": "Edit pages that the assistant can reference.<br> The assistant can reference up to {{limitLearnablePageCountPerAssistant}} pages including child pages.",
     "default_instruction": "You are the knowledge assistant for this Wiki.\n\n## Multilingual Support:\nRespond in the same language the user uses in their input.\n",

--- a/apps/app/public/static/locales/fr_FR/translation.json
+++ b/apps/app/public/static/locales/fr_FR/translation.json
@@ -568,6 +568,7 @@
     "select_source_pages": "Sélectionnez les pages que l'assistant doit référencer",
     "search_reference_pages_by_keyword": "Rechercher les pages de référence de l'assistant par mot-clé",
     "search_by_keyword": "Rechercher par mot-clé",
+    "enter_keywords": "Entrer des mots-clés",
     "select_from_page_tree": "Sélectionner depuis l'arborescence des pages",
     "edit_page_description": "Modifier les pages que l'assistant peut référencer.<br> L'assistant peut référencer jusqu'à {{limitLearnablePageCountPerAssistant}} pages, y compris les pages enfants.",
     "default_instruction": "Vous êtes l'assistant de connaissances pour ce Wiki.\n\n## Support multilingue :\nRépondez dans la même langue que celle utilisée par l'utilisateur dans sa requête.\n",

--- a/apps/app/public/static/locales/fr_FR/translation.json
+++ b/apps/app/public/static/locales/fr_FR/translation.json
@@ -568,6 +568,7 @@
     "select_source_pages": "Sélectionnez les pages que l'assistant doit référencer",
     "search_reference_pages_by_keyword": "Rechercher les pages de référence de l'assistant par mot-clé",
     "search_by_keyword": "Rechercher par mot-clé",
+    "max_items_space_separated_hint": "Saisissez jusqu'à 5 éléments séparés par des espaces",
     "enter_keywords": "Entrer des mots-clés",
     "select_from_page_tree": "Sélectionner depuis l'arborescence des pages",
     "edit_page_description": "Modifier les pages que l'assistant peut référencer.<br> L'assistant peut référencer jusqu'à {{limitLearnablePageCountPerAssistant}} pages, y compris les pages enfants.",

--- a/apps/app/public/static/locales/fr_FR/translation.json
+++ b/apps/app/public/static/locales/fr_FR/translation.json
@@ -566,6 +566,7 @@
       "update_failed": "Échec de la mise à jour de l'assistant"
     },
     "select_source_pages": "Sélectionnez les pages que l'assistant doit référencer",
+    "search_reference_pages_by_keyword": "Rechercher les pages de référence de l'assistant par mot-clé",
     "search_by_keyword": "Rechercher par mot-clé",
     "select_from_page_tree": "Sélectionner depuis l'arborescence des pages",
     "edit_page_description": "Modifier les pages que l'assistant peut référencer.<br> L'assistant peut référencer jusqu'à {{limitLearnablePageCountPerAssistant}} pages, y compris les pages enfants.",

--- a/apps/app/public/static/locales/ja_JP/translation.json
+++ b/apps/app/public/static/locales/ja_JP/translation.json
@@ -605,6 +605,7 @@
       "update_failed": "アシスタントの更新に失敗しました"
     },
     "select_source_pages": "アシスタントが参照するページを選択します",
+    "search_reference_pages_by_keyword": "アシスタントが参照するページをキーワードで検索",
     "search_by_keyword": "キーワードで検索",
     "select_from_page_tree": "ページツリーから選択",
     "edit_page_description": " アシスタントが参照するページを編集します。<br> 参照できるページは配下ページも含めて {{limitLearnablePageCountPerAssistant}} ページまでです。",

--- a/apps/app/public/static/locales/ja_JP/translation.json
+++ b/apps/app/public/static/locales/ja_JP/translation.json
@@ -607,6 +607,7 @@
     "select_source_pages": "アシスタントが参照するページを選択します",
     "search_reference_pages_by_keyword": "アシスタントが参照するページをキーワードで検索",
     "search_by_keyword": "キーワードで検索",
+    "enter_keywords": "キーワードを入力",
     "select_from_page_tree": "ページツリーから選択",
     "edit_page_description": " アシスタントが参照するページを編集します。<br> 参照できるページは配下ページも含めて {{limitLearnablePageCountPerAssistant}} ページまでです。",
     "default_instruction": "あなたはこのWikiの知識アシスタントです。\n\n## 多言語サポート:\nユーザーが入力で使用した言語と同じ言語で応答してください。\n",

--- a/apps/app/public/static/locales/ja_JP/translation.json
+++ b/apps/app/public/static/locales/ja_JP/translation.json
@@ -608,6 +608,7 @@
     "search_reference_pages_by_keyword": "アシスタントが参照するページをキーワードで検索",
     "search_by_keyword": "キーワードで検索",
     "enter_keywords": "キーワードを入力",
+    "max_items_space_separated_hint": "スペース区切りで最大5つまで入力できます",
     "select_from_page_tree": "ページツリーから選択",
     "edit_page_description": " アシスタントが参照するページを編集します。<br> 参照できるページは配下ページも含めて {{limitLearnablePageCountPerAssistant}} ページまでです。",
     "default_instruction": "あなたはこのWikiの知識アシスタントです。\n\n## 多言語サポート:\nユーザーが入力で使用した言語と同じ言語で応答してください。\n",

--- a/apps/app/public/static/locales/zh_CN/translation.json
+++ b/apps/app/public/static/locales/zh_CN/translation.json
@@ -564,6 +564,7 @@
     "select_source_pages": "选择助手要参考的页面",
     "search_reference_pages_by_keyword": "按关键词搜索助手参考的页面",
     "search_by_keyword": "按关键词搜索",
+    "enter_keywords": "输入关键词",
     "select_from_page_tree": "从页面树选择",
     "edit_page_description": "编辑助手可以参考的页面。<br> 助手可以参考最多 {{limitLearnablePageCountPerAssistant}} 个页面，包括子页面。",
     "default_instruction": "您是这个Wiki的知识助手。\n\n## 多语言支持：\n请使用用户输入中使用的相同语言进行回复。\n",

--- a/apps/app/public/static/locales/zh_CN/translation.json
+++ b/apps/app/public/static/locales/zh_CN/translation.json
@@ -564,6 +564,7 @@
     "select_source_pages": "选择助手要参考的页面",
     "search_reference_pages_by_keyword": "按关键词搜索助手参考的页面",
     "search_by_keyword": "按关键词搜索",
+    "max_items_space_separated_hint": "请输入最多5个项目，用空格分隔",
     "enter_keywords": "输入关键词",
     "select_from_page_tree": "从页面树选择",
     "edit_page_description": "编辑助手可以参考的页面。<br> 助手可以参考最多 {{limitLearnablePageCountPerAssistant}} 个页面，包括子页面。",

--- a/apps/app/public/static/locales/zh_CN/translation.json
+++ b/apps/app/public/static/locales/zh_CN/translation.json
@@ -562,6 +562,7 @@
       "update_failed": "更新助手失败"
     },
     "select_source_pages": "选择助手要参考的页面",
+    "search_reference_pages_by_keyword": "按关键词搜索助手参考的页面",
     "search_by_keyword": "按关键词搜索",
     "select_from_page_tree": "从页面树选择",
     "edit_page_description": "编辑助手可以参考的页面。<br> 助手可以参考最多 {{limitLearnablePageCountPerAssistant}} 个页面，包括子页面。",

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementKeywordSearch.module.scss
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementKeywordSearch.module.scss
@@ -1,0 +1,23 @@
+@use '@growi/core-styles/scss/variables/growi-official-colors';
+@use '@growi/core-styles/scss/bootstrap/init' as bs;
+@use '~/styles/variables' as var;
+
+
+.grw-ai-assistant-keyword-search :global {
+  .rbt {
+    .rbt-input-multi {
+      border: none;
+      border-bottom: 3px solid bs.$gray-200;
+      border-radius: 0;
+
+      &.focus {
+        border-color: var(--grw-primary-500);
+        box-shadow: none;
+      }
+    }
+
+    .rbt-menu {
+       display: none !important;
+    }
+  }
+}

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementKeywordSearch.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementKeywordSearch.tsx
@@ -1,8 +1,8 @@
-import type { KeyboardEvent } from 'react';
-import React, { useRef, useCallback } from 'react';
+import React, {
+  useRef, useCallback, type KeyboardEvent,
+} from 'react';
 
-import type { TypeaheadRef } from 'react-bootstrap-typeahead';
-import { Typeahead } from 'react-bootstrap-typeahead';
+import { type TypeaheadRef, Typeahead } from 'react-bootstrap-typeahead';
 import { useTranslation } from 'react-i18next';
 import {
   ModalBody,

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementKeywordSearch.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementKeywordSearch.tsx
@@ -1,5 +1,5 @@
 import React, {
-  useRef, useCallback, type KeyboardEvent,
+  useRef, useCallback, useState, type KeyboardEvent,
 } from 'react';
 
 import { type TypeaheadRef, Typeahead } from 'react-bootstrap-typeahead';
@@ -18,12 +18,23 @@ import styles from './AiAssistantManagementKeywordSearch.module.scss';
 
 const moduleClass = styles['grw-ai-assistant-keyword-search'] ?? '';
 
+type SelectedSearchKeyword = {
+  id: string
+  label: string
+}
+
 export const AiAssistantKeywordSearch = (): JSX.Element => {
   const { t } = useTranslation();
   const { data: aiAssistantManagementModalData } = useAiAssistantManagementModal();
   const isNewAiAssistant = aiAssistantManagementModalData?.aiAssistantData == null;
 
+  const [selectedSearchKeywords, setSelectedSearchKeywords] = useState<Array<SelectedSearchKeyword>>([]);
+
   const typeaheadRef = useRef<TypeaheadRef>(null);
+
+  const changeHandler = useCallback((selected: Array<SelectedSearchKeyword>) => {
+    setSelectedSearchKeywords(selected);
+  }, []);
 
   const keyDownHandler = useCallback((event: KeyboardEvent<HTMLElement>) => {
     if (event.code === 'Space') {
@@ -62,9 +73,11 @@ export const AiAssistantKeywordSearch = (): JSX.Element => {
           allowNew
           multiple
           options={[]}
+          selected={selectedSearchKeywords}
           placeholder={t('modal_ai_assistant.enter_keywords')}
           id="ai-assistant-keyword-search"
           ref={typeaheadRef}
+          onChange={changeHandler}
           onKeyDown={keyDownHandler}
         />
 

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementKeywordSearch.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementKeywordSearch.tsx
@@ -1,4 +1,5 @@
 
+import { useTranslation } from 'react-i18next';
 import {
   ModalBody,
 } from 'reactstrap';
@@ -11,6 +12,7 @@ import { AiAssistantManagementHeader } from './AiAssistantManagementHeader';
 
 
 export const AiAssistantKeywordSearch = (): JSX.Element => {
+  const { t } = useTranslation();
   const { data: aiAssistantManagementModalData } = useAiAssistantManagementModal();
   const isNewAiAssistant = aiAssistantManagementModalData?.aiAssistantData == null;
 
@@ -23,6 +25,9 @@ export const AiAssistantKeywordSearch = (): JSX.Element => {
       />
 
       <ModalBody className="px-4">
+        <h4 className="text-center mb-4 fw-bold">
+          {t('modal_ai_assistant.search_reference_pages_by_keyword')}
+        </h4>
       </ModalBody>
     </>
   );

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementKeywordSearch.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementKeywordSearch.tsx
@@ -1,4 +1,8 @@
+import type { KeyboardEvent } from 'react';
+import React, { useRef, useCallback } from 'react';
 
+import type { TypeaheadRef } from 'react-bootstrap-typeahead';
+import { Typeahead } from 'react-bootstrap-typeahead';
 import { useTranslation } from 'react-i18next';
 import {
   ModalBody,
@@ -10,14 +14,39 @@ import {
 
 import { AiAssistantManagementHeader } from './AiAssistantManagementHeader';
 
+import styles from './AiAssistantManagementKeywordSearch.module.scss';
+
+const moduleClass = styles['grw-ai-assistant-keyword-search'] ?? '';
 
 export const AiAssistantKeywordSearch = (): JSX.Element => {
   const { t } = useTranslation();
   const { data: aiAssistantManagementModalData } = useAiAssistantManagementModal();
   const isNewAiAssistant = aiAssistantManagementModalData?.aiAssistantData == null;
 
+  const typeaheadRef = useRef<TypeaheadRef>(null);
+
+  const keyDownHandler = useCallback((event: KeyboardEvent<HTMLElement>) => {
+    if (event.code === 'Space') {
+      event.preventDefault();
+
+      // fix: https://redmine.weseek.co.jp/issues/140689
+      // "event.isComposing" is not supported
+      const isComposing = event.nativeEvent.isComposing;
+      if (isComposing) {
+        return;
+      }
+
+      const initialItem = typeaheadRef?.current?.state?.initialItem;
+      const handleMenuItemSelect = typeaheadRef?.current?._handleMenuItemSelect;
+
+      if (initialItem != null && handleMenuItemSelect != null) {
+        handleMenuItemSelect(initialItem, event);
+      }
+    }
+  }, []);
+
   return (
-    <>
+    <div className={moduleClass}>
       <AiAssistantManagementHeader
         backButtonColor="secondary"
         backToPageMode={AiAssistantManagementModalPageMode.PAGE_SELECTION_METHOD}
@@ -28,7 +57,18 @@ export const AiAssistantKeywordSearch = (): JSX.Element => {
         <h4 className="text-center mb-4 fw-bold">
           {t('modal_ai_assistant.search_reference_pages_by_keyword')}
         </h4>
+
+        <Typeahead
+          allowNew
+          multiple
+          options={[]}
+          placeholder="キーワードを入力"
+          id="ai-assistant-keyword-search"
+          ref={typeaheadRef}
+          onKeyDown={keyDownHandler}
+          isLoading={false}
+        />
       </ModalBody>
-    </>
+    </div>
   );
 };

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementKeywordSearch.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementKeywordSearch.tsx
@@ -62,7 +62,7 @@ export const AiAssistantKeywordSearch = (): JSX.Element => {
           allowNew
           multiple
           options={[]}
-          placeholder="キーワードを入力"
+          placeholder={t('modal_ai_assistant.enter_keywords')}
           id="ai-assistant-keyword-search"
           ref={typeaheadRef}
           onKeyDown={keyDownHandler}

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementKeywordSearch.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementKeywordSearch.tsx
@@ -1,0 +1,29 @@
+
+import {
+  ModalBody,
+} from 'reactstrap';
+
+import {
+  useAiAssistantManagementModal, AiAssistantManagementModalPageMode,
+} from '../../../stores/ai-assistant';
+
+import { AiAssistantManagementHeader } from './AiAssistantManagementHeader';
+
+
+export const AiAssistantKeywordSearch = (): JSX.Element => {
+  const { data: aiAssistantManagementModalData } = useAiAssistantManagementModal();
+  const isNewAiAssistant = aiAssistantManagementModalData?.aiAssistantData == null;
+
+  return (
+    <>
+      <AiAssistantManagementHeader
+        backButtonColor="secondary"
+        backToPageMode={AiAssistantManagementModalPageMode.PAGE_SELECTION_METHOD}
+        labelTranslationKey={isNewAiAssistant ? 'modal_ai_assistant.header.add_new_assistant' : 'modal_ai_assistant.header.update_assistant'}
+      />
+
+      <ModalBody className="px-4">
+      </ModalBody>
+    </>
+  );
+};

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementKeywordSearch.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementKeywordSearch.tsx
@@ -66,7 +66,6 @@ export const AiAssistantKeywordSearch = (): JSX.Element => {
           id="ai-assistant-keyword-search"
           ref={typeaheadRef}
           onKeyDown={keyDownHandler}
-          isLoading={false}
         />
 
         <label htmlFor="ai-assistant-keyword-search" className="form-text text-muted mt-2">

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementKeywordSearch.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementKeywordSearch.tsx
@@ -68,6 +68,10 @@ export const AiAssistantKeywordSearch = (): JSX.Element => {
           onKeyDown={keyDownHandler}
           isLoading={false}
         />
+
+        <label htmlFor="ai-assistant-keyword-search" className="form-text text-muted mt-2">
+          {t('modal_ai_assistant.max_items_space_separated_hint')}
+        </label>
       </ModalBody>
     </div>
   );

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementModal.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementModal.tsx
@@ -30,6 +30,7 @@ import { AiAssistantManagementEditInstruction } from './AiAssistantManagementEdi
 import { AiAssistantManagementEditPages } from './AiAssistantManagementEditPages';
 import { AiAssistantManagementEditShare } from './AiAssistantManagementEditShare';
 import { AiAssistantManagementHome } from './AiAssistantManagementHome';
+import { AiAssistantKeywordSearch } from './AiAssistantManagementKeywordSearch';
 import { AiAssistantManagementPageSelectionMethod } from './AiAssistantManagementPageSelectionMethod';
 
 import styles from './AiAssistantManagementModal.module.scss';
@@ -240,6 +241,14 @@ const AiAssistantManagementModalSubstance = (): JSX.Element => {
   return (
     <>
       <TabContent activeTab={pageMode}>
+        <TabPane tabId={AiAssistantManagementModalPageMode.PAGE_SELECTION_METHOD}>
+          <AiAssistantManagementPageSelectionMethod />
+        </TabPane>
+
+        <TabPane tabId={AiAssistantManagementModalPageMode.KEYWORD_SEARCH}>
+          <AiAssistantKeywordSearch />
+        </TabPane>
+
         <TabPane tabId={AiAssistantManagementModalPageMode.HOME}>
           <AiAssistantManagementHome
             shouldEdit={shouldEdit}
@@ -276,10 +285,6 @@ const AiAssistantManagementModalSubstance = (): JSX.Element => {
             onSelect={selectPageHandler}
             onRemove={removePageHandler}
           />
-        </TabPane>
-
-        <TabPane tabId={AiAssistantManagementModalPageMode.PAGE_SELECTION_METHOD}>
-          <AiAssistantManagementPageSelectionMethod />
         </TabPane>
 
         <TabPane tabId={AiAssistantManagementModalPageMode.INSTRUCTION}>

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementPageSelectionMethod.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementPageSelectionMethod.tsx
@@ -5,7 +5,7 @@ import {
   ModalBody,
 } from 'reactstrap';
 
-import { useAiAssistantManagementModal } from '../../../stores/ai-assistant';
+import { useAiAssistantManagementModal, AiAssistantManagementModalPageMode } from '../../../stores/ai-assistant';
 
 import { AiAssistantManagementHeader } from './AiAssistantManagementHeader';
 
@@ -35,7 +35,7 @@ const SelectionButton = (props: { icon: string, label: string, onClick: () => vo
 
 export const AiAssistantManagementPageSelectionMethod = (): JSX.Element => {
   const { t } = useTranslation();
-  const { data: aiAssistantManagementModalData } = useAiAssistantManagementModal();
+  const { data: aiAssistantManagementModalData, changePageMode } = useAiAssistantManagementModal();
   const isNewAiAssistant = aiAssistantManagementModalData?.aiAssistantData == null;
 
   return (
@@ -51,11 +51,18 @@ export const AiAssistantManagementPageSelectionMethod = (): JSX.Element => {
         </h4>
         <div className="row justify-content-center">
           <div className="col-auto">
-            <SelectionButton icon="manage_search" label={t('modal_ai_assistant.search_by_keyword')} onClick={() => {}} />
+            <SelectionButton
+              icon="manage_search"
+              label={t('modal_ai_assistant.search_by_keyword')}
+              onClick={() => changePageMode(AiAssistantManagementModalPageMode.KEYWORD_SEARCH)}
+            />
           </div>
-
           <div className="col-auto">
-            <SelectionButton icon="account_tree" label={t('modal_ai_assistant.select_from_page_tree')} onClick={() => {}} />
+            <SelectionButton
+              icon="account_tree"
+              label={t('modal_ai_assistant.select_from_page_tree')}
+              onClick={() => changePageMode(AiAssistantManagementModalPageMode.PAGE_TREE_SELECTION)}
+            />
           </div>
         </div>
       </ModalBody>

--- a/apps/app/src/features/openai/client/stores/ai-assistant.tsx
+++ b/apps/app/src/features/openai/client/stores/ai-assistant.tsx
@@ -19,6 +19,8 @@ export const AiAssistantManagementModalPageMode = {
   PAGES: 'pages',
   INSTRUCTION: 'instruction',
   PAGE_SELECTION_METHOD: 'page-selection-method',
+  KEYWORD_SEARCH: 'keyword-search',
+  PAGE_TREE_SELECTION: 'page-tree-selection',
 } as const;
 
 export type AiAssistantManagementModalPageMode = typeof AiAssistantManagementModalPageMode[keyof typeof AiAssistantManagementModalPageMode];


### PR DESCRIPTION
## Task
- [#163538](https://redmine.weseek.co.jp/issues/163538) [GROWI AI Next] アシスタント作成ウィザードを利用できる
  - [#169237](https://redmine.weseek.co.jp/issues/169237) キーワード検索用のモーダル実装
  - [#169597](https://redmine.weseek.co.jp/issues/169597) react-bootstrap-typeahead を導入し、検索用の input を実装

## FIgma
<img width="888" height="488" alt="スクリーンショット 2025-07-29 16 43 52" src="https://github.com/user-attachments/assets/b9badd58-b202-4743-bdf4-27bcc9379aa1" />

## ScreenRecord
https://github.com/user-attachments/assets/87fa17fe-7c4a-45f0-b2a5-12633d4a207d


