### PR TITLE
fix(admin): Prevent flickering for V5 Page Migration section on app settings page

### DIFF
--- a/apps/app/src/client/components/Admin/App/AppSettingsPageContents.tsx
+++ b/apps/app/src/client/components/Admin/App/AppSettingsPageContents.tsx
@@ -1,9 +1,10 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useTranslation } from 'next-i18next';
 
 import AdminAppContainer from '~/client/services/AdminAppContainer';
 import { toastError } from '~/client/util/toastr';
 import { useIsMaintenanceMode } from '~/states/global';
+import { useSWRxAppSettings } from '~/stores/admin/app-settings';
 import { toArrayIfNot } from '~/utils/array-utils';
 import loggerFactory from '~/utils/logger';
 
@@ -28,7 +29,7 @@ const AppSettingsPageContents = (props: Props) => {
 
   const isMaintenanceMode = useIsMaintenanceMode();
 
-  const { isV5Compatible } = adminAppContainer.state;
+  const { data: appSettings } = useSWRxAppSettings();
 
   useEffect(() => {
     const fetchAppSettingsData = async () => {
@@ -73,7 +74,7 @@ const AppSettingsPageContents = (props: Props) => {
           </div>
         )
       }
-      {!isV5Compatible && (
+      {appSettings?.isV5Compatible === false && (
         <div className="row">
           <div className="col-lg-12">
             <h2

--- a/apps/app/src/client/services/AdminAppContainer.js
+++ b/apps/app/src/client/services/AdminAppContainer.js
@@ -23,7 +23,6 @@ export default class AdminAppContainer extends Container {
       isEmailPublishedForNewUser: true,
       isReadOnlyForNewUser: false,
 
-      isV5Compatible: null,
       siteUrl: '',
       siteUrlUseOnlyEnvVars: null,
       envSiteUrl: '',
@@ -68,7 +67,6 @@ export default class AdminAppContainer extends Container {
       globalLang: appSettingsParams.globalLang,
       isEmailPublishedForNewUser: appSettingsParams.isEmailPublishedForNewUser,
       isReadOnlyForNewUser: appSettingsParams.isReadOnlyForNewUser,
-      isV5Compatible: appSettingsParams.isV5Compatible,
       siteUrl: appSettingsParams.siteUrl,
       siteUrlUseOnlyEnvVars: appSettingsParams.siteUrlUseOnlyEnvVars,
       envSiteUrl: appSettingsParams.envSiteUrl,
@@ -125,13 +123,6 @@ export default class AdminAppContainer extends Container {
    */
   changeIsReadOnlyForNewUserShow(isReadOnlyForNewUser) {
     this.setState({ isReadOnlyForNewUser });
-  }
-
-  /**
-   * Change site url
-   */
-  changeIsV5Compatible(isV5Compatible) {
-    this.setState({ isV5Compatible });
   }
 
   /**


### PR DESCRIPTION
## Summary

- Fixed an issue where the "V5 Page Migration" section briefly appeared when opening the app settings page.
- Removed unnecessary `isV5Compatible` related code from `AdminAppContainer`.

## Root Cause

`AdminAppContainer.js` initialized `isV5Compatible` to `null`, causing the conditional expression `!isV5Compatible` in `AppSettingsPageContents.tsx` to evaluate to `!null === true`, resulting in the V5 Page Migration section briefly appearing before the API response was returned.

## Changes

- `AppSettingsPageContents.tsx`: Used `useSWRxAppSettings()` instead of `AdminAppContainer.state.isV5Compatible`. Change the conditional expression to `appSettings?.isV5Compatible === false` and hide the section while SWR's `data` is `undefined` (loading).
- `AdminAppContainer.js`: Remove the unnecessary initial state of `isV5Compatible`, the setState in `retrieveAppSettingsData()`, and the `changeIsV5Compatible()` method.

## Test Plan

- [ ] Open the admin panel → App Settings and confirm that the "V5 Page Migration" section is not displayed for a moment.
- [ ] Confirm that the "V5 Page Migration" section is displayed correctly in a V5 incompatible environment.
- [ ] Confirm that other settings in App Settings (site URL, email, file upload, etc.) work correctly.

ref: #10882

🤖 Generated with [Claude Code](https://claude.com/claude-code)