### PR TITLE
fix: Prevent edit activity from being created on first page save

### DIFF
--- a/apps/app/src/server/routes/apiv3/page/update-page.ts
+++ b/apps/app/src/server/routes/apiv3/page/update-page.ts
@@ -118,10 +118,12 @@ export const updatePageHandlersFactory = (crowi: Crowi): RequestHandler[] => {
       await yjsService.syncWithTheLatestRevisionForce(req.body.pageId);
     }
 
-    const isFirstSaveAfterCreation = previousRevision == null;
+    const ignoreEditWindow = 60 * 1000; // 60 seconds
+    const pageAgeMs =
+      updatedPage.updatedAt.getTime() - updatedPage.createdAt.getTime();
+    const isWithinIgnoreEditWindow = pageAgeMs < ignoreEditWindow;
 
-    // persist activity
-    if (!isFirstSaveAfterCreation) {
+    if (!isWithinIgnoreEditWindow) {
       const creator =
         updatedPage.creator != null
           ? getIdForRef(updatedPage.creator)


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/177734
https://redmine.weseek.co.jp/issues/177877

## Prevent "page edit" Activity on page creation
- Stop "page edit" Activity from being created on first page save.