### PR TITLE
fix(search): prevent Downshift from intercepting Home/End keys in search input

### DIFF
--- a/apps/app/src/features/search/client/components/SearchForm.tsx
+++ b/apps/app/src/features/search/client/components/SearchForm.tsx
@@ -46,9 +46,7 @@ export const SearchForm = (props: Props): JSX.Element => {
   const keyDownHandler = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
       if (e.key === 'Home' || e.key === 'End') {
-        (
-          e.nativeEvent as { preventDownshiftDefault?: boolean }
-        ).preventDownshiftDefault = true;
+        e.nativeEvent.preventDownshiftDefault = true;
       }
     },
     [],

--- a/apps/app/src/features/search/client/interfaces/downshift.ts
+++ b/apps/app/src/features/search/client/interfaces/downshift.ts
@@ -1,5 +1,14 @@
 import type { ControllerStateAndHelpers } from 'downshift';
 
+// Augment the global Event interface with downshift's custom property.
+// downshift checks event.nativeEvent.preventDownshiftDefault to skip
+// its default key handling. See: https://www.downshift-js.com/downshift#customizing-handlers
+declare global {
+  interface Event {
+    preventDownshiftDefault?: boolean;
+  }
+}
+
 export type DownshiftItem = { url: string };
 
 export type GetItemProps =


### PR DESCRIPTION
Home and End keys were being captured by Downshift's list navigation
(jumping to first/last item), instead of moving the cursor to the
beginning/end of the text input. Setting preventDownshiftDefault on
the native event tells Downshift to skip its handling for these keys.

https://claude.ai/code/session_019Mh5cVjsoTfZnxVjamHkvf