### PR TITLE
feat: add check-audit-log-bulk-export-job-in-progress-cron

### DIFF
--- a/apps/app/src/features/audit-log-bulk-export/server/service/check-audit-log-bulk-export-job-in-progress-cron.ts
+++ b/apps/app/src/features/audit-log-bulk-export/server/service/check-audit-log-bulk-export-job-in-progress-cron.ts
@@ -1,0 +1,37 @@
+import { configManager } from '~/server/service/config-manager';
+import CronService from '~/server/service/cron';
+
+import { AuditLogBulkExportJobInProgressJobStatus } from '../../interfaces/audit-log-bulk-export';
+import AuditLogExportJob from '../models/audit-log-bulk-export-job';
+
+/**
+ * Manages cronjob which checks if AuditLogExportJob in progress exists.
+ * If it does, and AuditLogExportJobCronService is not running, start AuditLogExportJobCronService
+ */
+class CheckAuditLogBulkExportJobInProgressCronService extends CronService {
+  override getCronSchedule(): string {
+    return '*/3 * * * *';
+  }
+
+  override async executeJob(): Promise<void> {
+    const isAuditLogEnabled = configManager.getConfig('app:auditLogEnabled');
+    if (!isAuditLogEnabled) return;
+
+    const auditLogExportJobInProgress = await AuditLogExportJob.findOne({
+      $or: Object.values(AuditLogBulkExportJobInProgressJobStatus).map(
+        (status) => ({
+          status,
+        }),
+      ),
+    });
+    const auditLogExportInProgressExists = auditLogExportJobInProgress != null;
+
+    if (auditLogExportInProgressExists) {
+      // TODO: Start the cron that actually performs audit-log export.
+      // This will be implemented in a later task.
+    }
+  }
+}
+
+export const checkAuditLogExportJobInProgressCronService =
+  new CheckAuditLogBulkExportJobInProgressCronService();

--- a/apps/app/src/server/crowi/index.js
+++ b/apps/app/src/server/crowi/index.js
@@ -8,6 +8,7 @@ import lsxRoutes from '@growi/remark-lsx/dist/server/index.cjs';
 import mongoose from 'mongoose';
 import next from 'next';
 
+import { checkAuditLogExportJobInProgressCronService } from '~/features/audit-log-bulk-export/server/service/check-audit-log-bulk-export-job-in-progress-cron';
 import { KeycloakUserGroupSyncService } from '~/features/external-user-group/server/service/keycloak-user-group-sync';
 import { LdapUserGroupSyncService } from '~/features/external-user-group/server/service/ldap-user-group-sync';
 import { startCronIfEnabled as startOpenaiCronIfEnabled } from '~/features/openai/server/services/cron';
@@ -363,6 +364,8 @@ Crowi.prototype.setupCron = function() {
 
   instanciatePageBulkExportJobCleanUpCronService(this);
   pageBulkExportJobCleanUpCronService.startCron();
+
+  checkAuditLogExportJobInProgressCronService.startCron();
 
   startOpenaiCronIfEnabled();
   startAccessTokenCron();


### PR DESCRIPTION
## Task
https://redmine.weseek.co.jp/issues/172030

## 補足
jobの作成を検知するためのcronを追加しました。実際のエクスポート処理は後続のタスクで実装するので、その箇所は
```
// TODO: Start the cron that actually performs audit-log export.
// This will be implemented in a later task.
```
というようにコメントだけしています