### PR TITLE
fix: History modal does not automatically appear when accessing page with compare query parameter

### DIFF
--- a/apps/app/src/client/components/PageAccessoriesModal/PageAccessoriesModal.tsx
+++ b/apps/app/src/client/components/PageAccessoriesModal/PageAccessoriesModal.tsx
@@ -18,8 +18,6 @@ import { CustomNavDropdown, CustomNavTab } from '../CustomNavigation/CustomNav';
 import CustomTabContent from '../CustomNavigation/CustomTabContent';
 import ExpandOrContractButton from '../ExpandOrContractButton';
 
-import { useAutoOpenModalByQueryParam } from './hooks';
-
 import styles from './PageAccessoriesModal.module.scss';
 
 
@@ -44,8 +42,6 @@ const PageAccessoriesModalSubstance = ({ isWindowExpanded, setIsWindowExpanded }
 
   const status = usePageAccessoriesModalStatus();
   const { close, selectContents } = usePageAccessoriesModalActions();
-
-  useAutoOpenModalByQueryParam();
 
   // Memoize heavy navTabMapping calculation
   const navTabMapping = useMemo(() => {

--- a/apps/app/src/client/components/PageAccessoriesModal/dynamic.tsx
+++ b/apps/app/src/client/components/PageAccessoriesModal/dynamic.tsx
@@ -3,10 +3,14 @@ import type { JSX } from 'react';
 import { useLazyLoader } from '~/components/utils/use-lazy-loader';
 import { usePageAccessoriesModalStatus } from '~/states/ui/modal/page-accessories';
 
+import { useAutoOpenModalByQueryParam } from './hooks';
+
 type PageAccessoriesModalProps = Record<string, unknown>;
 
 export const PageAccessoriesModalLazyLoaded = (): JSX.Element => {
   const status = usePageAccessoriesModalStatus();
+
+  useAutoOpenModalByQueryParam();
 
   const PageAccessoriesModal = useLazyLoader<PageAccessoriesModalProps>(
     'page-accessories-modal',


### PR DESCRIPTION
## Task
https://redmine.weseek.co.jp/issues/175881