### PR TITLE
ref: #178592-178647 limit user agent length

### DIFF
--- a/apps/app/src/server/crowi/index.ts
+++ b/apps/app/src/server/crowi/index.ts
@@ -624,9 +624,8 @@ class Crowi {
           parseUA: false,
           // ReDoS protection: Limit UA to 512 chars to prevent parsing overhead.
           format: (res) => {
-            const ua = res.req.headers['user-agent'] || '';
-            const safeUA = ua.length > 512 ? ua.substring(0, 512) : ua;
-            return `User-Agent: ${safeUA}`;
+            const ua = (res.req.headers['user-agent'] || '').substring(0, 512);
+            return `User-Agent: ${ua}`;
           },
         }),
       );


### PR DESCRIPTION
## TASK
https://redmine.weseek.co.jp/issues/178647

## 目的
User-Agent 解析処理における DoS 脆弱性の防止とパフォーマンス最適化

## 原因
ReDoS のリスク: parseUA: true 設定時、内部の useragent ライブラリが複雑な正規表現を用いて解析を行う。悪意を持って生成された極端に長い UA 文字列が送られた場合、正規表現のバックトラッキングにより CPU 使用率が 100% に張り付き、サービス不能状態（DoS）に陥る危険性がある。

## 解決策
1. 解析処理のスキップ: parseUA: false とすることで、ライブラリ内部での正規表現マッチングを無効化し、CPU 負荷を最小化する。
2. UA 文字列の長制限（512文字）: format 関数内で、生の user-agent ヘッダーを substring(0, 512) により切り出す。

## 注意点
トレードオフ: userAgent(osやブラウザの情報)の詳細な分析結果を得られることができなくなります。
parseUA: true では、内部で正規表現を実行し 「family, major, os」といった構造化データを自動生成しますが、本実装ではこれを行いません。

バラバラな生のuserAgentを複雑な正規表現を使い、os, familyというように構造化されたデータを自動生成します。しかしながら今回の実装ではreDos対策を優先するためこの機能をオフにしています。この機能をオフにしても生のuserAgentのデータは保存されるので問題ないと判断しました。