### PR TITLE
feat(page-create-modal): add template help link icon

### DIFF
--- a/apps/app/src/client/components/PageCreateModal.tsx
+++ b/apps/app/src/client/components/PageCreateModal.tsx
@@ -35,7 +35,7 @@ import styles from './PageCreateModal.module.scss';
 const { isCreatablePage, isUsersHomepage } = pagePathUtils;
 
 const PageCreateModal: React.FC = () => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
 
   const currentUser = useCurrentUser();
   const growiCloudUri = useGrowiCloudUri();
@@ -72,10 +72,11 @@ const PageCreateModal: React.FC = () => {
     [userHomepagePath, t, now],
   );
 
+  const templateHelpLang = i18n.language === 'ja' ? 'ja' : 'en';
   const templateHelpUrl =
     growiCloudUri != null
-      ? 'https://growi.cloud/help/ja/guide/features/template.html'
-      : 'https://docs.growi.org/ja/guide/features/template.html';
+      ? `https://growi.cloud/help/${templateHelpLang}/guide/features/template.html`
+      : `https://docs.growi.org/${templateHelpLang}/guide/features/template.html`;
 
   const [todayInput, setTodayInput] = useState('');
   const [pageNameInput, setPageNameInput] = useState(pageNameInputInitialValue);


### PR DESCRIPTION
## Task
https://redmine.weseek.co.jp/issues/180215

## Summary
- Add a help icon (?) next to the "Create template under" heading in the page create modal
- Clicking the icon opens the template documentation page in a new tab
- The link destination differs based on the environment:
  - GROWI: `https://docs.growi.org/ja/guide/features/template.html`
  - GROWI.cloud: `https://growi.cloud/help/ja/guide/features/template.html`

## Test plan
- [ ] Open the page create modal and verify the help icon appears next to the template section heading
- [ ] Click the help icon and verify it opens the correct documentation URL in a new tab
- [ ] Verify the link destination differs correctly for GROWI vs GROWI.cloud environments

🤖 Generated with [Claude Code](https://claude.com/claude-code)