### PR TITLE
feat: add admin ui for default read only for newuser

### DIFF
--- a/apps/app/public/static/locales/en_US/admin.json
+++ b/apps/app/public/static/locales/en_US/admin.json
@@ -356,6 +356,8 @@
     "confidential_example": "ex): internal use only",
     "default_language": "Default language for new users",
     "default_mail_visibility": "Disclose e-mail for new users",
+    "default_read_only_for_new_user": "New User Viewing Permissions Settings",
+    "editable": "Editable",
     "file_uploading": "File uploading",
     "enable_files_except_image": "Enabling this option will allow upload of any file type. Without this option, only image file upload is supported.",
     "attach_enable": "You can attach files other than image files if you enable this option.",

--- a/apps/app/public/static/locales/fr_FR/admin.json
+++ b/apps/app/public/static/locales/fr_FR/admin.json
@@ -356,6 +356,8 @@
     "confidential_example": "ex): usage interne seulement",
     "default_language": "Langue par défaut",
     "default_mail_visibility": "Mode d'affichage de l'adresse courriel",
+    "default_read_only_for_new_user": "Configuration des droits d'accès pour les nouveaux utilisateurs",
+    "editable": "modifiable",
     "file_uploading": "Téléversement de fichiers",
     "enable_files_except_image": "Autoriser tout les types de fichiers",
     "attach_enable": "Autorise le téléversement de tout les types de fichiers.",

--- a/apps/app/public/static/locales/ja_JP/admin.json
+++ b/apps/app/public/static/locales/ja_JP/admin.json
@@ -365,6 +365,8 @@
     "confidential_example": "例: 社外秘",
     "default_language": "新規ユーザーのデフォルト設定言語",
     "default_mail_visibility": "新規ユーザーの初期メール公開設定",
+    "default_read_only_for_new_user": "新規ユーザーの閲覧権限設定",
+    "editable": "編集可能",
     "file_uploading": "ファイルアップロード",
     "enable_files_except_image": "画像以外のファイルアップロードを許可",
     "attach_enable": "許可をしている場合、画像以外のファイルをページに添付可能になります。",

--- a/apps/app/public/static/locales/ko_KR/admin.json
+++ b/apps/app/public/static/locales/ko_KR/admin.json
@@ -356,6 +356,8 @@
     "confidential_example": "예): 내부 전용",
     "default_language": "새 사용자를 위한 기본 언어",
     "default_mail_visibility": "새 사용자를 위한 이메일 공개",
+    "default_read_only_for_new_user": "신규 사용자의 열람 권한 설정",
+    "editable": "편집 가능",
     "file_uploading": "파일 업로드",
     "enable_files_except_image": "이 옵션을 활성화하면 모든 파일 형식을 업로드할 수 있습니다. 이 옵션이 없으면 이미지 파일 업로드만 지원됩니다.",
     "attach_enable": "이 옵션을 활성화하면 이미지 파일 외의 파일을 첨부할 수 있습니다.",

--- a/apps/app/public/static/locales/zh_CN/admin.json
+++ b/apps/app/public/static/locales/zh_CN/admin.json
@@ -365,6 +365,8 @@
     "confidential_example": "ex）：仅供内部使用",
     "default_language": "新用户的默认语言",
     "default_mail_visibility": "新用户的默认电子邮件可见性",
+    "default_read_only_for_new_user": "新用戶的瀏覽權限設定",
+    "editable": "可編輯",
     "file_uploading": "文件上传",
     "enable_files_except_image": "启用此选项将允许上传任何文件类型。如果没有此选项，则仅支持图像文件上载。",
     "attach_enable": "如果启用此选项，则可以附加图像文件以外的文件。",

--- a/apps/app/src/client/components/Admin/App/AppSetting.jsx
+++ b/apps/app/src/client/components/Admin/App/AppSetting.jsx
@@ -35,6 +35,7 @@ const AppSetting = (props) => {
       globalLang: adminAppContainer.state.globalLang || 'en-US',
       // Convert boolean to string for radio button value
       isEmailPublishedForNewUser: String(adminAppContainer.state.isEmailPublishedForNewUser ?? true),
+      isReadOnlyForNewUser: String(adminAppContainer.state.isReadOnlyForNewUser ?? false),
       fileUpload: adminAppContainer.state.fileUpload ?? false,
     });
   }, [
@@ -42,6 +43,7 @@ const AppSetting = (props) => {
     adminAppContainer.state.confidential,
     adminAppContainer.state.globalLang,
     adminAppContainer.state.isEmailPublishedForNewUser,
+    adminAppContainer.state.isReadOnlyForNewUser,
     adminAppContainer.state.fileUpload,
     reset,
   ]);
