### PR TITLE
fix: Bulk export fails due to S3 upload minimal version

### DIFF
--- a/apps/app/src/features/page-bulk-export/server/service/page-bulk-export-job-cron/steps/compress-and-upload.ts
+++ b/apps/app/src/features/page-bulk-export/server/service/page-bulk-export-job-cron/steps/compress-and-upload.ts
@@ -76,27 +76,33 @@ export async function compressAndUpload(
 
   const fileUploadService: FileUploader = this.crowi.fileUploadService;
 
-  pageArchiver.directory(this.getTmpOutputDir(pageBulkExportJob), false);
-  pageArchiver.finalize();
-
   // Wrap with Node.js native PassThrough so that AWS SDK recognizes the stream as a native Readable
   const uploadStream = new PassThrough();
+
+  // Establish pipe before finalize to ensure data flows correctly
   pageArchiver.pipe(uploadStream);
   pageArchiver.on('error', (err) => {
     uploadStream.destroy(err);
+    pageArchiver.destroy();
   });
+
+  pageArchiver.directory(this.getTmpOutputDir(pageBulkExportJob), false);
+  pageArchiver.finalize();
 
   this.setStreamsInExecution(pageBulkExportJob._id, pageArchiver, uploadStream);
 
   try {
     await fileUploadService.uploadAttachment(uploadStream, attachment);
+    await postProcess.bind(this)(
+      pageBulkExportJob,
+      attachment,
+      pageArchiver.pointer(),
+    );
   } catch (e) {
     logger.error(e);
     this.handleError(e, pageBulkExportJob);
+  } finally {
+    pageArchiver.destroy();
+    uploadStream.destroy();
   }
-  await postProcess.bind(this)(
-    pageBulkExportJob,
-    attachment,
-    pageArchiver.pointer(),
-  );
 }


### PR DESCRIPTION
**[1段階目のPR](https://github.com/growilabs/growi/pull/10775)のレビューを反映したうえで、修正を必要最小限に変更したため、新たにPRを作成しました。**
**また、RCリリースにより本番環境(Inner Wiki)での動作を既に確認しています。**

## Task
https://redmine.weseek.co.jp/issues/178419
[Bulk Export] pdf-converter が AWS との組み合わせで発生している不具合を修正する

## 症状
AWS 環境で bulk export（Markdown/PDF 両方）が失敗し、ダウンロード時に NoSuchKey エラーが発生していた。GCS 環境では正常に動作していた。

## バグの原因
[PDFエクスポート>フロー概要図](https://dev.growi.org/66ee8495830566b31e02c953)ステップ14に続く、「PDFをストレージにアップロード（tar.gz化）」で、tar.gz圧縮データを生成する archiver のストリームを AWS SDK に渡した時点で型チェックに失敗し、データが一切流れないまま即座にエラーになっていた。

これは、archiver と AWS SDK が異なる Readable クラスを参照しているため、AWS SDK が archiver のストリームをストリームとして認識できていなかったことによる。GCS の実装はこの影響を受けないため、GCS 環境では正常に動作する。

## 変更点
### バグ対応

1. `compress-and-upload.ts`: archiver ストリームを PassThrough でラップ
archiver のストリームを、AWS SDK が認識できる Node.js ネイティブのストリーム（PassThrough）に中継させることで、instanceof Readable チェックを通過させた。
また、archiver のエラーを uploadStream に伝播させるハンドリングと、cleanup 時に uploadStream も破棄されるよう setStreamsInExecution への登録を追加した。


