### PR TITLE
imprv: Renaming feature on PageTree to consider the composition for IME and support mobile

### DIFF
--- a/apps/app/src/client/components/Common/SubmittableInput/index.ts
+++ b/apps/app/src/client/components/Common/SubmittableInput/index.ts
@@ -1,2 +1,4 @@
 export * from './SubmittableInput';
 export * from './AutosizeSubmittableInput';
+export * from './use-submittable';
+export type * from './types';

--- a/apps/app/src/client/components/Common/SubmittableInput/types.d.ts
+++ b/apps/app/src/client/components/Common/SubmittableInput/types.d.ts
@@ -1,3 +1,6 @@
+/**
+ * Props for full submittable input with value management
+ */
 export type SubmittableInputProps<T extends InputHTMLAttributes<HTMLInputElement> = InputHTMLAttributes<HTMLInputElement>> =
   Omit<InputHTMLAttributes<T>, 'value' | 'onKeyDown' | 'onSubmit'>
   & {
@@ -5,3 +8,25 @@ export type SubmittableInputProps<T extends InputHTMLAttributes<HTMLInputElement
     onSubmit?: (inputText: string) => void,
     onCancel?: () => void,
   }
+
+/**
+ * Props for keyboard-only mode (lightweight)
+ * Only handles Enter/Escape keys with IME composition awareness
+ * Does not manage value state or blur behavior
+ * Useful when integrating with external state management (e.g., headless-tree)
+ */
+export type KeyboardOnlySubmittableInputProps = Partial<Pick<
+  InputHTMLAttributes<HTMLInputElement>,
+  'onCompositionStart' | 'onCompositionEnd'
+>> & {
+  onSubmit?: () => void,
+  onCancel?: () => void,
+}
+
+/**
+ * Return type for keyboard-only mode
+ */
+export type KeyboardOnlySubmittableResult = Required<Pick<
+  InputHTMLAttributes<HTMLInputElement>,
+  'onKeyDown' | 'onCompositionStart' | 'onCompositionEnd'
+>>

--- a/apps/app/src/client/components/Common/SubmittableInput/use-submittable.ts
+++ b/apps/app/src/client/components/Common/SubmittableInput/use-submittable.ts
@@ -1,13 +1,87 @@
 import type {
   CompositionEvent,
+  KeyboardEvent,
 } from 'react';
 import type React from 'react';
 import {
   useCallback, useState,
 } from 'react';
 
-import type { SubmittableInputProps } from './types';
+import type { KeyboardOnlySubmittableInputProps, KeyboardOnlySubmittableResult, SubmittableInputProps } from './types';
 
