### PR TITLE
fix: display the badge of MOVE and the icon of EDIT

### DIFF
--- a/apps/app/src/client/components/Admin/Notification/ManageGlobalNotification.tsx
+++ b/apps/app/src/client/components/Admin/Notification/ManageGlobalNotification.tsx
@@ -303,7 +303,7 @@ const ManageGlobalNotification = (props: Props): JSX.Element => {
                 onChange={() => onChangeTriggerEvents(TriggerEventType.EDIT)}
               >
                 <span className="badge rounded-pill bg-warning text-dark">
-                  <span className="imaterial-symbols-outlined">edit</span> EDIT
+                  <span className="material-symbols-outlined">edit</span> EDIT
                 </span>
               </TriggerEventCheckBox>
             </div>
@@ -314,7 +314,7 @@ const ManageGlobalNotification = (props: Props): JSX.Element => {
                 checked={triggerEvents.has(TriggerEventType.MOVE)}
                 onChange={() => onChangeTriggerEvents(TriggerEventType.MOVE)}
               >
-                <span className="badge rounded-pill bg-pink">
+                <span className="badge rounded-pill bg-secondary">
                   <span className="material-symbols-outlined">redo</span>MOVE
                 </span>
               </TriggerEventCheckBox>


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/179724
MOVE の badge とEDIT のアイコンが表示されていなかったの表示している状態にしました。
[Before]
<img width="1251" height="748" alt="image" src="https://github.com/user-attachments/assets/c91faaaa-981a-4c43-b138-fc5e1bcb3f7c" />
<img width="1325" height="791" alt="image" src="https://github.com/user-attachments/assets/2cda815c-a6b8-4510-a5af-c15617be4a98" />
[After]
<img width="1296" height="741" alt="image" src="https://github.com/user-attachments/assets/7432590d-338b-4863-9d25-b8302843930a" />
<img width="1317" height="755" alt="image" src="https://github.com/user-attachments/assets/32931a38-ced5-4b0c-afb1-61d0f1df1411" />

