### PR TITLE
feat: Only display the action and date of an activity

### DIFF
--- a/apps/app/src/client/components/RecentActivity/ActivityListItem.tsx
+++ b/apps/app/src/client/components/RecentActivity/ActivityListItem.tsx
@@ -1,7 +1,5 @@
-import type { ActivityWithPageTarget, SupportedActivityActionType } from '~/interfaces/activity';
+import type { ActivityHasUserId, SupportedActivityActionType } from '~/interfaces/activity';
 import { ActivityLogActions } from '~/interfaces/activity';
-
-import { PageListItemS } from '../PageList/PageListItemS';
 
 export const ActivityActionTranslationMap: Record<
   SupportedActivityActionType,
@@ -23,7 +21,7 @@ const translateAction = (action: SupportedActivityActionType): string => {
 };
 
 
-export const ActivityListItem = ({ activity }: { activity: ActivityWithPageTarget }): JSX.Element => {
+export const ActivityListItem = ({ activity }: { activity: ActivityHasUserId }): JSX.Element => {
   const username = activity.user?.username;
   const action = activity.action as SupportedActivityActionType;
   const date = new Date(activity.createdAt).toLocaleString();
@@ -33,8 +31,6 @@ export const ActivityListItem = ({ activity }: { activity: ActivityWithPageTarge
       <p className="text-muted small mb-1">
         {username} {translateAction(action)} on {date}
       </p>
-
-      <PageListItemS page={activity.target} />
     </div>
   );
 };

--- a/apps/app/src/client/components/RecentActivity/RecentActivity.tsx
+++ b/apps/app/src/client/components/RecentActivity/RecentActivity.tsx
@@ -3,7 +3,7 @@ import React, {
 } from 'react';
 
 import { toastError } from '~/client/util/toastr';
-import type { IActivityHasId, ActivityWithPageTarget } from '~/interfaces/activity';
+import type { IActivityHasId, ActivityHasUserId } from '~/interfaces/activity';
 import { useSWRxRecentActivity } from '~/stores/recent-activity';
 import loggerFactory from '~/utils/logger';
 
@@ -15,14 +15,13 @@ import { ActivityListItem } from './ActivityListItem';
 const logger = loggerFactory('growi:RecentActivity');
 
 
-const hasPageTarget = (activity: IActivityHasId): activity is ActivityWithPageTarget => {
-  return activity.target != null
-        && typeof activity.target === 'object'
-        && '_id' in activity.target;
+const hasUser = (activity: IActivityHasId): activity is ActivityHasUserId => {
+  return activity.user != null
+        && typeof activity.user === 'object';
 };
 
 export const RecentActivity = (): JSX.Element => {
-  const [activities, setActivities] = useState<ActivityWithPageTarget[]>([]);
+  const [activities, setActivities] = useState<ActivityHasUserId[]>([]);
   const [activePage, setActivePage] = useState(1);
   const [limit] = useState(10);
   const [offset, setOffset] = useState(0);
@@ -45,7 +44,7 @@ export const RecentActivity = (): JSX.Element => {
 
     if (paginatedData) {
       const activitiesWithPages = paginatedData.docs
-        .filter(hasPageTarget);
+        .filter(hasUser);
 
       setActivities(activitiesWithPages);
     }

--- a/apps/app/src/interfaces/activity.ts
+++ b/apps/app/src/interfaces/activity.ts
@@ -682,8 +682,7 @@ export type IActivity = {
   snapshot?: ISnapshot;
 };
 
-export type ActivityWithPageTarget = IActivityHasId & {
-  target: IPageHasId;
+export type ActivityHasUserId = IActivityHasId & {
   user: IUserHasId;
 };
 


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/171499
┗ https://redmine.weseek.co.jp/issues/173165

- Remove the the title and link to the target page of an activity
- Only display the action type and date.

<img width="631" height="370" alt="activity-log" src="https://github.com/user-attachments/assets/36113592-9b0c-462e-b38f-c89876d89ddc" />
