### PR TITLE
re-run pdf-converter 1.1.2 release with fixed workflow

### DIFF
--- a/apps/pdf-converter/package.json
+++ b/apps/pdf-converter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@growi/pdf-converter",
-  "version": "1.1.3-RC.0",
+  "version": "1.1.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "license": "MIT",


### PR DESCRIPTION
https://github.com/growilabs/growi/pull/10477 で修正前の workflow が適用されてしまっていたため、修正後の workflow をマージし、再度 1.1.2 でリリースを走らせる。