### PR TITLE
fix: Use currentPageId for share link page fetching

### DIFF
--- a/apps/app/src/states/page/use-fetch-current-page.ts
+++ b/apps/app/src/states/page/use-fetch-current-page.ts
@@ -136,23 +136,28 @@ const buildApiParams = ({
     shareLinkId?: string;
   } = {};
 
-  if (shareLinkId != null) {
+  if (shareLinkId != null && shareLinkId.length > 0) {
     params.shareLinkId = shareLinkId;
   }
   if (revisionId != null) {
     params.revisionId = revisionId;
   }
 
-  // priority A: pageId > permalink > path
+  // priority A: fetchPageArgs.pageId
   if (fetchPageArgs?.pageId != null) {
     params.pageId = fetchPageArgs.pageId;
+  }
+  // priority B: currentPageId for share link (required by certifySharedPage middleware)
+  else if (shareLinkId != null && currentPageId != null) {
+    params.pageId = currentPageId;
   } else if (decodedPathname != null) {
+    // priority C: permalink > path
     if (isPermalink(decodedPathname)) {
       params.pageId = removeHeadingSlash(decodedPathname);
     } else {
       params.path = decodedPathname;
     }
-    // priority B: currentPageId > permalink(by location) > path(by location)
+    // priority D: currentPageId > permalink(by location) > path(by location)
   } else if (currentPageId != null) {
     params.pageId = currentPageId;
   } else if (isClient()) {


### PR DESCRIPTION
fix #10788

## Summary
- When accessing a page via share link (`/share/<shareLinkId>`), the CSR fetch now correctly uses `currentPageId` (hydrated from SSR) instead of sending the share link URL path to the API
- This fixes the issue where the `certifySharedPage` middleware could not validate the request because the API received `path=/share/...` instead of the actual `pageId`

## Test plan
- [x] Added test: share link with `currentPageId` sends `pageId` + `shareLinkId` (not `path`)
- [x] Added test: share link without `currentPageId` falls through to path-based logic
- [ ] Manual verification: access a shared page via share link URL and confirm page info loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)