### PR TITLE
fix: PageTree does not auto-scroll to target page path on initial render

### DIFF
--- a/apps/app/src/features/page-tree/hooks/_inner/use-scroll-to-selected-item.ts
+++ b/apps/app/src/features/page-tree/hooks/_inner/use-scroll-to-selected-item.ts
@@ -16,11 +16,17 @@ export const useScrollToSelectedItem = ({
 }: UseScrollToSelectedItemParams): void => {
   // Track the previous targetPathOrId to detect actual changes
   const prevTargetPathOrIdRef = useRef<string | undefined>(undefined);
+  // Track whether initial scroll has been completed successfully
+  const hasInitialScrolledRef = useRef(false);
 
   useEffect(() => {
-    // Only scroll when targetPathOrId actually changes, not on items change alone
-    // This prevents unwanted scrolling when creating a new page (items update but targetPathOrId stays the same)
-    if (targetPathOrId === prevTargetPathOrIdRef.current) return;
+    const targetChanged = targetPathOrId !== prevTargetPathOrIdRef.current;
+
+    // Skip if target hasn't changed AND initial scroll is already done
+    // This allows retrying scroll when items are loaded, but prevents unwanted scrolling
+    // when creating a new page (items update but targetPathOrId stays the same after initial scroll)
+    if (!targetChanged && hasInitialScrolledRef.current) return;
+
     prevTargetPathOrIdRef.current = targetPathOrId;
 
     if (targetPathOrId == null) return;
@@ -33,6 +39,7 @@ export const useScrollToSelectedItem = ({
     });
 
     if (selectedIndex !== -1) {
+      hasInitialScrolledRef.current = true;
       // Use a small delay to ensure the virtualizer is ready
       setTimeout(() => {
         virtualizer.scrollToIndex(selectedIndex, {


### PR DESCRIPTION
## Task
https://redmine.weseek.co.jp/issues/176904