### PR TITLE
fix: PDF-converter major/minor tags not updated on release

### DIFF
--- a/.github/workflows/release-pdf-converter.yml
+++ b/.github/workflows/release-pdf-converter.yml
@@ -28,7 +28,9 @@ jobs:
         images: growilabs/pdf-converter
         tags: |
           type=raw,value=latest
-          type=raw,value=${{ steps.package-json.outputs.packageVersion }}
+          type=semver,value=${{ steps.package-json.outputs.packageVersion }},pattern={{major}}
+          type=semver,value=${{ steps.package-json.outputs.packageVersion }},pattern={{major}}.{{minor}}
+          type=semver,value=${{ steps.package-json.outputs.packageVersion }},pattern={{major}}.{{minor}}.{{patch}}
 
     - name: Login to docker.io registry
       run: |


### PR DESCRIPTION
## What
pdf-converter のメジャー/マイナー image タグがリリース時に更新されていない事象を修正。

## task
https://redmine.weseek.co.jp/issues/173730