@@ -57,6 +59,8 @@ const AppSetting = (props) => {
       // Convert string 'true'/'false' to boolean
       const isEmailPublished = data.isEmailPublishedForNewUser === 'true' || data.isEmailPublishedForNewUser === true;
       await adminAppContainer.changeIsEmailPublishedForNewUserShow(isEmailPublished);
+      const isReadOnlyForNewUser = data.isReadOnlyForNewUser === 'true' || data.isReadOnlyForNewUser === true;
+      await adminAppContainer.changeIsReadOnlyForNewUserShow(isReadOnlyForNewUser);
       await adminAppContainer.changeFileUpload(data.fileUpload);
 
       await adminAppContainer.updateAppSettingHandler();
@@ -158,6 +162,39 @@ const AppSetting = (props) => {
               {...register('isEmailPublishedForNewUser')}
             />
             <label className="form-label form-check-label" htmlFor="radio-email-hide">{t('commons:Hide')}</label>
+          </div>
+
+        </div>
+      </div>
+
+      <div className="row mb-5">
+        <label
+          className="text-start text-md-end col-md-3 col-form-label"
+        >
+          {t('admin:app_setting.default_read_only_for_new_user')}
+        </label>
+        <div className="col-md-6 py-2">
+
+          <div className="form-check form-check-inline">
+            <input
+              type="radio"
+              id="radio-email-show"
+              className="form-check-input"
+              value="true"
+              {...register('isReadOnlyForNewUser')}
+            />
+            <label className="form-label form-check-label" htmlFor="radio-email-show">{t('admin:user_management.user_table.read_only')}</label>
+          </div>
+
+          <div className="form-check form-check-inline">
+            <input
+              type="radio"
+              id="radio-email-hide"
+              className="form-check-input"
+              value="false"
+              {...register('isReadOnlyForNewUser')}
+            />
+            <label className="form-label form-check-label" htmlFor="radio-email-hide">{t('admin:app_setting.editable')}</label>
           </div>
 
         </div>

--- a/apps/app/src/client/services/AdminAppContainer.js
+++ b/apps/app/src/client/services/AdminAppContainer.js
@@ -22,6 +22,7 @@ export default class AdminAppContainer extends Container {
       confidential: '',
       globalLang: '',
       isEmailPublishedForNewUser: true,
+      isReadOnlyForNewUser: false,
       fileUpload: '',
 
       isV5Compatible: null,
@@ -67,6 +68,7 @@ export default class AdminAppContainer extends Container {
       confidential: appSettingsParams.confidential,
       globalLang: appSettingsParams.globalLang,
       isEmailPublishedForNewUser: appSettingsParams.isEmailPublishedForNewUser,
+      isReadOnlyForNewUser: appSettingsParams.isReadOnlyForNewUser,
       fileUpload: appSettingsParams.fileUpload,
       isV5Compatible: appSettingsParams.isV5Compatible,
       siteUrl: appSettingsParams.siteUrl,
@@ -116,6 +118,13 @@ export default class AdminAppContainer extends Container {
    */
   changeIsEmailPublishedForNewUserShow(isEmailPublishedForNewUser) {
     this.setState({ isEmailPublishedForNewUser });
+  }
+
+  /**
+   * Change isReadOnlyForNewUser
+   */
+  changeIsReadOnlyForNewUserShow(isReadOnlyForNewUser) {
+    this.setState({ isReadOnlyForNewUser });
   }
 
   /**
@@ -207,6 +216,7 @@ export default class AdminAppContainer extends Container {
       confidential: this.state.confidential,
       globalLang: this.state.globalLang,
       isEmailPublishedForNewUser: this.state.isEmailPublishedForNewUser,
+      isReadOnlyForNewUser: this.state.isReadOnlyForNewUser,
       fileUpload: this.state.fileUpload,
     });
     const { appSettingParams } = response.data;


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/175483

- 閲覧のみ/編集可能設定後、新規ユーザー作成時、設定通りになる。（ユーザー管理画面から新規ユーザーの仮発行をした際もテスト済み）

<img width="1422" height="1163" alt="スクリーンショット 2025-12-08 191337" src="https://github.com/user-attachments/assets/77b0d1a3-4520-4edb-b968-50c0053d55fc" />
