### PR TITLE
fix: getServerSidePropsForInitial is not executed when transitioning from outside route

### DIFF
--- a/apps/app/src/pages/[[...path]]/index.page.tsx
+++ b/apps/app/src/pages/[[...path]]/index.page.tsx
@@ -279,7 +279,7 @@ export const getServerSideProps: GetServerSideProps<Props> = async (
     commonEachPropsResult,
     nextjsRoutingType === NextjsRoutingType.SAME_ROUTE
       ? await getServerSidePropsForSameRoute(context)
-      : await getServerSidePropsForInitial(context)
+      : await getServerSidePropsForInitial(context),
   );
 };
 


### PR DESCRIPTION
## Task
https://redmine.weseek.co.jp/issues/175487