### PR TITLE
fix: Allow viewing shared pages regardless of page permissions

### DIFF
--- a/apps/app/src/server/service/page/find-page-and-meta-data-by-viewer.ts
+++ b/apps/app/src/server/service/page/find-page-and-meta-data-by-viewer.ts
@@ -81,7 +81,7 @@ export async function findPageAndMetaDataByViewer(
   let page: PageDoc | null;
   if (isSharedPage && pageId != null) {
     // Share link access already validated upstream; skip permission filtering
-    page = await Page.findById(pageId);
+    page = await Page.findOne({ _id: { $eq: pageId } });
   } else if (pageId != null) {
     // prioritized
     page = await Page.findByIdAndViewer(pageId, user, null, true);


### PR DESCRIPTION
## Task
https://redmine.weseek.co.jp/issues/178107
[v7.4.x] 権限が設定されてるページで作成した share link 経由でページが閲覧できない

## 変更点
Share Link経由でのページアクセス時に、ページの権限に関わらず閲覧できるように修正

- `find-page-and-meta-data-by-viewer.ts`: 
`isSharedPage`がtrueの場合、`Page.findByIdAndViewer()`の代わりに`Page.findById()`を使い、権限フィルタリングをスキップするように変更