+
+/**
+ * Internal hook for composition-aware keyboard handling
+ * Shared by both useSubmittable and useKeyboardSubmittable
+ */
+const useCompositionState = (props: {
+  onCompositionStart?: React.CompositionEventHandler<HTMLInputElement>,
+  onCompositionEnd?: React.CompositionEventHandler<HTMLInputElement>,
+}) => {
+  const { onCompositionStart, onCompositionEnd } = props;
+  const [isComposing, setComposing] = useState(false);
+
+  const compositionStartHandler = useCallback((e: CompositionEvent<HTMLInputElement>) => {
+    setComposing(true);
+    onCompositionStart?.(e);
+  }, [onCompositionStart]);
+
+  const compositionEndHandler = useCallback((e: CompositionEvent<HTMLInputElement>) => {
+    setComposing(false);
+    onCompositionEnd?.(e);
+  }, [onCompositionEnd]);
+
+  return {
+    isComposing,
+    compositionStartHandler,
+    compositionEndHandler,
+  };
+};
+
+
+/**
+ * Lightweight hook for keyboard-only submission handling
+ * Only handles Enter/Escape keys with IME composition awareness
+ * Does not manage value state or blur behavior
+ * Useful when integrating with external state management (e.g., headless-tree)
+ */
+export const useKeyboardSubmittable = (props: KeyboardOnlySubmittableInputProps): KeyboardOnlySubmittableResult => {
+  const {
+    onSubmit, onCancel, onCompositionStart, onCompositionEnd,
+  } = props;
+
+  const {
+    isComposing,
+    compositionStartHandler,
+    compositionEndHandler,
+  } = useCompositionState({ onCompositionStart, onCompositionEnd });
+
+  const keyDownHandler = useCallback((e: KeyboardEvent<HTMLInputElement>) => {
+    switch (e.key) {
+      case 'Enter':
+        if (isComposing) return;
+        e.preventDefault();
+        onSubmit?.();
+        break;
+      case 'Escape':
+        if (isComposing) return;
+        onCancel?.();
+        break;
+    }
+  }, [isComposing, onCancel, onSubmit]);
+
+  return {
+    onKeyDown: keyDownHandler,
+    onCompositionStart: compositionStartHandler,
+    onCompositionEnd: compositionEndHandler,
+  };
+};
+
+
+/**
+ * Full-featured hook for submittable input with value management
+ * Handles value state, blur submission, and keyboard events
+ */
 export const useSubmittable = (props: SubmittableInputProps): Partial<React.InputHTMLAttributes<HTMLInputElement>> => {
 
   const {
@@ -19,7 +93,12 @@ export const useSubmittable = (props: SubmittableInputProps): Partial<React.Inpu
 
   const [inputText, setInputText] = useState(value ?? '');
   const [lastSubmittedInputText, setLastSubmittedInputText] = useState<string|undefined>(value ?? '');
-  const [isComposing, setComposing] = useState(false);
+
+  const {
+    isComposing,
+    compositionStartHandler,
+    compositionEndHandler,
+  } = useCompositionState({ onCompositionStart, onCompositionEnd });
 
   const changeHandler = useCallback(async(e: React.ChangeEvent<HTMLInputElement>) => {
     const inputText = e.target.value;
@@ -28,7 +107,7 @@ export const useSubmittable = (props: SubmittableInputProps): Partial<React.Inpu
     onChange?.(e);
   }, [onChange]);
 
-  const keyDownHandler = useCallback((e) => {
+  const keyDownHandler = useCallback((e: KeyboardEvent<HTMLInputElement>) => {
     switch (e.key) {
       case 'Enter':
         // Do nothing when composing
@@ -47,7 +126,7 @@ export const useSubmittable = (props: SubmittableInputProps): Partial<React.Inpu
     }
   }, [inputText, isComposing, onCancel, onSubmit]);
 
-  const blurHandler = useCallback((e) => {
+  const blurHandler = useCallback((e: React.FocusEvent<HTMLInputElement>) => {
     // suppress continuous calls to submit by blur event
     if (lastSubmittedInputText === inputText) {
       return;
@@ -58,16 +137,6 @@ export const useSubmittable = (props: SubmittableInputProps): Partial<React.Inpu
     onSubmit?.(inputText.trim());
     onBlur?.(e);
   }, [inputText, lastSubmittedInputText, onSubmit, onBlur]);
-
-  const compositionStartHandler = useCallback((e: CompositionEvent<HTMLInputElement>) => {
-    setComposing(true);
-    onCompositionStart?.(e);
-  }, [onCompositionStart]);
-
-  const compositionEndHandler = useCallback((e: CompositionEvent<HTMLInputElement>) => {
-    setComposing(false);
-    onCompositionEnd?.(e);
-  }, [onCompositionEnd]);
 
   const {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
# Issues an Tasks
- fix #7472
- https://redmine.weseek.co.jp/issues/176166

# Summary

変更サマリー:

## 1. types.d.ts - 新しい型を追加

```
  // 軽量モード用の props 型
  export type KeyboardOnlySubmittableInputProps = Partial<Pick<...>> & {
    onSubmit?: () => void,
    onCancel?: () => void,
  }

  // 戻り値の型
  export type KeyboardOnlySubmittableResult = Required<Pick<
    InputHTMLAttributes<HTMLInputElement>,
    'onKeyDown' | 'onCompositionStart' | 'onCompositionEnd'
```

## 2. use-submittable.ts - 新フック追加

```
  // 共通ロジックを抽出
  const useCompositionState = (props) => {
    // composition 状態管理
  }

  // 軽量フック（新規）
  export const useKeyboardSubmittable = (props): KeyboardOnlySubmittableResult => {
    // Enter/Escape キー + IME composition 対応のみ
  }

  // 既存フック（共通ロジックを使用するようリファクタ）
  export const useSubmittable = (props) => { ... }
```

## 3. TreeNameInput.tsx - useKeyboardSubmittable を使用

```
  const keyboardSubmittableProps = useKeyboardSubmittable({
    onSubmit: () => item.getTree().completeRenaming(),
    onCancel: () => item.getTree().abortRenaming(),
  });
```

## メリット:
  - useKeyboardSubmittable は headless-tree と競合しない（value/blur を管理しない）
  - onCompositionStart/onCompositionEnd で IME 状態を確実に追跡
  - e.key === 'Enter' でチェックするため Android でも動作
  - 共通ロジックを useCompositionState に抽出してコードを DRY に